### PR TITLE
fix `super` error when node version <8 #648

### DIFF
--- a/src/packagers/SourceMapPackager.js
+++ b/src/packagers/SourceMapPackager.js
@@ -17,7 +17,10 @@ class SourceMapPackager extends Packager {
   async end() {
     let file = path.basename(this.bundle.name);
     await this.dest.write(this.sourceMap.stringify(file));
-    await super.end();
+    this.stopend();
+  }
+  stopend(){
+    return super.end();
   }
 }
 


### PR DESCRIPTION
when  the build ,we will get two source folder.lib and src.
index.js will help us to choose the work folder.
the babel setting.target with 6.
then,will get some problem in the CoffeeScriptAsset/ReasonAsset/TypeScriptAsset.
 I found the problem the key in the babel converted code, when async/await transform, after await such as
```
await super.end ()
Will become
return _asyncToGenerator (function * () {
     yield super.end ()
})
```
This is not legal
To my surprise, the typescriptAsset coffescriptAsset in assets is always the same.
Probably a minority is using a node version less than eight

I think this is why parcel does not fully support the low version.
In the past, if you do not apply the corresponding asset extension error will not exist, but at this time if you do not make this change, then the lower version will no longer be used, then babel transform will be no meaning in parcel.

Either support better or not.
I think so

this edit is a demo show, we have many ways to make that problem resolved.~~

sorry my bad english.