### PR TITLE
Potential fix to parcel bundling issues when asset parent & commonBundle types differ

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -373,10 +373,9 @@ class Bundler extends EventEmitter {
           asset.parentBundle.type === commonBundle.type
         ) {
           this.moveAssetToBundle(asset, commonBundle);
+          return;
         }
-      }
-
-      return;
+      } else return;
     }
 
     // Create the root bundle if it doesn't exist

--- a/src/assets/LESSAsset.js
+++ b/src/assets/LESSAsset.js
@@ -32,7 +32,7 @@ function urlPlugin(asset) {
   return {
     install: (less, pluginManager) => {
       let visitor = new less.visitors.Visitor({
-        visitUrl: (node) => {
+        visitUrl: node => {
           node.value.value = asset.addURLDependency(
             node.value.value,
             node.currentFileInfo.filename

--- a/test/html.js
+++ b/test/html.js
@@ -16,9 +16,19 @@ describe('html', function() {
           childBundles: []
         },
         {
+          type: 'js',
+          assets: ['index.js'],
+          childBundles: []
+        },
+        {
           type: 'html',
           assets: ['other.html'],
           childBundles: [
+            {
+              type: 'css',
+              assets: ['index.css'],
+              childBundles: []
+            },
             {
               type: 'js',
               assets: ['index.js'],
@@ -155,5 +165,34 @@ describe('html', function() {
 
     let html = fs.readFileSync(__dirname + '/dist/index.html', 'utf8');
     assert(/<i>hello<\/i> <i>world<\/i>/.test(html));
+  });
+
+  it('should support child bundles of different types', async function() {
+    let b = await bundle(
+      __dirname + '/integration/child-bundle-different-types/index.html'
+    );
+
+    assertBundleTree(b, {
+      name: 'index.html',
+      assets: ['index.html'],
+      childBundles: [
+        {
+          type: 'js',
+          assets: ['main.js', 'util.js', 'other.js'],
+          childBundles: []
+        },
+        {
+          type: 'html',
+          assets: ['other.html'],
+          childBundles: [
+            {
+              type: 'js',
+              assets: ['index.js', 'util.js', 'other.js'],
+              childBundles: []
+            }
+          ]
+        }
+      ]
+    });
   });
 });

--- a/test/integration/child-bundle-different-types/index.html
+++ b/test/integration/child-bundle-different-types/index.html
@@ -1,0 +1,17 @@
+<!-- First page -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+  <div id="main">
+    Hello World Main2
+  </div>
+  <div id="main1">
+    Hello World Main1
+  </div>
+  <script src="./main.js"></script>
+  <a href="./other.html">GOOO</a>
+</body>
+</html>

--- a/test/integration/child-bundle-different-types/index.js
+++ b/test/integration/child-bundle-different-types/index.js
@@ -1,0 +1,5 @@
+var util = require('./util');
+
+document.getElementById("main").innerHTML= util.hello();
+
+document.getElementById("main1").innerHTML= util.b();

--- a/test/integration/child-bundle-different-types/main.js
+++ b/test/integration/child-bundle-different-types/main.js
@@ -1,0 +1,5 @@
+var util = require('./util');
+
+document.getElementById("main").innerHTML= util.hi();
+
+document.getElementById("main1").innerHTML= util.b();

--- a/test/integration/child-bundle-different-types/other.html
+++ b/test/integration/child-bundle-different-types/other.html
@@ -1,0 +1,17 @@
+<!-- First page -->
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+
+</head>
+<body>
+  <div id="main">
+    Heelo
+  </div>
+  <div id="main1">
+    Heelo
+  </div>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/test/integration/child-bundle-different-types/other.js
+++ b/test/integration/child-bundle-different-types/other.js
@@ -1,0 +1,3 @@
+module.exports = {
+  hello: () => "HELLO",
+}

--- a/test/integration/child-bundle-different-types/util.js
+++ b/test/integration/child-bundle-different-types/util.js
@@ -1,0 +1,7 @@
+var test = require('./other');
+
+module.exports = {
+  hi: () => "Hi",
+  hello: () => "HELLO",
+  b: () => test.hello()
+}


### PR DESCRIPTION
#294 #326 
This PR potentially fixes the issues mentioned above. It does the following
case (i):
If the below is true => i.e both types are the same (parent Bundle is JS and commonBundle is also JS) move it the common ancestor.
```
if (
          asset.parentBundle !== commonBundle &&
          asset.parentBundle.type === commonBundle.type
        ) {
          this.moveAssetToBundle(asset, commonBundle);
          return;
        }
```
case 2:
If they aren't the same, for eg: parentBundle is JS and commonBundle is HTML. Then allow it to continue further so that it adds this asset to the immediate parent.

case 3: 
If both parent bundles are equal, then just return.
```
if (asset.parentBundle !== bundle) {
```
