### PR TITLE
Make current Parcel version part of cache key.

### DIFF
--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -2,6 +2,7 @@ const fs = require('./utils/fs');
 const path = require('path');
 const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
+const pjson = require('../package.json');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr'];
@@ -10,8 +11,12 @@ class FSCache {
   constructor(options) {
     this.dir = path.resolve(options.cacheDir || '.cache');
     this.dirExists = false;
-    this.invalidated = new Set;
-    this.optionsHash = objectHash(OPTION_KEYS.reduce((p, k) => (p[k] = options[k], p), {}));
+    this.invalidated = new Set();
+    this.optionsHash = objectHash(
+      OPTION_KEYS.reduce((p, k) => ((p[k] = options[k]), p), {
+        version: pjosn.version,
+      })
+    );
   }
 
   async ensureDirExists() {

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -2,7 +2,7 @@ const fs = require('./utils/fs');
 const path = require('path');
 const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
-const pjson = require('../package.json');
+const pkg = require('../package.json');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr'];
@@ -14,7 +14,7 @@ class FSCache {
     this.invalidated = new Set();
     this.optionsHash = objectHash(
       OPTION_KEYS.reduce((p, k) => ((p[k] = options[k]), p), {
-        version: pjosn.version,
+        version: pkg.version,
       })
     );
   }


### PR DESCRIPTION
This pull request addresses #62. Updated `FSCache` to also include current Parcel version also in the package key.