### PR TITLE
Stop minifying svg

### DIFF
--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -36,7 +36,8 @@ async function getConfig(asset) {
         collapseWhitespace: 'conservative',
         minifyCss: {
           safe: true
-        }
+        },
+        minifySvg: false
       };
 
     config.plugins.push(htmlnano(htmlNanoConfig));


### PR DESCRIPTION
htmlnano has a really irritating error (it's possibly intentional, hard to tell) where it ruins svg tags that use the `<use>` tag. You can view an example I created [here](https://glitch.com/edit/#!/lying-equinox?path=transform.js:52:1).

1. No minification: https://lying-equinox.glitch.me/
2. Minification with minifySvg set to false: https://lying-equinox.glitch.me/minify_good
3. Minification with minifySvg set to default (which is true): https://lying-equinox.glitch.me/minify_bad

As you can see by inspect element, the minification that the `/minify_bad` path uses totally butchers the contents of the `<use>` tag.

I suggest this PR because I think Parcel should aim for the minimally disruptive behavior. That's important for encouraging new people to use the project. Power users can, of course, create a `.htmlnanorc` in their `/` directory to override the Parcel default setting. 