### PR TITLE
template literal fix for IE

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -40,7 +40,7 @@ if (!module.bundle.parent) {
     }
 
     if (data.type === 'error') {
-      console.error(`[parcel] 🚨 ${data.error.message}\n${data.error.stack}`);
+      console.error('[parcel] 🚨  ' + data.error.message + '\n' + 'data.error.stack');
     }
   };
 }


### PR DESCRIPTION
 IE doesn't support template literal.

related : https://github.com/parcel-bundler/parcel/pull/169
