### PR TITLE
Remove circular require in Asset.js

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -1,4 +1,3 @@
-const Parser = require('./Parser');
 const path = require('path');
 const fs = require('./utils/fs');
 const objectHash = require('./utils/objectHash');


### PR DESCRIPTION
When requiring `parcel-bundler/{lib,src}/assets/*` this error is thrown :
``` 
parcel/src/assets/RawAsset.js:4
class RawAsset extends Asset {
                       

TypeError: Class extends value #<Object> is not a constructor or null
```

This is because `Asset.js` depends on `Parser.js` which depends on `RawAsset.js` and it depends on `Asset.js`...

This PR just remove the `const Parser = require('./Parser')` on `Asset.js` as it is unused, and fixes the bug above.