### PR TITLE
Update default engines to > 0.25%

### DIFF
--- a/src/utils/getTargetEngines.js
+++ b/src/utils/getTargetEngines.js
@@ -2,7 +2,7 @@ const browserslist = require('browserslist');
 const semver = require('semver');
 
 const DEFAULT_ENGINES = {
-  browsers: ['> 1%', 'last 2 versions', 'Firefox ESR'],
+  browsers: ['> 0.25%'],
   node: '6'
 };
 


### PR DESCRIPTION
Don’t use “last 2 versions”. See https://jamie.build/last-2-versions. 

I think this should be an ok default query, see http://browserl.ist/?q=%3E0.25%25. I don't think we should drop IE 11 by default yet though, so this still means we are always running all plugins in babel-preset-env. A query like `> 0.5%, not ie 11, not android 4.4` would reduce that from 24 to 9 plugins... hmm. Thoughts?

cc. @jamiebuilds 