### PR TITLE
Add ES6 modules resolver tests

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -47,10 +47,11 @@ class Resolver {
         // Expose the path to the package.json file
         pkg.pkgfile = pkgfile;
 
-        // npm libraries can specify alternative main fields in their package.json,
-        // we resolve the "module" and "jsnext:main" in priority of "browser" to get the full dependency tree.
         // libraries like d3.js specifies node.js specific files in the "main" which breaks the build
-        const main = pkg.module || pkg['jsnext:main'] || pkg.browser;
+        // we use the "module" or "jsnext:main" field to get the full dependency tree if available
+        const main = [pkg.module, pkg['jsnext:main']].find(
+          entry => typeof entry === 'string'
+        );
 
         if (main) {
           pkg.main = main;

--- a/test/integration/resolve-entries/both-fields.js
+++ b/test/integration/resolve-entries/both-fields.js
@@ -1,0 +1,7 @@
+const required = require('./pkg-both')
+
+if(required.test() !== 'pkg-es6-module') {
+    throw new Error('Invalid module')
+}
+
+export const test = required.test

--- a/test/integration/resolve-entries/browser-multiple.js
+++ b/test/integration/resolve-entries/browser-multiple.js
@@ -1,0 +1,7 @@
+const required = require('./pkg-browser-multiple/projected')
+
+if(required.test() !== 'pkg-browser-multiple') {
+    throw new Error('Invalid module')
+}
+
+export const test = required.test

--- a/test/integration/resolve-entries/browser.js
+++ b/test/integration/resolve-entries/browser.js
@@ -1,0 +1,7 @@
+const required = require('./pkg-browser')
+
+if(required.test() !== 'pkg-browser') {
+    throw new Error('Invalid module')
+}
+
+export const test = required.test

--- a/test/integration/resolve-entries/jsnext-field.js
+++ b/test/integration/resolve-entries/jsnext-field.js
@@ -1,0 +1,7 @@
+const required = require('./pkg-jsnext-module')
+
+if(required.test() !== 'pkg-jsnext-module') {
+    throw new Error('Invalid module')
+}
+
+export const test = required.test

--- a/test/integration/resolve-entries/main-field.js
+++ b/test/integration/resolve-entries/main-field.js
@@ -1,0 +1,7 @@
+const required = require('./pkg-main')
+
+if(required.test() !== 'pkg-main-module') {
+    throw new Error('Invalid module')
+}
+
+export const test = required.test

--- a/test/integration/resolve-entries/module-field.js
+++ b/test/integration/resolve-entries/module-field.js
@@ -1,0 +1,7 @@
+const required = require('./pkg-es6-module')
+
+if(required.test() !== 'pkg-es6-module') {
+    throw new Error('Invalid module')
+}
+
+export const test = required.test

--- a/test/integration/resolve-entries/pkg-both/es6.module.js
+++ b/test/integration/resolve-entries/pkg-both/es6.module.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-es6-module'
+}

--- a/test/integration/resolve-entries/pkg-both/package.json
+++ b/test/integration/resolve-entries/pkg-both/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "pkg-both",
+    "main": "./does-not-exist.js",
+    "jsnext:main": "./jsnext.module.js",
+    "module": "./es6.module.js"
+}

--- a/test/integration/resolve-entries/pkg-browser-multiple/package.json
+++ b/test/integration/resolve-entries/pkg-browser-multiple/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "pkg-browser-multiple",
+    "main": "./does-not-exist.js",
+    "browser": {
+        "./projected.js": "./projected-module.js"
+    }
+}

--- a/test/integration/resolve-entries/pkg-browser-multiple/projected-module.js
+++ b/test/integration/resolve-entries/pkg-browser-multiple/projected-module.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-browser-multiple'
+}

--- a/test/integration/resolve-entries/pkg-browser/browser-module.js
+++ b/test/integration/resolve-entries/pkg-browser/browser-module.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-browser'
+}

