### PR TITLE
Use `var` over `let` in bundle loader built-in

### DIFF
--- a/src/builtins/bundle-loader.js
+++ b/src/builtins/bundle-loader.js
@@ -76,7 +76,7 @@ function loadCSSBundle(bundle) {
 }
 
 function requireModule(id) {
-  let res = require(id);
+  var res = require(id);
   if (res.__esModule) {
     return res.default;
   }


### PR DESCRIPTION
related to #131 

The rest of the code in this file uses `var`, and this was probably a typo.