### PR TITLE
Fix asset size always be zero when building vue project

### DIFF
--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -206,7 +206,11 @@ class Bundle {
     }
 
     await packager.addAsset(asset);
-    this.addAssetSize(asset, packager.getSize() - this.totalSize);
+
+    const assetSize = packager.getSize() - this.totalSize;
+    if (assetSize > 0) {
+      this.addAssetSize(asset, assetSize);
+    }
   }
 
   addAssetSize(asset, size) {


### PR DESCRIPTION
When called `packager.addAsset` to add an assert, the packager size will NOT change if the asset is already in packager. So `packager.getSize() - this.totalSize` will get `0` and `asset.bundledSize` is set to `0`.

Fixes: https://github.com/parcel-bundler/parcel/issues/1150