### PR TITLE
Update HMRServer handleSocketError for ErrorEvent

### DIFF
--- a/src/HMRServer.js
+++ b/src/HMRServer.js
@@ -81,11 +81,11 @@ class HMRServer {
   }
 
   handleSocketError(err) {
-    if (err.code === 'ECONNRESET') {
+    if (err.error.code === 'ECONNRESET') {
       // This gets triggered on page refresh, ignore this
       return;
     }
-    logger.log(err);
+    logger.warn(err);
   }
 
   broadcast(msg) {


### PR DESCRIPTION
It looks like `ws` changed the error passed to `onerror` to be an `ErrorEvent` (https://github.com/websockets/ws/pull/1261) in 4.0, which doesn't have `code` at the top-level.

The guard for ECONNRESET was falling through when closing the tab in chrome and throwing an error at the log line since err isn't a string which ends up killing the server.