### PR TITLE
Handle call expression during global insertion. Fixes #117

### DIFF
--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -102,10 +102,19 @@ function matchesPattern(member, match) {
 
 // Replaces the key in `parent` whose value is `from` with `to`
 function replace(parent, from, to) {
-  for (let key in parent) {
-    if (parent[key] === from) {
-      parent[key] = to;
-      break;
+  if (types.isCallExpression(parent)) {
+    for (let key in parent.arguments) {
+      if (parent.arguments[key] === from) {
+        parent.arguments[key] = to;
+        break;
+      }
+    }
+  } else {
+    for (let key in parent) {
+      if (parent[key] === from) {
+        parent[key] = to;
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
The global insertion was failing if the global parameter was passed as an argument to a function.

```javascript
function doSomethingAwesome(env) {}

doSomethingAwesome(process.env.NODE_ENV); // This would fail and this PR fixes it
```