### PR TITLE
Add babel-template and babel-types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "babel-core": "^6.25.0",
     "babel-generator": "^6.25.0",
+    "babel-template": "^6.25.0",
+    "babel-types": "^6.25.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babylon": "^6.17.4",
     "babylon-walk": "^1.0.2",


### PR DESCRIPTION
Fixes #561 -- Parcel doesn't properly build on my Windows 10 machine without this.