### PR TITLE
Remove arrow function syntax in hmr-runtime

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -14,7 +14,7 @@ function Module() {
 
 module.bundle.Module = Module;
 
-if (!module.bundle.parent && typeof WebSocket === 'undefined') {
+if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
   var ws = new WebSocket('ws://localhost:{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -14,7 +14,7 @@ function Module() {
 
 module.bundle.Module = Module;
 
-if (!module.bundle.parent) {
+if (!module.bundle.parent && typeof WebSocket === 'undefined') {
   var ws = new WebSocket('ws://localhost:{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -33,7 +33,7 @@ if (!module.bundle.parent) {
 
     if (data.type === 'reload') {
       ws.close();
-      ws.onclose = () => {
+      ws.onclose = function () {
         window.location.reload();
       }
     }


### PR DESCRIPTION
Issue & PR may be related: #169 #131 

hmr-runtime is inserted directly, so we shouldn't use arrow function here.
This PR #320 introduced the issue again : https://github.com/parcel-bundler/parcel/pull/320/files#diff-84b7f03297bb09457de68d252f8af43aR36