### PR TITLE
Add out-file option to set the output file name

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -174,9 +174,11 @@ class Asset {
 
     // If this asset is main file of the package, use the sanitized package name
     if (this.name === main) {
-      const packageName = sanitizeFilename(this.package.name, {
-        replacement: '-'
-      });
+      const packageName =
+        this.options.outFile ||
+        sanitizeFilename(this.package.name, {
+          replacement: '-'
+        });
       return packageName + ext;
     }
 

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -67,6 +67,7 @@ class Bundler extends EventEmitter {
     const watch =
       typeof options.watch === 'boolean' ? options.watch : !isProduction;
     return {
+      outFile: options.outFile || '',
       outDir: Path.resolve(options.outDir || 'dist'),
       publicURL: publicURL,
       watch: watch,

--- a/src/cli.js
+++ b/src/cli.js
@@ -29,6 +29,10 @@ program
     'set the output directory. defaults to "dist"'
   )
   .option(
+    '-f, --out-file <filename>',
+    'set the output filename. defaults to the package.json "name"'
+  )
+  .option(
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
   )
@@ -45,6 +49,10 @@ program
     'set the output directory. defaults to "dist"'
   )
   .option(
+    '-f, --out-file <filename>',
+    'set the output filename. defaults to the package.json "name"'
+  )
+  .option(
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
   )
@@ -58,6 +66,10 @@ program
   .option(
     '-d, --out-dir <path>',
     'set the output directory. defaults to "dist"'
+  )
+  .option(
+    '-f, --out-file <filename>',
+    'set the output filename. defaults to the package.json "name"'
   )
   .option(
     '--public-url <url>',


### PR DESCRIPTION
Add out-file option to set the output file name

If one is not set, default to current behavior (sanitized version of package name).

In a project I'm working on, we require the output files to have a specific name, and changing the package.json name is a less desirable solution vs expanding the API to accommodate.

I couldn't find any tests that reference `outDir` to copy to test this option, so I did not include any tests. I'm not familiar enough with the project or Mocha to greenfield it.