### PR TITLE
Parse --port string as an integer

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,11 @@ program.version(version);
 program
   .command('serve [input]')
   .description('starts a development server')
-  .option('-p, --port <port>', 'set the port to serve on. defaults to 1234')
+  .option(
+    '-p, --port <port>',
+    'set the port to serve on. defaults to 1234',
+    parseInt
+  )
   .option('-o, --open', 'automatically open in default browser')
   .option(
     '-d, --out-dir <path>',


### PR DESCRIPTION
The `--port` command was being passed as a string, causing an equality check to fail since Node is returning it as an integer, and the `options.port` was a string. With this PR, the port is parsed as an integer, and the warning message goes away.

Before:
```sh
Server running at http://localhost:9966 - configured port 9966 could not be used
```

After:
```sh
Server running at http://localhost:9966 
```