### PR TITLE
Fix RawAsset loading.

### DIFF
--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -6,8 +6,12 @@ class RawAsset extends Asset {
   load() {}
 
   generate() {
+    const pathToAsset = path.join(
+      this.options.publicURL,
+      this.generateBundleName()
+    );
     return {
-      js: `module.exports=${JSON.stringify(this.generateBundleName())};`
+      js: `module.exports=${pathToAsset};`
     };
   }
 }

--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -7,7 +7,7 @@ class RawAsset extends Asset {
 
   generate() {
     const pathToAsset = JSON.stringify(
-      `${this.options.publicURL}/${this.generateBundleName()}`
+      path.join(this.options.publicURL, this.generateBundleName())
     );
     return {
       js: `module.exports=${pathToAsset};`

--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -6,9 +6,8 @@ class RawAsset extends Asset {
   load() {}
 
   generate() {
-    const pathToAsset = path.join(
-      this.options.publicURL,
-      this.generateBundleName()
+    const pathToAsset = JSON.stringify(
+      `${this.options.publicURL}${this.generateBundleName()}`
     );
     return {
       js: `module.exports=${pathToAsset};`

--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -7,7 +7,7 @@ class RawAsset extends Asset {
 
   generate() {
     const pathToAsset = JSON.stringify(
-      `${this.options.publicURL}${this.generateBundleName()}`
+      `${this.options.publicURL}/${this.generateBundleName()}`
     );
     return {
       js: `module.exports=${pathToAsset};`

--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -1,5 +1,5 @@
 const Asset = require('../Asset');
-const path = require('path');
+const url = require('url');
 
 class RawAsset extends Asset {
   // Don't load raw assets. They will be copied by the RawPackager directly.
@@ -7,7 +7,7 @@ class RawAsset extends Asset {
 
   generate() {
     const pathToAsset = JSON.stringify(
-      path.join(this.options.publicURL, this.generateBundleName())
+      url.resolve(this.options.publicURL, this.generateBundleName())
     );
     return {
       js: `module.exports=${pathToAsset};`

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -136,8 +136,8 @@ describe('javascript', function() {
 
     let output = run(b);
     assert.equal(typeof output, 'function');
-    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output()));
-    assert(fs.existsSync(__dirname + output()));
+    assert(/^\/[0-9a-f]+\.txt$/.test(output()));
+    assert(fs.existsSync(__dirname + '/dist/' + output()));
   });
 
   it('should minify JS in production mode', async function() {

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -63,10 +63,12 @@ describe('javascript', function() {
     assertBundleTree(b, {
       name: 'index.js',
       assets: ['index.js', 'bundle-loader.js', 'bundle-url.js'],
-      childBundles: [{
-        assets: ['local.js'],
-        childBundles: []
-      }]
+      childBundles: [
+        {
+          assets: ['local.js'],
+          childBundles: []
+        }
+      ]
     });
 
     let output = run(b).default;
@@ -134,8 +136,8 @@ describe('javascript', function() {
 
     let output = run(b);
     assert.equal(typeof output, 'function');
-    assert(/^[0-9a-f]+\.txt$/.test(output()));
-    assert(fs.existsSync(__dirname + '/dist/' + output()));
+    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output()));
+    assert(fs.existsSync(__dirname + output()));
   });
 
   it('should minify JS in production mode', async function() {

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -66,8 +66,8 @@ describe('typescript', function() {
 
     let output = run(b);
     assert.equal(typeof output.getRaw, 'function');
-    assert(/^[0-9a-f]+\.txt$/.test(output.getRaw()));
-    assert(fs.existsSync(__dirname + '/dist/' + output.getRaw()));
+    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output.getRaw()));
+    assert(fs.existsSync(__dirname + output.getRaw()));
   });
 
   it('should minify in production mode', async function() {

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -66,8 +66,8 @@ describe('typescript', function() {
 
     let output = run(b);
     assert.equal(typeof output.getRaw, 'function');
-    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output.getRaw()));
-    assert(fs.existsSync(__dirname + output.getRaw()));
+    assert(/^\/[0-9a-f]+\.txt$/.test(output.getRaw()));
+    assert(fs.existsSync(__dirname + '/dist/' + output.getRaw()));
   });
 
   it('should minify in production mode', async function() {


### PR DESCRIPTION
Hello ! 

## Fixes : 
https://github.com/jaredpalmer/react-parcel-example/issues/6 https://github.com/parcel-bundler/parcel/issues/96 #186 

## Problem : 
In RawAsset, the generated bundle name was not prepended by the public url.

## This solution : 

Prepend RawAsset generated bundle name with options.publicURL (defaults to dist). Updated tests to reflect the change.

## Tests : 

Passing. I also, tested my fork against https://github.com/jaredpalmer/react-parcel-example and it works in both dev and prod mode. 


Thanks for the great work on Parcel ! 👍 
Please feel free to close if this code affects other parts negatively.


