### PR TITLE
Fix dev server index file

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -32,7 +32,9 @@ function middleware(bundler) {
     function sendIndex() {
       // If the main asset is an HTML file, serve it
       if (bundler.mainAsset.type === 'html') {
-        req.url = '/' + bundler.mainAsset.basename;
+        const basename = bundler.mainAsset.basename;
+        const extname = path.extname(basename);
+        req.url = `/${path.basename(basename, extname)}.html`;
         serve(req, res, send404);
       } else {
         send404();

--- a/src/Server.js
+++ b/src/Server.js
@@ -32,9 +32,7 @@ function middleware(bundler) {
     function sendIndex() {
       // If the main asset is an HTML file, serve it
       if (bundler.mainAsset.type === 'html') {
-        const basename = bundler.mainAsset.basename;
-        const extname = path.extname(basename);
-        req.url = `/${path.basename(basename, extname)}.html`;
+        req.url = `/${bundler.mainAsset.generateBundleName(true)}`;
         serve(req, res, send404);
       } else {
         send404();


### PR DESCRIPTION
When using custom template Asset (like [parcel-plugin-pug](https://github.com/Ty3uK/parcel-plugin-pug)) with `parcel src/index.pug` it generates correct index.html, but basename of file is index.pug rather than index.html, so server sends incorrect file.