### PR TITLE
Add `--open` option to automatically launch in default browser

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,6 +11,7 @@ program
   .command('serve [input]')
   .description('starts a development server')
   .option('-p, --port <port>', 'set the port to serve on. defaults to 1234')
+  .option('-o, --open', 'automatically open in default browser')
   .option(
     '-d, --out-dir <path>',
     'set the output directory. defaults to "dist"'
@@ -92,7 +93,10 @@ function bundle(main, command) {
   const bundler = new Bundler(main, command);
 
   if (command.name() === 'serve') {
-    bundler.serve(command.port || 1234);
+    const server = bundler.serve(command.port || 1234);
+    if (command.open) {
+      require('opn')(`http://localhost:${server.address().port}`);
+    }
   } else {
     bundler.bundle();
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "micromatch": "^3.0.4",
     "mkdirp": "^0.5.1",
     "node-libs-browser": "^2.0.0",
+    "opn": "^5.1.0",
     "parse-json": "^4.0.0",
     "physical-cpu-count": "^2.0.0",
     "postcss": "^6.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2508,6 +2508,10 @@ is-windows@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
+is-wsl@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -3412,6 +3416,12 @@ once@^1.3.0, once@^1.3.3:
 onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+opn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-5.1.0.tgz#72ce2306a17dbea58ff1041853352b4a8fc77519"
+  dependencies:
+    is-wsl "^1.1.0"
 
 optimist@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Add a new option `-o` `--open` to automatically launch the dev server in the default browser. 

Using [opn](https://www.npmjs.com/package/opn) to launch the browser, which is also used by [webpack-dev-server](https://github.com/webpack/webpack-dev-server/blob/0a8f8965fba4a46a862497f6e7d1ad9377040a15/bin/webpack-dev-server.js#L468), [browser-sync](https://github.com/BrowserSync/browser-sync/blob/3aced708d47f032905721d01dd435d809d8feb33/lib/utils.js#L175-L189), [create-react-app](https://github.com/facebookincubator/create-react-app/blob/2e82ebb3371731a5c4e346f310848ddb23fd0976/packages/react-dev-utils/openBrowser.js#L100), and a lot [more](https://www.npmjs.com/browse/depended/opn).