### PR TITLE
Add 'id' to the module variable

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -1,7 +1,7 @@
 var global = (1, eval)('this');
 var OldModule = module.bundle.Module;
-function Module() {
-  OldModule.call(this);
+function Module(moduleName) {
+  OldModule.call(this, moduleName);
   this.hot = {
     accept: function (fn) {
       this._acceptCallback = fn || function () {};

--- a/src/builtins/prelude.js
+++ b/src/builtins/prelude.js
@@ -37,7 +37,7 @@ require = (function (modules, cache, entry) {
       
       localRequire.resolve = resolve;
 
-      var module = cache[name] = new newRequire.Module;
+      var module = cache[name] = new newRequire.Module(name);
 
       modules[name][0].call(module.exports, localRequire, module, module.exports);
     }
@@ -53,7 +53,8 @@ require = (function (modules, cache, entry) {
     }
   }
 
-  function Module() {
+  function Module(moduleName) {
+    this.id = moduleName;
     this.bundle = newRequire;
     this.exports = {};
   }

--- a/test/hmr.js
+++ b/test/hmr.js
@@ -180,8 +180,12 @@ describe('hmr', function() {
     b = bundler(__dirname + '/input/index.js', {watch: true, hmr: true});
     let bundle = await b.bundle();
     let outputs = [];
+    let moduleId = '';
 
     run(bundle, {
+      reportModuleId(id) {
+        moduleId = id;
+      },
       output(o) {
         outputs.push(o);
       }
@@ -195,7 +199,13 @@ describe('hmr', function() {
     );
 
     await nextEvent(b, 'bundled');
-    assert.deepEqual(outputs, [3, 'dispose', 10, 'accept']);
+    assert.notEqual(moduleId, undefined);
+    assert.deepEqual(outputs, [
+      3,
+      'dispose-' + moduleId,
+      10,
+      'accept-' + moduleId
+    ]);
   });
 
   it('should work across bundles', async function() {

--- a/test/integration/hmr-callbacks/index.js
+++ b/test/integration/hmr-callbacks/index.js
@@ -6,10 +6,13 @@ function run() {
 
 run();
 
+// eslint-disable-next-line no-undef
+reportModuleId(module.id);
+
 module.hot.dispose(function () {
-  output('dispose');
+  output('dispose-' + module.id);
 });
 
 module.hot.accept(function () {
-  output('accept');
+  output('accept-' + module.id);
 });


### PR DESCRIPTION
Just letting `module.id` to exists.

Partially fixes #619.
Making parcel compatible with React-hot-loader v4 (https://github.com/gaearon/react-hot-loader/pull/818)