### PR TITLE
Logger singleton

### DIFF
--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -3,6 +3,7 @@ const path = require('path');
 const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
 const pkg = require('../package.json');
+const logger = require('./Logger');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr'];
@@ -46,7 +47,7 @@ class FSCache {
       await fs.writeFile(this.getCacheFile(filename), JSON.stringify(data));
       this.invalidated.delete(filename);
     } catch (err) {
-      console.error('Error writing to cache', err);
+      logger.error('Error writing to cache', err);
     }
   }
 

--- a/src/HMRServer.js
+++ b/src/HMRServer.js
@@ -1,5 +1,6 @@
 const WebSocket = require('ws');
 const prettyError = require('./utils/prettyError');
+const logger = require('./Logger');
 
 class HMRServer {
   async start(port) {
@@ -76,8 +77,7 @@ class HMRServer {
       // This gets triggered on page refresh, ignore this
       return;
     }
-    // TODO: Use logger to print errors
-    console.log(prettyError(err));
+    logger.log(err);
   }
 
   broadcast(msg) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -5,12 +5,19 @@ const emoji = require('./utils/emoji');
 
 class Logger {
   constructor(options) {
-    this.logLevel = typeof options.logLevel === 'number' ? options.logLevel : 3;
-    this.color =
-      typeof options.color === 'boolean' ? options.color : chalk.supportsColor;
-    this.chalk = new chalk.constructor({enabled: this.color});
     this.lines = 0;
     this.statusLine = null;
+    this.setOptions(options);
+  }
+
+  setOptions(options) {
+    this.logLevel =
+      options && typeof options.logLevel === 'number' ? options.logLevel : 3;
+    this.color =
+      options && typeof options.color === 'boolean'
+        ? options.color
+        : chalk.supportsColor;
+    this.chalk = new chalk.constructor({enabled: this.color});
   }
 
   write(message, persistent = false) {
@@ -108,6 +115,17 @@ class Logger {
       this.lines++;
     }
   }
+
+  handleMessage(options) {
+    this[options.method](...options.args);
+  }
 }
 
-module.exports = Logger;
+let logger;
+function getInstance() {
+  if (!logger) logger = new Logger();
+  return logger;
+}
+
+module.exports = getInstance();
+module.exports.class = Logger;

--- a/src/Server.js
+++ b/src/Server.js
@@ -4,6 +4,7 @@ const serveStatic = require('serve-static');
 const getPort = require('get-port');
 const serverErrors = require('./utils/customErrors').serverErrors;
 const generateCertificate = require('./utils/generateCertificate');
+const logger = require('./Logger');
 
 serveStatic.mime.define({
   'application/wasm': ['wasm']
@@ -71,20 +72,20 @@ async function serve(bundler, port, useHTTPS = false) {
 
   return new Promise((resolve, reject) => {
     server.on('error', err => {
-      bundler.logger.error(new Error(serverErrors(err, server.address().port)));
+      logger.error(new Error(serverErrors(err, server.address().port)));
       reject(err);
     });
 
     server.once('listening', () => {
       let addon =
         server.address().port !== port
-          ? `- ${bundler.logger.chalk.yellow(
+          ? `- ${logger.chalk.yellow(
               `configured port ${port} could not be used.`
             )}`
           : '';
 
-      bundler.logger.persistent(
-        `Server running at ${bundler.logger.chalk.cyan(
+      logger.persistent(
+        `Server running at ${logger.chalk.cyan(
           `${useHTTPS ? 'https' : 'http'}://localhost:${server.address().port}`
         )} ${addon}`
       );

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -2,6 +2,7 @@ const {EventEmitter} = require('events');
 const os = require('os');
 const Farm = require('worker-farm/lib/farm');
 const promisify = require('./utils/promisify');
+const logger = require('./Logger');
 
 let shared = null;
 
@@ -60,6 +61,8 @@ class WorkerFarm extends Farm {
 
     if (data.event) {
       this.emit(data.event, ...data.args);
+    } else if (data.type === 'logger') {
+      logger.handleMessage(data);
     } else {
       super.receive(data);
     }

--- a/src/transforms/uglify.js
+++ b/src/transforms/uglify.js
@@ -26,8 +26,7 @@ module.exports = async function(asset) {
   // Log all warnings
   if (result.warnings) {
     result.warnings.forEach(warning => {
-      // TODO: warn this using the logger
-      console.log(warning);
+      asset.write([warning], 'warn');
     });
   }
 

--- a/src/transforms/uglify.js
+++ b/src/transforms/uglify.js
@@ -1,4 +1,5 @@
 const {minify} = require('uglify-es');
+const logger = require('../Logger');
 
 module.exports = async function(asset) {
   await asset.parseIfNeeded();
@@ -26,7 +27,7 @@ module.exports = async function(asset) {
   // Log all warnings
   if (result.warnings) {
     result.warnings.forEach(warning => {
-      asset.write([warning], 'warn');
+      logger.warn('[uglify] ' + warning);
     });
   }
 

--- a/src/utils/generateCertificate.js
+++ b/src/utils/generateCertificate.js
@@ -2,6 +2,7 @@ const forge = require('node-forge');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
+const logger = require('../Logger');
 
 function generateCertificate(options = {}) {
   const privateKeyPath = path.join(options.cacheDir, 'private.pem');
@@ -19,7 +20,7 @@ function generateCertificate(options = {}) {
     }
   }
 
-  console.log('Generating SSL Certificate...');
+  logger.log('Generating SSL Certificate...');
 
   const pki = forge.pki;
   const keys = pki.rsa.generateKeyPair(2048);


### PR DESCRIPTION
Converts Logger into a singleton, so everything outside of bundler can use it.
Also created IPC for logger so that assets can send messages to the workerfarm, instead of overloading logger singleton.

After seeing #207 was too big of change and failing times and times again to fix the glitches with status i thought it be a better idea to just extract the singleton part of that PR and make a fresh clean new PR, without the conflicts, ...