### PR TITLE
WIP: Add TypeScript language service

### DIFF
--- a/src/assets/TypeScriptAsset.js
+++ b/src/assets/TypeScriptAsset.js
@@ -2,11 +2,44 @@ const JSAsset = require('./JSAsset');
 const config = require('../utils/config');
 const localRequire = require('../utils/localRequire');
 
+const compilerServices = new WeakMap();
+
 class TypeScriptAsset extends JSAsset {
   async parse(code) {
-    // require typescript, installed locally in the app
-    let typescript = localRequire('typescript', this.name);
-    let transpilerOptions = {
+    // Get the current build context shared TypeScript instance
+    const services = await this.getCompilerService();
+
+    // Transpile Module using TypeScript
+    const output = services.getEmitOutput(this.name);
+
+    // Merge all diagnostics
+    const diags = services
+      .getSyntacticDiagnostics(this.name)
+      .concat(services.getSemanticDiagnostics(this.name));
+
+    if (diags.length > 0) {
+      // TODO: properly handle errors
+
+      throw new Error(diags[0].messageText);
+    }
+
+    // TODO : properly match the file
+    const file = output.outputFiles.pop(); //.find(output => output.name === this.name)
+    const source = file && file.text;
+
+    if (!source) {
+      throw new Error('what should i do');
+    }
+
+    this.contents = source;
+
+    // Parse result as ast format through babylon
+    return super.parse(this.contents);
+  }
+
+  async getTsConfig(typescript) {
+    const tsconfig = await config.load(this.name, ['tsconfig.json']);
+    const transpilerOptions = {
       compilerOptions: {
         module: typescript.ModuleKind.CommonJS,
         jsx: typescript.JsxEmit.Preserve
@@ -14,18 +47,83 @@ class TypeScriptAsset extends JSAsset {
       fileName: this.basename
     };
 
-    let tsconfig = await config.load(this.name, ['tsconfig.json']);
-
     // Overwrite default if config is found
-    if (tsconfig) transpilerOptions.compilerOptions = tsconfig.compilerOptions;
+    if (tsconfig) {
+      transpilerOptions.compilerOptions = tsconfig.compilerOptions;
+      transpilerOptions.files = tsconfig.files;
+      transpilerOptions.include = tsconfig.include;
+      transpilerOptions.exclude = tsconfig.exclude;
+    }
+
     transpilerOptions.compilerOptions.noEmit = false;
 
-    // Transpile Module using TypeScript and parse result as ast format through babylon
-    this.contents = typescript.transpileModule(
-      code,
-      transpilerOptions
-    ).outputText;
-    return await super.parse(this.contents);
+    return transpilerOptions;
+  }
+
+  async getCompilerService() {
+    // Fetch the instance linked to our parser
+    let service = compilerServices.get(this.options.parser);
+
+    // If we already have the service in cache let's reuse it
+    if (service) {
+      return service;
+    }
+
+    // Require typescript, installed locally in the app
+    const typescript = localRequire('typescript', this.name);
+    const config = await this.getTsConfig(typescript);
+
+    // Turn the tsconfig object into TypeScript command line options
+    const {fileNames, options} = typescript.parseJsonConfigFileContent(
+      config,
+      typescript.sys,
+      // TODO: do not use process.cwd()
+      process.cwd()
+    );
+    // We will keep a revision index for each source file here
+    const files = {};
+
+    // initialize the list of files
+    fileNames.forEach(
+      fileName =>
+        (files[fileName] = {
+          version: 0
+        })
+    );
+
+    // A host to tell the service how to parse/handle the project
+    const servicesHost = {
+      getScriptFileNames: () => fileNames,
+      getScriptVersion: fileName =>
+        files[fileName] && files[fileName].version.toString(),
+      getScriptSnapshot: fileName => {
+        if (!typescript.sys.fileExists(fileName)) {
+          return;
+        }
+
+        return typescript.ScriptSnapshot.fromString(
+          typescript.sys.readFile(fileName)
+        );
+      },
+      getCurrentDirectory: () => process.cwd(),
+      getCompilationSettings: () => options,
+      getDefaultLibFileName: options =>
+        typescript.getDefaultLibFilePath(options),
+      fileExists: typescript.sys.fileExists,
+      readFile: typescript.sys.readFile,
+      readDirectory: typescript.sys.readDirectory
+    };
+
+    // Create the language service host using the configuration and user options
+    service = typescript.createLanguageService(
+      servicesHost,
+      typescript.createDocumentRegistry()
+    );
+
+    // Save the service for a future use
+    compilerServices.set(this.options.parser, service);
+
+    return service;
   }
 }
 


### PR DESCRIPTION
![Demo](http://g.recordit.co/D1K7leJA0E.gif)

Parcel currently uses `transpileModule` which does not do any type-checking, to correctly get error reporting we need to use the TypeScript language service.
This service is used by many loaders and by IDEs, it gives type-checking and faster incremental builds (idk if it's slower than `transpileModule`, but if we type-check this makes everything faster).

This PR adds a language service to `TypeScriptAsset`, so Parcel will be able to log any semantic or syntactic error.

- the asset will check if we already have created a TypeScript instance for the parser, if not we create it
- currently if any errors it will throw an `Error` with the first error localized, it should use Parcel error reporting, and be able to reports multiple errors at a time

TODO : 
- [x] build
- [x] type-check
- [ ] correctly report diagnostic errors
- [ ] we may override the TypeScript system `readFile` property to reduce I/O (currently it will cause a double-read, one from Parcel, on from TypeScript). Don't know if it's immediately necessary (and I think TypeScript is doing sync I/O) and it may be complicated to do it the right way

Thanks for this project and for the premium TypeScript support!