### PR TITLE
remove logs files from getting committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ lib
 *.min.js
 test/integration/**/target
 test/integration/**/Cargo.lock
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
i made a pr and had accidentally committed yarn-debug.log, hence this PR.
should perhaps add more files to ignore, similar to the github's .gitignore template
