### PR TITLE
Fix loading modules with AMD defines

### DIFF
--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -15,7 +15,7 @@ const SourceMap = require('../SourceMap');
 
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
 const ENV_RE = /\b(?:process\.env)\b/;
-const GLOBAL_RE = /\b(?:process|__dirname|__filename|global|Buffer)\b/;
+const GLOBAL_RE = /\b(?:process|__dirname|__filename|global|Buffer|define)\b/;
 const FS_RE = /\breadFileSync\b/;
 const SW_RE = /\bnavigator\s*\.\s*serviceWorker\s*\.\s*register\s*\(/;
 const WORKER_RE = /\bnew\s*Worker\s*\(/;

--- a/src/visitors/globals.js
+++ b/src/visitors/globals.js
@@ -13,7 +13,12 @@ const VARS = {
   Buffer: asset => {
     asset.addDependency('buffer');
     return 'var Buffer = require("buffer").Buffer;';
-  }
+  },
+  // Prevent AMD defines from working when loading UMD bundles.
+  // Ideally the CommonJS check would come before the AMD check, but many
+  // existing modules do the checks the opposite way leading to modules
+  // not exporting anything to Parcel.
+  define: () => 'var define;'
 };
 
 module.exports = {

--- a/test/integration/define-amd/index.js
+++ b/test/integration/define-amd/index.js
@@ -1,0 +1,7 @@
+if (typeof define === 'function' && define.amd) {
+  define(function () {
+    return 4;
+  });
+} else if (typeof module === 'object') {
+  module.exports = 2;
+}

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -884,4 +884,16 @@ describe('javascript', function() {
     const ctx = run(b, null, {require: false});
     assert.equal(ctx.window.testing(), 'Test!');
   });
+
+  it('should set `define` to undefined so AMD checks in UMD modules do not pass', async function() {
+    let b = await bundle(__dirname + '/integration/define-amd/index.js');
+    let test;
+    const mockDefine = function(f) {
+      test = f();
+    };
+    mockDefine.amd = true;
+
+    run(b, {define: mockDefine});
+    assert.equal(test, 2);
+  });
 });


### PR DESCRIPTION
Some UMD modules like moment-timezone have their AMD check before the CommonJS one. When an AMD loader like RequireJS is on the page, this causes the module to call `define` instead of exposing the exports to Parcel via CommonJS.

This PR sets `define` to `undefined` inside modules so that the AMD check will not pass and the exports will be exposed to CommonJS instead.