### PR TITLE
Pass lowerCaseAttributeNames: true to posthtml-parser (fix version bump)

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -67,7 +67,7 @@ class HTMLAsset extends Asset {
   }
 
   parse(code) {
-    let res = parse(code);
+    let res = parse(code, {lowerCaseAttributeNames: true});
     res.walk = api.walk;
     res.match = api.match;
     return res;


### PR DESCRIPTION
Hey 👋 

This PR fixes the failing test ([here](https://github.com/parcel-bundler/parcel/blob/master/test/html.js#L266)) on CI for Node v8. The test is failing consistently after #799 that I think bumped several versions of 3rd-party dependencies by accident. The specific dependency bump that causes the fail is [posthtml-parser](https://github.com/posthtml/posthtml-parser) (from v0.1.3 to v0.4.0).

The only breaking change was [this change](https://github.com/posthtml/posthtml-parser/commit/21450896d5f09d394497c0361882266e7a166f24) that changed the default `lowerCaseAttributeNames` option that is being passed to [htmlparser2](https://github.com/fb55/htmlparser2). This PR passes this option as true to keep previous behavior while still keeping the new versions (should be good if nothing breaks, some dependencies were with 2016 versions).

Please let me know if anything is missing, thanks!