### PR TITLE
Conserve the html spacing between tags

### DIFF
--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -32,7 +32,10 @@ async function getConfig(asset) {
   config.plugins = await loadPlugins(config.plugins, asset.name);
 
   if (asset.options.minify) {
-    config.plugins.push(htmlnano());
+    const htmlNanoOptions = {
+      collapseWhitespace: 'conservative'
+    };
+    config.plugins.push(htmlnano(htmlNanoOptions));
   }
 
   config.skipParse = true;

--- a/test/html.js
+++ b/test/html.js
@@ -147,4 +147,13 @@ describe('html', function() {
       }
     }
   });
+
+  it('should conserve the spacing in the HTML tags', async function() {
+    await bundle(__dirname + '/integration/html/index.html', {
+      production: true
+    });
+
+    let html = fs.readFileSync(__dirname + '/dist/index.html', 'utf8');
+    assert(/<i>hello<\/i> <i>world<\/i>/.test(html));
+  });
 });

--- a/test/integration/html/index.html
+++ b/test/integration/html/index.html
@@ -11,5 +11,6 @@
   <a href="tel:+33636757575">Tel link</a>
   <script src="index.js"></script>
   <script src="https://unpkg.com/parcel-bundler"></script>
+  <i>hello</i> <i>world</i>
 </body>
 </html>


### PR DESCRIPTION
#372 

Currently, HTML minification strips the space between two <i> tags. The result might become "helloworld"

```
<i>hello</i> <i>world</i>
```
This PR would prevent that from happening.