### PR TITLE
Send warning to logger if plugin loading failed

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -89,7 +89,9 @@ class Bundler extends EventEmitter {
           localRequire(dep, this.mainFile)(this);
         }
       }
-    } catch (err) {}
+    } catch (err) {
+      this.logger.warn(err);
+    }
   }
 
   async bundle() {


### PR DESCRIPTION
Currently no error/warning is shown whenever a plugin failed loading.
Added the logger line to the error handling, to give some feedback to the user if something is wrong with the plugin.