### PR TITLE
Allow handling of external modules and scripts

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -293,7 +293,10 @@ class Bundler extends EventEmitter {
     let asset = this.parser.getAsset(path, pkg, this.options);
     this.loadedAssets.set(path, asset);
 
-    this.watch(path, asset);
+    if (!path.startsWith('external://')) {
+      this.watch(path, asset);
+    }
+
     return asset;
   }
 

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const RawAsset = require('./assets/RawAsset');
+const ExternalAsset = require('./assets/ExternalAsset');
 const GlobAsset = require('./assets/GlobAsset');
 const glob = require('glob');
 
@@ -53,6 +54,10 @@ class Parser {
   }
 
   findParser(filename) {
+    if (filename && filename.startsWith('external://')) {
+      return ExternalAsset;
+    }
+
     if (/[*+{}]/.test(filename) && glob.hasMagic(filename)) {
       return GlobAsset;
     }

--- a/src/assets/ExternalAsset.js
+++ b/src/assets/ExternalAsset.js
@@ -1,0 +1,26 @@
+const Asset = require('../Asset');
+
+class ExternalAsset extends Asset {
+  constructor(name, pkg, options) {
+    super(name, pkg, options);
+  }
+
+  // Don't load external assets.
+  load() {}
+
+  generate() {
+    // Don't return a URL to the JS bundle if there is a bundle loader defined for this asset type.
+    // This will cause the actual asset to be automatically preloaded prior to the JS bundle running.
+    if (this.options.bundleLoaders[this.type]) {
+      return {};
+    }
+
+    const external = JSON.parse(this.name.slice('external://'.length));
+
+    return {
+      js: `module.exports=${external};//external`
+    };
+  }
+}
+
+module.exports = ExternalAsset;

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -15,3 +15,5 @@ exports.exists = function(filename) {
 };
 
 exports.mkdirp = promisify(mkdirp);
+
+exports.existsSync = fs.existsSync;


### PR DESCRIPTION
This patch allows two related things for handling externals:

# Externals in package.json

A package.json might now have an external section. An external module will not be bundled, but rather a module stub generated that (re)exports the global variable.

Example:

```
{
 ...
 "externals": {
    "cesium": "Cesium"
  }
}
```
This example will create a module `cesium` that exports `Cesium`.

# External scripts in URLs

If an dependency URL (e.g. in HTML) starts with a forward slash `/`, the reference is treated to be external and to point to a file in the output directory. The URL is then prefixed with the public URL.

Example:
```
<html>
<body>
  <script src="/lib/Cesium/Cesium.js"></script>
</body>
</html>
```

Here, Parcel will assume that there exists a file `lib/Cesium/Cesium.js` in the output directory. The file will not be bundled. But, rather Parcel will warn if the file does NOT exist.