### PR TITLE
Improve CSS loader

### DIFF
--- a/src/assets/CSSAsset.js
+++ b/src/assets/CSSAsset.js
@@ -98,16 +98,18 @@ class CSSAsset extends Asset {
   }
 
   generate() {
-    let css = this.ast ? this.ast.render() : this.contents;
+    const css = this.ast ? this.ast.render() : this.contents;
 
     let js = '';
     if (this.options.hmr) {
       this.addDependency('_css_loader');
 
+      const style = JSON.stringify(css);
       js = `
-        var reloadCSS = require('_css_loader');
-        module.hot.dispose(reloadCSS);
-        module.hot.accept(reloadCSS);
+        var reloadCSS = require('_css_loader')(${style});
+        if (module.hot) {
+          module.hot.dispose(reloadCSS);
+        }
       `;
     }
 

--- a/src/builtins/css-loader.js
+++ b/src/builtins/css-loader.js
@@ -1,30 +1,25 @@
-var bundle = require('./bundle-url');
+var inserted = exports.cache = {}
 
-function updateLink(link) {
-  var newLink = link.cloneNode();
-  newLink.onload = function () {
-    link.remove();
-  };
-  newLink.href = link.href.split('?')[0] + '?' + Date.now();
-  link.parentNode.insertBefore(newLink, link.nextSibling);
-}
+function noop () {}
 
-var cssTimeout = null;
-function reloadCSS() {
-  if (cssTimeout) {
-    return;
+function reloadCSS(css) {
+  if (inserted[css]) return noop
+  inserted[css] = true
+
+  var elem = document.createElement('style')
+  elem.setAttribute('type', 'text/css')
+
+  if ('textContent' in elem) {
+    elem.textContent = css
+  } else {
+    elem.styleSheet.cssText = css
   }
 
-  cssTimeout = setTimeout(function () {
-    var links = document.querySelectorAll('link[rel="stylesheet"]');
-    for (var i = 0; i < links.length; i++) {
-      if (bundle.getBaseURL(links[i].href) === bundle.getBundleURL()) {
-        updateLink(links[i]);
-      }
-    }
-
-    cssTimeout = null;
-  }, 50);
+  document.getElementsByTagName('head')[0].appendChild(elem)
+  return function () {
+    document.getElementsByTagName('head')[0].removeChild(elem)
+    inserted[css] = false
+  }
 }
 
 module.exports = reloadCSS;


### PR DESCRIPTION
When implementing Vue support, I ran into an issue with our existing
CSS loader. When I made changes to CSS files, the results wouldn't
show up for >5 seconds.

This CSS loader is derived from either vueify or vue-loader (I forget
which). Either way, it's battle tested and simple. There is no delay
whenever CSS code changes.