### PR TITLE
[Fix] Prevent build from breaking when .scss file is empty

### DIFF
--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -48,7 +48,7 @@ class SASSAsset extends Asset {
     return [
       {
         type: 'css',
-        value: this.ast.css.toString(),
+        value: this.ast ? this.ast.css.toString() : '',
         hasDependencies: false
       }
     ];

--- a/test/integration/scss-empty/index.js
+++ b/test/integration/scss-empty/index.js
@@ -1,0 +1,5 @@
+require('./index.scss');
+
+module.exports = function () {
+  return 2;
+};

--- a/test/sass.js
+++ b/test/sass.js
@@ -82,6 +82,32 @@ describe('sass', function() {
     assert(css.includes('.base'));
   });
 
+  it('should support requiring empty scss files', async function() {
+    let b = await bundle(__dirname + '/integration/scss-empty/index.js');
+
+    assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js', 'index.scss'],
+      childBundles: [
+        {
+          type: 'map'
+        },
+        {
+          name: 'index.css',
+          assets: ['index.scss'],
+          childBundles: []
+        }
+      ]
+    });
+
+    let output = run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 2);
+
+    let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
+    assert.equal(css, '');
+  });
+
   it('should support linking to assets with url() from scss', async function() {
     let b = await bundle(__dirname + '/integration/scss-url/index.js');
 


### PR DESCRIPTION
I was attempting to set up my build with SASS according to the guides. In order to get the build working as quickly as possible I created an empty `app.scss` file and imported it into my main module. I expected the build to complete, but instead received this error:

![image](https://user-images.githubusercontent.com/727536/38785911-5e662cba-40f2-11e8-989d-130fd5048dbf.png)

Not sure how you feel about this solution, but I traced the problem down to `/src/Asset.js:70`. 

```js
if (this.contents && this.mightHaveDependencies()) {
  await this.parseIfNeeded();
  await this.collectDependencies();
}
```

`this.contents` is equal to an empty string, therefore this check evaluates falsy and the contents are not parsed. The end result is that `this.ast` is not set and remains `null`.

Because of this, `/src/SASSAsset.js:51` blows up:

```js
generate() {
  return [
    {
      type: 'css',
      value: this.ast.css.toString() // this.ast is null
      hasDependencies: false
    }
  ];
}
```