### PR TITLE
Ignore noop dependencies

### DIFF
--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -38,7 +38,8 @@ module.exports = {
       callee.name === 'require' &&
       args.length === 1 &&
       types.isStringLiteral(args[0]) &&
-      !hasBinding(ancestors, 'require');
+      !hasBinding(ancestors, 'require') &&
+      !hasNoOpParent(ancestors);
 
     if (isRequire) {
       let optional = ancestors.some(a => types.isTryStatement(a)) || undefined;
@@ -88,6 +89,19 @@ module.exports = {
     }
   }
 };
+
+function hasNoOpParent(ancestors) {
+  return ancestors.some(node => {
+    if (
+      types.isIfStatement(node) &&
+      types.isLiteral(node.test) &&
+      !node.test.value
+    ) {
+      // only ignore if it's in the consequent branch
+      return ancestors.indexOf(node.consequent) !== -1;
+    }
+  });
+}
 
 function hasBinding(node, name) {
   if (Array.isArray(node)) {

--- a/test/integration/optional-dep/index.js
+++ b/test/integration/optional-dep/index.js
@@ -1,5 +1,19 @@
 try {
-  require('optional-dep');
+  require('try-optional-dep');
 } catch (err) {
   module.exports = err;
+}
+
+if(false) {
+  require('if-false-optional-dep');
+}
+
+if(false) {
+  globalStuff(() =>
+    require('if-false-optional-dep-deep')
+  )
+}
+
+if('') {
+  require('if-falsy-optional-dep');
 }


### PR DESCRIPTION
Ignore dependencies in a falsy branch, example `if(false)` or `if('')`.

This is needed when consuming Webpack generated UMD modules. For example in `react-data-grid`: 

```js
if (false) {
    var REACT_ELEMENT_TYPE = (typeof Symbol === 'function' &&
    Symbol.for &&
    Symbol.for('react.element')) ||
    0xeac7;

    var isValidElement = function(object) {
    return typeof object === 'object' &&
        object !== null &&
        object.$$typeof === REACT_ELEMENT_TYPE;
    };

    // By explicitly using `prop-types` you are opting into new development behavior.
    // http://fb.me/prop-types-in-prod
    var throwOnDirectAccess = true;
    module.exports = require('./factoryWithTypeCheckers')(isValidElement, throwOnDirectAccess);
}
```

Triggers this error : 

```
C:\~\node_modules\react-data-grid\dist\react-data-grid.js:93:28: Cannot resolve dependency './factoryWithTypeCheckers'
  91 | a  // http://fb.me/prop-types-in-prod\react-data-
  92 |    var throwOnDirectAccess = true;
> 93 |    module.exports = require('./factoryWithTypeCheckers')(isValidElement, throwOnDirectAccess);
     |                             ^
  94 |  } else {
  95 |    // By explicitly using `prop-types` you are opting into new production behavior.
  96 |    // http://fb.me/prop-types-in-prod
```

----

Reported by `Jindřich Pergler`