### PR TITLE
changed parse-json requires to json5

### DIFF
--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -3,7 +3,7 @@ const path = require('path');
 const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
 const pkg = require('../package.json');
-const parseJson = require('parse-json');
+const json5 = require('json5');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr'];
@@ -56,7 +56,7 @@ class FSCache {
       }
 
       let data = await fs.readFile(cacheFile);
-      return parseJson(data);
+      return json5.parse(data);
     } catch (err) {
       return null;
     }

--- a/test/hmr.js
+++ b/test/hmr.js
@@ -6,7 +6,7 @@ const rimraf = require('rimraf');
 const promisify = require('../src/utils/promisify');
 const ncp = promisify(require('ncp'));
 const WebSocket = require('ws');
-const parseJson = require('parse-json');
+const json5 = require('json5');
 
 describe('hmr', function() {
   let b, ws;
@@ -45,7 +45,7 @@ describe('hmr', function() {
       'exports.a = 5; exports.b = 5;'
     );
 
-    let msg = parseJson(await nextEvent(ws, 'message'));
+    let msg = json5.parse(await nextEvent(ws, 'message'));
     assert.equal(msg.type, 'update');
     assert.equal(msg.assets.length, 1);
     assert.equal(msg.assets[0].generated.js, 'exports.a = 5; exports.b = 5;');
@@ -65,7 +65,7 @@ describe('hmr', function() {
       'require("fs"); exports.a = 5; exports.b = 5;'
     );
 
-    let msg = parseJson(await nextEvent(ws, 'message'));
+    let msg = json5.parse(await nextEvent(ws, 'message'));
     assert.equal(msg.type, 'update');
     assert.equal(msg.assets.length, 2);
   });


### PR DESCRIPTION
Instead of re-adding (https://github.com/parcel-bundler/parcel/pull/269) `parse-json` dependency to parcel i changed `parse-json` requires in favour of `json5` on the remaining places.

The reason is that https://github.com/parcel-bundler/parcel/pull/256 removed parse-json dep, but was not changed in these two files i have changed it in.

thanks @DeMoorJasper for figuring this out and point me in the right direction.