### PR TITLE
close HMR server when HMRServer.stop() is called

### DIFF
--- a/src/HMRServer.js
+++ b/src/HMRServer.js
@@ -9,17 +9,16 @@ const logger = require('./Logger');
 class HMRServer {
   async start(options = {}) {
     await new Promise(async resolve => {
-      let server;
       if (!options.https) {
-        server = http.createServer();
+        this.server = http.createServer();
       } else if (typeof options.https === 'boolean') {
-        server = https.createServer(generateCertificate(options));
+        this.server = https.createServer(generateCertificate(options));
       } else {
-        server = https.createServer(await getCertificate(options.https));
+        this.server = https.createServer(await getCertificate(options.https));
       }
 
-      this.wss = new WebSocket.Server({server});
-      server.listen(options.hmrPort, resolve);
+      this.wss = new WebSocket.Server({server: this.server});
+      this.server.listen(options.hmrPort, resolve);
     });
 
     this.wss.on('connection', ws => {
@@ -36,6 +35,7 @@ class HMRServer {
 
   stop() {
     this.wss.close();
+    this.server.close();
   }
 
   emitError(err) {


### PR DESCRIPTION
Hey 👋 

Normally, when the bundler is stopped the HTTP server for HMR keeps on running. This PR closes it down when `bundler.stop()` is called.

We don't see it in our tests ([see here](https://github.com/parcel-bundler/parcel/blob/master/test/hmr.js)) because in our tests we use port 0, which causes Node to look for an available port. But we still have multiple servers open until Mocha closes them eventually by closing the entire process when it's finished.