### PR TITLE
Improve Windows emoji support detection

### DIFF
--- a/src/utils/emoji.js
+++ b/src/utils/emoji.js
@@ -1,4 +1,5 @@
-const supportsEmoji = process.platform !== 'win32' || process.env.VSCODE_PID;
+const supportsEmoji =
+  process.platform !== 'win32' || process.env.TERM === 'xterm-256color';
 
 // Fallback symbols for Windows from https://en.wikipedia.org/wiki/Code_page_437
 exports.progress = supportsEmoji ? '⏳' : '∞';


### PR DESCRIPTION
I've started using [Hyper](https://hyper.is/) on Windows, which supports emoji. This PR enhances the support check to detect `xterm-256color` to enable emoji's for all platforms using [xterm.js](https://github.com/xtermjs/xterm.js) instead of just VS Code (which uses xterm.js).

Hyper:

![image](https://user-images.githubusercontent.com/4730164/35199950-d89a0eae-fed3-11e7-876a-583e7fb856d2.png)


VS Code:

![image](https://user-images.githubusercontent.com/4730164/35199964-f4fb8b7c-fed3-11e7-99fe-f26367229374.png)
