### PR TITLE
added support for re using same browser tab for google chrome on osx

### DIFF
--- a/src/utils/openInBrowser.js
+++ b/src/utils/openInBrowser.js
@@ -1,8 +1,37 @@
 const opn = require('opn');
+const execSync = require('child_process').execSync;
 
 const openInBrowser = async (url, browser) => {
+  const OSX_CHROME = 'google chrome';
+
+  const isBrowserString = typeof browser === 'string';
+
+  const shouldTryOpenChromeWithAppleScript =
+    process.platform === 'darwin' &&
+    (!isBrowserString || browser === OSX_CHROME);
+
+  if (shouldTryOpenChromeWithAppleScript) {
+    try {
+      // check if chrome is running
+      execSync('ps cax | grep "Google Chrome"');
+      const command = `osascript -l JavaScript reuseChromeTabInMacOS.js ${encodeURI(
+        url
+      )}`;
+      // try our best to reuse existing tab
+      execSync(command, {
+        cwd: __dirname,
+        stdio: 'ignore'
+      });
+      return true;
+    } catch (err) {
+      // Ignore errors.
+    }
+  }
+
+  // Fallback to opn
+  // (It will always open new tab)
   try {
-    const options = typeof browser === 'string' ? {app: browser} : undefined;
+    const options = isBrowserString ? {app: browser} : undefined;
 
     await opn(url, options);
   } catch (err) {

--- a/src/utils/reuseChromeTabInMacOS.js
+++ b/src/utils/reuseChromeTabInMacOS.js
@@ -1,0 +1,51 @@
+// eslint-disable-next-line
+const Chrome = Application('Chrome');
+
+// although there is ES6 support , but "run" function
+// can't use fat arrow functions.
+// https://github.com/JXA-Cookbook/JXA-Cookbook/wiki/ES6-Features-in-JXA#arrow-functions
+// eslint-disable-next-line
+function run(args) {
+  const url = args[0];
+  const tabData = findTabForUrl(url);
+
+  if (tabData) {
+    // set the specified window to be the active window
+    Chrome.windows[tabData.windowKey].activeTabIndex = tabData.tabKey + 1;
+
+    // reload the tab
+    tabData.tab.reload();
+
+    // set the specified tab to be active
+    Chrome.windows[tabData.windowKey].index = 1;
+  } else {
+    // create tab
+    const tab = Chrome.Tab({url});
+
+    // add tab to front window, making it the active tab
+    Chrome.windows[0].tabs.push(tab);
+  }
+  // bring the window to front
+  Chrome.activate();
+}
+
+function findTabForUrl(url) {
+  const urlPattern = new RegExp(`^${url}.*`);
+
+  // Chrome.windows is array like and can be looped
+  for (let i = 0; i < Chrome.windows.length; i++) {
+    const currentWindow = Chrome.windows[i];
+    // same as chrome.windows, currentWindow.tabs is array like and can be looped.
+    for (let j = 0; j < currentWindow.tabs.length; j++) {
+      const currentTab = currentWindow.tabs[j];
+
+      if (urlPattern.test(currentTab.url())) {
+        return {
+          windowKey: i,
+          tabKey: j,
+          tab: currentTab
+        };
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR aims to added support for re using existing browser tab for google chrome on osx.
This is implemented using [Mac OS automation scripting](https://developer.apple.com/library/content/documentation/LanguagesUtilities/Conceptual/MacAutomationScriptingGuide/index.html) using javascript.

Although this is very specific case of just supporting chrome on osx, but supporting other browser is currently not possible.

Prior discussions https://github.com/parcel-bundler/parcel/pull/960#discussion_r173371973