### PR TITLE
Invalidate cache on config and environment variable changes

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -4,6 +4,7 @@ const objectHash = require('./utils/objectHash');
 const md5 = require('./utils/md5');
 const isURL = require('./utils/is-url');
 const sanitizeFilename = require('sanitize-filename');
+const config = require('./utils/config');
 
 let ASSET_ID = 1;
 
@@ -80,6 +81,19 @@ class Asset {
     return this.options.parser
       .getAsset(resolved, this.package, this.options)
       .generateBundleName();
+  }
+
+  async getConfig(filenames) {
+    // Resolve the config file
+    let conf = await config.resolve(this.name, filenames);
+    if (conf) {
+      // Add as a dependency so it is added to the watcher and invalidates
+      // this asset when the config changes.
+      this.addDependency(conf, {includedInParent: true});
+      return await config.load(this.name, filenames);
+    }
+
+    return null;
   }
 
   mightHaveDependencies() {

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -34,6 +34,11 @@ class Asset {
     this.depAssets = new Map();
     this.parentBundle = null;
     this.bundles = new Set();
+    this.cacheData = {};
+  }
+
+  shouldInvalidate() {
+    return false;
   }
 
   async loadIfNeeded() {

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -317,7 +317,7 @@ class Bundler extends EventEmitter {
 
     // First try the cache, otherwise load and compile in the background
     let processed = this.cache && (await this.cache.read(asset.name));
-    if (!processed) {
+    if (!processed || asset.shouldInvalidate(processed.cacheData)) {
       processed = await this.farm.run(asset.name, asset.package, this.options);
       if (this.cache) {
         this.cache.write(asset.name, processed);

--- a/src/HMRServer.js
+++ b/src/HMRServer.js
@@ -57,9 +57,8 @@ class HMRServer {
         type: 'update',
         assets: assets.map(asset => {
           let deps = {};
-          for (let dep of asset.dependencies.values()) {
-            let mod = asset.depAssets.get(dep.name);
-            deps[dep.name] = mod.id;
+          for (let [dep, depAsset] of asset.depAssets) {
+            deps[dep.name] = depAsset.id;
           }
 
           return {

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -25,6 +25,17 @@ class JSAsset extends Asset {
     this.isAstDirty = false;
     this.isES6Module = false;
     this.outputCode = null;
+    this.cacheData.env = {};
+  }
+
+  shouldInvalidate(cacheData) {
+    for (let key in cacheData.env) {
+      if (cacheData.env[key] !== process.env[key]) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   mightHaveDependencies() {

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -10,7 +10,6 @@ const fsVisitor = require('../visitors/fs');
 const babel = require('../transforms/babel');
 const generate = require('babel-generator').default;
 const uglify = require('../transforms/uglify');
-const config = require('../utils/config');
 
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
 const GLOBAL_RE = /\b(?:process|__dirname|__filename|global|Buffer)\b/;
@@ -55,7 +54,7 @@ class JSAsset extends Asset {
     // Check if there is a babel config file. If so, determine which parser plugins to enable
     this.babelConfig =
       (this.package && this.package.babel) ||
-      (await config.load(this.name, ['.babelrc', '.babelrc.js']));
+      (await this.getConfig(['.babelrc', '.babelrc.js']));
     if (this.babelConfig) {
       const file = new BabelFile({filename: this.name});
       options.plugins.push(...file.parserOpts.plugins);

--- a/src/assets/LESSAsset.js
+++ b/src/assets/LESSAsset.js
@@ -1,5 +1,4 @@
 const CSSAsset = require('./CSSAsset');
-const config = require('../utils/config');
 const localRequire = require('../utils/localRequire');
 const promisify = require('../utils/promisify');
 
@@ -11,7 +10,7 @@ class LESSAsset extends CSSAsset {
 
     let opts =
       this.package.less ||
-      (await config.load(this.name, ['.lessrc', '.lessrc.js'])) ||
+      (await this.getConfig(['.lessrc', '.lessrc.js'])) ||
       {};
     opts.filename = this.name;
     opts.plugins = (opts.plugins || []).concat(urlPlugin(this));

--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -1,5 +1,4 @@
 const CSSAsset = require('./CSSAsset');
-const config = require('../utils/config');
 const localRequire = require('../utils/localRequire');
 const promisify = require('../utils/promisify');
 const path = require('path');
@@ -12,7 +11,7 @@ class SASSAsset extends CSSAsset {
 
     let opts =
       this.package.sass ||
-      (await config.load(this.name, ['.sassrc', '.sassrc.js'])) ||
+      (await this.getConfig(['.sassrc', '.sassrc.js'])) ||
       {};
     opts.includePaths = (opts.includePaths || []).concat(
       path.dirname(this.name)

--- a/src/assets/StylusAsset.js
+++ b/src/assets/StylusAsset.js
@@ -1,5 +1,4 @@
 const CSSAsset = require('./CSSAsset');
-const config = require('../utils/config');
 const localRequire = require('../utils/localRequire');
 const Resolver = require('../Resolver');
 
@@ -11,7 +10,7 @@ class StylusAsset extends CSSAsset {
     let stylus = await localRequire('stylus', this.name);
     let opts =
       this.package.stylus ||
-      (await config.load(this.name, ['.stylusrc', '.stylusrc.js']));
+      (await this.getConfig(['.stylusrc', '.stylusrc.js']));
     let style = stylus(code, opts);
     style.set('filename', this.name);
     style.set('include css', true);

--- a/src/assets/TypeScriptAsset.js
+++ b/src/assets/TypeScriptAsset.js
@@ -1,5 +1,4 @@
 const JSAsset = require('./JSAsset');
-const config = require('../utils/config');
 const localRequire = require('../utils/localRequire');
 
 class TypeScriptAsset extends JSAsset {
@@ -14,7 +13,7 @@ class TypeScriptAsset extends JSAsset {
       fileName: this.basename
     };
 
-    let tsconfig = await config.load(this.name, ['tsconfig.json']);
+    let tsconfig = await this.getConfig(['tsconfig.json']);
 
     // Overwrite default if config is found
     if (tsconfig) {

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -36,9 +36,7 @@ class JSPackager extends Packager {
     }
 
     let deps = {};
-    for (let dep of asset.dependencies.values()) {
-      let mod = asset.depAssets.get(dep.name);
-
+    for (let [dep, mod] of asset.depAssets) {
       // For dynamic dependencies, list the child bundles to load along with the module id
       if (dep.dynamic && this.bundle.childBundles.has(mod.parentBundle)) {
         let bundles = [path.basename(mod.parentBundle.name)];

--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -1,5 +1,4 @@
 const babel = require('babel-core');
-const config = require('../utils/config');
 
 module.exports = async function(asset) {
   if (!await shouldTransform(asset)) {
@@ -40,6 +39,6 @@ async function shouldTransform(asset) {
     return true;
   }
 
-  let babelrc = await config.resolve(asset.name, ['.babelrc', '.babelrc.js']);
+  let babelrc = await asset.getConfig(['.babelrc', '.babelrc.js']);
   return !!babelrc;
 }

--- a/src/transforms/uglify.js
+++ b/src/transforms/uglify.js
@@ -1,5 +1,4 @@
 const {minify} = require('uglify-es');
-const config = require('../utils/config');
 
 module.exports = async function(asset) {
   await asset.parseIfNeeded();
@@ -7,7 +6,7 @@ module.exports = async function(asset) {
   // Convert AST into JS
   let code = asset.generate().js;
 
-  let customConfig = await config.load(asset.name, ['.uglifyrc']);
+  let customConfig = await asset.getConfig(['.uglifyrc']);
   let options = {
     warnings: true,
     mangle: {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -21,8 +21,6 @@ async function resolve(filepath, filenames, root = path.parse(filepath).root) {
       existsCache.set(file, true);
       return file;
     }
-
-    existsCache.set(file, false);
   }
 
   return resolve(filepath, filenames, root);

--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -26,6 +26,7 @@ module.exports = {
         let val = types.valueToNode(process.env[key.value]);
         morph(node, val);
         asset.isAstDirty = true;
+        asset.cacheData.env[key.value] = process.env[key.value];
       }
     }
   },

--- a/src/worker.js
+++ b/src/worker.js
@@ -17,7 +17,8 @@ exports.run = async function(path, pkg, options, callback) {
     callback(null, {
       dependencies: Array.from(asset.dependencies.values()),
       generated: asset.generated,
-      hash: asset.hash
+      hash: asset.hash,
+      cacheData: asset.cacheData
     });
   } catch (err) {
     let returned = err;

--- a/test/integration/babel/.babelrc
+++ b/test/integration/babel/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [["env", {
+    "targets": {
+      "browsers": ["last 2 Chrome versions"]
+    }
+  }]]
+}

--- a/test/integration/babel/.eslintrc.json
+++ b/test/integration/babel/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/test/integration/babel/foo.js
+++ b/test/integration/babel/foo.js
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/test/integration/babel/index.js
+++ b/test/integration/babel/index.js
@@ -1,0 +1,4 @@
+import Foo from './foo';
+
+export {Foo};
+export class Bar {}


### PR DESCRIPTION
Closes #297. Fixes #66.

This PR does three things:

1. Adds config files as dependencies. This means that they are automatically watched, so for example if you change your `.babelrc`, Parcel will immediately recompile all files that depend on it. Also, if you restart Parcel after making changes, those files will also be recompiled (since #514).
2. Adds a `cacheData` object to assets, and a `shouldInvalidate` method which accepts a cacheData object to compare. If it returns false, the asset is re-generated. JSAsset uses this to implement environment variable cache invalidation. If your JS file has `process.env.MY_ENV`, and you change `MY_ENV` to a new value, the cache will be invalidated.
3. Fixes an issue where assets that have multiple parents that include them weren't recompiled on change. For example, if you had a stylus file that was @imported by several parents, only one of them would get recompiled when that file changed. This also affected .babelrc and other config changes, etc.