### PR TITLE
Use verbose output during testing

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -36,7 +36,7 @@ function bundler(file, opts) {
         cache: false,
         killWorkers: false,
         hmr: false,
-        logLevel: 0
+        logLevel: 3
       },
       opts
     )


### PR DESCRIPTION
Currently, we use `logLevel: 0` when running tests.

`logLevel: 3` has several advantages, most notably that it doesn't
suppress errors.

(If you run `yarn test` with `logLevel: 3`, you'll see we currently
have an error in test/html.js that went unnoticed, for example.)