### PR TITLE
Do not try to use the sanitized package name as the bundle name

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "posthtml-parser": "^0.4.0",
     "posthtml-render": "^1.1.0",
     "resolve": "^1.4.0",
-    "sanitize-filename": "^1.6.1",
     "semver": "^5.4.1",
     "serialize-to-js": "^1.1.1",
     "serve-static": "^1.12.4",

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -4,7 +4,6 @@ const fs = require('./utils/fs');
 const objectHash = require('./utils/objectHash');
 const md5 = require('./utils/md5');
 const isURL = require('./utils/is-url');
-const sanitizeFilename = require('sanitize-filename');
 const config = require('./utils/config');
 
 let ASSET_ID = 1;
@@ -176,11 +175,6 @@ class Asset {
   }
 
   generateBundleName() {
-    // Resolve the main file of the package.json
-    const main =
-      this.package && this.package.main
-        ? path.resolve(path.dirname(this.package.pkgfile), this.package.main)
-        : null;
     const ext = '.' + this.type;
 
     const isEntryPoint = this.name === this.options.mainFile;
@@ -193,14 +187,6 @@ class Asset {
           path.extname(this.options.outFile)
         ) + ext
       );
-    }
-
-    // If this asset is main file of the package, use the sanitized package name
-    if (this.name === main) {
-      const packageName = sanitizeFilename(this.package.name, {
-        replacement: '-'
-      });
-      return packageName + ext;
     }
 
     // If this is the entry point of the root bundle, use the original filename

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,6 +86,12 @@ ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 any-observable@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
@@ -1112,6 +1118,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chardet@^0.4.0:
   version "0.4.2"
@@ -2507,6 +2521,10 @@ has-flag@^1.0.0:
 has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -4007,7 +4025,7 @@ node-pre-gyp@^0.6.39:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-sass@^4.5.3:
+node-sass@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.7.2.tgz#9366778ba1469eb01438a9e8592f4262bcb6794e"
   dependencies:
@@ -4712,13 +4730,21 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.1, postcss@^6.0.10:
+postcss@^6.0.1:
   version "6.0.16"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.16.tgz#112e2fe2a6d2109be0957687243170ea5589e146"
   dependencies:
     chalk "^2.3.0"
     source-map "^0.6.1"
     supports-color "^5.1.0"
+
+postcss@^6.0.19:
+  version "6.0.19"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.19.tgz#76a78386f670b9d9494a655bf23ac012effd1555"
+  dependencies:
+    chalk "^2.3.1"
+    source-map "^0.6.1"
+    supports-color "^5.2.0"
 
 posthtml-include@^1.1.0:
   version "1.1.0"
@@ -5250,12 +5276,6 @@ samsam@1.x:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
-sanitize-filename@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
-  dependencies:
-    truncate-utf8-bytes "^1.0.0"
-
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -5754,6 +5774,12 @@ supports-color@^5.1.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.2.0, supports-color@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
 svgo@^0.7.0, svgo@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
@@ -5908,12 +5934,6 @@ trim-right@^1.0.1:
   dependencies:
     glob "^6.0.4"
 
-truncate-utf8-bytes@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
-  dependencies:
-    utf8-byte-length "^1.0.1"
-
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -6052,10 +6072,6 @@ use@^2.0.0:
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
-
-utf8-byte-length@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
It does not work because not all part of the code agree on this.
Also, I guess we ***want*** the hash anyways, as a cache buster.

Take this simple example:
 
`$ tree src`
```sh
src
└── index.html
```

`$ cat src/index.html`
```html
<script type="text/javascript" src="../node_modules/jquery/dist/jquery.js"></script>
```

### Without this PR 

```sh
$ ./node_modules/.bin/parcel build src/index.html
```

`$ tree dist`
```sh
dist
├── index.html
├── jquery.js
└── jquery.map
```

`$ cat dist/index.html`
```html
<script src="/dist/1d486a6abe13f93fbb4e2e63028ada7c.js"></script>
```

This will cause a 404!

### With this PR

```sh
$ ./node_modules/.bin/parcel build src/index.html
```

`$ tree dist`
```sh
dist
├── 1d486a6abe13f93fbb4e2e63028ada7c.js
├── 1d486a6abe13f93fbb4e2e63028ada7c.map
└── index.html
```

`$ cat dist/index.html`
```html
<script src="/dist/1d486a6abe13f93fbb4e2e63028ada7c.js"></script>
```

Fantastic!
