### PR TITLE
minimal svg sprite support

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -20,7 +20,8 @@ const ATTRS = {
     'embed'
   ],
   href: ['link', 'a'],
-  poster: ['video']
+  poster: ['video'],
+  'xlink:href': ['use']
 };
 
 class HTMLAsset extends Asset {

--- a/test/html.js
+++ b/test/html.js
@@ -11,6 +11,11 @@ describe('html', function() {
       assets: ['index.html'],
       childBundles: [
         {
+          type: 'svg',
+          assets: ['icons.svg'],
+          childBundles: []
+        },
+        {
           type: 'css',
           assets: ['index.css'],
           childBundles: []

--- a/test/integration/html/icons.svg
+++ b/test/integration/html/icons.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <symbol viewBox="0 0 14 16" id="icon-code" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></symbol>
+  <symbol viewBox="0 0 12 16" id="icon-gist" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M7.5 5L10 7.5 7.5 10l-.75-.75L8.5 7.5 6.75 5.75 7.5 5zm-3 0L2 7.5 4.5 10l.75-.75L3.5 7.5l1.75-1.75L4.5 5zM0 13V2c0-.55.45-1 1-1h10c.55 0 1 .45 1 1v11c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1zm1 0h10V2H1v11z"/></symbol>
+</svg>

--- a/test/integration/html/index.html
+++ b/test/integration/html/index.html
@@ -12,5 +12,6 @@
   <script src="index.js"></script>
   <script src="https://unpkg.com/parcel-bundler"></script>
   <i>hello</i> <i>world</i>
+  <svg><use xlink:href="icons.svg#icon-repo-pull"></use></svg>
 </body>
 </html>


### PR DESCRIPTION
Hello! I'm looking for feedback on adding some basic support for svg sprites to parcel... Here's an example:

Assuming there's a svg sprite sheet named `icons.svg`, it would be nice if HTMLAsset added url dependencies when it encountered these types of references:

```html
...
<body>
  ...
  <svg>
    <use xlink:href="icons.svg#icon-repo-pull"></use>
  </svg>
  ...
</body>
...
```

For this to work the url's hash needs to be preserved. This got me thinking- should HTMLAsset preserve each url dependency's search and hash components in all cases? For example, bundling html with `<a href="test.html?foo=bar#baz">test</a>` results in `<a href="/dist/eb3da15aa2712be35d36a6920165de75.html">test</a>` which seems like a bug/missing feature.

Thoughts?