### PR TITLE
Update addBundleLoader to accept multiple targets

### DIFF
--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -148,7 +148,8 @@ class JSPackager extends Packager {
     for (let bundleType of this.bundleLoaders) {
       let loader = this.options.bundleLoaders[bundleType];
       if (loader) {
-        let asset = await this.bundler.getAsset(loader);
+        let target = this.options.target === 'node' ? 'node' : 'browser';
+        let asset = await this.bundler.getAsset(loader[target]);
         await this.addAssetToBundle(asset);
         loads +=
           'b.register(' +


### PR DESCRIPTION
Follow up to #981 based on [@devongovett comment](https://github.com/parcel-bundler/parcel/pull/981#discussion_r177645431) :

> would be cool to add support for registering bundle loaders for specific environments. this would allow third party plugins to do the same:
>
>```javascript
> bundler.addBundleLoader('wasm', {
>  node: require.resolve('./node/wasm-loader'),
>  browser: require.resolve('./browser/wasm-loader')
>});
>```