### PR TITLE
Add --use-polling option.

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -85,7 +85,9 @@ class Bundler extends EventEmitter {
         typeof options.sourceMaps === 'boolean'
           ? options.sourceMaps
           : !isProduction,
-      hmrHostname: options.hmrHostname || ''
+      hmrHostname: options.hmrHostname || '',
+      usePolling:
+        typeof options.usePolling === 'boolean' ? options.usePolling : false
     };
   }
 
@@ -238,8 +240,10 @@ class Bundler extends EventEmitter {
     if (this.options.watch) {
       // FS events on macOS are flakey in the tests, which write lots of files very quickly
       // See https://github.com/paulmillr/chokidar/issues/612
+      const usePolling =
+        this.options.usePolling || process.env.NODE_ENV === 'test';
       this.watcher = new FSWatcher({
-        useFsEvents: process.env.NODE_ENV !== 'test'
+        usePolling: usePolling
       });
 
       this.watcher.on('change', this.onChange.bind(this));

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,10 @@ program
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
   )
+  .option(
+    '--use-polling',
+    'poll instead of using fs events. needed for networked filesystems'
+  )
   .option('--no-hmr', 'disable hot module replacement')
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
@@ -48,6 +52,10 @@ program
   .option(
     '--public-url <url>',
     'set the public URL to serve on. defaults to the same as the --out-dir option'
+  )
+  .option(
+    '--use-polling',
+    'poll instead of using fs events. needed for networked filesystems'
   )
   .option('--no-hmr', 'disable hot module replacement')
   .option('--no-cache', 'disable the filesystem cache')


### PR DESCRIPTION
I know there's a good chance this will not get accepted, because it adds a new configuration option, but I figured I'd propose it anyways.

There really doesn't seem to be a good, reasonably portable way to detect that filesystem events will be unreliable. You could do it for a specific platform and mostly be right, but having an override seems like the way to go here.

Related to #564, but without option to set the interval.