### PR TITLE
Fix circular bundles, and never hoist the entry asset

### DIFF
--- a/test/html.js
+++ b/test/html.js
@@ -299,4 +299,36 @@ describe('html', function() {
       ]
     });
   });
+
+  it('should support circular dependencies', async function() {
+    let b = await bundle(__dirname + '/integration/circular/index.html');
+
+    assertBundleTree(b, {
+      name: 'index.html',
+      assets: ['index.html'],
+      childBundles: [
+        {
+          type: 'html',
+          assets: ['about.html'],
+          childBundles: [
+            {
+              type: 'js',
+              assets: ['about.js', 'index.js'],
+              childBundles: []
+            },
+            {
+              type: 'html',
+              assets: ['test.html'],
+              childBundles: []
+            }
+          ]
+        },
+        {
+          type: 'js',
+          assets: ['about.js', 'index.js'],
+          childBundles: []
+        }
+      ]
+    });
+  });
 });

--- a/test/integration/circular/.eslintrc.json
+++ b/test/integration/circular/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/test/integration/circular/about.html
+++ b/test/integration/circular/about.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+  <script src="./about.js"></script>
+</head>
+<body>
+  On About
+
+  <a href="./index.html">Home</a>
+  <a href="./about.html">About</a>
+  <a href="./test.html">Test</a>
+
+</body>
+</html>

--- a/test/integration/circular/about.js
+++ b/test/integration/circular/about.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-unused-vars
+import index from './index';

--- a/test/integration/circular/index.html
+++ b/test/integration/circular/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+  <script src="./index.js"></script>
+</head>
+<body>
+  On Home
+
+  <a href="./index.html">Home</a>
+  <a href="./about.html">About</a>
+  <a href="./test.html">Test</a>
+
+</body>
+</html>

--- a/test/integration/circular/index.js
+++ b/test/integration/circular/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-unused-vars
+import about from './about';

--- a/test/integration/circular/test.html
+++ b/test/integration/circular/test.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Document</title>
+</head>
+<body>
+  Test
+
+  <a href="./index.html">Home</a>
+  <a href="./about.html">About</a>
+  <a href="./test.html">Test</a>
+
+</body>
+</html>


### PR DESCRIPTION
Slightly simpler, more generic version of #489.

There were two issues:

1. Infinite recursion on circular bundles. This is solved by tracking the current bundle stack.
2. HTML files getting merged into one bundle. This was because Parcel tried to hoist the common dependencies. However, this should never be done for the entry asset of a bundle since those assets were explicitly requested to be placed in a separate bundle (deps marked as `dynamic`).

Added test covers both cases. cc. @shawwn @ipmb 