### PR TITLE
Use babel-register for tests only with node < 8

### DIFF
--- a/test/babel-register.js
+++ b/test/babel-register.js
@@ -1,0 +1,3 @@
+if (process.version.match(/^v(\d+)\.\d+\.\d+$/)[1] < 8) {
+  require('babel-register');
+}

--- a/test/babel-register.js
+++ b/test/babel-register.js
@@ -1,3 +1,3 @@
-if (process.version.match(/^v(\d+)\.\d+\.\d+$/)[1] < 8) {
+if (parseInt(process.versions.node, 10) < 8) {
   require('babel-register');
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --timeout 25000
---require babel-register
+--require ./test/babel-register


### PR DESCRIPTION
Hey,

#789 added `babel-register` before running `mocha` tests. Using `babel-register` slows down tests, adds flakiness and it's redundant for Node v8.x.x.

This PR adds `babel-regsiter` only for when Node's version is <8.