### PR TITLE
WIP: Don't serve on non html main assets

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -177,8 +177,8 @@ async function bundle(main, command) {
   }
 
   const bundler = new Bundler(main, command);
-
-  if (command.name() === 'serve') {
+  const mainFileExtension = main.split('.').pop();
+  if (command.name() === 'serve' && mainFileExtension === 'html') {
     const server = await bundler.serve(command.port || 1234, command.https);
     if (command.open) {
       await require('./utils/openInBrowser')(


### PR DESCRIPTION
This PR will fix #1005.

I currently do a strict check, whether the main entry asset has the `.html` file extension or not.
I don't know if anyone still does this today, but this would fail on `.htm` or `.html5` main files.
This could be solved using a RegExp, like e.g. `/htm|html|html5/`.

But is it intended to support main `.hbs` or other template language files as main assets?

I'd be happy if anyone has a suggestion / tip for this problem.

Regards
Nico 