### PR TITLE
fix: replacing process.env member node with value node

### DIFF
--- a/test/integration/env/index.js
+++ b/test/integration/env/index.js
@@ -1,3 +1,1 @@
-module.exports = function () {
-  return process.env.NODE_ENV;
-};
+module.exports = (x => x)(process.env.NODE_ENV);

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -63,10 +63,12 @@ describe('javascript', function() {
     assertBundleTree(b, {
       name: 'index.js',
       assets: ['index.js', 'bundle-loader.js', 'bundle-url.js'],
-      childBundles: [{
-        assets: ['local.js'],
-        childBundles: []
-      }]
+      childBundles: [
+        {
+          assets: ['local.js'],
+          childBundles: []
+        }
+      ]
     });
 
     let output = run(b).default;
@@ -167,7 +169,7 @@ describe('javascript', function() {
     let b = await bundle(__dirname + '/integration/env/index.js');
 
     let output = run(b);
-    assert.equal(output(), 'test');
+    assert.equal(output, 'test');
   });
 
   it('should support adding implicit dependencies', async function() {


### PR DESCRIPTION
Hi, 
Thanks for this project!

Fixes: https://github.com/parcel-bundler/parcel/issues/117 The bug is happening because replace function doesn't work with a CallExpression node.

`replaceIn(parent, from, to)` dives deep into `parent` object properties and arrays until the first occurrence of argument `from` which it replaces into argument `to`. I made an assumption, about AST, that nodes are present in parent at most once.

Some ideas how to improve this: 
- make `replaceIn` and `deepEquals` as general node utility functions.
- implement in Node type hierarchy, one per type. 
- compare node only on base of some id, maybe it's enough to compare `loc` and `type`?