### PR TITLE
Add server reference to bundler

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -574,10 +574,9 @@ class Bundler extends EventEmitter {
   }
 
   async serve(port = 1234, https = false) {
-    let server = await Server.serve(this, port, https);
-    this.server = server;
+    this.server = await Server.serve(this, port, https);
     this.bundle();
-    return server;
+    return this.server;
   }
 }
 

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -575,6 +575,7 @@ class Bundler extends EventEmitter {
 
   async serve(port = 1234, https = false) {
     let server = await Server.serve(this, port, https);
+    this.server = server;
     this.bundle();
     return server;
   }


### PR DESCRIPTION
I need to get the development server's port number for use in a plugin. Attaching the server to the bundler allows me to call `bundler.server.address().port`. This seems to be the only way to access it since the server's port can vary if the user provided port is already being used.