### PR TITLE
standardize comments on empty implementation method

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -98,7 +98,9 @@ class Asset {
     // do nothing by default
   }
 
-  async pretransform() {}
+  async pretransform() {
+    // do nothing by default
+  }
 
   async transform() {
     // do nothing by default


### PR DESCRIPTION
tweek & comment only chage.

`async pretransform()` was uncommented among the empty implementation methods of the `Asset` class, it a little strange for me.

of course you could reject PR, if there is any reason.

thanks!
