### PR TITLE
Expose entry points exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
     "es6": true
   },
   "globals": {
-    "parcelRequire": true
+    "parcelRequire": true,
+    "define": true
   }
 }

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -99,6 +99,7 @@ class Bundler extends EventEmitter {
         options.hmrHostname ||
         (options.target === 'electron' ? 'localhost' : ''),
       detailedReport: options.detailedReport || false,
+      global: options.global,
       autoinstall:
         typeof options.autoinstall === 'boolean'
           ? options.autoinstall

--- a/src/builtins/prelude.js
+++ b/src/builtins/prelude.js
@@ -7,7 +7,7 @@
 // orig method which is the require for previous bundles
 
 // eslint-disable-next-line no-global-assign
-parcelRequire = (function (modules, cache, entry) {
+parcelRequire = (function (modules, cache, entry, globalName) {
   // Save the require from previous bundle to this closure if any
   var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
   var nodeRequire = typeof require === 'function' && require;
@@ -73,6 +73,27 @@ parcelRequire = (function (modules, cache, entry) {
 
   for (var i = 0; i < entry.length; i++) {
     newRequire(entry[i]);
+  }
+
+  if (entry.length) {
+    // Expose entry point to Node, AMD or browser globals
+    // Based on https://github.com/ForbesLindesay/umd/blob/master/template.js
+    var mainExports = newRequire(entry[entry.length - 1]);
+
+    // CommonJS
+    if (typeof exports === "object" && typeof module !== "undefined") {
+      module.exports = mainExports;
+
+    // RequireJS
+    } else if (typeof define === "function" && define.amd) {
+     define(function () {
+       return mainExports;
+     });
+
+    // <script>
+    } else if (globalName) {
+      this[globalName] = mainExports;
+    }
   }
 
   // Override the current require with this new one

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,6 +41,7 @@ program
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
   )
+  .option('--global <variable>', 'expose your module through a global variable')
   .option('--no-hmr', 'disable hot module replacement')
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
@@ -73,6 +74,7 @@ program
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
   )
+  .option('--global <variable>', 'expose your module through a global variable')
   .option(
     '--hmr-port <port>',
     'set the port to serve HMR websockets, defaults to random',
@@ -113,6 +115,7 @@ program
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
   )
+  .option('--global <variable>', 'expose your module through a global variable')
   .option('--no-minify', 'disable minification')
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -203,7 +203,13 @@ class JSPackager extends Packager {
       entry.push(this.bundle.entryAsset.id);
     }
 
-    await this.write('},{},' + JSON.stringify(entry) + ')');
+    await this.dest.write(
+      '},{},' +
+        JSON.stringify(entry) +
+        ', ' +
+        JSON.stringify(this.options.global || null) +
+        ')'
+    );
     if (this.options.sourceMaps) {
       // Add source map url if a map bundle exists
       let mapBundle = this.bundle.siblingBundlesMap.get('map');

--- a/test/integration/entry-point/index.js
+++ b/test/integration/entry-point/index.js
@@ -1,0 +1,5 @@
+function test() {
+  return 'Test!';
+}
+
+module.exports = test;

--- a/test/integration/entry-point/test.html
+++ b/test/integration/entry-point/test.html
@@ -1,0 +1,3 @@
+<html>
+<script src="dist/index.js"></script>
+</html>

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -834,4 +834,33 @@ describe('javascript', function() {
 
     assert.equal(failed, false);
   });
+
+  it('should expose to CommonJS entry point', async function() {
+    let b = await bundle(__dirname + '/integration/entry-point/index.js');
+
+    delete require.cache[require.resolve(b.name)];
+    const test = require(b.name);
+    assert.equal(test(), 'Test!');
+  });
+
+  it('should expose to RequireJS entry point', async function() {
+    let b = await bundle(__dirname + '/integration/entry-point/index.js');
+    let test;
+    const mockDefine = function(f) {
+      test = f();
+    };
+    mockDefine.amd = true;
+
+    run(b, {define: mockDefine});
+    assert.equal(test(), 'Test!');
+  });
+
+  it('should expose variable with --browser-global', async function() {
+    let b = await bundle(__dirname + '/integration/entry-point/index.js', {
+      global: 'testing'
+    });
+
+    const ctx = run(b, null, {require: false});
+    assert.equal(ctx.window.testing(), 'Test!');
+  });
 });

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -838,9 +838,9 @@ describe('javascript', function() {
   it('should expose to CommonJS entry point', async function() {
     let b = await bundle(__dirname + '/integration/entry-point/index.js');
 
-    delete require.cache[require.resolve(b.name)];
-    const test = require(b.name);
-    assert.equal(test(), 'Test!');
+    let module = {};
+    run(b, {module, exports: {}});
+    assert.equal(module.exports(), 'Test!');
   });
 
   it('should expose to RequireJS entry point', async function() {


### PR DESCRIPTION
The way the code is bundled is perfect for the browser. It is also perfect for Node.js if you want to do server-side rendering. However, it was impossible to expose functions that you could import from Node.js by requiring the bundle. The expected behaviour would be to access the entry point exports. Here is an example of what I was trying to accomplish:

test.js
```js
module.exports = function test(req) {
  req.send();
};
```

index.js
```js
const req = {
  send() {
    console.log('MEOW!');
  }
};

const test = require('./dist/test');
test(req);
```

 - Step 1: bundling: `parcel build test.js`
 - Step 2: run `node index`

The expected behaviour would be to have printed on the console `MEOW!`. Right now, it would throw `test is undefined`.

There is many benefits of working this way when you do server-rendering. You still have zero-configuration. The hashed asset names are already converted within the bundle. And many more.

I am not sure if there is only 1 entry point and it is always the first. Maybe someone that knows the code better would be able to confirm if this approach is correct.
