### PR TITLE
Remove unnecessary files from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.DS_Store
-yarn.lock
-package-lock.json
-test
-coverage
-.nyc_output
-.cache
-dist
-.babelrc

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
+  "files": ["bin/", "lib/", "src/", "index.js"],
   "dependencies": {
     "babel-code-frame": "^6.26.0",
     "babel-core": "^6.25.0",


### PR DESCRIPTION
There're some unnecessary files (eslint, prettier, CI configs, etc) in `node_modules/parcel-bundler` after installation. 
This PR removes them, leaving only what is needed.
