### PR TITLE
Do not use window global in HMR runtime

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -15,7 +15,7 @@ function Module() {
 module.bundle.Module = Module;
 
 if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
-  var ws = new WebSocket('ws://' + window.location.hostname + ':{{HMR_PORT}}/');
+  var ws = new WebSocket('ws://' + location.hostname + ':{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);
 
@@ -34,7 +34,7 @@ if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
     if (data.type === 'reload') {
       ws.close();
       ws.onclose = function () {
-        window.location.reload();
+        location.reload();
       }
     }
 


### PR DESCRIPTION
The name of the global object may differ based on the context in which the
script is running. For example, web workers use "self" instead of "window". As
location is a property of the global, it can be referenced directly as a global
variable, which avoids having to deal with this naming inconsistency.

Fixes #528