### PR TITLE
Fix error when dynamic importing js files which imports raw files

### DIFF
--- a/src/builtins/bundle-loader.js
+++ b/src/builtins/bundle-loader.js
@@ -32,7 +32,10 @@ function loadBundle(bundle) {
   }
 
   var type = bundle.match(/\.(.+)$/)[1].toLowerCase();
-  return bundles[bundle] = bundleLoaders[type](getBundleURL() + bundle);
+  var bundleLoader = bundleLoaders[type];
+  if (bundleLoader) {
+    return bundles[bundle] = bundleLoader(getBundleURL() + bundle);
+  }
 }
 
 function loadJSBundle(bundle) {

--- a/test/integration/dynamic-references-raw/index.js
+++ b/test/integration/dynamic-references-raw/index.js
@@ -1,0 +1,7 @@
+var local = import('./local');
+
+module.exports = function () {
+  return local.then(function (l) {
+    return l.a + l.b;
+  });
+};

--- a/test/integration/dynamic-references-raw/local.js
+++ b/test/integration/dynamic-references-raw/local.js
@@ -1,0 +1,4 @@
+import raw from './test.txt';
+
+exports.a = 1;
+exports.b = 2;

--- a/test/integration/dynamic-references-raw/test.txt
+++ b/test/integration/dynamic-references-raw/test.txt
@@ -1,0 +1,1 @@
+raw file

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -57,16 +57,39 @@ describe('javascript', function() {
     assert.equal(await output(), 3);
   });
 
+  it('should dynamic import files which import raw files', async function() {
+    let b = await bundle(
+      __dirname + '/integration/dynamic-references-raw/index.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js', 'bundle-loader.js', 'bundle-url.js'],
+      childBundles: [
+        {
+          assets: ['local.js', 'test.txt'],
+          childBundles: ['test.txt']
+        }
+      ]
+    });
+
+    let output = run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(await output(), 3);
+  });
+
   it('should return all exports as an object when using ES modules', async function() {
     let b = await bundle(__dirname + '/integration/dynamic-esm/index.js');
 
     assertBundleTree(b, {
       name: 'index.js',
       assets: ['index.js', 'bundle-loader.js', 'bundle-url.js'],
-      childBundles: [{
-        assets: ['local.js'],
-        childBundles: []
-      }]
+      childBundles: [
+        {
+          assets: ['local.js'],
+          childBundles: []
+        }
+      ]
     });
 
     let output = run(b).default;


### PR DESCRIPTION
For example given the following files:

_cat.js_
```
import cat from './cat.jpg';

export default function renderCat() {
  // renders <img src={cat} > somehow
}
```

_app.js_
```
import('./cat.js').then(modules => modules.default())
```

Throws `TypeError: bundleLoaders[type] is not a function` because bundleLoaders has just css and js handlers.

Note this is different from dynamic importing the jpg file directly, which I believe is not supported in the moment. In this case we are lazy loading a js file but it depends on a raw asset.