### PR TITLE
Flaky test: Don't expect setTimeout to be exact

### DIFF
--- a/test/watcher.js
+++ b/test/watcher.js
@@ -124,7 +124,7 @@ describe('watcher', function() {
         f => (fs.statSync(__dirname + '/dist/' + f).mtime.getTime() / 1000) | 0
       );
 
-    await sleep(1000); // mtime only has second level precision
+    await sleep(1100); // mtime only has second level precision
     fs.writeFileSync(
       __dirname + '/input/b.js',
       'module.exports = require("./common")'


### PR DESCRIPTION
The build https://ci.appveyor.com/project/devongovett/parcel/build/1.0.821 failed. The most probable reason is that the `sleep(1000)` took little less than one second because `setTimeout` is not precise in any way. To avoid further failure, add a margin of error by sleeping 1.1 seconds.