### PR TITLE
Uglify Sourcemap improvements

### DIFF
--- a/src/SourceMap.js
+++ b/src/SourceMap.js
@@ -200,8 +200,8 @@ class SourceMap {
     let middleIndex = Math.floor((stopIndex + startIndex) / 2);
 
     while (
-      this.mappings[middleIndex][key].line !== line &&
-      startIndex < stopIndex
+      startIndex < stopIndex &&
+      this.mappings[middleIndex][key].line !== line
     ) {
       if (line < this.mappings[middleIndex][key].line) {
         stopIndex = middleIndex - 1;
@@ -211,8 +211,9 @@ class SourceMap {
       middleIndex = Math.floor((stopIndex + startIndex) / 2);
     }
 
-    if (this.mappings[middleIndex][key].line !== line) {
-      return middleIndex;
+    let mapping = this.mappings[middleIndex];
+    if (!mapping || mapping[key].line !== line) {
+      return this.mappings.length - 1;
     }
 
     while (
@@ -221,6 +222,7 @@ class SourceMap {
     ) {
       middleIndex--;
     }
+
     while (
       middleIndex < this.mappings.length - 1 &&
       this.mappings[middleIndex + 1][key].line === line &&
@@ -228,6 +230,7 @@ class SourceMap {
     ) {
       middleIndex++;
     }
+
     return middleIndex;
   }
 

--- a/src/transforms/uglify.js
+++ b/src/transforms/uglify.js
@@ -8,12 +8,32 @@ module.exports = async function(asset) {
   let source = (await asset.generate()).js;
 
   let customConfig = await asset.getConfig(['.uglifyrc']);
+  let sourceMap = asset.options.sourceMap && new SourceMap();
   let options = {
     warnings: true,
     mangle: {
       toplevel: true
     },
-    sourceMap: asset.options.sourceMaps ? {filename: asset.relativeName} : false
+    output: sourceMap
+      ? {
+          source_map: {
+            add(source, gen_line, gen_col, orig_line, orig_col, name) {
+              sourceMap.addMapping({
+                source,
+                name,
+                original: {
+                  line: orig_line,
+                  column: orig_col
+                },
+                generated: {
+                  line: gen_line,
+                  column: gen_col
+                }
+              });
+            }
+          }
+        }
+      : {}
   };
 
   if (customConfig) {
@@ -26,15 +46,14 @@ module.exports = async function(asset) {
     throw result.error;
   }
 
-  if (result.map) {
-    result.map = await new SourceMap().addMap(JSON.parse(result.map));
+  if (sourceMap) {
     if (asset.sourceMap) {
       asset.sourceMap = await new SourceMap().extendSourceMap(
         asset.sourceMap,
-        result.map
+        sourceMap
       );
     } else {
-      asset.sourceMap = result.map;
+      asset.sourceMap = sourceMap;
     }
   }
 

--- a/src/transforms/uglify.js
+++ b/src/transforms/uglify.js
@@ -8,33 +8,35 @@ module.exports = async function(asset) {
   let source = (await asset.generate()).js;
 
   let customConfig = await asset.getConfig(['.uglifyrc']);
-  let sourceMap = asset.options.sourceMap && new SourceMap();
   let options = {
     warnings: true,
     mangle: {
       toplevel: true
-    },
-    output: sourceMap
-      ? {
-          source_map: {
-            add(source, gen_line, gen_col, orig_line, orig_col, name) {
-              sourceMap.addMapping({
-                source,
-                name,
-                original: {
-                  line: orig_line,
-                  column: orig_col
-                },
-                generated: {
-                  line: gen_line,
-                  column: gen_col
-                }
-              });
-            }
-          }
-        }
-      : {}
+    }
   };
+
+  let sourceMap;
+  if (asset.options.sourceMap) {
+    sourceMap = new SourceMap();
+    options.output = {
+      source_map: {
+        add(source, gen_line, gen_col, orig_line, orig_col, name) {
+          sourceMap.addMapping({
+            source,
+            name,
+            original: {
+              line: orig_line,
+              column: orig_col
+            },
+            generated: {
+              line: gen_line,
+              column: gen_col
+            }
+          });
+        }
+      }
+    };
+  }
 
   if (customConfig) {
     options = Object.assign(options, customConfig);


### PR DESCRIPTION
Just a couple improvements. Please test them out and merge if you like it @DeMoorJasper! 😄 

1. Fixed a couple bugs I found in testing with the mapping search going out of bounds.
2. Made the uglify sourcemaps slightly faster by using the raw mappings rather than generating and parsing the sourcemap. This is done using the `output.source_map` option which is normally uglify's [internal sourcemap generator](https://github.com/mishoo/UglifyJS2/blob/082e004b872ecb158e5a28702898688742b5da86/lib/sourcemap.js) but we emulate the add function to point to our sourcemap instead.