### PR TITLE
Export path to a js dep when it has no loader associated

### DIFF
--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -69,8 +69,19 @@ class JSPackager extends Packager {
           !this.bundle.assets.has(mod) &&
           (!this.bundle.parentBundle || this.bundle.parentBundle.type !== 'js')
         ) {
-          this.externalModules.add(mod);
-          this.bundleLoaders.add(mod.type);
+          if (this.options.bundleLoaders[mod.type]) {
+            this.externalModules.add(mod);
+            this.bundleLoaders.add(mod.type);
+          } else {
+            const pathToAsset = urlJoin(
+              this.options.publicURL,
+              mod.generateBundleName()
+            );
+            await this.writeModule(
+              mod.id,
+              `module.exports=${JSON.stringify(pathToAsset)};`
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes the fact that an HTML dependency of a JS asset was wrongly written in the JS as an (not working) bundle loader that could make an app crash at runtime with a message like : `Cannot find module '6'`.

This is one of the two points (required to be able to do require('./other.html')) mentioned in [this comment](https://github.com/parcel-bundler/parcel/pull/926#issuecomment-373782658)