### PR TITLE
Web Worker bundle does not include all dependencies

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -91,6 +91,14 @@ class Bundle {
     return this.assets.size === 0;
   }
 
+  get isIsolated() {
+    return (
+      this.entryAsset &&
+      this.entryAsset.parentDeps &&
+      Array.from(this.entryAsset.parentDeps.values()).some(dep => dep.isolated)
+    );
+  }
+
   getBundleNameMap(contentHash, hashes = new Map()) {
     let hashedName = this.getHashedBundleName(contentHash);
     hashes.set(Path.basename(this.name), hashedName);

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -555,7 +555,9 @@ class Bundler extends EventEmitter {
     }
 
     for (let bundle of Array.from(asset.bundles)) {
-      bundle.removeAsset(asset);
+      if (!bundle.isIsolated) {
+        bundle.removeAsset(asset);
+      }
       commonBundle.getSiblingBundle(bundle.type).addAsset(asset);
     }
 

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -498,6 +498,9 @@ class Bundler extends EventEmitter {
         ) {
           this.moveAssetToBundle(asset, commonBundle);
           return;
+        } else if(bundle.isIsolated && asset.parentBundle.type === commonBundle.type) {
+          bundle.addAsset(asset);
+          return;
         }
       } else {
         return;

--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -68,7 +68,7 @@ module.exports = {
     if (isRegisterServiceWorker) {
       // Treat service workers as an entry point so filenames remain consistent across builds.
       // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#avoid_changing_the_url_of_your_service_worker_script
-      addURLDependency(asset, args[0], {entry: true});
+      addURLDependency(asset, args[0], {entry: true, isolated: true});
       return;
     }
   },
@@ -83,7 +83,7 @@ module.exports = {
       types.isStringLiteral(args[0]);
 
     if (isWebWorker) {
-      addURLDependency(asset, args[0]);
+      addURLDependency(asset, args[0], {isolated: true});
       return;
     }
   }

--- a/test/integration/workers/common.js
+++ b/test/integration/workers/common.js
@@ -1,0 +1,4 @@
+// required by worker and index, must be bundled separately
+exports.commonFunction = function (source) {
+  return 'commonText' + source;
+};

--- a/test/integration/workers/feature.js
+++ b/test/integration/workers/feature.js
@@ -1,0 +1,3 @@
+const workerClient = require('./worker-client');
+
+workerClient.startWorker();

--- a/test/integration/workers/index-alternative.js
+++ b/test/integration/workers/index-alternative.js
@@ -1,4 +1,4 @@
-exports.commonFunction = require('./common').commonFunction;
 exports.startWorker = require('./worker-client').startWorker;
+exports.commonFunction = require('./common').commonFunction;
 exports.feature = require('./feature');
 

--- a/test/integration/workers/worker-client.js
+++ b/test/integration/workers/worker-client.js
@@ -1,0 +1,11 @@
+const commonText = require('./common').commonFunction('Index');
+
+navigator.serviceWorker.register('service-worker.js', { scope: './' });
+
+exports.startWorker = function() {
+  const worker = new Worker('worker.js');
+  worker.postMessage(commonText);
+};
+
+
+

--- a/test/integration/workers/worker.js
+++ b/test/integration/workers/worker.js
@@ -1,1 +1,5 @@
-self.addEventListener('message', () => {});
+const commonText = require('./common').commonFunction('Worker');
+
+self.addEventListener('message', () => {
+  self.postMessage(commonText);
+});

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -158,7 +158,7 @@ describe('javascript', function() {
 
     assertBundleTree(b, {
       name: 'index.js',
-      assets: ['index.js'],
+      assets: ['index.js', 'common.js', 'worker-client.js', 'feature.js'],
       childBundles: [
         {
           type: 'map'
@@ -172,7 +172,44 @@ describe('javascript', function() {
           ]
         },
         {
-          assets: ['worker.js'],
+          assets: ['worker.js', 'common.js'],
+          childBundles: [
+            {
+              type: 'map'
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('should support bundling workers with different order', async function() {
+    let b = await bundle(
+      __dirname + '/integration/workers/index-alternative.js'
+    );
+
+    assertBundleTree(b, {
+      name: 'index-alternative.js',
+      assets: [
+        'index-alternative.js',
+        'common.js',
+        'worker-client.js',
+        'feature.js'
+      ],
+      childBundles: [
+        {
+          type: 'map'
+        },
+        {
+          assets: ['service-worker.js'],
+          childBundles: [
+            {
+              type: 'map'
+            }
+          ]
+        },
+        {
+          assets: ['worker.js', 'common.js'],
           childBundles: [
             {
               type: 'map'


### PR DESCRIPTION
### What I did
I extended the Worker test in javascript.js to show that a common dependency, that is required by the index.js and the worker.js should be contained in the worker bundle, too.

### Story
PR #441 added support for web workers with `asset.addURLDependency`. But it didn't take into account, that the `Bundler.createBundleTree` optimizes the tree and possibly moves common assets to another bundle.

### Requirement
The worker bundle must have a copy of all assets, because it runs in the browser in a different context and can't access what is provided by other bundles.

### What I tried
Unfortunately my tries to fiddle with the Bundler to support this were not successful and depending on the order of imports. That is why there is a second test 'should support bundling workers with different order'.

Maybe someone more familiar with how parcel works, can suggest a solution?

