### PR TITLE
Fix babel handling for node: DEFAULT_ENGINES

### DIFF
--- a/src/utils/getTargetEngines.js
+++ b/src/utils/getTargetEngines.js
@@ -3,7 +3,7 @@ const semver = require('semver');
 
 const DEFAULT_ENGINES = {
   browsers: ['> 1%', 'last 2 versions', 'Firefox ESR'],
-  node: '>= 6'
+  node: '6'
 };
 
 /**


### PR DESCRIPTION
If bundling anything with `--target=node`, the following error will be thrown:

```
🚨  Error: Invalid version passed for target "node": ">= 6.0.0". Versions must be in semver format (major.minor.patch)
    at /home/guilherme/Cubos/zak-api/node_modules/babel-preset-env/lib/index.js:69:13
    at Array.filter (<anonymous>)
    at isPluginRequired (/home/guilherme/Cubos/zak-api/node_modules/babel-preset-env/lib/index.js:59:54)
    at filterItem (/home/guilherme/Cubos/zak-api/node_modules/babel-preset-env/lib/index.js:99:20)
    at Array.filter (<anonymous>)
    at Object.buildPreset [as default] (/home/guilherme/Cubos/zak-api/node_modules/babel-preset-env/lib/index.js:149:56)
    at getEnvPlugins (/home/guilherme/Cubos/zak-api/node_modules/parcel-bundler/src/transforms/babel.js:250:34)
    at getEnvConfig (/home/guilherme/Cubos/zak-api/node_modules/parcel-bundler/src/transforms/babel.js:217:25)

```

For node, specifying `>= 6` is wrong, it should say just `6`.

If possible, please release 1.6.2 with this fix, otherwise targeting node won't work