### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "babel-core": "^6.25.0",
     "babel-generator": "^6.25.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
-    "babel-to-estree": "^0.0.2",
+    "babel-to-estree": "^0.0.3",
     "babylon": "^6.17.4",
     "babylon-walk": "^1.0.2",
     "browser-resolve": "^1.11.2",
@@ -31,14 +31,14 @@
     "physical-cpu-count": "^2.0.0",
     "postcss": "^6.0.10",
     "postcss-value-parser": "^3.3.0",
-    "posthtml": "^0.9.2",
+    "posthtml": "^0.10.1",
     "resolve": "^1.4.0",
     "serve-static": "^1.12.4",
     "strip-json-comments": "^2.0.1",
     "uglify-js": "^3.0.28",
     "v8-compile-cache": "^1.1.0",
     "worker-farm": "^1.4.1",
-    "ws": "^3.1.0"
+    "ws": "^3.3.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,9 +673,9 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-to-estree@^0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/babel-to-estree/-/babel-to-estree-0.0.2.tgz#505bc2bda6d962a9fbaf58e8aa06c6aed73497d0"
+babel-to-estree@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/babel-to-estree/-/babel-to-estree-0.0.3.tgz#8a6c5dc9e57d4f9d9397cd1aa98afc554f928824"
   dependencies:
     babel-traverse "^6.23.1"
     babel-types "^6.23.0"
@@ -3911,9 +3911,9 @@ posthtml-parser@^0.1.1, posthtml-parser@^0.1.3:
   dependencies:
     htmlparser2 "^3.8.3"
 
-posthtml-parser@^0.2.0:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.2.1.tgz#35d530de386740c2ba24ff2eb2faf39ccdf271dd"
+posthtml-parser@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.3.0.tgz#af16ea406769f0f33d0011c48fac1f55502fca29"
   dependencies:
     htmlparser2 "^3.8.3"
     isobject "^2.1.0"
@@ -3922,18 +3922,18 @@ posthtml-render@^1.0.5, posthtml-render@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.0.6.tgz#1b88b8e7860a8ebdfe2f2a1310a4642a55cf5bda"
 
+posthtml@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.10.1.tgz#029caa80591d2788ac1903dcf92352f46cec3cb5"
+  dependencies:
+    posthtml-parser "^0.3.0"
+    posthtml-render "^1.0.5"
+
 posthtml@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.8.7.tgz#aba6124c6cf87b4ceea6bab5f7e50268f2c2006d"
   dependencies:
     posthtml-parser "^0.1.3"
-    posthtml-render "^1.0.5"
-
-posthtml@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.9.2.tgz#f4c06db9f67b61fd17c4e256e7e3d9515bf726fd"
-  dependencies:
-    posthtml-parser "^0.2.0"
     posthtml-render "^1.0.5"
 
 prepend-http@^1.0.0:
@@ -5085,7 +5085,7 @@ write-file-atomic@^1.1.4:
     imurmurhash "^0.1.4"
     slide "^1.1.5"
 
-ws@^3.1.0:
+ws@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.2.tgz#96c1d08b3fefda1d5c1e33700d3bfaa9be2d5608"
   dependencies:


### PR DESCRIPTION
Now that we added a [Dependency Badge](https://david-dm.org/parcel-bundler/parcel), we should make sure our dependencies are up-to-date.

1 had a security vulnerability (it would never affect anybody since it's on the dev server), and 2 were just out of date.
