### PR TITLE
Feature/open browser

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -23,7 +23,10 @@ program
     'set the hostname of HMR websockets, defaults to location.hostname of current window'
   )
   .option('--https', 'serves files over HTTPS')
-  .option('--open', 'automatically open in default browser')
+  .option(
+    '--open [browser]',
+    'automatically open in specified browser, defaults to default browser'
+  )
   .option(
     '-d, --out-dir <path>',
     'set the output directory. defaults to "dist"'
@@ -151,10 +154,11 @@ async function bundle(main, command) {
   if (command.name() === 'serve') {
     const server = await bundler.serve(command.port || 1234, command.https);
     if (command.open) {
-      require('opn')(
+      require('./openInBrowser')(
         `${command.https ? 'https' : 'http'}://localhost:${
           server.address().port
-        }`
+        }`,
+        command.open
       );
     }
   } else {

--- a/src/openInBrowser.js
+++ b/src/openInBrowser.js
@@ -1,0 +1,14 @@
+const opn = require('opn');
+
+const openInBrowser = (url, browser) => {
+  try {
+    const options = typeof browser === 'string' ? {app: browser} : undefined;
+
+    opn(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
+    return true;
+  } catch (err) {
+    return false;
+  }
+};
+
+module.exports = openInBrowser;

--- a/src/openInBrowser.js
+++ b/src/openInBrowser.js
@@ -1,8 +1,37 @@
 const opn = require('opn');
+const execSync = require('child_process').execSync;
 
 const openInBrowser = (url, browser) => {
+  const OSX_CHROME = 'google chrome';
+
+  const isBrowserString = typeof browser === 'string';
+
+  const shouldTryOpenChromeWithAppleScript =
+    process.platform === 'darwin' &&
+    (!isBrowserString || browser === OSX_CHROME);
+
+  if (shouldTryOpenChromeWithAppleScript) {
+    try {
+      // check if chrome is running
+      execSync('ps cax | grep "Google Chrome"');
+      const command = `osascript -l JavaScript reuseChromeTabInMacOS.js ${encodeURI(
+        url
+      )}`;
+      // try our best to reuse existing tab
+      execSync(command, {
+        cwd: __dirname,
+        stdio: 'ignore'
+      });
+      return true;
+    } catch (err) {
+      // Ignore errors.
+    }
+  }
+
+  // Fallback to opn
+  // (It will always open new tab)
   try {
-    const options = typeof browser === 'string' ? {app: browser} : undefined;
+    const options = isBrowserString ? {app: browser} : undefined;
 
     opn(url, options).catch(() => {}); // Prevent `unhandledRejection` error.
     return true;

--- a/src/reuseChromeTabInMacOS.js
+++ b/src/reuseChromeTabInMacOS.js
@@ -1,0 +1,51 @@
+// eslint-disable-next-line
+const Chrome = Application('Chrome');
+
+// although there is ES6 support , but "run" function
+// can't use fat arrow functions.
+// https://github.com/JXA-Cookbook/JXA-Cookbook/wiki/ES6-Features-in-JXA#arrow-functions
+// eslint-disable-next-line
+function run(args) {
+  const url = args[0];
+  const tabData = findTabForUrl(url);
+
+  if (tabData) {
+    // set the specified window to be the active window
+    Chrome.windows[tabData.windowKey].activeTabIndex = tabData.tabKey + 1;
+
+    // reload the tab
+    tabData.tab.reload();
+
+    // set the specified tab to be active
+    Chrome.windows[tabData.windowKey].index = 1;
+  } else {
+    // create tab
+    const tab = Chrome.Tab({url});
+
+    // add tab to front window, making it the active tab
+    Chrome.windows[0].tabs.push(tab);
+  }
+  // bring the window to front
+  Chrome.activate();
+}
+
+function findTabForUrl(url) {
+  const urlPattern = new RegExp(`^${url}.*`);
+
+  // Chrome.windows is array like and can be looped
+  for (let i = 0; i < Chrome.windows.length; i++) {
+    const currentWindow = Chrome.windows[i];
+    // same as chrome.windows, currentWindow.tabs is array like and can be looped.
+    for (let j = 0; j < currentWindow.tabs.length; j++) {
+      const currentTab = currentWindow.tabs[j];
+
+      if (urlPattern.test(currentTab.url())) {
+        return {
+          windowKey: i,
+          tabKey: j,
+          tab: currentTab
+        };
+      }
+    }
+  }
+}


### PR DESCRIPTION
[**edited**]
Parcel cli has an option `--open`, which opens default browser.
There are two aspects that i would like to change

1. Allow providing custom browser option (eg: “parcel  ...  --open ‘firefox’ “)
2. Try best to re use existing open tab.

The first one is fairly simple, for the second one, ~~i have seen a reasonable solution in create-react-app, they have a custom applescript, which on macos for only chrome, tries (and in most cases successfully does) reusing existing tab.~~
~~https://github.com/facebook/create-react-app/blob/next/packages/react-dev-utils/openChrome.applescript~~

i implemented a macOS automation script written in javascript to re use chrome tab in macOS.
This has a benifit that we donot introduce applescript, but the catch is this would be supported on macOS version >= 10.10 ([refer](https://developer.apple.com/library/content/releasenotes/InterapplicationCommunication/RN-JavaScriptForAutomation/Articles/OSX10-10.html#//apple_ref/doc/uid/TP40014508-CH109-SW1))

This PR implements both 1 and 2.
I implemented them in separate commits to make it easy to cherry pick as i am not sure if it is in scope of parcel.

Additionally, can also log which browser the cli is opening it in.
something like (`opening ${url} in ${browser} ...`)