### PR TITLE
Add support for the action attribute of the HTML form tag

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -20,7 +20,8 @@ const ATTRS = {
     'embed'
   ],
   href: ['link', 'a'],
-  poster: ['video']
+  poster: ['video'],
+  action: ['form']
 };
 
 class HTMLAsset extends Asset {


### PR DESCRIPTION
Since the `action` attribute of the `form` tag can be a relative path, it should be added to the list of all HTML attributes that should produce a dependency in `HTMLAsset.js`.