### PR TITLE
Move JSAsset's options gathering code into separate method

### DIFF
--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -34,7 +34,7 @@ class JSAsset extends Asset {
     );
   }
 
-  async parse(code) {
+  async getOptions() {
     // Babylon options. We enable a few plugins by default.
     const options = {
       filename: this.name,
@@ -55,6 +55,12 @@ class JSAsset extends Asset {
       const file = new BabelFile({filename: this.name});
       options.plugins.push(...file.parserOpts.plugins);
     }
+
+    return options;
+  }
+
+  async parse(code) {
+    const options = await this.getOptions();
 
     return babylon.parse(code, options);
   }

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -34,7 +34,7 @@ class JSAsset extends Asset {
     );
   }
 
-  async getOptions() {
+  async getParserOptions() {
     // Babylon options. We enable a few plugins by default.
     const options = {
       filename: this.name,
@@ -60,7 +60,7 @@ class JSAsset extends Asset {
   }
 
   async parse(code) {
-    const options = await this.getOptions();
+    const options = await this.getParserOptions();
 
     return babylon.parse(code, options);
   }


### PR DESCRIPTION
So that classes that extend JSAsset can get the base Babylon config with `super.getBabylonOptions()`, and don't have to duplicate it.

Would like to use this in an example plugin which uses a fork of Babylon, but can see it being useful for a plugin in that requires extra options but would still like to use the base options.

pull request for discusson.