### PR TITLE
Fix methods of LazyPromise

### DIFF
--- a/src/builtins/bundle-loader.js
+++ b/src/builtins/bundle-loader.js
@@ -73,9 +73,11 @@ function LazyPromise(executor) {
 }
 
 LazyPromise.prototype.then = function (onSuccess, onError) {
-  return this.promise || (this.promise = new Promise(this.executor).then(onSuccess, onError));
+  if (this.promise === null) this.promise = new Promise(this.executor)
+  return this.promise.then(onSuccess, onError)
 };
 
 LazyPromise.prototype.catch = function (onError) {
-  return this.promise || (this.promise = new Promise(this.executor).catch(onError));
+  if (this.promise === null) this.promise = new Promise(this.executor)
+  return this.promise.catch(onError)
 };


### PR DESCRIPTION
I was running into problems using code splitting, and eventually discovered it was because of a bug in LazyPromise.

If you have code like this:

```
const foo = import('./foo')
foo.then(() => console.log('1'))
foo.then(() => console.log('2'))
```

Then I would expect the the file would log both `'1'` and `'2'`. Before this fix, it logs only '`1`', because if the promise executor has already been invoked, then `LazyPromise.prototype.then` is a no-op, just returning the existing promise.

The fix is to always invoke the appropriate callback, even if the promise has already been executed.

I ran into this issue when doing code splitting because I wanted to eagerly, but asynchronously load a dependency, and then use it later. I suspect this problem will also occur in any situation where a dynamic `import()` is used in multiple places in a single file.