### PR TITLE
Add support for optional dependencies

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -328,6 +328,10 @@ class Bundler extends EventEmitter {
       let thrown = err;
 
       if (thrown.message.indexOf(`Cannot find module '${dep.name}'`) === 0) {
+        if (dep.optional) {
+          return;
+        }
+
         thrown.message = `Cannot resolve dependency '${dep.name}'`;
 
         // Add absolute path to the error message if the dependency specifies a relative path
@@ -403,7 +407,10 @@ class Bundler extends EventEmitter {
           this.watch(dep.name, asset);
         } else {
           let assetDep = await this.resolveDep(asset, dep);
-          await this.loadAsset(assetDep);
+          if (assetDep) {
+            await this.loadAsset(assetDep);
+          }
+
           return assetDep;
         }
       })

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -87,7 +87,7 @@ class JSAsset extends Asset {
   }
 
   collectDependencies() {
-    this.traverseFast(collectDependencies);
+    walk.ancestor(this.ast, collectDependencies, this);
   }
 
   async pretransform() {

--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -30,7 +30,7 @@ module.exports = {
     asset.isES6Module = true;
   },
 
-  CallExpression(node, asset) {
+  CallExpression(node, asset, ancestors) {
     let {callee, arguments: args} = node;
 
     let isRequire =
@@ -40,7 +40,8 @@ module.exports = {
       types.isStringLiteral(args[0]);
 
     if (isRequire) {
-      addDependency(asset, args[0]);
+      let optional = ancestors.some(a => types.isTryStatement(a)) || undefined;
+      addDependency(asset, args[0], {optional});
       return;
     }
 

--- a/test/integration/optional-dep/index.js
+++ b/test/integration/optional-dep/index.js
@@ -1,0 +1,5 @@
+try {
+  require('optional-dep');
+} catch (err) {
+  module.exports = err;
+}

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -676,4 +676,25 @@ describe('javascript', function() {
     let file = fs.readFileSync(__dirname + '/dist/index.js', 'utf8');
     assert(file.includes('h("div"'));
   });
+
+  it('should support optional dependencies in try...catch blocks', async function() {
+    let b = await bundle(__dirname + '/integration/optional-dep/index.js');
+
+    assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js'],
+      childBundles: [
+        {
+          type: 'map'
+        }
+      ]
+    });
+
+    let output = run(b);
+
+    let err = new Error('Cannot find module "optional-dep"');
+    err.code = 'MODULE_NOT_FOUND';
+
+    assert.deepEqual(output, err);
+  });
 });


### PR DESCRIPTION
Put a `require` call inside a try…catch block, and it becomes optional. If that dependency cannot be resolved, it will throw a runtime error instead of a build time one. Fixes #210.