### PR TITLE
Content hash output file names

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -148,7 +148,7 @@ class Asset {
       await this.getDependencies();
       await this.transform();
       this.generated = await this.generate();
-      this.hash = this.generateHash();
+      this.hash = await this.generateHash();
     }
 
     return this.generated;

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -175,27 +175,9 @@ class Asset {
   }
 
   generateBundleName() {
-    const ext = '.' + this.type;
-
-    const isEntryPoint = this.name === this.options.mainFile;
-
-    // If this is the entry point of the root bundle, use outFile filename if provided
-    if (isEntryPoint && this.options.outFile) {
-      return (
-        path.basename(
-          this.options.outFile,
-          path.extname(this.options.outFile)
-        ) + ext
-      );
-    }
-
-    // If this is the entry point of the root bundle, use the original filename
-    if (isEntryPoint) {
-      return path.basename(this.name, path.extname(this.name)) + ext;
-    }
-
-    // Otherwise generate a unique name
-    return md5(this.name) + ext;
+    // Generate a unique name. This will be replaced with a nicer
+    // name later as part of content hashing.
+    return md5(this.name) + '.' + this.type;
   }
 
   generateErrorMessage(err) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -20,6 +20,10 @@ class Logger {
         ? options.color
         : chalk.supportsColor;
     this.chalk = new chalk.constructor({enabled: this.color});
+    this.isTest =
+      options && typeof options.isTest === 'boolean'
+        ? options.isTest
+        : process.env.NODE_ENV === 'test';
   }
 
   countLines(message) {
@@ -87,7 +91,7 @@ class Logger {
   }
 
   clear() {
-    if (!this.color) {
+    if (!this.color || this.isTest) {
       return;
     }
 

--- a/src/Server.js
+++ b/src/Server.js
@@ -6,6 +6,7 @@ const serverErrors = require('./utils/customErrors').serverErrors;
 const generateCertificate = require('./utils/generateCertificate');
 const getCertificate = require('./utils/getCertificate');
 const logger = require('./Logger');
+const path = require('path');
 
 serveStatic.mime.define({
   'application/wasm': ['wasm']
@@ -56,8 +57,8 @@ function middleware(bundler) {
 
     function sendIndex() {
       // If the main asset is an HTML file, serve it
-      if (bundler.mainAsset.type === 'html') {
-        req.url = `/${bundler.mainAsset.generateBundleName()}`;
+      if (bundler.mainBundle.type === 'html') {
+        req.url = `/${path.basename(bundler.mainBundle.name)}`;
         serve(req, res, send404);
       } else {
         send404();

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -64,6 +64,9 @@ const META = {
 const OPTIONS = {
   a: {
     href: {entry: true}
+  },
+  iframe: {
+    src: {entry: true}
   }
 };
 

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -60,6 +60,13 @@ const META = {
   ]
 };
 
+// Options to be passed to `addURLDependency` for certain tags + attributes
+const OPTIONS = {
+  a: {
+    href: {entry: true}
+  }
+};
+
 class HTMLAsset extends Asset {
   constructor(name, pkg, options) {
     super(name, pkg, options);
@@ -74,20 +81,20 @@ class HTMLAsset extends Asset {
     return res;
   }
 
-  processSingleDependency(path) {
-    let assetPath = this.addURLDependency(decodeURIComponent(path));
+  processSingleDependency(path, opts) {
+    let assetPath = this.addURLDependency(decodeURIComponent(path), opts);
     if (!isURL(assetPath)) {
       assetPath = urlJoin(this.options.publicURL, assetPath);
     }
     return assetPath;
   }
 
-  collectSrcSetDependencies(srcset) {
+  collectSrcSetDependencies(srcset, opts) {
     const newSources = [];
     for (const source of srcset.split(',')) {
       const pair = source.trim().split(' ');
       if (pair.length === 0) continue;
-      pair[0] = this.processSingleDependency(pair[0]);
+      pair[0] = this.processSingleDependency(pair[0], opts);
       newSources.push(pair.join(' '));
     }
     return newSources.join(',');
@@ -120,9 +127,15 @@ class HTMLAsset extends Asset {
           if (node.tag === 'a' && node.attrs[attr].lastIndexOf('.') < 1) {
             continue;
           }
+
           if (elements && elements.includes(node.tag)) {
             let depHandler = this.getAttrDepHandler(attr);
-            node.attrs[attr] = depHandler.call(this, node.attrs[attr]);
+            let options = OPTIONS[node.tag];
+            node.attrs[attr] = depHandler.call(
+              this,
+              node.attrs[attr],
+              options && options[attr]
+            );
             this.isAstDirty = true;
           }
         }

--- a/src/assets/RawAsset.js
+++ b/src/assets/RawAsset.js
@@ -1,5 +1,6 @@
 const Asset = require('../Asset');
 const urlJoin = require('../utils/urlJoin');
+const md5 = require('../utils/md5');
 
 class RawAsset extends Asset {
   // Don't load raw assets. They will be copied by the RawPackager directly.
@@ -20,6 +21,10 @@ class RawAsset extends Asset {
     return {
       js: `module.exports=${JSON.stringify(pathToAsset)};`
     };
+  }
+
+  async generateHash() {
+    return await md5.file(this.name);
   }
 }
 

--- a/src/packagers/CSSPackager.js
+++ b/src/packagers/CSSPackager.js
@@ -22,7 +22,7 @@ class CSSPackager extends Packager {
       css = `@media ${media.join(', ')} {\n${css.trim()}\n}\n`;
     }
 
-    await this.dest.write(css);
+    await this.write(css);
   }
 }
 

--- a/src/packagers/HTMLPackager.js
+++ b/src/packagers/HTMLPackager.js
@@ -31,7 +31,7 @@ class HTMLPackager extends Packager {
       ).process(html, {sync: true}).html;
     }
 
-    await this.dest.write(html);
+    await this.write(html);
   }
 
   addBundlesToTree(bundles, tree) {

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -30,7 +30,7 @@ class JSPackager extends Packager {
           this.options.hmrHostname
         )};` + preludeCode;
     }
-    await this.dest.write(preludeCode + '({');
+    await this.write(preludeCode + '({');
     this.lineOffset = lineCounter(preludeCode);
   }
 
@@ -101,7 +101,7 @@ class JSPackager extends Packager {
     wrapped += ']';
 
     this.first = false;
-    await this.dest.write(wrapped);
+    await this.write(wrapped);
 
     // Use the pre-computed line count from the source map if possible
     let lineCount = map && map.lineCount ? map.lineCount : lineCounter(code);
@@ -198,10 +198,10 @@ class JSPackager extends Packager {
       entry.push(this.bundle.entryAsset.id);
     }
 
-    await this.dest.write('},{},' + JSON.stringify(entry) + ')');
+    await this.write('},{},' + JSON.stringify(entry) + ')');
     if (this.options.sourceMaps) {
       // Add source map url
-      await this.dest.write(
+      await this.write(
         `\n//# sourceMappingURL=${urlJoin(
           this.options.publicURL,
           path.basename(this.bundle.name, '.js') + '.map'

--- a/src/packagers/RawPackager.js
+++ b/src/packagers/RawPackager.js
@@ -1,7 +1,5 @@
 const Packager = require('./Packager');
 const fs = require('../utils/fs');
-const path = require('path');
-const url = require('url');
 
 class RawPackager extends Packager {
   // Override so we don't create a file for this bundle.
@@ -9,22 +7,13 @@ class RawPackager extends Packager {
   setup() {}
 
   async addAsset(asset) {
-    // Use the bundle name if this is the entry asset, otherwise generate one.
-    let name = this.bundle.name;
-    if (asset !== this.bundle.entryAsset) {
-      name = url.resolve(
-        path.join(path.dirname(this.bundle.name), asset.generateBundleName()),
-        ''
-      );
-    }
-
     let contents = asset.generated[asset.type];
     if (!contents || (contents && contents.path)) {
       contents = await fs.readFile(contents ? contents.path : asset.name);
     }
 
     this.size = contents.length;
-    await fs.writeFile(name, contents);
+    await fs.writeFile(this.bundle.name, contents);
   }
 
   getSize() {

--- a/src/packagers/SourceMapPackager.js
+++ b/src/packagers/SourceMapPackager.js
@@ -16,7 +16,7 @@ class SourceMapPackager extends Packager {
 
   async end() {
     let file = path.basename(this.bundle.name);
-    await this.dest.write(this.sourceMap.stringify(file));
+    await this.write(this.sourceMap.stringify(file));
     await super.end();
   }
 }

--- a/src/utils/md5.js
+++ b/src/utils/md5.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const fs = require('fs');
 
 function md5(string) {
   return crypto
@@ -6,5 +7,17 @@ function md5(string) {
     .update(string)
     .digest('hex');
 }
+
+md5.file = function(filename) {
+  return new Promise((resolve, reject) => {
+    fs
+      .createReadStream(filename)
+      .pipe(crypto.createHash('md5').setEncoding('hex'))
+      .on('finish', function() {
+        resolve(this.read());
+      })
+      .on('error', reject);
+  });
+};
 
 module.exports = md5;

--- a/test/contentHashing.js
+++ b/test/contentHashing.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+const fs = require('fs');
+const {bundle} = require('./utils');
+const rimraf = require('rimraf');
+const promisify = require('../src/utils/promisify');
+const ncp = promisify(require('ncp'));
+
+describe('content hashing', function() {
+  beforeEach(function() {
+    rimraf.sync(__dirname + '/input');
+  });
+
+  it('should update content hash when content changes', async function() {
+    await ncp(__dirname + '/integration/html-css', __dirname + '/input');
+
+    await bundle(__dirname + '/input/index.html', {
+      production: true
+    });
+
+    let html = fs.readFileSync(__dirname + '/dist/index.html', 'utf8');
+    let filename = html.match(
+      /<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}(input\.[a-f0-9]+\.css)">/
+    )[1];
+    assert(fs.existsSync(__dirname + '/dist/' + filename));
+
+    fs.writeFileSync(
+      __dirname + '/input/index.css',
+      'body { background: green }'
+    );
+
+    await bundle(__dirname + '/input/index.html', {
+      production: true
+    });
+
+    html = fs.readFileSync(__dirname + '/dist/index.html', 'utf8');
+    let newFilename = html.match(
+      /<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}(input\.[a-f0-9]+\.css)">/
+    )[1];
+    assert(fs.existsSync(__dirname + '/dist/' + newFilename));
+
+    assert.notEqual(filename, newFilename);
+  });
+
+  it('should update content hash when raw asset changes', async function() {
+    await ncp(__dirname + '/integration/import-raw', __dirname + '/input');
+
+    await bundle(__dirname + '/input/index.js', {
+      production: true
+    });
+
+    let js = fs.readFileSync(__dirname + '/dist/index.js', 'utf8');
+    let filename = js.match(/\/dist\/(test\.[0-9a-f]+\.txt)/)[1];
+    assert(fs.existsSync(__dirname + '/dist/' + filename));
+
+    fs.writeFileSync(__dirname + '/input/test.txt', 'hello world');
+
+    await bundle(__dirname + '/input/index.js', {
+      production: true
+    });
+
+    js = fs.readFileSync(__dirname + '/dist/index.js', 'utf8');
+    let newFilename = js.match(/\/dist\/(test\.[0-9a-f]+\.txt)/)[1];
+    assert(fs.existsSync(__dirname + '/dist/' + newFilename));
+
+    assert.notEqual(filename, newFilename);
+  });
+});

--- a/test/css.js
+++ b/test/css.js
@@ -131,7 +131,7 @@ describe('css', function() {
     assert.equal(output(), 2);
 
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
-    assert(/url\("[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
     assert(css.includes('url("data:image/gif;base64,quotes")'));
@@ -141,7 +141,7 @@ describe('css', function() {
 
     assert(
       fs.existsSync(
-        __dirname + '/dist/' + css.match(/url\("([0-9a-f]+\.woff2)"\)/)[1]
+        __dirname + '/dist/' + css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]
       )
     );
   });
@@ -176,7 +176,7 @@ describe('css', function() {
     assert.equal(output(), 2);
 
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
-    assert(/url\([0-9a-f]+\.woff2\)/.test(css), 'woff ext found in css');
+    assert(/url\(test\.[0-9a-f]+\.woff2\)/.test(css), 'woff ext found in css');
     assert(css.includes('url(http://google.com)'), 'url() found');
     assert(css.includes('.index'), '.index found');
     assert(css.includes('url("data:image/gif;base64,quotes")'));
@@ -186,7 +186,7 @@ describe('css', function() {
 
     assert(
       fs.existsSync(
-        __dirname + '/dist/' + css.match(/url\(([0-9a-f]+\.woff2)\)/)[1]
+        __dirname + '/dist/' + css.match(/url\((test\.[0-9a-f]+\.woff2)\)/)[1]
       )
     );
   });

--- a/test/html.js
+++ b/test/html.js
@@ -142,7 +142,7 @@ describe('html', function() {
 
     let html = fs.readFileSync(__dirname + '/dist/index.html');
     assert(
-      /<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}[a-f0-9]+\.css">/.test(
+      /<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}html-css\.[a-f0-9]+\.css">/.test(
         html
       )
     );
@@ -174,7 +174,7 @@ describe('html', function() {
 
     let html = fs.readFileSync(__dirname + '/dist/index.html');
     assert(
-      /<html>\s*<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}[a-f0-9]+\.css">\s*<body>/.test(
+      /<html>\s*<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}html-css-head\.[a-f0-9]+\.css">\s*<body>/.test(
         html
       )
     );
@@ -212,7 +212,9 @@ describe('html', function() {
     });
 
     let html = fs.readFileSync(__dirname + '/dist/index.html');
-    assert(/<script src="[/\\]{1}dist[/\\]{1}[a-f0-9]+\.js">/.test(html));
+    assert(
+      /<script src="[/\\]{1}dist[/\\]{1}html-css-js\.[a-f0-9]+\.js">/.test(html)
+    );
   });
 
   it('should insert sibling bundles at correct location in tree when optional elements are absent', async function() {
@@ -247,7 +249,7 @@ describe('html', function() {
 
     let html = fs.readFileSync(__dirname + '/dist/index.html');
     assert(
-      /<\/script>\s*<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}[a-f0-9]+\.css"><h1>Hello/.test(
+      /<\/script>\s*<link rel="stylesheet" href="[/\\]{1}dist[/\\]{1}html-css-optional-elements\.[a-f0-9]+\.css"><h1>Hello/.test(
         html
       )
     );

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -307,7 +307,7 @@ describe('javascript', function() {
 
     let output = run(b);
     assert.equal(typeof output, 'function');
-    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output()));
+    assert(/^\/dist\/test\.[0-9a-f]+\.txt$/.test(output()));
     assert(fs.existsSync(__dirname + output()));
   });
 

--- a/test/less.js
+++ b/test/less.js
@@ -84,13 +84,13 @@ describe('less', function() {
     assert.equal(output(), 2);
 
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
-    assert(/url\("[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
 
     assert(
       fs.existsSync(
-        __dirname + '/dist/' + css.match(/url\("([0-9a-f]+\.woff2)"\)/)[1]
+        __dirname + '/dist/' + css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]
       )
     );
   });

--- a/test/logger.js
+++ b/test/logger.js
@@ -87,7 +87,7 @@ describe('Logger', () => {
   });
 
   it('should reset on clear', () => {
-    const l = new Logger.constructor({color: true});
+    const l = new Logger.constructor({color: true, isTest: false});
     stub(l);
 
     l.lines = 10;

--- a/test/sass.js
+++ b/test/sass.js
@@ -110,13 +110,13 @@ describe('sass', function() {
     assert.equal(output(), 2);
 
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
-    assert(/url\("[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
 
     assert(
       fs.existsSync(
-        __dirname + '/dist/' + css.match(/url\("([0-9a-f]+\.woff2)"\)/)[1]
+        __dirname + '/dist/' + css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]
       )
     );
   });

--- a/test/stylus.js
+++ b/test/stylus.js
@@ -87,13 +87,13 @@ describe('stylus', function() {
     assert.equal(output(), 2);
 
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
-    assert(/url\("[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
 
     assert(
       fs.existsSync(
-        __dirname + '/dist/' + css.match(/url\("([0-9a-f]+\.woff2)"\)/)[1]
+        __dirname + '/dist/' + css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]
       )
     );
   });

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -69,7 +69,7 @@ describe('typescript', function() {
 
     let output = run(b);
     assert.equal(typeof output.getRaw, 'function');
-    assert(/^\/dist\/[0-9a-f]+\.txt$/.test(output.getRaw()));
+    assert(/^\/dist\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()));
     assert(fs.existsSync(__dirname + output.getRaw()));
   });
 


### PR DESCRIPTION
This implements the strategy described in #872. In production mode, a hash of bundle content is appended to names of files that aren't entry points (e.g. HTML files, things linked to a `<a href>`, service workers, etc.). Unhashed files retain their original name, and path relative to the main entry point.

In development mode, rather than using content hashes, the hash of the filename is used as before, so that filenames don't change during development. The hashes are necessary at all to avoid name collisions since the file structure is flattened. In addition, the filenames look more similar to the real production ones - the hashes just don't change.

It works by using a temporary filename (md5 of asset path) as references (which should be unique), and at the end, once file contents is known for all bundles, it replaces those temporary names with the real content-hashed names during packaging.

To do:

- [x] fix hashing of raw assets (which aren't in memory)
- [x] more unit tests
- [ ] test in real world apps.

Please help me test! cc. @zeakd @songlipeng2003 @ssuman @Munter @benhutton @shanebo @leeching @gamebox @npup