### PR TITLE
Check if asset path is a URL before prepending public path

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cssnano": "^3.10.0",
     "glob": "^7.1.2",
     "htmlnano": "^0.1.6",
+    "is-url": "^1.2.2",
     "js-yaml": "^3.10.0",
     "micromatch": "^3.0.4",
     "mkdirp": "^0.5.1",

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -3,8 +3,7 @@ const path = require('path');
 const fs = require('./utils/fs');
 const objectHash = require('./utils/objectHash');
 const md5 = require('./utils/md5');
-
-const URL_RE = /^(([a-z]+:)|\/|#)/;
+const isURL = require('is-url');
 
 let ASSET_ID = 1;
 
@@ -63,7 +62,7 @@ class Asset {
   }
 
   addURLDependency(url, from = this.name, opts) {
-    if (!url || URL_RE.test(url)) {
+    if (!url || isURL(url)) {
       return url;
     }
 

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -6,6 +6,7 @@ const path = require('path');
 const md5 = require('../utils/md5');
 const render = require('posthtml-render');
 const posthtmlTransform = require('../transforms/posthtml');
+const isURL = require('is-url');
 
 // A list of all attributes that should produce a dependency
 // Based on https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
@@ -35,7 +36,11 @@ class HTMLAsset extends Asset {
         for (let attr in node.attrs) {
           let elements = ATTRS[attr];
           if (elements && elements.includes(node.tag)) {
-            node.attrs[attr] = path.join(this.options.publicURL, this.addURLDependency(node.attrs[attr]));
+            let assetPath = this.addURLDependency(node.attrs[attr]);
+            if (!isURL(assetPath)) {
+              assetPath = path.join(this.options.publicURL, assetPath);
+            }
+            node.attrs[attr] = assetPath;
             this.isAstDirty = true;
           }
         }

--- a/test/html.js
+++ b/test/html.js
@@ -95,4 +95,11 @@ describe('html', function () {
     assert(css.includes('Other page'));
     assert(!css.includes('\n'));
   });
+
+  it('should not prepend the public path to assets with remote URLs', async function () {
+    let b = await bundle(__dirname + '/integration/html/index.html');
+
+    let html = fs.readFileSync(__dirname + '/dist/index.html', 'utf8');
+    assert(html.includes('<script src="https://unpkg.com/parcel-bundler"></script>'));
+  });
 });

--- a/test/integration/html/index.html
+++ b/test/integration/html/index.html
@@ -7,5 +7,6 @@
   <h1>Hello world</h1>
   <p>Linking to <a href="other.html">another page</a></p>
   <script src="index.js"></script>
+  <script src="https://unpkg.com/parcel-bundler"></script>
 </body>
 </html>


### PR DESCRIPTION
Resolves #12 


While `addURLDependency` checked for URLs, `HTMLAsset` was always prepending the public path. This PR adds a new (small) dependency `is-url`, a common utility for this, and adds the necessary check in `HTMLAsset`