### PR TITLE
fix: global env problem by morphing a Node object

### DIFF
--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -24,7 +24,7 @@ module.exports = {
       let key = types.toComputedKey(node);
       if (types.isStringLiteral(key)) {
         let val = types.valueToNode(process.env[key.value]);
-        replace(ancestors[ancestors.length - 2], node, val);
+        morph(node, val);
         delete node.object; // prevent traversing into this node
         asset.isAstDirty = true;
       }
@@ -105,12 +105,12 @@ function matchesPattern(member, match) {
   return true;
 }
 
-// Replaces the key in `parent` whose value is `from` with `to`
-function replace(parent, from, to) {
-  for (let key in parent) {
-    if (parent[key] === from) {
-      parent[key] = to;
-      break;
-    }
+// replace object properties
+function morph(object, newProperties) {
+  for (let key in object) {
+    delete object[key];
+  }
+  for (let key in newProperties) {
+    object[key] = newProperties[key];
   }
 }

--- a/test/integration/env/index.js
+++ b/test/integration/env/index.js
@@ -1,3 +1,1 @@
-module.exports = function () {
-  return process.env.NODE_ENV;
-};
+module.exports = (x => x)(process.env.NODE_ENV);

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -63,10 +63,12 @@ describe('javascript', function() {
     assertBundleTree(b, {
       name: 'index.js',
       assets: ['index.js', 'bundle-loader.js', 'bundle-url.js'],
-      childBundles: [{
-        assets: ['local.js'],
-        childBundles: []
-      }]
+      childBundles: [
+        {
+          assets: ['local.js'],
+          childBundles: []
+        }
+      ]
     });
 
     let output = run(b).default;
@@ -167,7 +169,7 @@ describe('javascript', function() {
     let b = await bundle(__dirname + '/integration/env/index.js');
 
     let output = run(b);
-    assert.equal(output(), 'test');
+    assert.equal(output, 'test');
   });
 
   it('should support adding implicit dependencies', async function() {


### PR DESCRIPTION
Closes: https://github.com/parcel-bundler/parcel/issues/117

This is a line from current code
```replace(ancestors[ancestors.length - 2], node, val);```

Parameters are called
```replace(parent, from, to)```

I just realized that `from` parameter is referentially same (will pass `obj === obj` comparison) as one of the fields somewhere in `parent`. So instead of manipulating in `parent`, we can change MemberExpression (or whatever node type of `from` is) into StringLiteral by just replacing its parameters while keeping its object identity.