### PR TITLE
Remove `-h` alias for `hmr-port` option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -14,7 +14,7 @@ program
     parseInt
   )
   .option(
-    '-h, --hmr-port <port>',
+    '--hmr-port <port>',
     'set the port to serve HMR websockets, defaults to random',
     parseInt
   )


### PR DESCRIPTION
The alias was clashing with the alias for `help`.

<hr />
Closes #655.