### PR TITLE
feat(Resolver): give high priority to extension of parent file

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -31,11 +31,18 @@ class Resolver {
       return {path: path.resolve(path.dirname(parent), filename)};
     }
 
+    let extensions = Object.keys(this.options.extensions);
+    if (parent) {
+      const parentExt = path.extname(parent);
+      // parent's extension given high priority
+      extensions = [parentExt, ...extensions.filter(ext => ext !== parentExt)];
+    }
+
     return resolver(filename, {
       filename: parent,
       paths: this.options.paths,
       modules: builtins,
-      extensions: Object.keys(this.options.extensions),
+      extensions: extensions,
       packageFilter(pkg, pkgfile) {
         // Expose the path to the package.json file
         pkg.pkgfile = pkgfile;


### PR DESCRIPTION
#158

Stylus will add `@import 'stylus\lib\functions'` to the beginning of `style.styl` file.

Now call [`resolver.resolveSync('stylus\lib\functions', 'style.styl')`](https://github.com/parcel-bundler/parcel/blob/cf6902a30a4acc49a5b4572be42781ebf3ed356a/src/assets/StylusAsset.js#L58) in StylusAsset, and `stylus\lib\functions\index.js` is returned.

`stylus\lib\functions\index.styl` may be what we want, so we tell Resolver to give high priority to the extension (`.styl`) found in parent file (`style.styl`).