### PR TITLE
Fix error when no "targets" options in .babelrc

### DIFF
--- a/src/utils/getTargetEngines.js
+++ b/src/utils/getTargetEngines.js
@@ -110,7 +110,7 @@ async function loadBabelrc(asset, path) {
         Array.isArray(plugin) &&
         (plugin[0] === 'env' || plugin[0] === '@babel/env')
     );
-    if (env && env[1].targets) {
+    if (env && env[1] && env[1].targets) {
       return env[1].targets;
     }
   }


### PR DESCRIPTION
When `.babelrc` has no `"targets"` option in `env`, like:

```
{
  "presets": ["env"]
}
```
Then it will cause an error:

```
Cannot read property 'targets' of undefined
    at loadBabelrc (/node_modules/parcel-bundler/src/utils/getTargetEngines.js:113:23)
    at <anonymous>
```

This PR is to fix it.