### PR TITLE
Discourage global parcel install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@
 1. Install with yarn:
 
 ```shell
-yarn global add parcel-bundler
+yarn add parcel-bundler
 ```
 
 or with npm:
 
 ```shell
-npm install -g parcel-bundler
+npm install parcel-bundler --save
 ```
 
 2. Parcel can take any type of file as an entry point, but an HTML or JavaScript file is a good place to start. If you link your main JavaScript file in the HTML using a relative path, Parcel will also process it for you, and replace the reference with a URL to the output file.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@
 1. Install with yarn:
 
 ```shell
-yarn add parcel-bundler
+yarn add parcel-bundler -D
 ```
 
 or with npm:
 
 ```shell
-npm install parcel-bundler --save
+npm install parcel-bundler -D
 ```
 
 2. Parcel can take any type of file as an entry point, but an HTML or JavaScript file is a good place to start. If you link your main JavaScript file in the HTML using a relative path, Parcel will also process it for you, and replace the reference with a URL to the output file.


### PR DESCRIPTION
As global installing of parcel brings some unwanted issues and generally is a bad practise (in most cases) it should probably not be encouraged, this PR changes the commands into local installs.