### PR TITLE
Use PARCEL_WORKERS environment variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,12 @@ yarn test
 [node]: https://nodejs.org/
 [yarn]: https://yarnpkg.com/
 
+## Environment variables
+
+You can set `PARCEL_WORKERS` to the number of worker processes to spawn.
+
+`PARCEL_WORKERS=0` is handy for debugging, because that will cause all code to be run on the main thread. This allows you to place breakpoints in Asset code, for example.
+
 ## Financial contributions
 
 We also welcome financial contributions in full transparency on our [open collective](https://opencollective.com/parcel).

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -45,7 +45,9 @@ class WorkerFarm extends Farm {
     }
 
     await Promise.all(promises);
-    this.started = true;
+    if (this.options.maxConcurrentWorkers > 0) {
+      this.started = true;
+    }
   }
 
   receive(data) {
@@ -97,6 +99,9 @@ for (let key in EventEmitter.prototype) {
 }
 
 function getNumWorkers() {
+  if (process.env.PARCEL_WORKERS) {
+    return parseInt(process.env.PARCEL_WORKERS);
+  }
   let cores;
   try {
     cores = require('physical-cpu-count');

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -100,8 +100,9 @@ for (let key in EventEmitter.prototype) {
 
 function getNumWorkers() {
   if (process.env.PARCEL_WORKERS) {
-    return parseInt(process.env.PARCEL_WORKERS);
+    return parseInt(process.env.PARCEL_WORKERS, 10);
   }
+
   let cores;
   try {
     cores = require('physical-cpu-count');


### PR DESCRIPTION
Per the slack convo, `PARCEL_WORKERS` environment variable controls how many workers to spawn, and `PARCEL_WORKERS=0` makes all code run on the main thread.

`PARCEL_WORKERS=0 yarn test` runs about 33% faster.