### PR TITLE
Wait for the next event loop iteration when loading WASM

### DIFF
--- a/src/builtins/loaders/node/js-loader.js
+++ b/src/builtins/loaders/node/js-loader.js
@@ -6,7 +6,11 @@ module.exports = function loadJSBundle(bundle) {
       if (err) {
         reject(err);
       } else {
-        resolve(data);
+        // wait for the next event loop iteration, so we are sure
+        // the current module is fully loaded
+        setImmediate(function() {
+          resolve(data);
+        });
       }
     });
   })

--- a/test/utils.js
+++ b/test/utils.js
@@ -123,7 +123,8 @@ function prepareNodeContext(bundle, globals) {
       },
       console,
       process: process,
-      setTimeout: setTimeout
+      setTimeout: setTimeout,
+      setImmediate: setImmediate
     },
     globals
   );


### PR DESCRIPTION
The test `should load a wasm file in parallel with a dynamic JS import` was failing randomly since #981 was merged, this fixes it.

Combined with #1068 the tests should be reliable again.