### PR TITLE
HTML bundle serving bug.

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -51,6 +51,11 @@ function middleware(bundler) {
       } else {
         // Otherwise, serve the file from the dist folder
         req.url = req.url.slice(bundler.options.publicURL.length);
+        // If we're serving an html bundle, and the requested path has not file
+        // extension, serve the index.html. Otherwise go to the file server.
+        if (bundler.mainAsset.type === 'html' && path.extname(req.url) == "") {
+          return sendIndex();
+        }
         return serve(req, res, send404);
       }
     }

--- a/src/Server.js
+++ b/src/Server.js
@@ -45,17 +45,16 @@ function middleware(bundler) {
     function respond() {
       if (bundler.errored) {
         return send500();
-      } else if (!req.url.startsWith(bundler.options.publicURL)) {
-        // If the URL doesn't start with the public path, send the main HTML bundle
+      } else if (
+        !req.url.startsWith(bundler.options.publicURL) ||
+        path.extname(req.url) === ''
+      ) {
+        // If the URL doesn't start with the public path, or the URL doesn't
+        // have a file extension, send the main HTML bundle.
         return sendIndex();
       } else {
         // Otherwise, serve the file from the dist folder
         req.url = req.url.slice(bundler.options.publicURL.length);
-        // If we're serving an html bundle, and the requested path has not file
-        // extension, serve the index.html. Otherwise go to the file server.
-        if (bundler.mainAsset.type === 'html' && path.extname(req.url) == "") {
-          return sendIndex();
-        }
         return serve(req, res, send404);
       }
     }

--- a/test/server.js
+++ b/test/server.js
@@ -106,4 +106,18 @@ describe('server', function() {
     let data = await get('/dist/index.js', https);
     assert.equal(data, fs.readFileSync(__dirname + '/dist/index.js', 'utf8'));
   });
+
+  it('should serve static assets as well as html', async function() {
+    let b = bundler(__dirname + '/integration/html/index.html', {
+      publicUrl: '/'
+    });
+    server = await b.serve(0);
+    // When accessing / we should get the index page.
+    let data = await get('/');
+    assert.equal(data, fs.readFileSync(__dirname + '/dist/index.html', 'utf8'));
+    // When accessing /hello.txt we should get txt document.
+    fs.writeFileSync(__dirname + '/dist/hello.txt', 'hello');
+    data = await get('/hello.txt');
+    assert.equal(data, 'hello');
+  });
 });


### PR DESCRIPTION
When serving HTML bundle with publicUrl="/", allow the server to send static assets other than html.

Fixes #782 