### PR TITLE
Implement pipelines to compose multiple asset types together

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -26,7 +26,7 @@ class Asset {
     this.type = path.extname(this.name).slice(1);
 
     this.processed = false;
-    this.contents = null;
+    this.contents = options.rendition ? options.rendition.value : null;
     this.ast = null;
     this.generated = null;
     this.hash = null;
@@ -58,6 +58,13 @@ class Asset {
   }
 
   async getDependencies() {
+    if (
+      this.options.rendition &&
+      this.options.rendition.hasDependencies === false
+    ) {
+      return;
+    }
+
     await this.loadIfNeeded();
 
     if (this.contents && this.mightHaveDependencies()) {
@@ -152,6 +159,10 @@ class Asset {
     }
 
     return this.generated;
+  }
+
+  async postProcess(generated) {
+    return generated;
   }
 
   generateHash() {

--- a/src/Pipeline.js
+++ b/src/Pipeline.js
@@ -1,0 +1,102 @@
+const Parser = require('./Parser');
+const path = require('path');
+const md5 = require('./utils/md5');
+
+/**
+ * A Pipeline composes multiple Asset types together.
+ */
+class Pipeline {
+  constructor(options) {
+    this.options = options;
+    this.parser = new Parser(options);
+  }
+
+  async process(path, pkg, options) {
+    let asset = this.parser.getAsset(path, pkg, options);
+    let generated = await this.processAsset(asset);
+    let generatedMap = {};
+    for (let rendition of generated) {
+      generatedMap[rendition.type] = rendition.value;
+    }
+
+    return {
+      dependencies: Array.from(asset.dependencies.values()),
+      generated: generatedMap,
+      hash: asset.hash,
+      cacheData: asset.cacheData
+    };
+  }
+
+  async processAsset(asset) {
+    try {
+      await asset.process();
+    } catch (err) {
+      throw asset.generateErrorMessage(err);
+    }
+
+    let inputType = path.extname(asset.name).slice(1);
+    let generated = [];
+
+    for (let rendition of this.iterateRenditions(asset)) {
+      let {type, value} = rendition;
+      if (typeof value !== 'string' || rendition.final) {
+        generated.push(rendition);
+        continue;
+      }
+
+      // Find an asset type for the rendition type.
+      // If the asset is not already an instance of this asset type, process it.
+      let AssetType = this.parser.findParser(
+        asset.name.slice(0, -inputType.length) + type
+      );
+      if (!(asset instanceof AssetType)) {
+        let opts = Object.assign({rendition}, asset.options);
+        let subAsset = new AssetType(asset.name, asset.package, opts);
+        subAsset.contents = value;
+        subAsset.dependencies = asset.dependencies;
+
+        let processed = await this.processAsset(subAsset);
+        generated = generated.concat(processed);
+        Object.assign(asset.cacheData, subAsset.cacheData);
+        asset.hash = md5(asset.hash + subAsset.hash);
+      } else {
+        generated.push(rendition);
+      }
+    }
+
+    // Post process. This allows assets a chance to modify the output produced by sub-asset types.
+    asset.generated = generated;
+    try {
+      generated = await asset.postProcess(generated);
+    } catch (err) {
+      throw asset.generateErrorMessage(err);
+    }
+
+    return generated;
+  }
+
+  *iterateRenditions(asset) {
+    if (Array.isArray(asset.generated)) {
+      return yield* asset.generated;
+    }
+
+    if (typeof asset.generated === 'string') {
+      return yield {
+        type: asset.type,
+        value: asset.generated
+      };
+    }
+
+    // Backward compatibility support for the old API.
+    // Assume all renditions are final - don't compose asset types together.
+    for (let type in asset.generated) {
+      yield {
+        type,
+        value: asset.generated[type],
+        final: true
+      };
+    }
+  }
+}
+
+module.exports = Pipeline;

--- a/src/assets/CSSAsset.js
+++ b/src/assets/CSSAsset.js
@@ -116,7 +116,17 @@ class CSSAsset extends Asset {
         'module.exports = ' + JSON.stringify(this.cssModules, false, 2) + ';';
     }
 
-    return {css, js};
+    return [
+      {
+        type: 'css',
+        value: css
+      },
+      {
+        type: 'js',
+        value: js,
+        final: true
+      }
+    ];
   }
 
   generateErrorMessage(err) {

--- a/src/assets/CoffeeScriptAsset.js
+++ b/src/assets/CoffeeScriptAsset.js
@@ -1,24 +1,35 @@
-const JSAsset = require('./JSAsset');
+const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 
-class CoffeeScriptAsset extends JSAsset {
-  async parse(code) {
+class CoffeeScriptAsset extends Asset {
+  constructor(name, pkg, options) {
+    super(name, pkg, options);
+    this.type = 'js';
+  }
+
+  async generate() {
     // require coffeescript, installed locally in the app
     let coffee = await localRequire('coffeescript', this.name);
 
     // Transpile Module using CoffeeScript and parse result as ast format through babylon
-    let transpiled = coffee.compile(code, {
+    let transpiled = coffee.compile(this.contents, {
       sourceMap: this.options.sourceMaps
     });
 
+    let sourceMap;
     if (transpiled.sourceMap) {
-      this.sourceMap = transpiled.sourceMap.generate();
-      this.sourceMap.sources = [this.relativeName];
-      this.sourceMap.sourcesContent = [this.contents];
+      sourceMap = transpiled.sourceMap.generate();
+      sourceMap.sources = [this.relativeName];
+      sourceMap.sourcesContent = [this.contents];
     }
 
-    this.contents = this.options.sourceMaps ? transpiled.js : transpiled;
-    return await super.parse(this.contents);
+    return [
+      {
+        type: 'js',
+        value: this.options.sourceMaps ? transpiled.js : transpiled,
+        sourceMap
+      }
+    ];
   }
 }
 

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -160,8 +160,7 @@ class HTMLAsset extends Asset {
   }
 
   generate() {
-    let html = this.isAstDirty ? render(this.ast) : this.contents;
-    return {html};
+    return this.isAstDirty ? render(this.ast) : this.contents;
   }
 }
 

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -27,6 +27,7 @@ class JSAsset extends Asset {
     this.isES6Module = false;
     this.outputCode = null;
     this.cacheData.env = {};
+    this.sourceMap = options.rendition ? options.rendition.sourceMap : null;
   }
 
   shouldInvalidate(cacheData) {

--- a/src/assets/LESSAsset.js
+++ b/src/assets/LESSAsset.js
@@ -1,8 +1,13 @@
-const CSSAsset = require('./CSSAsset');
+const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 const promisify = require('../utils/promisify');
 
-class LESSAsset extends CSSAsset {
+class LESSAsset extends Asset {
+  constructor(name, pkg, options) {
+    super(name, pkg, options);
+    this.type = 'css';
+  }
+
   async parse(code) {
     // less should be installed locally in the module that's being required
     let less = await localRequire('less', this.name);
@@ -15,15 +20,23 @@ class LESSAsset extends CSSAsset {
     opts.filename = this.name;
     opts.plugins = (opts.plugins || []).concat(urlPlugin(this));
 
-    let res = await render(code, opts);
-    res.render = () => res.css;
-    return res;
+    return await render(code, opts);
   }
 
   collectDependencies() {
     for (let dep of this.ast.imports) {
       this.addDependency(dep, {includedInParent: true});
     }
+  }
+
+  generate() {
+    return [
+      {
+        type: 'css',
+        value: this.ast.css,
+        hasDependencies: false
+      }
+    ];
   }
 }
 

--- a/src/assets/ReasonAsset.js
+++ b/src/assets/ReasonAsset.js
@@ -1,9 +1,14 @@
-const JSAsset = require('./JSAsset');
+const Asset = require('../Asset');
 const fs = require('../utils/fs');
 const localRequire = require('../utils/localRequire');
 
-class ReasonAsset extends JSAsset {
-  async parse() {
+class ReasonAsset extends Asset {
+  constructor(name, pkg, options) {
+    super(name, pkg, options);
+    this.type = 'js';
+  }
+
+  async generate() {
     const bsb = await localRequire('bsb-js', this.name);
 
     // This runs BuckleScript - the Reason to JS compiler.
@@ -18,10 +23,7 @@ class ReasonAsset extends JSAsset {
     // BuckleScript configuration to simplify the file processing.
     const outputFile = this.name.replace(/\.(re|ml)$/, '.bs.js');
     const outputContent = await fs.readFile(outputFile);
-    this.contents = outputContent.toString();
-
-    // After loading the compiled JS source, use the normal JS behavior.
-    return await super.parse(this.contents);
+    return outputContent.toString();
   }
 }
 

--- a/src/assets/StylusAsset.js
+++ b/src/assets/StylusAsset.js
@@ -1,11 +1,17 @@
-const CSSAsset = require('./CSSAsset');
+// const CSSAsset = require('./CSSAsset');
+const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 const Resolver = require('../Resolver');
 const syncPromise = require('../utils/syncPromise');
 
 const URL_RE = /^(?:url\s*\(\s*)?['"]?(?:[#/]|(?:https?:)?\/\/)/i;
 
-class StylusAsset extends CSSAsset {
+class StylusAsset extends Asset {
+  constructor(name, pkg, options) {
+    super(name, pkg, options);
+    this.type = 'css';
+  }
+
   async parse(code) {
     // stylus should be installed locally in the module that's being required
     let stylus = await localRequire('stylus', this.name);
@@ -26,8 +32,14 @@ class StylusAsset extends CSSAsset {
     return style;
   }
 
-  collectDependencies() {
-    // Do nothing. Dependencies are collected by our custom evaluator.
+  generate() {
+    return [
+      {
+        type: 'css',
+        value: this.ast.render(),
+        hasDependencies: false
+      }
+    ];
   }
 
   generateErrorMessage(err) {

--- a/src/assets/WebManifestAsset.js
+++ b/src/assets/WebManifestAsset.js
@@ -31,9 +31,7 @@ class WebManifestAsset extends Asset {
   }
 
   generate() {
-    return {
-      webmanifest: JSON.stringify(this.ast)
-    };
+    return JSON.stringify(this.ast);
   }
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,10 +1,10 @@
 require('v8-compile-cache');
-const Parser = require('./Parser');
+const Pipeline = require('./Pipeline');
 
-let parser;
+let pipeline;
 
 exports.init = function(options, callback) {
-  parser = new Parser(options || {});
+  pipeline = new Pipeline(options || {});
   Object.assign(process.env, options.env || {});
   process.env.HMR_PORT = options.hmrPort;
   process.env.HMR_HOSTNAME = options.hmrHostname;
@@ -14,22 +14,11 @@ exports.init = function(options, callback) {
 exports.run = async function(path, pkg, options, isWarmUp, callback) {
   try {
     options.isWarmUp = isWarmUp;
-    var asset = parser.getAsset(path, pkg, options);
-    await asset.process();
+    var result = await pipeline.process(path, pkg, options);
 
-    callback(null, {
-      dependencies: Array.from(asset.dependencies.values()),
-      generated: asset.generated,
-      hash: asset.hash,
-      cacheData: asset.cacheData
-    });
+    callback(null, result);
   } catch (err) {
     let returned = err;
-
-    if (asset) {
-      returned = asset.generateErrorMessage(returned);
-    }
-
     returned.fileName = path;
     callback(returned);
   }


### PR DESCRIPTION
Rather than asset type classes extending one another, Parcel now takes care of composing asset types together. The output returned by an asset type's `generate` method is now recursively processed. This means, for example, that the `TypeScriptAsset` just returns JavaScript from its generate method and Parcel will automatically pass this to the `JSAsset` for further processing.

The API for `generate` changed slightly, but remains backward compatible. Now, instead of using object keys to return multiple renditions from an asset, an array is returned. This allows more options to be specified along with the actual value.

```javascript
generate() {
  return [{
    type: 'css',
    value: ...
  }, {
    type: 'js',
    value: ...
  }];
}
```

There are a couple options that allow some control over how the composition works:

1. The `final` option can be specified, which means the code is final and should not be processed by other asset types.
2. The `hasDependencies` option can be set to `false`, which means the code is guaranteed not to have any further dependencies in it. This is useful as an optimization. For example, the SASS asset type uses the SASS AST to collect dependencies, so the CSS asset type doesn't need to do it.

More options could be added in the future.

This change should be fully backward compatible. If the old API is used, composition doesn't happen at all so it should work exactly the same way as it does today.

This pipeline approach should be much more extendible, especially for plugins which no longer need to rely on the internal asset types in order to extend them. It will also allow us to do things like Vue support much more easily.