### PR TITLE
use NODE_ENV = development by default on parcel serve

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -59,6 +59,8 @@ function bundle(main, command) {
 
   if (command.name() === 'build') {
     process.env.NODE_ENV = 'production';
+  } else {
+    process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   }
 
   const bundler = new Bundler(main, command);


### PR DESCRIPTION
Hey there. Nice project, I am really excited about the things happening here.

While testing this project to create a react app I noticed that process.env.NODE_ENV is not set for the serve command. So babel-plugin-react-app shows an error with ```Using `babel-preset-react-app` requires that you specify `NODE_ENV` or `BABEL_ENV` environment variables. Valid values are "development", "test", and "production". Instead, received: undefined.```.
I think it makes sense to use this as a default. Thoughts?