### PR TITLE
Add Travis CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
     <img alt="Parcel" src="https://user-images.githubusercontent.com/19409/31321658-f6aed0f2-ac3d-11e7-8100-1587e676e0ec.png" width="749">
   </a>
 </p>
+  
 <p align="center">
+  <a href="https://travis-ci.org/parcel-bundler/parcel/">
+    <img alt="Build Status" src="https://travis-ci.org/parcel-bundler/parcel.svg?branch=master">
+  </a>
   <a href="https://slack.parceljs.org/">
     <img alt="Slack" src="https://slack.parceljs.org/badge.svg">
   </a>


### PR DESCRIPTION
Seems like Travis is used for continuous integration. Just added its badge to show the build status