--- a/test/integration/resolve-entries/pkg-browser/package.json
+++ b/test/integration/resolve-entries/pkg-browser/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "pkg-browser",
+    "main": "./does-not-exist.js",
+    "browser": "./browser-module.js"
+}

--- a/test/integration/resolve-entries/pkg-es6-module/es6.module.js
+++ b/test/integration/resolve-entries/pkg-es6-module/es6.module.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-es6-module'
+}

--- a/test/integration/resolve-entries/pkg-es6-module/package.json
+++ b/test/integration/resolve-entries/pkg-es6-module/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "pkg-es6-module",
+    "main": "./does-not-exist.js",
+    "module": "./es6.module.js"
+}

--- a/test/integration/resolve-entries/pkg-jsnext-module/jsnext.module.js
+++ b/test/integration/resolve-entries/pkg-jsnext-module/jsnext.module.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-jsnext-module'
+}

--- a/test/integration/resolve-entries/pkg-jsnext-module/package.json
+++ b/test/integration/resolve-entries/pkg-jsnext-module/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "pkg-jsnext-module",
+    "main": "./does-not-exist.js",
+    "jsnext:main": "./jsnext.module.js"
+}

--- a/test/integration/resolve-entries/pkg-main/main.js
+++ b/test/integration/resolve-entries/pkg-main/main.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-main-module'
+}

--- a/test/integration/resolve-entries/pkg-main/package.json
+++ b/test/integration/resolve-entries/pkg-main/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "pkg-main",
+    "main": "./main.js"
+}

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -257,4 +257,104 @@ describe('javascript', function() {
     assert.equal(typeof output, 'function');
     assert.equal(output(), 3);
   });
+
+  it('should resolve the browser field before main', async function() {
+    let b = await bundle(__dirname + '/integration/resolve-entries/browser.js');
+
+    assertBundleTree(b, {
+      name: 'browser.js',
+      assets: ['browser.js', 'browser-module.js'],
+      childBundles: []
+    });
+
+    let output = run(b);
+
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'pkg-browser');
+  });
+
+  it('should resolve advanced browser resolution', async function() {
+    let b = await bundle(
+      __dirname + '/integration/resolve-entries/browser-multiple.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'browser-multiple.js',
+      assets: ['browser-multiple.js', 'projected-module.js'],
+      childBundles: []
+    });
+
+    let output = run(b);
+
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'pkg-browser-multiple');
+  });
+
+  it('should resolve the module field before main', async function() {
+    let b = await bundle(
+      __dirname + '/integration/resolve-entries/module-field.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'module-field.js',
+      assets: ['module-field.js', 'es6.module.js'],
+      childBundles: []
+    });
+
+    let output = run(b);
+
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'pkg-es6-module');
+  });
+
+  it('should resolve the jsnext:main field before main', async function() {
+    let b = await bundle(
+      __dirname + '/integration/resolve-entries/jsnext-field.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'jsnext-field.js',
+      assets: ['jsnext-field.js', 'jsnext.module.js'],
+      childBundles: []
+    });
+
+    let output = run(b);
+
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'pkg-jsnext-module');
+  });
+
+  it('should resolve the module field before jsnext:main', async function() {
+    let b = await bundle(
+      __dirname + '/integration/resolve-entries/both-fields.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'both-fields.js',
+      assets: ['both-fields.js', 'es6.module.js'],
+      childBundles: []
+    });
+
+    let output = run(b);
+
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'pkg-es6-module');
+  });
+
+  it('should resolve the main field', async function() {
+    let b = await bundle(
+      __dirname + '/integration/resolve-entries/main-field.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'main-field.js',
+      assets: ['main-field.js', 'main.js'],
+      childBundles: []
+    });
+
+    let output = run(b);
+
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'pkg-main-module');
+  });
 });


### PR DESCRIPTION
This is a follow up for #299. I added tests a fixed a bug where `react-dom` wouldn't load because of how it defines it's `browser` field. I removed the `browser` handling because it turns out `browser-resolve` already resolves it.