### PR TITLE
fix PromiseQueue returning null when there are no jobs

### DIFF
--- a/src/utils/PromiseQueue.js
+++ b/src/utils/PromiseQueue.js
@@ -28,12 +28,14 @@ class PromiseQueue {
       return this.runPromise;
     }
 
-    const runPromise = (this.runPromise = new Promise((resolve, reject) => {
+    const runPromise = new Promise((resolve, reject) => {
       this.resolve = resolve;
       this.reject = reject;
-    }));
+    });
 
+    this.runPromise = runPromise;
     this._next();
+
     return runPromise;
   }
 

--- a/src/utils/PromiseQueue.js
+++ b/src/utils/PromiseQueue.js
@@ -28,13 +28,13 @@ class PromiseQueue {
       return this.runPromise;
     }
 
-    this.runPromise = new Promise((resolve, reject) => {
+    const runPromise = (this.runPromise = new Promise((resolve, reject) => {
       this.resolve = resolve;
       this.reject = reject;
-    });
+    }));
 
     this._next();
-    return this.runPromise;
+    return runPromise;
   }
 
   async _runJob(job, args) {


### PR DESCRIPTION
When PromiseQueue is called with no jobs it returns null instead of a promise that is already resolved with an empty set. This causes "await run()" to evaluate to null, and a "Cannot read property 'Symbol(Symbol.iterator)' of null" error.

Fixes #664