### PR TITLE
Add missing description property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "parcel-bundler",
   "version": "1.4.1",
+  "description": "Blazing fast, zero configuration web application bundler",
   "main": "index.js",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- "description" property is missing in package.json
- because of that the result of search in https://www.npmjs.com/ looks ugly

<img width="1010" alt="2018-01-19 15 28 06" src="https://user-images.githubusercontent.com/613956/35137918-302db2d4-fd2f-11e7-9a4b-dbee123de622.png">

This PR solves the above problem.