### PR TITLE
Add data so it is possible to include globals scss variables

### DIFF
--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -2,6 +2,7 @@ const CSSAsset = require('./CSSAsset');
 const localRequire = require('../utils/localRequire');
 const promisify = require('../utils/promisify');
 const path = require('path');
+const os = require('os');
 
 class SASSAsset extends CSSAsset {
   async parse(code) {
@@ -16,7 +17,7 @@ class SASSAsset extends CSSAsset {
     opts.includePaths = (opts.includePaths || []).concat(
       path.dirname(this.name)
     );
-    opts.data = code;
+    opts.data = opts.data ? (opts.data + os.EOL + code) : code;
     opts.indentedSyntax =
       typeof opts.indentedSyntax === 'boolean'
         ? opts.indentedSyntax


### PR DESCRIPTION
This is a fix for #1032 - gives the possibility to use globals variables within the `data` attribute - same as https://github.com/webpack-contrib/sass-loader/blob/master/lib/normalizeOptions.js#L24