### PR TITLE
[WIP/PoC] Watchman backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cssnano": "^3.10.0",
     "deasync": "^0.1.12",
     "dotenv": "^5.0.0",
+    "fb-watchman": "^2.0.0",
     "filesize": "^3.6.0",
     "get-port": "^3.2.0",
     "glob": "^7.1.2",

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -4,7 +4,11 @@ const Parser = require('./Parser');
 const WorkerFarm = require('./WorkerFarm');
 const Path = require('path');
 const Bundle = require('./Bundle');
-const {FSWatcher} = require('chokidar');
+const Watcher = process.env.PARCEL_WATCHMAN
+  ? require('./Watchman')
+  : require('chokidar').FSWatcher.bind(null, {
+      useFsEvents: process.env.NODE_ENV !== 'test'
+    });
 const FSCache = require('./FSCache');
 const HMRServer = require('./HMRServer');
 const Server = require('./Server');
@@ -198,7 +202,7 @@ class Bundler extends EventEmitter {
       this.bundleHashes = await bundle.package(this, this.bundleHashes);
 
       // Unload any orphaned assets
-      this.unloadOrphanedAssets();
+      await this.unloadOrphanedAssets();
 
       let buildTime = Date.now() - startTime;
       let time = prettifyTime(buildTime);
@@ -227,7 +231,7 @@ class Bundler extends EventEmitter {
 
       // If not in watch mode, stop the worker farm so we don't keep the process running.
       if (!this.watcher && this.options.killWorkers) {
-        this.stop();
+        await this.stop();
       }
     }
   }
