### PR TITLE
Fix reference pass error in package config

### DIFF
--- a/src/assets/LESSAsset.js
+++ b/src/assets/LESSAsset.js
@@ -13,10 +13,10 @@ class LESSAsset extends Asset {
     let less = await localRequire('less', this.name);
     let render = promisify(less.render.bind(less));
 
-    let opts =
-      this.package.less ||
-      (await this.getConfig(['.lessrc', '.lessrc.js'])) ||
-      {};
+    let opts = Object.assign(
+      {},
+      this.package.less || (await this.getConfig(['.lessrc', '.lessrc.js']))
+    );
     opts.filename = this.name;
     opts.plugins = (opts.plugins || []).concat(urlPlugin(this));
 

--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -15,10 +15,10 @@ class SASSAsset extends Asset {
     let sass = await localRequire('node-sass', this.name);
     let render = promisify(sass.render.bind(sass));
 
-    let opts =
-      this.package.sass ||
-      (await this.getConfig(['.sassrc', '.sassrc.js'])) ||
-      {};
+    let opts = Object.assign(
+      {},
+      this.package.sass || (await this.getConfig(['.sassrc', '.sassrc.js']))
+    );
     opts.includePaths = (opts.includePaths || []).concat(
       path.dirname(this.name)
     );

--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -31,7 +31,7 @@ async function getConfig(asset) {
     return;
   }
 
-  config = config || {};
+  config = Object.assign({}, config);
 
   let postcssModulesConfig = {
     getJSON: (filename, json) => (asset.cssModules = json)

--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -26,7 +26,7 @@ async function getConfig(asset) {
     return;
   }
 
-  config = config || {};
+  config = Object.assign({}, config);
   config.plugins = await loadPlugins(config.plugins, asset.name);
   config.skipParse = true;
   return config;


### PR DESCRIPTION
### Type

Bugfix

### Tests

All tests are passing

### Description

We will get an error config if we loading config multiple times from `package.json`, because the config is passed by reference.

For example, we use `postcss` and add a `postcss` field into `package.json` like this:

```json
...
"postcss": {
  "plugins": {
    "autoprefixer": {
      "grid": true
    }
  }
}
...
```

Then the first time in [`./src/transforms/postcss.js:L34`](https://github.com/parcel-bundler/parcel/blob/master/src/transforms/postcss.js#L34) we can get a correct config like above.

But if we change some styles, in the second time we will get an error config like this:

```json
"postcss": {
  "plugins": [null, null, null],
  "from": "...",
  "to": "..."
}
```

All `plugins` will missing because it has been overwritten in [`./src/transforms/postcss.js:L48`](https://github.com/parcel-bundler/parcel/blob/master/src/transforms/postcss.js#L48), then compiling will break.