### PR TITLE
Find a[href] dependencies when other attrs precede it

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -44,7 +44,7 @@ class HTMLAsset extends Asset {
           let elements = ATTRS[attr];
           // Check for virtual paths
           if (node.tag === 'a' && node.attrs[attr].lastIndexOf('.') < 1) {
-            break;
+            continue;
           }
           if (elements && elements.includes(node.tag)) {
             let assetPath = this.addURLDependency(node.attrs[attr]);

--- a/test/html.js
+++ b/test/html.js
@@ -48,6 +48,22 @@ describe('html', function() {
     }
   });
 
+  it('should find href attr when not first', async function() {
+    let b = await bundle(__dirname + '/integration/html-attr-order/index.html');
+
+    assertBundleTree(b, {
+      name: 'index.html',
+      assets: ['index.html'],
+      childBundles: [
+        {
+          type: 'html',
+          assets: ['other.html'],
+          childBundles: []
+        }
+      ]
+    });
+  });
+
   it('should support transforming HTML with posthtml', async function() {
     let b = await bundle(__dirname + '/integration/posthtml/index.html');
 

--- a/test/integration/html-attr-order/index.html
+++ b/test/integration/html-attr-order/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+</head>
+<body>
+  <h1>Hello world</h1>
+  <p>Linking to <a class="link" href="other.html">another page</a></p>
+</body>
+</html>

--- a/test/integration/html-attr-order/other.html
+++ b/test/integration/html-attr-order/other.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+</head>
+<body>
+  <h1>Other page</h1>
+</body>
+</html>


### PR DESCRIPTION
`<a href="other.html">other</a>` worked as expected, but `<a class="hi" href="other.html">other</a> would not.