### PR TITLE
Display absolute path on failed dependency resolve.

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -273,7 +273,8 @@ class Bundler extends EventEmitter {
       return await this.resolveAsset(dep.name, asset.name);
     } catch (err) {
       if (err.message.indexOf(`Cannot find module '${dep.name}'`) === 0) {
-        err.message = `Cannot resolve dependency '${dep.name}'`;
+        const absPath = Path.resolve(dep.name);
+        err.message = `Cannot resolve dependency '${absPath}'`;
 
         // Generate a code frame where the dependency was used
         if (dep.loc) {

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -273,7 +273,7 @@ class Bundler extends EventEmitter {
       return await this.resolveAsset(dep.name, asset.name);
     } catch (err) {
       if (err.message.indexOf(`Cannot find module '${dep.name}'`) === 0) {
-        const absPath = Path.resolve(dep.name);
+        const absPath = Path.resolve(Path.dirname(asset.name), dep.name);
         err.message = `Cannot resolve dependency '${absPath}'`;
 
         // Generate a code frame where the dependency was used

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -274,7 +274,7 @@ class Bundler extends EventEmitter {
     } catch (err) {
       if (err.message.indexOf(`Cannot find module '${dep.name}'`) === 0) {
         const absPath = Path.resolve(Path.dirname(asset.name), dep.name);
-        err.message = `Cannot resolve dependency '${absPath}'`;
+        err.message = `Cannot resolve dependency '${dep.name}' at '${absPath}'`;
 
         // Generate a code frame where the dependency was used
         if (dep.loc) {


### PR DESCRIPTION
When a file path can not be resolved the error message is cleaned
up but the relative path to file is displayed.

In cases where a mistake have been made this path can be very confusing,
like `Cannot resolve dependency './../../../../../../main.js'` for when
a path starts with `/`.

This PR resolves path into an absolute path in hope of
reducing confusion and minimize cognitive overhead of `../` chasing.

The above example would now display 
```
Cannot resolve dependency '/main.js' at '/main.js'
```
and for relative unresolvable path
```
Cannot resolve dependency './even-more/x.js' at '/mnt/c/Users/pom/Development/pom/parcel-implementation/src/script/more/even-more/x.js'
```