### PR TITLE
Introduce .webmanifestrc

### DIFF
--- a/src/assets/WebManifestAsset.js
+++ b/src/assets/WebManifestAsset.js
@@ -1,4 +1,5 @@
 const Asset = require('../Asset');
+const webmanifestTransform = require('../transforms/webmanifest');
 
 class WebManifestAsset extends Asset {
   constructor(name, pkg, options) {
@@ -28,6 +29,10 @@ class WebManifestAsset extends Asset {
         this.ast.serviceworker.src
       );
     }
+  }
+
+  async pretransform() {
+    await webmanifestTransform(this);
   }
 
   generate() {

--- a/src/transforms/webmanifest.js
+++ b/src/transforms/webmanifest.js
@@ -1,0 +1,18 @@
+module.exports = async function(asset) {
+  let config =
+    asset.package.webmanifest ||
+    (await asset.getConfig([
+      '.webmanifestrc',
+      '.webmanifestrc.js',
+      'webmanifest.config.js'
+    ]));
+  if (!config && !asset.options.minify) {
+    return;
+  }
+
+  await asset.parseIfNeeded();
+  let res = await config(asset.ast);
+
+  asset.ast = res;
+  asset.isAstDirty = true;
+};

--- a/test/html.js
+++ b/test/html.js
@@ -520,6 +520,27 @@ describe('html', function() {
     });
   });
 
+  it('should support transforming webmanifest', async function() {
+    let b = await bundle(
+      __dirname + '/integration/webmanifest-transform/index.html'
+    );
+
+    assertBundleTree(b, {
+      name: 'index.html',
+      assets: ['index.html'],
+      childBundles: [
+        {
+          type: 'webmanifest',
+          assets: ['manifest.webmanifest']
+        }
+      ]
+    });
+
+    const childBundles = Array.from(b.childBundles);
+    const manifest = fs.readFileSync(childBundles[0].name);
+    assert(manifest.includes('Foo'));
+  });
+
   it('should bundle svg files correctly', async function() {
     let b = await bundle(__dirname + '/integration/html-svg/index.html');
 

--- a/test/integration/webmanifest-transform/.webmanifestrc.js
+++ b/test/integration/webmanifest-transform/.webmanifestrc.js
@@ -1,0 +1,5 @@
+module.exports = function (manifest) {
+  const str = JSON.stringify(manifest)
+    .replace('{{ APP_NAME }}', 'Foo')
+  return JSON.parse(str)
+}

--- a/test/integration/webmanifest-transform/index.html
+++ b/test/integration/webmanifest-transform/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html>
+    <head><link rel="manifest" href="manifest.webmanifest"></head>
+    <body></body>
+</html>

--- a/test/integration/webmanifest-transform/manifest.webmanifest
+++ b/test/integration/webmanifest-transform/manifest.webmanifest
@@ -1,0 +1,4 @@
+{
+    "name": "{{ APP_NAME }}",
+    "display": "standalone"
+}


### PR DESCRIPTION
I have no idea if this is the best approach for this problem, but it seemed to (kind of) fit into the same pattern used for `.posthtmlrc.js`, and `.postcssrc.js`.

`.webmanifestrc.js` is expected to export a single function which will have the webmanifest object passed to it. This allows modifying the output `webmanifest` at compile time.

The use case that I had in mind was compiling `webmanifest` as a handlebars (or other) template, so that I can set `name` and other variables from an `.env` file - this is kind of demonstrated in `test/html.js`