### PR TITLE
Add “private: true” to package.json files in tests.

### DIFF
--- a/test/integration/autoinstall/npm/package.json
+++ b/test/integration/autoinstall/npm/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "parcel-test-autoinstall-npm"
+  "name": "parcel-test-autoinstall-npm",
+  "private": true
 }

--- a/test/integration/autoinstall/yarn/package.json
+++ b/test/integration/autoinstall/yarn/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "parcel-test-autoinstall-yarn"
+  "name": "parcel-test-autoinstall-yarn",
+  "private": true
 }

--- a/test/integration/babel-default/package.json
+++ b/test/integration/babel-default/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "parcel-test-browser-browserslist"
+  "name": "parcel-test-browser-browserslist",
+  "private": true
 }

--- a/test/integration/babel-node-modules/package.json
+++ b/test/integration/babel-node-modules/package.json
@@ -1,4 +1,5 @@
 {
   "name": "parcel-test-browser-browserslist",
+  "private": true,
   "browserslist": ["last 2 Chrome versions", "IE >= 11"]
 }

--- a/test/integration/babel-polyfill/package.json
+++ b/test/integration/babel-polyfill/package.json
@@ -1,4 +1,5 @@
 {
   "name": "parcel-test-babel-polyfill-browserslist",
+  "private": true,
   "browserslist": ["last 2 Chrome versions"]
 }

--- a/test/integration/jsx-hyperapp/package.json
+++ b/test/integration/jsx-hyperapp/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
  "dependencies": {
     "hyperapp": "*"
   }

--- a/test/integration/jsx-nervjs/package.json
+++ b/test/integration/jsx-nervjs/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "nervjs": "*"
   }

--- a/test/integration/jsx-preact/package.json
+++ b/test/integration/jsx-preact/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "preact": "*"
   }

--- a/test/integration/jsx-react/package.json
+++ b/test/integration/jsx-react/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "react": "*"
   }

--- a/test/integration/plugins/package.json
+++ b/test/integration/plugins/package.json
@@ -1,5 +1,6 @@
 {
   "name": "parcel-test",
+  "private": true,
   "dependencies": {
     "parcel-plugin-test": "*"
   }

--- a/test/integration/resolver/package.json
+++ b/test/integration/resolver/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolver",
+  "private": true,
   "alias": {
     "aliased": "foo",
     "aliased-file": "./bar.js",


### PR DESCRIPTION
Reduces amount of warnings during tests.