### PR TITLE
Fix for ipc closed error in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tomlify-j0.4": "^3.0.0",
     "uglify-es": "^3.2.1",
     "v8-compile-cache": "^1.1.0",
-    "worker-farm": "^1.4.1",
+    "worker-farm": "^1.5.2",
     "ws": "^3.3.3"
   },
   "devDependencies": {

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -51,6 +51,12 @@ class WorkerFarm extends Farm {
   }
 
   receive(data) {
+    if (!this.children[data.child]) {
+      // This handles premature death
+      // normally only accurs for workers
+      // that are still warming up when killed
+      return;
+    }
     if (data.event) {
       this.emit(data.event, ...data.args);
     } else {
@@ -79,7 +85,12 @@ class WorkerFarm extends Farm {
   }
 
   end() {
-    super.end();
+    this.ending = true;
+    Object.keys(this.children).forEach(
+      function(child) {
+        this.stopChild(child);
+      }.bind(this)
+    );
     shared = null;
   }
 

--- a/src/WorkerFarm.js
+++ b/src/WorkerFarm.js
@@ -57,6 +57,7 @@ class WorkerFarm extends Farm {
       // that are still warming up when killed
       return;
     }
+
     if (data.event) {
       this.emit(data.event, ...data.args);
     } else {
@@ -85,12 +86,13 @@ class WorkerFarm extends Farm {
   }
 
   end() {
+    // Force kill all children
     this.ending = true;
-    Object.keys(this.children).forEach(
-      function(child) {
-        this.stopChild(child);
-      }.bind(this)
-    );
+    for (let child in this.children) {
+      this.stopChild(child);
+    }
+
+    this.ending = false;
     shared = null;
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -34,3 +34,10 @@ exports.run = async function(path, pkg, options, isWarmUp, callback) {
     callback(returned);
   }
 };
+
+process.on('unhandledRejection', function(err) {
+  // ERR_IPC_CHANNEL_CLOSED happens when the worker is killed before it finishes processing
+  if (err.code !== 'ERR_IPC_CHANNEL_CLOSED') {
+    console.error('Unhandled promise rejection:', err.stack);
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5753,7 +5753,7 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@^1.4.1:
+worker-farm@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.2.tgz#32b312e5dc3d5d45d79ef44acc2587491cd729ae"
   dependencies:


### PR DESCRIPTION
In the tests there sometimes accurs an ipc closed while sending data error, this is due to the main thread being killed before the children died.
This should force-kill the children, preventing this from happening. Another solution is awaiting the super.end using a promise or callback but this caused many tests to fail and in theory this fix would be just as solid and will not wait for unused data to be received.