### PR TITLE
Notify browser on error

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -133,6 +133,9 @@ class Bundler extends EventEmitter {
     } catch (err) {
       this.errored = true;
       this.logger.error(err);
+      if (this.hmr) {
+        this.hmr.emitError(err);
+      }
     } finally {
       this.pending = false;
       this.emit('buildEnd');

--- a/src/HMRServer.js
+++ b/src/HMRServer.js
@@ -6,6 +6,12 @@ class HMRServer {
       this.wss = new WebSocket.Server({port: 0}, resolve);
     });
 
+    this.wss.on('connection', (ws) => {
+      if (this.unresolvedError) {
+        ws.send(JSON.stringify(this.unresolvedError))
+      }
+    });
+
     return this.wss._server.address().port;
   }
 
@@ -13,8 +19,50 @@ class HMRServer {
     this.wss.close();
   }
 
+  emitError(err) {
+    let message = typeof err === 'string' ? err : err.message;
+    if (!message) {
+      message = 'unknown error'
+    }
+
+    if (err.fileName) {
+      let fileName = err.fileName;
+      if (err.loc) {
+        fileName += `:${err.loc.line}:${err.loc.column}`;
+      }
+
+      message = `${fileName}: ${message}`;
+    }
+
+    let stack
+    if (err.codeFrame) {
+      stack = err.codeFrame;
+    } else if (err.stack) {
+      stack = err.stack.slice(err.stack.indexOf('\n') + 1);
+    }
+    
+    // store the most recent error so we can notify new connections
+    // and so we can broadcast when the error is resolved
+    this.unresolvedError = {
+      type: 'error',
+      error: {
+        message,
+        stack
+      }
+    }
+
+    this.broadcast(this.unresolvedError)
+  }
+
   emitUpdate(assets) {
-    let msg = JSON.stringify({
+    if (this.unresolvedError) {
+      this.unresolvedError = null
+      this.broadcast({
+        type: 'error-resolved'
+      })
+    }
+
+    this.broadcast({
       type: 'update',
       assets: assets.map(asset => {
         let deps = {};
@@ -30,9 +78,12 @@ class HMRServer {
         };
       })
     });
-
+  }
+  
+  broadcast(msg) {
+    const json = JSON.stringify(msg)
     for (let ws of this.wss.clients) {
-      ws.send(msg);
+      ws.send(json);
     }
   }
 }

--- a/src/Server.js
+++ b/src/Server.js
@@ -15,8 +15,10 @@ function middleware(bundler) {
     }
 
     function respond() {
-      // If the URL doesn't start with the public path, send the main HTML bundle
-      if (!req.url.startsWith(bundler.options.publicURL)) {
+      if (bundler.errored) {
+        return send500();
+      } else if (!req.url.startsWith(bundler.options.publicURL)) {
+        // If the URL doesn't start with the public path, send the main HTML bundle
         return sendIndex();
       } else {
         // Otherwise, serve the file from the dist folder
@@ -33,6 +35,11 @@ function middleware(bundler) {
       } else {
         send404();
       }
+    }
+
+    function send500() {
+      res.writeHead(500);
+      res.end('🚨 Build error, check the console for details.');
     }
 
     function send404() {

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -30,6 +30,14 @@ if (!module.bundle.parent) {
         }
       }
     }
+    
+    if (data.type === 'error-resolved') {
+      console.log('[parcel-bundler] ✨  Error resolved');
+    }
+
+    if (data.type === 'error') {
+      console.error(`[parcel-bundler] 🚨  Build error\n${data.error.message}\n${data.error.stack}`);
+    }
   };
 }
 

--- a/test/hmr.js
+++ b/test/hmr.js
@@ -67,6 +67,56 @@ describe('hmr', function () {
     assert.equal(msg.assets.length, 2);
   });
 
