### PR TITLE
fix(RawAsset): fix incorrect bundle path

### DIFF
--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -6,9 +6,13 @@ class RawAsset extends Asset {
   load() {}
 
   generate() {
+    let publicURL = this.options.publicURL;
+    publicURL = /\/$/.test(publicURL) ? publicURL : `${publicURL}/`;
+
     const pathToAsset = JSON.stringify(
-      url.resolve(this.options.publicURL, this.generateBundleName())
+      url.resolve(publicURL, this.generateBundleName())
     );
+
     return {
       js: `module.exports=${pathToAsset};`
     };

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -158,8 +158,8 @@ describe('javascript', function() {
 
     let output = run(b);
     assert.equal(typeof output, 'function');
-    assert(/^\/[0-9a-f]+\.txt$/.test(output()));
-    assert(fs.existsSync(__dirname + '/dist/' + output()));
+    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output()));
+    assert(fs.existsSync(__dirname + output()));
   });
 
   it('should minify JS in production mode', async function() {

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -66,8 +66,8 @@ describe('typescript', function() {
 
     let output = run(b);
     assert.equal(typeof output.getRaw, 'function');
-    assert(/^\/[0-9a-f]+\.txt$/.test(output.getRaw()));
-    assert(fs.existsSync(__dirname + '/dist/' + output.getRaw()));
+    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output.getRaw()));
+    assert(fs.existsSync(__dirname + output.getRaw()));
   });
 
   it('should minify in production mode', async function() {


### PR DESCRIPTION
#160 It seems that this PR didn't fix related issues. So I fixed it and it works fine in [Raincal/parcel-reason-react-app](https://github.com/Raincal/parcel-reason-react-app.git) and [jaredpalmer/react-parcel-example](https://github.com/jaredpalmer/react-parcel-example.git)