### PR TITLE
Fix property descriptor of config.internal in transforms/babel.js

### DIFF
--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -65,7 +65,7 @@ async function getConfig(asset) {
     let internal = config.internal;
     delete config.internal;
     Object.defineProperty(config, 'internal', {
-      value: internal
+      value: internal, configurable: true
     });
   }
 

--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -65,7 +65,8 @@ async function getConfig(asset) {
     let internal = config.internal;
     delete config.internal;
     Object.defineProperty(config, 'internal', {
-      value: internal, configurable: true
+      value: internal,
+      configurable: true
     });
   }
 


### PR DESCRIPTION
The default descriptor for 'configurable'is `false`, which causes the error `Cannot delete property 'internal' of #<Object>`
I am developing a plugin (https://github.com/dalcib/parcel-plugin-react-native-web) and found this error. 