### PR TITLE
Add .pcss as a CSSAsset extension

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -20,6 +20,7 @@ class Parser {
     this.registerExtension('yml', './assets/YAMLAsset');
 
     this.registerExtension('css', './assets/CSSAsset');
+    this.registerExtension('pcss', './assets/CSSAsset');
     this.registerExtension('styl', './assets/StylusAsset');
     this.registerExtension('less', './assets/LESSAsset');
     this.registerExtension('sass', './assets/SASSAsset');


### PR DESCRIPTION
closes #268 

This just adds the extension, for the extended syntax it's up to the user to add `postcss-nested`, `postcss-mixins` etc and add them to their `.postcssrc` as with modules.

