### PR TITLE
Make hmr-runtime builtin ES3-compatible

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -18,11 +18,11 @@ if (!module.bundle.parent) {
   var ws = new WebSocket('ws://localhost:{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);
-    var key, asset;
+    var index, asset;
 
     if (data.type === 'update') {
-      for (key in data.assets) {
-        asset = data.assets[key];
+      for (index = 0; index < data.assets.length; index++) {
+        asset = data.assets[index];
         hmrApply(global.require, asset);
         if (!asset.isNew) {
           hmrAccept(global.require, asset.id);

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -1,4 +1,4 @@
-var global = (1,eval)('this');
+var global = (1, eval)('this');
 var OldModule = module.bundle.Module;
 function Module() {
   OldModule.call(this);
@@ -16,15 +16,14 @@ module.bundle.Module = Module;
 
 if (!module.bundle.parent) {
   var ws = new WebSocket('ws://localhost:{{HMR_PORT}}/');
-  ws.onmessage = (e) => {
-    var data = JSON.parse(e.data);
+  ws.onmessage = function(event) {
+    var data = JSON.parse(event.data);
+    var key, asset;
 
     if (data.type === 'update') {
-      for (let asset of data.assets) {
+      for (key in data.assets) {
+        asset = data.assets[key];
         hmrApply(global.require, asset);
-      }
-
-      for (let asset of data.assets) {
         if (!asset.isNew) {
           hmrAccept(global.require, asset.id);
         }
@@ -47,10 +46,12 @@ function getParents(bundle, id) {
     return [];
   }
 
-  let parents = [];
-  for (let k in modules) {
-    for (let d in modules[k][1]) {
-      let dep = modules[k][1][d];
+  var parents = [];
+  var k, d, dep;
+
+  for (k in modules) {
+    for (d in modules[k][1]) {
+      dep = modules[k][1][d];
       if (dep === id || (Array.isArray(dep) && dep[dep.length - 1] === id)) {
         parents.push(+k);
       }
@@ -71,7 +72,7 @@ function hmrApply(bundle, asset) {
   }
 
   if (modules[asset.id] || !bundle.parent) {
-    let fn = new Function('require', 'module', 'exports', asset.generated.js);
+    var fn = new Function('require', 'module', 'exports', asset.generated.js);
     asset.isNew = !modules[asset.id];
     modules[asset.id] = [fn, asset.deps];
   } else if (bundle.parent) {
@@ -89,7 +90,7 @@ function hmrAccept(bundle, id) {
     return hmrAccept(bundle.parent, id);
   }
 
-  let cached = bundle.cache[id];
+  var cached = bundle.cache[id];
   if (cached && cached.hot._disposeCallback) {
     cached.hot._disposeCallback();
   }
@@ -103,5 +104,7 @@ function hmrAccept(bundle, id) {
     return true;
   }
 
-  return getParents(global.require, id).some(id => hmrAccept(global.require, id));
+  return getParents(global.require, id).some(function (id) {
+    return hmrAccept(global.require, id)
+  });
 }


### PR DESCRIPTION
This is the only builtin that uses non-es3 code. 
My use-case is that I'm debugging our site in IE11, and I can't use `parcel watch` for it at present, as the HMR-runtime builtin causes the script to die.

this closes #131 as far as i'm concerned