### PR TITLE
Remove `eval` usage. Fixes CSP cases.

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -1,6 +1,5 @@
 var OVERLAY_ID = '__parcel__error__overlay__';
 
-var global = (1, eval)('this');
 var OldModule = module.bundle.Module;
 
 function Module(moduleName) {

--- a/src/builtins/prelude.js
+++ b/src/builtins/prelude.js
@@ -45,7 +45,7 @@ parcelRequire = (function (modules, cache, entry) {
 
       var module = cache[name] = new newRequire.Module(name);
 
-      modules[name][0].call(module.exports, localRequire, module, module.exports);
+      modules[name][0].call(module.exports, localRequire, module, module.exports, this);
     }
 
     return cache[name].exports;

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -94,11 +94,14 @@ class JSPackager extends Packager {
   }
 
   async writeModule(id, code, deps = {}, map) {
-    let wrapped = this.first ? '' : ',';
-    wrapped +=
-      id + ':[function(require,module,exports) {\n' + (code || '') + '\n},';
-    wrapped += JSON.stringify(deps);
-    wrapped += ']';
+    let wrapped =
+      (this.first ? '' : ',') +
+      id +
+      ':[function(require,module,exports,global) {\n' +
+      (code || '') +
+      '\n},' +
+      JSON.stringify(deps) +
+      ']';
 
     this.first = false;
     await this.write(wrapped);

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -94,14 +94,11 @@ class JSPackager extends Packager {
   }
 
   async writeModule(id, code, deps = {}, map) {
-    let wrapped =
-      (this.first ? '' : ',') +
-      id +
-      ':[function(require,module,exports,global) {\n' +
-      (code || '') +
-      '\n},' +
-      JSON.stringify(deps) +
-      ']';
+    let wrapped = this.first ? '' : ',';
+    wrapped +=
+      id + ':[function(require,module,exports) {\n' + (code || '') + '\n},';
+    wrapped += JSON.stringify(deps);
+    wrapped += ']';
 
     this.first = false;
     await this.write(wrapped);

--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -7,7 +7,7 @@ const VARS = {
     asset.addDependency('process');
     return 'var process = require("process");';
   },
-  global: () => 'var global = (1,eval)("this");',
+  global: () => 'var global = typeof global === "object" ? global : typeof window === "object" ? window :typeof self === "object" ? self : this;',
   __dirname: asset =>
     `var __dirname = ${JSON.stringify(Path.dirname(asset.name))};`,
   __filename: asset => `var __filename = ${JSON.stringify(asset.name)};`,

--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -7,6 +7,7 @@ const VARS = {
     asset.addDependency('process');
     return 'var process = require("process");';
   },
+  global: () => 'var global = arguments[3];',
   __dirname: asset =>
     `var __dirname = ${JSON.stringify(Path.dirname(asset.name))};`,
   __filename: asset => `var __filename = ${JSON.stringify(asset.name)};`,

--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -7,7 +7,6 @@ const VARS = {
     asset.addDependency('process');
     return 'var process = require("process");';
   },
-  global: () => 'var global = typeof global === "object" ? global : typeof window === "object" ? window :typeof self === "object" ? self : this;',
   __dirname: asset =>
     `var __dirname = ${JSON.stringify(Path.dirname(asset.name))};`,
   __filename: asset => `var __filename = ${JSON.stringify(asset.name)};`,

--- a/test/integration/global-redeclare/index.js
+++ b/test/integration/global-redeclare/index.js
@@ -1,0 +1,4 @@
+const global = {};
+module.exports = function () {
+  return !!global.document;
+};

--- a/test/integration/global-redeclare/package.json
+++ b/test/integration/global-redeclare/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "parcel-test-global-redeclare",
+  "private": true,
+  "browserslist": ["last 2 Chrome versions"]
+}

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -376,6 +376,13 @@ describe('javascript', function() {
     });
   });
 
+  it('should handle re-declaration of the global constant', async function() {
+    let b = await bundle(__dirname + '/integration/global-redeclare/index.js');
+
+    let output = run(b);
+    assert.deepEqual(output(), false);
+  });
+
   it('should insert environment variables', async function() {
     let b = await bundle(__dirname + '/integration/env/index.js');
 


### PR DESCRIPTION
Picks up on work done by @mBeierl (closes #353).
Fixes #335.
