### PR TITLE
Use minified version of prelude only if it exists ...

### DIFF
--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -4,15 +4,16 @@ const Packager = require('./Packager');
 const urlJoin = require('../utils/urlJoin');
 const lineCounter = require('../utils/lineCounter');
 
-const prelude = {
-  source: fs
-    .readFileSync(path.join(__dirname, '../builtins/prelude.js'), 'utf8')
-    .trim(),
-  minified: fs
-    .readFileSync(path.join(__dirname, '../builtins/prelude.min.js'), 'utf8')
+const prelude = {};
+const preludePath = path.join(__dirname, '../builtins/prelude.js');
+prelude.minified = prelude.source = fs.readFileSync(preludePath, 'utf8').trim();
+const preludeMinPath = path.join(__dirname, '../builtins/prelude.min.js');
+if (fs.existsSync(preludeMinPath)) {
+  prelude.minified = fs
+    .readFileSync(preludeMinPath, 'utf8')
     .trim()
-    .replace(/;$/, '')
-};
+    .replace(/;$/, '');
+}
 
 class JSPackager extends Packager {
   async start() {


### PR DESCRIPTION
... which does not when using the src only, and this leads to:

```
(node:56732) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/Users/pierredavidbelanger/Dev/parcel/src/builtins/prelude.min.js'
    at Object.fs.openSync (fs.js:663:18)
    at Object.fs.readFileSync (fs.js:568:33)
    at Object.<anonymous> (/Users/pierredavidbelanger/Dev/parcel/src/packagers/JSPackager.js:12:6)
    at Module._compile (/Users/pierredavidbelanger/Dev/parcel/node_modules/v8-compile-cache/v8-compile-cache.js:178:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Module.require (module.js:604:17)
    at require (/Users/pierredavidbelanger/Dev/parcel/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
```

With this PR, one can use the fresh out-of-the-box parcel source to build.
