### PR TITLE
Fix HMR with content hashing changes

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -180,6 +180,20 @@ class Asset {
     return md5(this.name) + '.' + this.type;
   }
 
+  replaceBundleNames(bundleNameMap) {
+    for (let key in this.generated) {
+      let value = this.generated[key];
+      if (typeof value === 'string') {
+        // Replace temporary bundle names in the output with the final content-hashed names.
+        for (let [name, map] of bundleNameMap) {
+          value = value.split(name).join(map);
+        }
+
+        this.generated[key] = value;
+      }
+    }
+  }
+
   generateErrorMessage(err) {
     return err;
   }

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -163,7 +163,11 @@ class JSPackager extends Packager {
     if (this.externalModules.size > 0) {
       let preload = [];
       for (let mod of this.externalModules) {
-        preload.push([mod.generateBundleName(), mod.id]);
+        // Find the bundle that has the module as its entry point
+        let bundle = Array.from(mod.bundles).find(b => b.entryAsset === mod);
+        if (bundle) {
+          preload.push([path.basename(bundle.name), mod.id]);
+        }
       }
 
       if (this.bundle.entryAsset) {

--- a/src/packagers/Packager.js
+++ b/src/packagers/Packager.js
@@ -22,16 +22,7 @@ class Packager {
   }
 
   async write(string) {
-    await this.dest.write(this.replaceBundleNames(string));
-  }
-
-  replaceBundleNames(string) {
-    // Replace temporary bundle names in the output with the final content-hashed names.
-    for (let [name, map] of this.bundler.bundleNameMap) {
-      string = string.split(name).join(map);
-    }
-
-    return string;
+    await this.dest.write(string);
   }
 
   async start() {}


### PR DESCRIPTION
After #1025, HMR was broken since bundle names weren’t properly being replaced with the final hashed versions. This was happening in the Packager, but the HMR update happens independently from packaging.

This patch moves that bundle name replacement into a separate step prior to both HMR and packaging. This way it happens in one place that affects both outputs.