### PR TITLE
Support all Bundler options

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "uglify-es": "^3.2.1",
     "v8-compile-cache": "^1.1.0",
     "worker-farm": "^1.5.2",
-    "ws": "^3.3.3"
+    "ws": "^3.3.3",
+    "yargs-parser": "^9.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,11 +2,13 @@ require('v8-compile-cache');
 const chalk = require('chalk');
 const program = require('commander');
 const version = require('../package.json').version;
+const argv = require('yargs-parser')(process.argv.slice(2));
 
 program.version(version);
 
 program
   .command('serve [input]')
+  .allowUnknownOption()
   .description('starts a development server')
   .option(
     '-p, --port <port>',
@@ -40,6 +42,7 @@ program
 
 program
   .command('watch [input]')
+  .allowUnknownOption()
   .description('starts the bundler in watch mode')
   .option(
     '-d, --out-dir <path>',
@@ -56,6 +59,7 @@ program
 
 program
   .command('build [input]')
+  .allowUnknownOption()
   .description('bundles for production')
   .option(
     '-d, --out-dir <path>',
@@ -71,6 +75,7 @@ program
 
 program
   .command('help [command]')
+  .allowUnknownOption()
   .description('display help information for a command')
   .action(function(command) {
     let cmd = program.commands.find(c => c.name() === command) || program;
@@ -105,7 +110,8 @@ async function bundle(main, command) {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   }
 
-  const bundler = new Bundler(main, command);
+  const options = Object.assign({}, argv, command);
+  const bundler = new Bundler(main, options);
 
   if (command.name() === 'serve') {
     const server = await bundler.serve(command.port || 1234, command.https);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5817,6 +5817,12 @@ yargs-parser@^8.0.0, yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.0.3:
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.1.tgz#5fe1ea306985a099b33492001fa19a1e61efe285"


### PR DESCRIPTION
The intent here is to support _all_ Bundler options ([here](https://github.com/parcel-bundler/parcel/blob/master/src/Bundler.js#L61-L91)) via the CLI without the need for adding a new explicit CLI flag to commander every time. The CLI interface is becoming crowded, often to handle edge cases. This change would automatically expose any new options as well. Ideally, this functionality would be added to documentation noting that "any Bundler option is supported" via the CLI. 

This would close #709. The following has been tested:

```shell
parcel .\index.html --cache-dir ".demo"
```

Pros:
- Support "all" options
- Support new options automatically 
- Keep CLI "interface" minimal for 99% use-case

Cons:
- Undocumented (via parcel help) functionality 

