### PR TITLE
Fix rust projects with hyphenated names

### DIFF
--- a/src/assets/RustAsset.js
+++ b/src/assets/RustAsset.js
@@ -153,7 +153,8 @@ class RustAsset extends Asset {
 
     // Get output file paths
     let outDir = path.join(cargoDir, 'target', RUST_TARGET, 'release');
-    let rustName = cargoConfig.package.name;
+    // Rust converts '-' to '_' when outputting files.
+    let rustName = cargoConfig.package.name.replace('-', '_');
     this.wasmPath = path.join(outDir, rustName + '.wasm');
     this.depsPath = path.join(outDir, rustName + '.d');
   }

--- a/src/assets/RustAsset.js
+++ b/src/assets/RustAsset.js
@@ -153,8 +153,9 @@ class RustAsset extends Asset {
 
     // Get output file paths
     let outDir = path.join(cargoDir, 'target', RUST_TARGET, 'release');
+
     // Rust converts '-' to '_' when outputting files.
-    let rustName = cargoConfig.package.name.replace('-', '_');
+    let rustName = cargoConfig.package.name.replace(/-/g, '_');
     this.wasmPath = path.join(outDir, rustName + '.wasm');
     this.depsPath = path.join(outDir, rustName + '.d');
   }

--- a/test/integration/rust-cargo/Cargo.toml
+++ b/test/integration/rust-cargo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo"
+name = "cargo-test"
 version = "0.1.0"
 authors = ["josealbizures <albizures3601@gmail.com>"]
 


### PR DESCRIPTION
Currently, parcel will not successfully bundle rust code if the cargo project name has a hyphen in it. This PR fixes this bug.

In Rust, hyphens in project names are converted to underscores both in code and in output file names.