### PR TITLE
Fix browser entry-point resolution

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -267,10 +267,16 @@ class Resolver {
   }
 
   getPackageMain(pkg) {
+    let {browser} = pkg;
+
+    if (typeof browser === 'object' && browser[pkg.name]) {
+      browser = browser[pkg.name];
+    }
+
     // libraries like d3.js specifies node.js specific files in the "main" which breaks the build
     // we use the "module" or "browser" field to get the full dependency tree if available.
     // If this is a linked module with a `source` field, use that as the entry point.
-    let main = [pkg.source, pkg.module, pkg.browser, pkg.main].find(
+    let main = [pkg.source, pkg.module, browser, pkg.main].find(
       entry => typeof entry === 'string'
     );
 

--- a/test/integration/resolve-entries/browser-multiple.js
+++ b/test/integration/resolve-entries/browser-multiple.js
@@ -1,7 +1,13 @@
-const required = require('./pkg-browser-multiple/projected')
+const projected = require('./pkg-browser-multiple/projected')
 
-if(required.test() !== 'pkg-browser-multiple') {
+if(projected.test() !== 'pkg-browser-multiple') {
     throw new Error('Invalid module')
 }
 
-export const test = required.test
+const entry = require('./pkg-browser-multiple')
+
+if(entry.test() !== 'pkg-browser-multiple browser-entry') {
+    throw new Error('Invalid module')
+}
+
+export const test = {projected, entry}

--- a/test/integration/resolve-entries/pkg-browser-multiple/browser-entry.js
+++ b/test/integration/resolve-entries/pkg-browser-multiple/browser-entry.js
@@ -1,0 +1,3 @@
+export function test() {
+    return 'pkg-browser-multiple browser-entry'
+}

--- a/test/integration/resolve-entries/pkg-browser-multiple/package.json
+++ b/test/integration/resolve-entries/pkg-browser-multiple/package.json
@@ -2,6 +2,7 @@
     "name": "pkg-browser-multiple",
     "main": "./does-not-exist.js",
     "browser": {
-        "./projected.js": "./projected-module.js"
+        "./projected.js": "./projected-module.js",
+        "pkg-browser-multiple": "browser-entry.js"
     }
 }

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -507,7 +507,11 @@ describe('javascript', function() {
 
     assertBundleTree(b, {
       name: 'browser-multiple.js',
-      assets: ['browser-multiple.js', 'projected-module.js'],
+      assets: [
+        'browser-multiple.js',
+        'projected-module.js',
+        'browser-entry.js'
+      ],
       childBundles: [
         {
           type: 'map'
@@ -515,10 +519,12 @@ describe('javascript', function() {
       ]
     });
 
-    let output = run(b);
+    let {test: output} = run(b);
 
-    assert.equal(typeof output.test, 'function');
-    assert.equal(output.test(), 'pkg-browser-multiple');
+    assert.equal(typeof output.projected.test, 'function');
+    assert.equal(typeof output.entry.test, 'function');
+    assert.equal(output.projected.test(), 'pkg-browser-multiple');
+    assert.equal(output.entry.test(), 'pkg-browser-multiple browser-entry');
   });
 
   it('should resolve the module field before main', async function() {


### PR DESCRIPTION
Fixes #1283. Libraries with a self-referencing `browser` object are incorrectly resolved.

- [`when@3.7.8`](https://unpkg.com/when@3.7.8/package.json)
```json
{
  "browser": {
    "when": "./dist/browser/when.js",
    "vertx": false
  }
}
```