### PR TITLE
Safe cssnano transforms by default

### DIFF
--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -51,7 +51,15 @@ async function getConfig(asset) {
 
   if (asset.options.minify) {
     config.plugins.push(
-      cssnano((await asset.getConfig(['cssnano.config.js'])) || {})
+      cssnano(
+        (await asset.getConfig(['cssnano.config.js'])) || {
+          // Only enable safe css transforms by default.
+          // See: https://github.com/parcel-bundler/parcel/issues/698
+          // Note: Remove when upgrading cssnano to v4
+          // See: https://github.com/ben-eb/cssnano/releases/tag/v4.0.0-rc.0
+          safe: true
+        }
+      )
     );
   }
 


### PR DESCRIPTION
Pass `{safe: true}` to cssnano by default, to avoid the dangers of the advanced transforms that it would enable by default in cssnano@3.x

Adds a test (well co-opts an existing test) to ensure that @font-face files make it through to the final css bundle when `{ production: true }`

Once cssnano v4 is finally released as stable, the default options can be removed, as cssnano 4 will default to safe transforms only.

Fix #698 