### PR TITLE
Fix serving files with query params

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -7,6 +7,7 @@ const generateCertificate = require('./utils/generateCertificate');
 const getCertificate = require('./utils/getCertificate');
 const logger = require('./Logger');
 const path = require('path');
+const url = require('url');
 
 serveStatic.mime.define({
   'application/wasm': ['wasm']
@@ -43,18 +44,19 @@ function middleware(bundler) {
     }
 
     function respond() {
+      let {pathname} = url.parse(req.url);
       if (bundler.errored) {
         return send500();
       } else if (
-        !req.url.startsWith(bundler.options.publicURL) ||
-        path.extname(req.url) === ''
+        !pathname.startsWith(bundler.options.publicURL) ||
+        path.extname(pathname) === ''
       ) {
         // If the URL doesn't start with the public path, or the URL doesn't
         // have a file extension, send the main HTML bundle.
         return sendIndex();
       } else {
         // Otherwise, serve the file from the dist folder
-        req.url = req.url.slice(bundler.options.publicURL.length);
+        req.url = pathname.slice(bundler.options.publicURL.length);
         return serve(req, res, send404);
       }
     }

--- a/test/server.js
+++ b/test/server.js
@@ -130,4 +130,14 @@ describe('server', function() {
     data = await get('/hello.txt');
     assert.equal(data, 'hello');
   });
+
+  it('should work with query parameters that contain a dot', async function() {
+    let b = bundler(__dirname + '/integration/html/index.html', {
+      publicUrl: '/'
+    });
+    server = await b.serve(0);
+
+    let data = await get('/?foo=bar.baz');
+    assert.equal(data, fs.readFileSync(__dirname + '/dist/index.html', 'utf8'));
+  });
 });


### PR DESCRIPTION
If query params containing a dot character were on a request to `/`, they would get treated as the file extension. This parses the pathname from the requested URL and matches the extname against that instead. Fixes #1164.