### PR TITLE
standalone bundles for node

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -104,6 +104,7 @@ class Bundler extends EventEmitter {
       minify:
         typeof options.minify === 'boolean' ? options.minify : isProduction,
       target: target,
+      bundleAll: options.bundleAll || false,
       hmr:
         target === 'node'
           ? false

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -105,6 +105,7 @@ class Bundler extends EventEmitter {
         typeof options.minify === 'boolean' ? options.minify : isProduction,
       target: target,
       bundleAll: options.bundleAll || false,
+      ignore: options.ignore ? new Set(options.ignore.split(',')) : new Set(),
       hmr:
         target === 'node'
           ? false
@@ -399,6 +400,11 @@ class Bundler extends EventEmitter {
 
   async resolveDep(asset, dep, install = true) {
     try {
+      // Check for ignored modules
+      if (this.options.ignore.has(dep.name)) {
+        return;
+      }
+
       return await this.resolveAsset(dep.name, asset.name);
     } catch (err) {
       // If the dep is optional, return before we throw

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -6,7 +6,7 @@ const pkg = require('../package.json');
 const logger = require('./Logger');
 
 // These keys can affect the output, so if they differ, the cache should not match
-const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target', 'bundleAll'];
+const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target', 'bundleAll', 'ignore'];
 
 class FSCache {
   constructor(options) {

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -6,7 +6,7 @@ const pkg = require('../package.json');
 const logger = require('./Logger');
 
 // These keys can affect the output, so if they differ, the cache should not match
-const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target'];
+const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target', 'bundleAll'];
 
 class FSCache {
   constructor(options) {

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -270,7 +270,7 @@ class Resolver {
     // libraries like d3.js specifies node.js specific files in the "main" which breaks the build
     // we use the "module" or "browser" field to get the full dependency tree if available.
     // If this is a linked module with a `source` field, use that as the entry point.
-    let main = [pkg.source, pkg.module, pkg.browser, pkg.main].find(
+    let main = [pkg.source, pkg.module, (this.options.target === 'browser' ? pkg.browser : undefined), pkg.main].find(
       entry => typeof entry === 'string'
     );
 
@@ -327,7 +327,7 @@ class Resolver {
     return (
       this.getAlias(filename, pkg.pkgdir, pkg.source) ||
       this.getAlias(filename, pkg.pkgdir, pkg.alias) ||
-      this.getAlias(filename, pkg.pkgdir, pkg.browser) ||
+      (this.options.target === 'browser' && this.getAlias(filename, pkg.pkgdir, pkg.browser)) ||
       filename
     );
   }

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -104,7 +104,7 @@ class JSAsset extends Asset {
   }
 
   async transform() {
-    if (this.options.target === 'browser') {
+    if (this.options.target === 'browser' || this.options.bundleAll) {
       if (this.dependencies.has('fs') && FS_RE.test(this.contents)) {
         await this.parseIfNeeded();
         this.traverse(fsVisitor);

--- a/src/builtins/prelude.js
+++ b/src/builtins/prelude.js
@@ -11,6 +11,7 @@ parcelRequire = (function (modules, cache, entry, globalName) {
   // Save the require from previous bundle to this closure if any
   var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
   var nodeRequire = typeof require === 'function' && require;
+  var builtinModules = nodeRequire && new Set(nodeRequire('module').builtinModules);
 
   function newRequire(name, jumped) {
     if (!cache[name]) {
@@ -55,6 +56,8 @@ parcelRequire = (function (modules, cache, entry, globalName) {
     }
 
     function resolve(x){
+      // Make sure that local modules never override builtin node modules.
+      if (builtinModules && builtinModules.has(x)) return x;
       return modules[name][1][x] || x;
     }
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -55,6 +55,10 @@ program
     '-A, --bundle-all',
     'for node or electron targets, bundle all dependencies into standalone output'
   )
+  .option(
+    '-i, --ignore <modules>',
+    'comma-separated list of modules to ignore. useful for ignoring conditional requires such as "lib-cov"'
+  )
   .option('-V, --version', 'output the version number')
   .option(
     '--log-level <level>',
@@ -102,6 +106,10 @@ program
     'for node or electron targets, bundle all dependencies into standalone output'
   )
   .option(
+    '-i, --ignore <modules>',
+    'comma-separated list of modules to ignore. useful for ignoring conditional requires such as "lib-cov"'
+  )
+  .option(
     '--log-level <level>',
     'set the log level, either "0" (no output), "1" (errors), "2" (warnings + errors) or "3" (all).',
     /^([0-3])$/
@@ -135,6 +143,10 @@ program
   .option(
     '-A, --bundle-all',
     'for node or electron targets, bundle all dependencies into standalone output'
+  )
+  .option(
+    '-i, --ignore <modules>',
+    'comma-separated list of modules to ignore. useful for ignoring conditional requires such as "lib-cov"'
   )
   .option(
     '--detailed-report',

--- a/src/cli.js
+++ b/src/cli.js
@@ -51,6 +51,10 @@ program
     'set the runtime environment, either "node", "browser" or "electron". defaults to "browser"',
     /^(node|browser|electron)$/
   )
+  .option(
+    '-A, --bundle-all',
+    'for node or electron targets, bundle all dependencies into standalone output'
+  )
   .option('-V, --version', 'output the version number')
   .option(
     '--log-level <level>',
@@ -94,6 +98,10 @@ program
     /^(node|browser|electron)$/
   )
   .option(
+    '-A, --bundle-all',
+    'for node or electron targets, bundle all dependencies into standalone output'
+  )
+  .option(
     '--log-level <level>',
     'set the log level, either "0" (no output), "1" (errors), "2" (warnings + errors) or "3" (all).',
     /^([0-3])$/
@@ -123,6 +131,10 @@ program
     '-t, --target <target>',
     'set the runtime environment, either "node", "browser" or "electron". defaults to "browser"',
     /^(node|browser|electron)$/
+  )
+  .option(
+    '-A, --bundle-all',
+    'for node or electron targets, bundle all dependencies into standalone output'
   )
   .option(
     '--detailed-report',

--- a/src/utils/morph.js
+++ b/src/utils/morph.js
@@ -1,0 +1,12 @@
+module.exports = morph;
+
+// replace object properties
+function morph(object, newProperties) {
+  for (let key in object) {
+    delete object[key];
+  }
+
+  for (let key in newProperties) {
+    object[key] = newProperties[key];
+  }
+}

--- a/src/visitors/dependencies.js
+++ b/src/visitors/dependencies.js
@@ -150,7 +150,7 @@ function evaluateExpression(node) {
 }
 
 function addDependency(asset, node, opts = {}) {
-  if (asset.options.target !== 'browser') {
+  if (asset.options.target !== 'browser' && !asset.options.bundleAll) {
     const isRelativeImport = /^[/~.]/.test(node.value);
     if (!isRelativeImport) return;
   }

--- a/src/visitors/env.js
+++ b/src/visitors/env.js
@@ -4,7 +4,7 @@ const matchesPattern = require('./matches-pattern');
 module.exports = {
   MemberExpression(node, asset) {
     // Inline environment variables accessed on process.env
-    if (matchesPattern(node.object, 'process.env')) {
+    if (matchesPattern(node.object, 'process.env') && asset.options.target === 'browser') {
       let key = types.toComputedKey(node);
       if (types.isStringLiteral(key)) {
         let val = types.valueToNode(process.env[key.value]);

--- a/src/visitors/env.js
+++ b/src/visitors/env.js
@@ -1,5 +1,6 @@
 const types = require('babel-types');
 const matchesPattern = require('./matches-pattern');
+const morph = require('../utils/morph');
 
 module.exports = {
   MemberExpression(node, asset) {
@@ -15,14 +16,3 @@ module.exports = {
     }
   }
 };
-
-// replace object properties
-function morph(object, newProperties) {
-  for (let key in object) {
-    delete object[key];
-  }
-
-  for (let key in newProperties) {
-    object[key] = newProperties[key];
-  }
-}


### PR DESCRIPTION
This is a more complete version of #1196. It adds an optional flag, `--bundle-all` (or `-A`) when targeting `node` or `electron` which will make parcel produce a standalone `.js` output which bundles all node modules. This can significantly reduce deployed code size for node applications by eliminating the need to deploy `node_modules`.

This does not attempt to solve the issue of node modules that dynamically load files from the filesystem, as mentioned in comments on #652. For applications using such modules, this feature likely will not work.