### PR TITLE
[RFC] Support custom TypeScript transformers

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -93,9 +93,11 @@ class Asset {
     return URL.format(parsed);
   }
 
-  async getConfig(filenames) {
-    // Resolve the config file
-    let conf = await config.resolve(this.name, filenames);
+  getConfigPath(filenames) {
+    return config.resolve(this.name, filenames);
+  }
+
+  async loadConfig(conf, filenames) {
     if (conf) {
       // Add as a dependency so it is added to the watcher and invalidates
       // this asset when the config changes.
@@ -104,6 +106,12 @@ class Asset {
     }
 
     return null;
+  }
+  async getConfig(filenames) {
+    // Resolve the config file
+    let conf = await this.getConfigPath(filenames);
+
+    return this.loadConfig(conf, filenames);
   }
 
   mightHaveDependencies() {

--- a/test/integration/typescript-transformers/custom-transformer.js
+++ b/test/integration/typescript-transformers/custom-transformer.js
@@ -1,0 +1,17 @@
+const ts = require('typescript')
+
+module.exports =
+  () => ({
+    before: [
+      context =>
+        source =>
+          ts.visitNode(source, function visit(node) {
+            if(ts.isStringLiteral(node)) {
+              return ts.createLiteral(node.text.replace(/failed/, 'passed'))
+            }
+
+            return ts.visitEachChild(node, visit, context)
+          }
+        )
+    ]
+  })

--- a/test/integration/typescript-transformers/index.ts
+++ b/test/integration/typescript-transformers/index.ts
@@ -1,0 +1,4 @@
+
+export = {
+  test: () => 'the typescript transformer test failed'
+}

--- a/test/integration/typescript-transformers/tsconfig.json
+++ b/test/integration/typescript-transformers/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "parcel": {
+    "transformers": "./custom-transformer.js"
+  }
+}

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -99,4 +99,24 @@ describe('typescript', function() {
     let js = fs.readFileSync(__dirname + '/dist/index.js', 'utf8');
     assert(!js.includes('/* test comment */'));
   });
+
+  it('should support custom transformers', async function() {
+    let b = await bundle(
+      __dirname + '/integration/typescript-transformers/index.ts'
+    );
+
+    assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.ts'],
+      childBundles: [
+        {
+          type: 'map'
+        }
+      ]
+    });
+
+    let output = run(b);
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'the typescript transformer test passed');
+  });
 });


### PR DESCRIPTION
Fixes #699 

**Configuration proposal** :
- A `parcel` field is added to the `tsconfig.json`.
- This field can contain the `transformers` property, the property should be a path relative to the `tsconfig.json` to a Common JS module.
- This module should export a function that returns an object conform to the TypeScript transformer API, it should follow this interface :
```ts
import {SourceFile, TransformerFactory} from 'typescript'

type TransformerModule =
  () => {
    after?: TransformerFactory<SourceFile>[]
    before?: TransformerFactory<SourceFile>[]
  }

```

**Example** : 
`tsconfig.json` :
```json
{
  "parcel": {
    "transformers": "./custom-transformer"
  }
}
```

`custom-transformer.js` :
```js
const {anotherTransformer, coolTransformer} = require('somewhere')

module.exports =
  () => ({
    before: [coolTransformer()],
    after: [anotherTransformer()]
  })

```