+  it('should emit an HMR error on bundle failure', async function () {
+    await ncp(__dirname + '/integration/commonjs', __dirname + '/input');
+
+    b = bundler(__dirname + '/input/index.js', {watch: true, hmr: true});
+    let bundle = await b.bundle();
+
+    ws = new WebSocket('ws://localhost:' + b.options.hmrPort);
+
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"; exports.a = 5; exports.b = 5;');
+
+    let msg = JSON.parse(await nextEvent(ws, 'message'));
+    assert.equal(msg.type, 'error');
+    assert.equal(msg.error.message, __dirname + '/input/local.js:1:12: Unexpected token, expected , (1:12)');
+    assert.equal(msg.error.stack, '> 1 | require("fs"; exports.a = 5; exports.b = 5;\n    |             ^');
+  });
+
+  it('should emit an HMR error to new connections after a bundle failure', async function () {
+    await ncp(__dirname + '/integration/commonjs', __dirname + '/input');
+
+    b = bundler(__dirname + '/input/index.js', {watch: true, hmr: true});
+    let bundle = await b.bundle();
+    
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"; exports.a = 5; exports.b = 5;');
+    await nextEvent(b, 'buildEnd');
+    await sleep(50);
+
+    ws = new WebSocket('ws://localhost:' + b.options.hmrPort);
+    let msg = JSON.parse(await nextEvent(ws, 'message'));
+    assert.equal(msg.type, 'error');
+  });
+
+  it('should emit an HMR error-resolved on build after error', async function () {
+    await ncp(__dirname + '/integration/commonjs', __dirname + '/input');
+
+    b = bundler(__dirname + '/input/index.js', {watch: true, hmr: true});
+    let bundle = await b.bundle();
+
+    ws = new WebSocket('ws://localhost:' + b.options.hmrPort);
+
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"; exports.a = 5; exports.b = 5;');
+
+    let msg = JSON.parse(await nextEvent(ws, 'message'));
+    assert.equal(msg.type, 'error');
+
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"); exports.a = 5; exports.b = 5;');
+
+    let msg2 = JSON.parse(await nextEvent(ws, 'message'));
+    assert.equal(msg2.type, 'error-resolved');
+  });
+
   it('should accept HMR updates in the runtime', async function () {
     await ncp(__dirname + '/integration/hmr', __dirname + '/input');
 
@@ -130,5 +180,52 @@ describe('hmr', function () {
     await nextEvent(b, 'bundled');
     await sleep(50);
     assert.deepEqual(outputs, [3, 10]);
+  });
+
+  it('should log emitted errors', async function () {
+    await ncp(__dirname + '/integration/commonjs', __dirname + '/input');
+
+    b = bundler(__dirname + '/input/index.js', {watch: true, hmr: true});
+    let bundle = await b.bundle();
+
+    let logs = [];
+    run(bundle, {
+      console: {
+        error(msg) { logs.push(msg) },
+      }
+    });
+    
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"; exports.a = 5; exports.b = 5;');
+    await nextEvent(b, 'buildEnd');
+    await sleep(50);
+    
+    assert.equal(logs.length, 1)
+    assert(logs[0].trim().startsWith('[parcel-bundler] 🚨'));
+  });
+
+  it('should log when errors resolve', async function () {
+    await ncp(__dirname + '/integration/commonjs', __dirname + '/input');
+
+    b = bundler(__dirname + '/input/index.js', {watch: true, hmr: true});
+    let bundle = await b.bundle();
+
+    let logs = [];
+    run(bundle, {
+      console: {
+        error(msg) { logs.push(msg) },
+        log(msg) { logs.push(msg) },
+      }
+    });
+    
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"; exports.a = 5; exports.b = 5;');
+    await nextEvent(b, 'buildEnd');
+    
+    fs.writeFileSync(__dirname + '/input/local.js', 'require("fs"); exports.a = 5; exports.b = 5;');
+    await nextEvent(b, 'buildEnd');
+    await sleep(50);
+    
+    assert.equal(logs.length, 2)
+    assert(logs[0].trim().startsWith('[parcel-bundler] 🚨'));
+    assert(logs[1].trim().startsWith('[parcel-bundler] ✨'));
   });
 });

--- a/test/server.js
+++ b/test/server.js
@@ -61,4 +61,21 @@ describe('server', function () {
 
     assert(threw);
   });
+
+  it('should serve a 500 if the bundler errored', async function () {
+    let b = bundler(__dirname + '/integration/html/index.html');
+    server = b.serve(0);
+    
+    b.errored = true;
+    
+    try {
+      await get('/');
+      throw new Error('GET / responded with 200')
+    } catch (err) {
+      assert.equal(err.message, 'Request failed: 500');
+    }
+    
+    b.errored = false;
+    await get('/');
+  });
 });


### PR DESCRIPTION
Closes #100

 - Emit `error` events on the HMR socket when the bundler fails
 - Emit `error` events on new HMR sockets when the bundler has not completed successfully since the last error
 - Emit `error-resolved` events on the HMR socket when the bundler passes after failing
 - Serve 500s when the build fails

![2017-12-07 14 40 01](https://user-images.githubusercontent.com/1329312/33740099-b6a1cbf6-db5c-11e7-996d-c7877a45e80d.gif)
