### PR TITLE
Generate DOT graphs

### DIFF
--- a/test/encodedURI.js
+++ b/test/encodedURI.js
@@ -21,7 +21,7 @@ describe('encodedURI', function() {
     let files = fs.readdirSync(__dirname + '/dist');
     let html = fs.readFileSync(__dirname + '/dist/index.html');
     for (let file of files) {
-      if (file !== 'index.html') {
+      if (file !== 'index.html' && file !== 'index.dot') {
         assert(html.includes(file));
       }
     }

--- a/test/html.js
+++ b/test/html.js
@@ -42,7 +42,7 @@ describe('html', function() {
     let files = fs.readdirSync(__dirname + '/dist');
     let html = fs.readFileSync(__dirname + '/dist/index.html');
     for (let file of files) {
-      if (file !== 'index.html') {
+      if (file !== 'index.html' && file !== 'index.dot') {
         assert(html.includes(file));
       }
     }


### PR DESCRIPTION
When running e.g. `parcel index.html`, Parcel now generates `dist/index.dot` in addition to `dist/index.html`.

You can then use `dot` or http://www.webgraphviz.com/ to render the graph.

test/dist/index.dot
```
digraph assets {
  "test/\ninput/\nindex.js" -> "test/\ninput/\nfoo.js" [label="./\nfoo"]
}
```

Copy-paste into webraphviz.com:

![image](https://user-images.githubusercontent.com/59632/34779275-586b42f8-f5e5-11e7-8b78-371a80a771e4.png)
