### PR TITLE
Only use os.cpus() and filter out core like physical-cpu-count did

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "mkdirp": "^0.5.1",
     "node-libs-browser": "^2.0.0",
     "parse-json": "^4.0.0",
-    "physical-cpu-count": "^2.0.0",
     "postcss": "^6.0.10",
     "postcss-value-parser": "^3.3.0",
     "posthtml": "^0.9.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mkdirp": "^0.5.1",
     "node-libs-browser": "^2.0.0",
     "parse-json": "^4.0.0",
+    "physical-cpu-count": "^2.0.0",
     "postcss": "^6.0.10",
     "postcss-value-parser": "^3.3.0",
     "posthtml": "^0.9.2",

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -1,4 +1,4 @@
-const { EventEmitter } = require('events');
+const {EventEmitter} = require('events');
 const os = require('os');
 const Farm = require('worker-farm/lib/farm');
 const promisify = require('./utils/promisify');
@@ -92,7 +92,7 @@ function getNumWorkers() {
   try {
     cores = require('physical-cpu-count');
   } catch (err) {
-    cores = os.cpus();
+    cores = os.cpus().length;
   }
   return cores || 1;
 }

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -88,12 +88,13 @@ for (let key in EventEmitter.prototype) {
 }
 
 function getNumWorkers() {
-  const cores = os.cpus().filter(function(cpu, index) {
-    const hasHyperthreading = cpu.model.includes('Intel');
-    const isOdd = index % 2 === 1;
-    return !hasHyperthreading || isOdd;
-  });
-  return cores.length || 1;
+  let cores;
+  try {
+    cores = require('physical-cpu-count');
+  } catch (err) {
+    cores = os.cpus();
+  }
+  return cores || 1;
 }
 
 module.exports = WorkerFarm;

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -1,4 +1,5 @@
-const {EventEmitter} = require('events');
+const { EventEmitter } = require('events');
+const os = require('os');
 const Farm = require('worker-farm/lib/farm');
 const promisify = require('./utils/promisify');
 
@@ -8,7 +9,7 @@ class WorkerFarm extends Farm {
   constructor(options) {
     let opts = {
       autoStart: true,
-      maxConcurrentWorkers: require('physical-cpu-count')
+      maxConcurrentWorkers: getNumWorkers(),
     };
 
     super(opts, require.resolve('./worker'));
@@ -84,6 +85,15 @@ class WorkerFarm extends Farm {
 
 for (let key in EventEmitter.prototype) {
   WorkerFarm.prototype[key] = EventEmitter.prototype[key];
+}
+
+function getNumWorkers() {
+  const cores = os.cpus().filter(function(cpu, index) {
+    const hasHyperthreading = cpu.model.includes('Intel');
+    const isOdd = index % 2 === 1;
+    return !hasHyperthreading || isOdd;
+  });
+  return cores.length || 1;
 }
 
 module.exports = WorkerFarm;


### PR DESCRIPTION
The problem is with heroku and some CI, the physical-cpu-count linux branch requires a binary and access not provided by these environments.