### PR TITLE
Allow building standalone bundles for node.js

### DIFF
--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -117,7 +117,7 @@ function hasBinding(node, name) {
 }
 
 function addDependency(asset, node, opts = {}) {
-  if (asset.options.target !== 'browser') {
+  if (asset.options.target !== 'browser' && !asset.options.bundleAll) {
     const isRelativeImport = /^[/~.]/.test(node.value);
     if (!isRelativeImport) return;
   }


### PR DESCRIPTION
**Proposal**
Create new option `bundleAll` to create standalone bundle for `node.js` and `electron` environments.

**Actual situation**
Currently `node_modules` files are not bundled. That's not full standalone bundle.