### PR TITLE
Make HMR work in Worker contexts

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -15,7 +15,7 @@ function Module() {
 module.bundle.Module = Module;
 
 if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
-  var ws = new WebSocket('ws://' + location.hostname + ':{{HMR_PORT}}/');
+  var ws = new WebSocket('ws://' + global.location.hostname + ':{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);
 

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -15,7 +15,7 @@ function Module() {
 module.bundle.Module = Module;
 
 if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
-  var ws = new WebSocket('ws://' + window.location.hostname + ':{{HMR_PORT}}/');
+  var ws = new WebSocket('ws://' + location.hostname + ':{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);
 

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -34,7 +34,7 @@ if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
     if (data.type === 'reload') {
       ws.close();
       ws.onclose = function () {
-        window.location.reload();
+        global.location.reload();
       }
     }
 


### PR DESCRIPTION
The `window` object is not available in the context of Web Workers
and Service Workers, therefore `window.location` won't work, the way
to make HMR work is by accessing `location` through the implicit
global context.