@@ -245,13 +249,10 @@ class Bundler extends EventEmitter {
     this.options.env = process.env;
 
     if (this.options.watch) {
-      // FS events on macOS are flakey in the tests, which write lots of files very quickly
-      // See https://github.com/paulmillr/chokidar/issues/612
-      this.watcher = new FSWatcher({
-        useFsEvents: process.env.NODE_ENV !== 'test'
-      });
+      this.watcher = new Watcher(this.options.rootDir);
+      if (process.env.PARCEL_WATCHMAN) await this.watcher.init();
 
-      this.watcher.on('change', this.onChange.bind(this));
+      await this.watcher.on('change', this.onChange.bind(this));
     }
 
     if (this.options.hmr) {
@@ -262,13 +263,13 @@ class Bundler extends EventEmitter {
     this.farm = WorkerFarm.getShared(this.options);
   }
 
-  stop() {
+  async stop() {
     if (this.farm) {
       this.farm.end();
     }
 
     if (this.watcher) {
-      this.watcher.close();
+      await this.watcher.close();
     }
 
     if (this.hmr) {
@@ -292,24 +293,24 @@ class Bundler extends EventEmitter {
     let asset = this.parser.getAsset(path, pkg, this.options);
     this.loadedAssets.set(path, asset);
 
-    this.watch(path, asset);
+    await this.watch(path, asset);
     return asset;
   }
 
-  watch(path, asset) {
+  async watch(path, asset) {
     if (!this.watcher) {
       return;
     }
 
     if (!this.watchedAssets.has(path)) {
-      this.watcher.add(path);
+      await this.watcher.add(path);
       this.watchedAssets.set(path, new Set());
     }
 
     this.watchedAssets.get(path).add(asset);
   }
 
-  unwatch(path, asset) {
+  async unwatch(path, asset) {
     if (!this.watchedAssets.has(path)) {
       return;
     }
@@ -319,7 +320,7 @@ class Bundler extends EventEmitter {
 
     if (watched.size === 0) {
       this.watchedAssets.delete(path);
-      this.watcher.unwatch(path);
+      await this.watcher.unwatch(path);
     }
   }
 
@@ -408,7 +409,7 @@ class Bundler extends EventEmitter {
           // This dependency is already included in the parent's generated output,
           // so no need to load it. We map the name back to the parent asset so
           // that changing it triggers a recompile of the parent.
-          this.watch(dep.name, asset);
+          await this.watch(dep.name, asset);
         } else {
           let assetDep = await this.resolveDep(asset, dep);
           if (assetDep) {
@@ -525,21 +526,21 @@ class Bundler extends EventEmitter {
     }
   }
 
-  unloadOrphanedAssets() {
+  async unloadOrphanedAssets() {
     for (let asset of this.findOrphanAssets()) {
-      this.unloadAsset(asset);
+      await this.unloadAsset(asset);
     }
   }
 
-  unloadAsset(asset) {
+  async unloadAsset(asset) {
     this.loadedAssets.delete(asset.name);
     if (this.watcher) {
-      this.unwatch(asset.name, asset);
+      await this.unwatch(asset.name, asset);
 
       // Unwatch all included dependencies that map to this asset
       for (let dep of asset.dependencies.values()) {
         if (dep.includedInParent) {
-          this.unwatch(dep.name, asset);
+          await this.unwatch(dep.name, asset);
         }
       }
     }

--- a/src/Watchman.js
+++ b/src/Watchman.js
@@ -1,0 +1,81 @@
+const watchman = require('fb-watchman');
+const path = require('path');
+
+class Watcher {
+  constructor(root) {
+    this.root = root;
+    this.client = new watchman.Client();
+  }
+
+  init() {
+    return new Promise((res, rej) =>
+      this.client.command(['watch-project', this.root], (error, resp) => {
+        if (error) {
+          rej(error);
+          return;
+        }
+        this.root = resp.watch;
+        res(resp);
+      })
+    );
+  }
+
+  add(p) {
+    p = path.relative(this.root, p);
+    return new Promise((res, rej) =>
+      this.client.command(['clock', this.root], (error, resp) => {
+        if (error) {
+          rej(error);
+          return;
+        }
+
+        const sub = {
+          expression: ['match', p, 'wholename'],
+          fields: ['name', 'exists'],
+          since: resp.clock // only log changes
+        };
+
+        this.client.command(
+          ['subscribe', this.root, 'PARCEL:' + p, sub],
+          (error, resp) => {
+            if (error) {
+              rej(error);
+            }
+            res(resp);
+          }
+        );
+      })
+    );
+  }
+
+  unwatch(p) {
+    p = path.relative(this.root, p);
+    return new Promise((res, rej) =>
+      this.client.command(
+        ['unsubscribe', this.root, 'PARCEL:' + p],
+        (error, resp) => {
+          if (error) {
+            rej(error);
+          }
+          res(resp);
+        }
+      )
+    );
+  }
+
+  on(event, callback) {
+    if (event == 'change') {
+      this.client.on('subscription', resp => {
+        if (resp.subscription.indexOf('PARCEL:') != 0) return;
+
+        resp.files.forEach(f => callback(path.join(resp.root, f.name)));
+      });
+    }
+  }
+
+  close() {
+    this.client.end();
+  }
+}
+
+module.exports = Watcher;

--- a/yarn.lock
+++ b/yarn.lock
@@ -890,6 +890,23 @@ braces@^2.3.0:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+braces@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.1.tgz#7086c913b4e5a08dbe37ac0ee6a2500c4ba691bb"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    kind-of "^6.0.2"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
 brfs@^1.2.0:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/brfs/-/brfs-1.4.4.tgz#fc316bc4880180fa8ee25bcaab65f86910ce1dd5"
@@ -983,6 +1000,12 @@ browserslist@^2.11.2:
 bsb-js@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bsb-js/-/bsb-js-1.0.2.tgz#b9e7af1dfdb8de6191bb36fdff43f59359a7dfe7"
+
+bser@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
+  dependencies:
+    node-int64 "^0.4.0"
 
 buffer-equal@0.0.1:
   version "0.0.1"
@@ -1133,8 +1156,8 @@ chokidar@^1.6.1:
     fsevents "^1.0.0"
 
 chokidar@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.1.tgz#6e67e9998fe10e8f651e975ca62460456ff8e297"
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.2.tgz#4dc65139eeb2714977735b6a35d06e97b494dfd7"
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.0"
@@ -1146,7 +1169,7 @@ chokidar@^2.0.1:
     normalize-path "^2.1.1"
     path-is-absolute "^1.0.0"
     readdirp "^2.0.0"
-    upath "1.0.0"
+    upath "^1.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
 
@@ -1650,6 +1673,13 @@ define-property@^1.0.0:
   dependencies:
     is-descriptor "^1.0.0"
 
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
@@ -2016,7 +2046,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend-shallow@^3.0.0:
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
   dependencies:
@@ -2041,7 +2071,7 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
-extglob@^2.0.2:
+extglob@^2.0.2, extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
   dependencies:
@@ -2086,6 +2116,12 @@ fast-levenshtein@~2.0.4:
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
+
+fb-watchman@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
+  dependencies:
+    bser "^2.0.0"
 
 figures@^1.7.0:
   version "1.7.0"
@@ -2833,7 +2869,7 @@ is-descriptor@^0.1.0:
     is-data-descriptor "^0.1.4"
     kind-of "^5.0.0"
 
-is-descriptor@^1.0.0:
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
   dependencies:
@@ -2928,6 +2964,10 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+
 is-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
@@ -2943,6 +2983,12 @@ is-odd@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-1.0.0.tgz#3b8a932eb028b3775c39bb09e91767accdb69088"
   dependencies:
     is-number "^3.0.0"
+
+is-odd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-2.0.0.tgz#7646624671fd7ea558ccd9a2795182f2958f1b24"
+  dependencies:
+    is-number "^4.0.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -3019,6 +3065,10 @@ is-utf8@^0.2.0:
 is-windows@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
+
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -3521,6 +3571,10 @@ lodash.defaults@~2.3.0:
     lodash._objecttypes "~2.3.0"
     lodash.keys "~2.3.0"
 
+lodash.endswith@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.endswith/-/lodash.endswith-4.2.1.tgz#fed59ac1738ed3e236edd7064ec456448b37bc09"
+
 lodash.escape@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-2.3.0.tgz#844c38c58f844e1362ebe96726159b62cf5f2a58"
@@ -3560,6 +3614,10 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isfunction@^3.0.8:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+
 lodash.isfunction@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz#6b2973e47a647cf12e70d676aea13643706e5267"
@@ -3569,6 +3627,10 @@ lodash.isobject@~2.3.0:
   resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.3.0.tgz#2e16d3fc583da9831968953f2d8e6d73434f6799"
   dependencies:
     lodash._objecttypes "~2.3.0"
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
 
 lodash.keys@^3.0.0:
   version "3.1.2"
@@ -3597,6 +3659,10 @@ lodash.mergewith@^4.6.0:
 lodash.noop@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-2.3.0.tgz#3059d628d51bbf937cd2a0b6fc3a7f212a669c2c"
+
+lodash.startswith@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.startswith/-/lodash.startswith-4.2.1.tgz#c598c4adce188a27e53145731cdc6c0e7177600c"
 
 lodash.support@~2.3.0:
   version "2.3.0"
@@ -3632,10 +3698,6 @@ lodash.values@~2.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-2.3.0.tgz#ca96fbe60a20b0b0ec2ba2ba5fc6a765bd14a3ba"
   dependencies:
     lodash.keys "~2.3.0"
-
-lodash@3.x:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
 lodash@^4.0.0, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
@@ -3782,7 +3844,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.4, micromatch@^3.1.4:
+micromatch@^3.0.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
   dependencies:
@@ -3795,6 +3857,24 @@ micromatch@^3.0.4, micromatch@^3.1.4:
     fragment-cache "^0.2.1"
     kind-of "^6.0.0"
     nanomatch "^1.2.5"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
+micromatch@^3.1.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.8.tgz#5c8caa008de588eebb395e8c0ad12c128f25fff1"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
@@ -3913,6 +3993,23 @@ nanomatch@^1.2.5:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+nanomatch@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.9.tgz#879f7150cb2dab7a471259066c104eee6e0fa7c2"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-odd "^2.0.0"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
@@ -3962,6 +4059,10 @@ node-gyp@^3.3.1:
     semver "~5.3.0"
     tar "^2.0.0"
     which "1"
+
+node-int64@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
 node-libs-browser@^2.0.0:
   version "2.1.0"
@@ -5978,10 +6079,6 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
-underscore.string@2.3.x:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.3.3.tgz#71c08bf6b428b1133f37e78fa3a21c82f7329b0d"
-
 unicode-trie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-0.3.1.tgz#d671dddd89101a08bac37b6a5161010602052085"
@@ -6019,12 +6116,14 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
-upath@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.0.tgz#b4706b9461ca8473adf89133d235689ca17f3656"
+upath@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.2.tgz#80aaae5395abc5fd402933ae2f58694f0860204c"
   dependencies:
-    lodash "3.x"
-    underscore.string "2.3.x"
+    lodash.endswith "^4.2.1"
+    lodash.isfunction "^3.0.8"
+    lodash.isstring "^4.0.1"
+    lodash.startswith "^4.2.1"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This pull request adds a watchman backend, currently intended mainly for (performance) testing (@davidnagli). The api of the watchman wrapper (at src/Watchman.js) is the same as the one from `require('chokidar').FSWatcher`, so deciding which to use at runtime should be quiet easy. 
I added more `await`s because all commands are sent to watchman asynchronosly.
There could be room for optimization.

To use watchman, set the environment variable `PARCEL_WATCHMAN=1`. The tests pass with watchman and chokidar:
```sh
yarn test test/watcher.js
PARCEL_WATCHMAN=1 yarn test test/watcher.js
```

For the original discussion see #863.

This code doesn't check if watchman is actually installed! (Will be added via `fb-watchman`'s `client.capabilityCheck` if this gets well received.)