### PR TITLE
[WIP/RFC] Warn when a fs call cannot be evaluated

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -44,12 +44,16 @@ class Logger {
     this.write(this.chalk.bold(message), true);
   }
 
-  warn(message) {
+  warn(err) {
     if (this.logLevel < 2) {
       return;
     }
 
+    let {message, stack} = prettyError(err, {color: this.color});
     this.write(this.chalk.yellow(`${emoji.warning}  ${message}`));
+    if (stack) {
+      this.write(stack);
+    }
   }
 
   error(err) {

--- a/test/fs.js
+++ b/test/fs.js
@@ -76,6 +76,41 @@ describe('fs', function() {
       assert.equal(typeof output.test, 'function');
       assert.equal(output.test(), 'test-pkg-ignore-fs-ok');
     });
+
+    // TODO: check if the logger has warned the user
+    it('should ignore fs calls when the filename is not evaluable', async function() {
+      let b = await bundle(
+        __dirname + '/integration/fs-file-non-evaluable/index.js'
+      );
+      let thrown = false;
+
+      try {
+        run(b);
+      } catch (e) {
+        assert.equal(e.message, 'require(...).readFileSync is not a function');
+
+        thrown = true;
+      }
+
+      assert.equal(thrown, true);
+    });
+
+    it('should ignore fs calls when the options are not evaluable', async function() {
+      let b = await bundle(
+        __dirname + '/integration/fs-options-non-evaluable/index.js'
+      );
+      let thrown = false;
+
+      try {
+        run(b);
+      } catch (e) {
+        assert.equal(e.message, 'require(...).readFileSync is not a function');
+
+        thrown = true;
+      }
+
+      assert.equal(thrown, true);
+    });
   });
 
   describe('--target=node', function() {
@@ -126,40 +161,5 @@ describe('fs', function() {
       let output = run(b);
       assert.equal(output, 'hey');
     });
-  });
-
-  // TODO: check if the logger has warned the user
-  it('should ignore fs calls when the filename is not evaluable', async function() {
-    let b = await bundle(
-      __dirname + '/integration/fs-file-non-evaluable/index.js'
-    );
-    let thrown = false;
-
-    try {
-      run(b);
-    } catch (e) {
-      assert.equal(e.message, 'require(...).readFileSync is not a function');
-
-      thrown = true;
-    }
-
-    assert.equal(thrown, true);
-  });
-
-  it('should ignore fs calls when the options are not evaluable', async function() {
-    let b = await bundle(
-      __dirname + '/integration/fs-options-non-evaluable/index.js'
-    );
-    let thrown = false;
-
-    try {
-      run(b);
-    } catch (e) {
-      assert.equal(e.message, 'require(...).readFileSync is not a function');
-
-      thrown = true;
-    }
-
-    assert.equal(thrown, true);
   });
 });

--- a/test/fs.js
+++ b/test/fs.js
@@ -127,4 +127,39 @@ describe('fs', function() {
       assert.equal(output, 'hey');
     });
   });
+
+  // TODO: check if the logger has warned the user
+  it('should ignore fs calls when the filename is not evaluable', async function() {
+    let b = await bundle(
+      __dirname + '/integration/fs-file-non-evaluable/index.js'
+    );
+    let thrown = false;
+
+    try {
+      run(b);
+    } catch (e) {
+      assert.equal(e.message, 'require(...).readFileSync is not a function');
+
+      thrown = true;
+    }
+
+    assert.equal(thrown, true);
+  });
+
+  it('should ignore fs calls when the options are not evaluable', async function() {
+    let b = await bundle(
+      __dirname + '/integration/fs-options-non-evaluable/index.js'
+    );
+    let thrown = false;
+
+    try {
+      run(b);
+    } catch (e) {
+      assert.equal(e.message, 'require(...).readFileSync is not a function');
+
+      thrown = true;
+    }
+
+    assert.equal(thrown, true);
+  });
 });

--- a/test/integration/fs-file-non-evaluable/index.js
+++ b/test/integration/fs-file-non-evaluable/index.js
@@ -1,0 +1,1 @@
+module.exports = require('fs').readFileSync(Date.now())

--- a/test/integration/fs-options-non-evaluable/index.js
+++ b/test/integration/fs-options-non-evaluable/index.js
@@ -1,0 +1,5 @@
+const dir = __dirname
+
+module.exports = require('fs').readFileSync(dir + '/test.txt', {
+  encoding: (typeof Date.now()).replace(/number/, 'utf-8')
+})


### PR DESCRIPTION
![screen shot 2018-01-19 at 16 42 09](https://user-images.githubusercontent.com/5746414/35158566-be68b758-fd37-11e7-9a48-7e2a11c14971.png)


This PR will warn instead of throwing when a `fs` call cannot be evaluated.

Remarks :
- I added a commit to create a logger singleton, we might want to wait for #462 to land first and then remove the commit.
- It warns using a code frame, maybe it's too much, waiting for your feedback for that
- The warning will not be propagated to the browser console
- If the call cannot be evaluated then the `fs` module will be required as an empty module (`Uncaught TypeError: fs.readFileSync is not a function` on the runtime)
- See the `nodeNotEvaluated` var in `fs.js`, I don't know if it's elegant
- Should we handle the case where the filename is not a string? (eg. `readFileSync({notAString: true})`)

TODO:
- [x] warn
- [x] add a sweet emoji right before the start of the warning (#588)
- [x] add tests
- [x] needs #462 for the logger
