### PR TITLE
Transform HTML prior to collecting dependencies

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -65,10 +65,6 @@ class HTMLAsset extends Asset {
     await posthtmlTransform(this);
   }
 
-  async transform() {
-    await posthtmlTransform(this);
-  }
-
   generate() {
     let html = this.isAstDirty ? render(this.ast) : this.contents;
     return {html};

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -61,6 +61,10 @@ class HTMLAsset extends Asset {
     });
   }
 
+  async pretransform() {
+    await posthtmlTransform(this);
+  }
+
   async transform() {
     await posthtmlTransform(this);
   }

--- a/test/html.js
+++ b/test/html.js
@@ -75,8 +75,6 @@ describe('html', function() {
         }
       ]
     });
-
-    // TODO assert index.js is copied to /dist
   });
 
   it('should insert sibling CSS bundles for JS files in the HEAD', async function() {

--- a/test/html.js
+++ b/test/html.js
@@ -61,6 +61,24 @@ describe('html', function() {
     assert(html.includes('<h1>Other page</h1>'));
   });
 
+  it('should find assets inside posthtml', async function() {
+    let b = await bundle(__dirname + '/integration/posthtml-assets/index.html');
+
+    assertBundleTree(b, {
+      name: 'index.html',
+      assets: ['index.html'],
+      childBundles: [
+        {
+          type: 'js',
+          assets: ['index.js'],
+          childBundles: []
+        }
+      ]
+    });
+
+    // TODO assert index.js is copied to /dist
+  });
+
   it('should insert sibling CSS bundles for JS files in the HEAD', async function() {
     let b = await bundle(__dirname + '/integration/html-css/index.html');
 

--- a/test/integration/posthtml-assets/.posthtmlrc.js
+++ b/test/integration/posthtml-assets/.posthtmlrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    "posthtml-include": {
+      root: __dirname
+    }
+  }
+};

--- a/test/integration/posthtml-assets/index.html
+++ b/test/integration/posthtml-assets/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+    <include src="other.html"></include>
+</body>
+</html>

--- a/test/integration/posthtml-assets/index.js
+++ b/test/integration/posthtml-assets/index.js
@@ -1,0 +1,1 @@
+window.alert("Hello world!");

--- a/test/integration/posthtml-assets/other.html
+++ b/test/integration/posthtml-assets/other.html
@@ -1,0 +1,2 @@
+<h1>Other page</h1>
+<script src="index.js"></script>


### PR DESCRIPTION
Parcel assumes it is working with complete HTML when collecting dependencies, but until it is transformed, not all the assets may be visible. The test includes an example with `posthtml-include`, but I also had issues with `posthtml-extend`.