### PR TITLE
Add url dependency for serviceWorker.register calls

### DIFF
--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -15,6 +15,7 @@ const config = require('../utils/config');
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
 const GLOBAL_RE = /\b(?:process|__dirname|__filename|global|Buffer)\b/;
 const FS_RE = /\breadFileSync\b/;
+const SW_RE = /\bserviceWorker\s*\.\s*register\s*\(/;
 
 class JSAsset extends Asset {
   constructor(name, pkg, options) {
@@ -30,7 +31,8 @@ class JSAsset extends Asset {
     return (
       !/.js$/.test(this.name) ||
       IMPORT_RE.test(this.contents) ||
-      GLOBAL_RE.test(this.contents)
+      GLOBAL_RE.test(this.contents) ||
+      SW_RE.test(this.contents)
     );
   }
 

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -15,7 +15,7 @@ const config = require('../utils/config');
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
 const GLOBAL_RE = /\b(?:process|__dirname|__filename|global|Buffer)\b/;
 const FS_RE = /\breadFileSync\b/;
-const SW_RE = /\bserviceWorker\s*\.\s*register\s*\(/;
+const SW_RE = /\bnavigator\s*\.\s*serviceWorker\s*\.\s*register\s*\(/;
 
 class JSAsset extends Asset {
   constructor(name, pkg, options) {

--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -2,9 +2,11 @@ const types = require('babel-types');
 const template = require('babel-template');
 const urlJoin = require('../utils/urlJoin');
 const isURL = require('../utils/is-url');
+const matchesPattern = require('./matches-pattern');
 
 const requireTemplate = template('require("_bundle_loader")');
 const argTemplate = template('require.resolve(MODULE)');
+const serviceWorkerPattern = ['navigator', 'serviceWorker', 'register'];
 
 module.exports = {
   ImportDeclaration(node, asset) {
@@ -58,12 +60,8 @@ module.exports = {
     }
 
     const isRegisterServiceWorker =
-      callee.property !== undefined &&
-      callee.property.name === 'register' &&
-      callee.object !== undefined &&
-      callee.object.property !== undefined &&
-      callee.object.property.name === 'serviceWorker' &&
-      types.isStringLiteral(args[0]);
+      types.isStringLiteral(args[0]) &&
+      matchesPattern(callee, serviceWorkerPattern);
 
     if (isRegisterServiceWorker) {
       let assetPath = asset.addURLDependency(args[0].value);

--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -1,5 +1,6 @@
 const Path = require('path');
 const types = require('babel-types');
+const matchesPattern = require('./matches-pattern');
 
 const VARS = {
   process: asset => {
@@ -60,47 +61,6 @@ function inScope(ancestors) {
   }
 
   return false;
-}
-
-// from babel-types. remove when we upgrade to babel 7.
-// https://github.com/babel/babel/blob/0189b387026c35472dccf45d14d58312d249f799/packages/babel-types/src/index.js#L347
-function matchesPattern(member, match) {
-  // not a member expression
-  if (!types.isMemberExpression(member)) {
-    return false;
-  }
-
-  const parts = Array.isArray(match) ? match : match.split('.');
-  const nodes = [];
-
-  let node;
-  for (node = member; types.isMemberExpression(node); node = node.object) {
-    nodes.push(node.property);
-  }
-
-  nodes.push(node);
-
-  if (nodes.length !== parts.length) {
-    return false;
-  }
-
-  for (let i = 0, j = nodes.length - 1; i < parts.length; i++, j--) {
-    const node = nodes[j];
-    let value;
-    if (types.isIdentifier(node)) {
-      value = node.name;
-    } else if (types.isStringLiteral(node)) {
-      value = node.value;
-    } else {
-      return false;
-    }
-
-    if (parts[i] !== value) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 // replace object properties

--- a/src/visitors/matches-pattern.js
+++ b/src/visitors/matches-pattern.js
@@ -1,0 +1,36 @@
+const types = require('babel-types');
+
+// from babel-types. remove when we upgrade to babel 7.
+// https://github.com/babel/babel/blob/0189b387026c35472dccf45d14d58312d249f799/packages/babel-types/src/index.js#L347
+module.exports = function matchesPattern(member, match, allowPartial) {
+  // not a member expression
+  if (!types.isMemberExpression(member)) return false;
+
+  const parts = Array.isArray(match) ? match : match.split('.');
+  const nodes = [];
+
+  let node;
+  for (node = member; types.isMemberExpression(node); node = node.object) {
+    nodes.push(node.property);
+  }
+  nodes.push(node);
+
+  if (nodes.length < parts.length) return false;
+  if (!allowPartial && nodes.length > parts.length) return false;
+
+  for (let i = 0, j = nodes.length - 1; i < parts.length; i++, j--) {
+    const node = nodes[j];
+    let value;
+    if (types.isIdentifier(node)) {
+      value = node.name;
+    } else if (types.isStringLiteral(node)) {
+      value = node.value;
+    } else {
+      return false;
+    }
+
+    if (parts[i] !== value) return false;
+  }
+
+  return true;
+};

--- a/test/integration/service-worker/index.js
+++ b/test/integration/service-worker/index.js
@@ -1,0 +1,1 @@
+navigator.serviceWorker.register('worker.js', { scope: './' });

--- a/test/integration/service-worker/worker.js
+++ b/test/integration/service-worker/worker.js
@@ -1,0 +1,1 @@
+self.addEventListener('message', () => {});

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -58,6 +58,21 @@ describe('javascript', function() {
     assert.equal(await output(), 3);
   });
 
+  it('should support bundling service workers', async function() {
+    let b = await bundle(__dirname + '/integration/service-worker/index.js');
+
+    assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js'],
+      childBundles: [
+        {
+          assets: ['worker.js'],
+          childBundles: []
+        }
+      ]
+    });
+  });
+
   it('should dynamic import files which import raw files', async function() {
     let b = await bundle(
       __dirname + '/integration/dynamic-references-raw/index.js'


### PR DESCRIPTION
Adds support for `serviceWorker.register('foo.js')`.

Maybe we should support `self.importScripts('foo.js', 'bar.js', ...);` too?