### PR TITLE
Auto-install peerDependencies 

### DIFF
--- a/src/utils/localRequire.js
+++ b/src/utils/localRequire.js
@@ -13,7 +13,7 @@ async function localRequire(name, path, triedInstall = false) {
       resolved = resolve.sync(name, {basedir});
     } catch (e) {
       if (e.code === 'MODULE_NOT_FOUND' && !triedInstall) {
-        await install(path, name);
+        await install(path, [name]);
         return localRequire(name, path, true);
       }
       throw e;

--- a/test/css.js
+++ b/test/css.js
@@ -200,6 +200,9 @@ describe('css', function() {
     let package = require('./input/package.json');
     assert(package.devDependencies['postcss-cssnext']);
 
+    // peer dependency caniuse-lite was installed
+    assert(package.devDependencies['caniuse-lite']);
+
     // cssnext is applied
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
     assert(css.includes('rgba'));
@@ -216,6 +219,9 @@ describe('css', function() {
     // cssnext was installed
     let package = require('./input/package.json');
     assert(package.devDependencies['postcss-cssnext']);
+
+    // peer dependency caniuse-lite was installed
+    assert(package.devDependencies['caniuse-lite']);
 
     // appveyor is not currently writing to the yarn.lock file and will require further investigation
     // let lockfile = fs.readFileSync(__dirname + '/input/yarn.lock', 'utf8');


### PR DESCRIPTION
`peerDependencies` are now installed automatically when `installPackage` is run. Only direct-peers are currently installed (e.g. peers of peers are ignored).

Fortunately, the `postcss-cssnext` tests could be tapped into to verify the peer functionality without adding more installation tests... which are slow. 

Independently verified the `graphql-tag` `graphql` use-case as well by running the integration test scenario ([here](https://github.com/parcel-bundler/parcel/tree/master/test/integration/graphql)) with a package.json. Both install as expected! 

---
Closes #419 