### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.js text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-* text=auto
-*.js text eol=lf


### PR DESCRIPTION
This is to avoid having to deal with line endings on different OSes.

I was going to instead make a PR adding `.editorconfig` but then realized that not everyone might have an extension/support for it.

Let me know your thoughts. Cheers! 💖

<hr />

__EDIT__: After review, opting for `.editorconfig` instead. 😅