### PR TITLE
Resolve "module", "jsnext:main" and "browser" before "main"

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -46,6 +46,16 @@ class Resolver {
       packageFilter(pkg, pkgfile) {
         // Expose the path to the package.json file
         pkg.pkgfile = pkgfile;
+
+        // npm libraries can specify alternative main fields in their package.json,
+        // we resolve the "module" and "jsnext:main" in priority of "browser" to get the full dependency tree.
+        // libraries like d3.js specifies node.js specific files in the "main" which breaks the build
+        const main = pkg.module || pkg['jsnext:main'] || pkg.browser;
+
+        if (main) {
+          pkg.main = main;
+        }
+
         return pkg;
       }
     });


### PR DESCRIPTION
This is needed for a lot of libraries who ship their Node.js version in the `main` field (see #298). This will also use the ES6 modules version of some libraries (instead of UMD) and might lead to a better bundling/sharing of dependencies.