### PR TITLE
Give priority to styl files in StylusAsset resolver

### DIFF
--- a/src/assets/StylusAsset.js
+++ b/src/assets/StylusAsset.js
@@ -50,19 +50,6 @@ class StylusAsset extends Asset {
   }
 }
 
-function getResolverExtensions(options) {
-  if (!options || !options.extensions) {
-    return [];
-  }
-
-  let extensions = Array.isArray(options.extensions)
-    ? options.extensions.slice()
-    : Object.keys(options.extensions);
-
-  // Sort to give .styl files priority
-  return extensions.sort(e => (e === '.styl' ? -1 : 1));
-}
-
 async function createEvaluator(asset) {
   const Evaluator = await localRequire(
     'stylus/lib/visitor/evaluator',
@@ -71,7 +58,7 @@ async function createEvaluator(asset) {
   const utils = await localRequire('stylus/lib/utils', asset.name);
   const resolver = new Resolver(
     Object.assign({}, asset.options, {
-      extensions: getResolverExtensions(asset.options)
+      extensions: ['.styl', '.css']
     })
   );
 

--- a/src/assets/StylusAsset.js
+++ b/src/assets/StylusAsset.js
@@ -50,13 +50,30 @@ class StylusAsset extends Asset {
   }
 }
 
+function getResolverExtensions(options) {
+  if (!options || !options.extensions) {
+    return [];
+  }
+
+  let extensions = Array.isArray(options.extensions)
+    ? options.extensions.slice()
+    : Object.keys(options.extensions);
+
+  // Sort to give .styl files priority
+  return extensions.sort(e => (e === '.styl' ? -1 : 1));
+}
+
 async function createEvaluator(asset) {
   const Evaluator = await localRequire(
     'stylus/lib/visitor/evaluator',
     asset.name
   );
   const utils = await localRequire('stylus/lib/utils', asset.name);
-  const resolver = new Resolver(asset.options);
+  const resolver = new Resolver(
+    Object.assign({}, asset.options, {
+      extensions: getResolverExtensions(asset.options)
+    })
+  );
 
   // This is a custom stylus evaluator that extends stylus with support for the node
   // require resolution algorithm. It also adds all dependencies to the parcel asset


### PR DESCRIPTION
Stylus's base case expects a `.styl` file. If a folder has two or more files with the same name, but different extensions, any `styl` file should take precedence for the sake of resolution. This sorts `styl` to the top of the list so that it is checked first. 
Closes #1110