### PR TITLE
Add test to not dedupe imports with same contents but different dependency paths

### DIFF
--- a/test/integration/import_same_content/.eslintrc.json
+++ b/test/integration/import_same_content/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/test/integration/import_same_content/index.js
+++ b/test/integration/import_same_content/index.js
@@ -1,0 +1,6 @@
+import {a} from './module_A/test';
+import {b} from './module_B/test';
+
+export default function () {
+  return a + b;
+};

--- a/test/integration/import_same_content/module_A/index.js
+++ b/test/integration/import_same_content/module_A/index.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/test/integration/import_same_content/module_A/test/index.js
+++ b/test/integration/import_same_content/module_A/test/index.js
@@ -1,0 +1,1 @@
+export * from '..'

--- a/test/integration/import_same_content/module_B/index.js
+++ b/test/integration/import_same_content/module_B/index.js
@@ -1,0 +1,1 @@
+export const b = 2;

--- a/test/integration/import_same_content/module_B/test/index.js
+++ b/test/integration/import_same_content/module_B/test/index.js
@@ -1,0 +1,1 @@
+export * from '..'

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -802,4 +802,15 @@ describe('javascript', function() {
 
     assert.equal(failed, false);
   });
+
+  it('should not dedupe imports with same content but different dependency paths', async function() {
+    let b = await bundle(
+      __dirname + '/integration/import_same_content/index.js'
+    );
+
+    let output = run(b);
+    assert.equal(typeof output, 'object');
+    assert.equal(typeof output.default, 'function');
+    assert.equal(output.default(), 3);
+  });
 });


### PR DESCRIPTION
This PR adds a test for the scenario described in #933 and fixed in #1011.
At the moment it's failing, but after merging #1011 it will pass.