### PR TITLE
[RFC] Get rid of multiprocessing – parcel becomes twice as fast

### DIFF
--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -1,6 +1,4 @@
 const {EventEmitter} = require('events');
-const os = require('os');
-const Farm = require('worker-farm/lib/farm');
 const promisify = require('./utils/promisify');
 
 let shared = null;

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -5,25 +5,14 @@ const promisify = require('./utils/promisify');
 
 let shared = null;
 
-class WorkerFarm extends Farm {
-  constructor(options) {
-    let opts = {
-      autoStart: true,
-      maxConcurrentWorkers: getNumWorkers()
-    };
-
-    super(opts, require.resolve('./worker'));
-
+class WorkerFarm {
+  constructor() {
     this.localWorker = this.promisifyWorker(require('./worker'));
-    this.remoteWorker = this.promisifyWorker(this.setup(['init', 'run']));
-
-    this.started = false;
-    this.init(options);
   }
 
   init(options) {
+    this.options = options;
     this.localWorker.init(options);
-    this.initRemoteWorkers(options);
   }
 
   promisifyWorker(worker) {
@@ -36,48 +25,19 @@ class WorkerFarm extends Farm {
     return res;
   }
 
-  async initRemoteWorkers(options) {
-    this.started = false;
-
-    let promises = [];
-    for (let i = 0; i < this.activeChildren; i++) {
-      promises.push(this.remoteWorker.init(options));
-    }
-
-    await Promise.all(promises);
-    this.started = true;
-  }
-
-  receive(data) {
-    if (data.event) {
-      this.emit(data.event, ...data.args);
-    } else {
-      super.receive(data);
-    }
-  }
-
   async run(...args) {
-    // Child process workers are slow to start (~600ms).
-    // While we're waiting, just run on the main thread.
-    // This significantly speeds up startup time.
-    if (!this.started) {
-      return this.localWorker.run(...args);
-    } else {
-      return this.remoteWorker.run(...args);
-    }
+    return this.localWorker.run(...args);
   }
 
   end() {
-    super.end();
     shared = null;
   }
 
   static getShared(options) {
     if (!shared) {
-      shared = new WorkerFarm(options);
-    } else {
-      shared.init(options);
+      shared = new WorkerFarm();
     }
+    shared.init(options);
 
     return shared;
   }
@@ -85,16 +45,6 @@ class WorkerFarm extends Farm {
 
 for (let key in EventEmitter.prototype) {
   WorkerFarm.prototype[key] = EventEmitter.prototype[key];
-}
-
-function getNumWorkers() {
-  let cores;
-  try {
-    cores = require('physical-cpu-count');
-  } catch (err) {
-    cores = os.cpus().length;
-  }
-  return cores || 1;
 }
 
 module.exports = WorkerFarm;


### PR DESCRIPTION
<!---
Thanks for filing an issue 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have asked the same thing before!
-->

🐛 bug report

<!--- Provide a general summary of the issue in the title above -->

### 🎛 Configuration (.babelrc, package.json, cli command)

`yarn test`. I've also tested this with a large codebase.

<!--- If describing a bug, tell us what your babel configuration looks like -->

### 🤔 Expected Behavior

<!--- If you're describing a bug, tell us what should happen -->

Intuitively, multiprocessing should increase performance, but Parcel runs much faster after turning it off.

<!--- If you're suggesting a change/improvement, tell us how it should work -->


### 😯 Current Behavior

<!--- If describing a bug, tell us what happens instead of the expected behavior -->

Performance tests using the current HEAD:

`parcel --no-cache demo/index.html`, multiprocessing / worker processes ON:

![image](https://user-images.githubusercontent.com/59632/34595204-abedaacc-f19b-11e7-812e-173469a270ac.png)


`parcel build --no-cache demo/index.html`, multiprocessing / worker processes ON:
![image](https://user-images.githubusercontent.com/59632/34595263-212fe200-f19c-11e7-9b98-822946876663.png)


`time yarn test`, multiprocessing / worker processes ON:

![image](https://user-images.githubusercontent.com/59632/34595289-6f7ab58e-f19c-11e7-9dcc-9395ae105a0c.png)



After applying the following patch to disable worker processes, you can see a sharp increase in performance:

![image](https://user-images.githubusercontent.com/59632/34594768-b0d765a8-f198-11e7-85aa-0fa19d8ccbc1.png)

`parcel --no-cache demo/index.html`, single process:

![image](https://user-images.githubusercontent.com/59632/34595186-7af06cb6-f19b-11e7-84b2-239805110b6d.png)



`parcel build --no-cache demo/index.html`, single process:

![image](https://user-images.githubusercontent.com/59632/34595088-a1dac69c-f19a-11e7-8d32-9dbb5f69309d.png)

`time yarn test`, single process:

![image](https://user-images.githubusercontent.com/59632/34595305-8c6cf2ba-f19c-11e7-9569-4a99e9598fef.png)




<!--- If you are seeing an error, please include the full error message and stack trace -->

<!--- If suggesting a change/improvement, explain the difference from current behavior -->

### 💁 Possible Solution

<!--- Not obligatory, but suggest a fix/reason for the bug, -->

<!--- or ideas how to implement the addition or change -->

### 🔦 Context

<!--- How has this issue affected you? What are you trying to accomplish? -->

Benefits of stripping out multiprocessing:

`yarn test` runs 2.4x faster (60% time decrease).

`parcel foo.html` starts ~50% faster

`parcel build foo.html` is slightly faster

IDE debugging becomes much easier, since breakpoints can be placed in Asset classes. (Normally this functionality runs in a separate process.)

The code becomes far less complicated, since this removes the need for an RPC interface between child processes and the host.

<!--- Providing context helps us come up with a solution that is most useful in the real world -->

### 💻 Code Sample

<!-- If you are seeing an error, please provide a code repository, gist or sample files to reproduce the issue -->

### 🌍 Your Environment

<!--- Include as many relevant details about the environment you experienced the bug in -->

| Software         | Version(s) |
| ---------------- | ---------- |
| Parcel           | HEAD
| Node             | v9.3.0
| npm/Yarn         | yarn 1.3.2
| Operating System | macOS

<!-- Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate -->
