### PR TITLE
Don’t pass package.json and options over IPC

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -5,6 +5,8 @@ const objectHash = require('./utils/objectHash');
 const md5 = require('./utils/md5');
 const isURL = require('./utils/is-url');
 const config = require('./utils/config');
+const syncPromise = require('./utils/syncPromise');
+const logger = require('./Logger');
 
 let ASSET_ID = 1;
 
@@ -101,6 +103,13 @@ class Asset {
       .generateBundleName();
 
     return URL.format(parsed);
+  }
+
+  get package() {
+    logger.warn(
+      '`asset.package` is deprecated. Please use `await asset.getPackage()` instead.'
+    );
+    return syncPromise(this.getPackage());
   }
 
   async getPackage() {

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -357,12 +357,16 @@ class Bundler extends EventEmitter {
   }
 
   async resolveAsset(name, parent) {
-    let {path, pkg} = await this.resolver.resolve(name, parent);
+    let {path} = await this.resolver.resolve(name, parent);
+    return this.getLoadedAsset(path);
+  }
+
+  getLoadedAsset(path) {
     if (this.loadedAssets.has(path)) {
       return this.loadedAssets.get(path);
     }
 
-    let asset = this.parser.getAsset(path, pkg, this.options);
+    let asset = this.parser.getAsset(path, this.options);
     this.loadedAssets.set(path, asset);
 
     this.watch(path, asset);
@@ -490,7 +494,7 @@ class Bundler extends EventEmitter {
     let startTime = Date.now();
     let processed = this.cache && (await this.cache.read(asset.name));
     if (!processed || asset.shouldInvalidate(processed.cacheData)) {
-      processed = await this.farm.run(asset.name, asset.package, this.options);
+      processed = await this.farm.run(asset.name);
       if (this.cache) {
         this.cache.write(asset.name, processed);
       }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -75,10 +75,10 @@ class Parser {
     return parser;
   }
 
-  getAsset(filename, pkg, options = {}) {
+  getAsset(filename, options = {}) {
     let Asset = this.findParser(filename);
     options.parser = this;
-    return new Asset(filename, pkg, options);
+    return new Asset(filename, options);
   }
 }
 

--- a/src/Pipeline.js
+++ b/src/Pipeline.js
@@ -11,8 +11,13 @@ class Pipeline {
     this.parser = new Parser(options);
   }
 
-  async process(path, pkg, options) {
-    let asset = this.parser.getAsset(path, pkg, options);
+  async process(path, isWarmUp) {
+    let options = this.options;
+    if (isWarmUp) {
+      options = Object.assign({isWarmUp}, options);
+    }
+
+    let asset = this.parser.getAsset(path, options);
     let generated = await this.processAsset(asset);
     let generatedMap = {};
     for (let rendition of generated) {
@@ -51,7 +56,7 @@ class Pipeline {
       );
       if (!(asset instanceof AssetType)) {
         let opts = Object.assign({rendition}, asset.options);
-        let subAsset = new AssetType(asset.name, asset.package, opts);
+        let subAsset = new AssetType(asset.name, opts);
         subAsset.contents = value;
         subAsset.dependencies = asset.dependencies;
 

--- a/src/assets/CSSAsset.js
+++ b/src/assets/CSSAsset.js
@@ -9,8 +9,8 @@ const IMPORT_RE = /@import/;
 const PROTOCOL_RE = /^[a-z]+:/;
 
 class CSSAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'css';
   }
 

--- a/src/assets/CoffeeScriptAsset.js
+++ b/src/assets/CoffeeScriptAsset.js
@@ -2,8 +2,8 @@ const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 
 class CoffeeScriptAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/GLSLAsset.js
+++ b/src/assets/GLSLAsset.js
@@ -5,8 +5,8 @@ const promisify = require('../utils/promisify');
 const Resolver = require('../Resolver');
 
 class GLSLAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/GlobAsset.js
+++ b/src/assets/GlobAsset.js
@@ -4,8 +4,8 @@ const micromatch = require('micromatch');
 const path = require('path');
 
 class GlobAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = null; // allows this asset to be included in any type bundle
   }
 

--- a/src/assets/GraphqlAsset.js
+++ b/src/assets/GraphqlAsset.js
@@ -2,8 +2,8 @@ const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 
 class GraphqlAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -73,8 +73,8 @@ const OPTIONS = {
 };
 
 class HTMLAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'html';
     this.isAstDirty = false;
   }

--- a/src/assets/JSONAsset.js
+++ b/src/assets/JSONAsset.js
@@ -4,8 +4,8 @@ const json5 = require('json5');
 const {minify} = require('uglify-es');
 
 class JSONAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/LESSAsset.js
+++ b/src/assets/LESSAsset.js
@@ -3,8 +3,8 @@ const localRequire = require('../utils/localRequire');
 const promisify = require('../utils/promisify');
 
 class LESSAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'css';
   }
 
@@ -13,10 +13,9 @@ class LESSAsset extends Asset {
     let less = await localRequire('less', this.name);
     let render = promisify(less.render.bind(less));
 
-    let opts = Object.assign(
-      {},
-      this.package.less || (await this.getConfig(['.lessrc', '.lessrc.js']))
-    );
+    let opts =
+      (await this.getConfig(['.lessrc', '.lessrc.js'], {packageKey: 'less'})) ||
+      {};
     opts.filename = this.name;
     opts.plugins = (opts.plugins || []).concat(urlPlugin(this));
 

--- a/src/assets/PugAsset.js
+++ b/src/assets/PugAsset.js
@@ -3,8 +3,8 @@ const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 
 class PugAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'html';
   }
 

--- a/src/assets/ReasonAsset.js
+++ b/src/assets/ReasonAsset.js
@@ -3,8 +3,8 @@ const fs = require('../utils/fs');
 const localRequire = require('../utils/localRequire');
 
 class ReasonAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/RustAsset.js
+++ b/src/assets/RustAsset.js
@@ -18,8 +18,8 @@ let rustInstalled = false;
 let wasmGCInstalled = false;
 
 class RustAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'wasm';
   }
 

--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -7,8 +7,8 @@ const Resolver = require('../Resolver');
 const syncPromise = require('../utils/syncPromise');
 
 class SASSAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'css';
   }
 
@@ -21,10 +21,9 @@ class SASSAsset extends Asset {
       rootDir: this.options.rootDir
     });
 
-    let opts = Object.assign(
-      {},
-      this.package.sass || (await this.getConfig(['.sassrc', '.sassrc.js']))
-    );
+    let opts =
+      (await this.getConfig(['.sassrc', '.sassrc.js'], {packageKey: 'sass'})) ||
+      {};
     opts.includePaths = (opts.includePaths || []).concat(
       path.dirname(this.name)
     );

--- a/src/assets/StylusAsset.js
+++ b/src/assets/StylusAsset.js
@@ -7,17 +7,17 @@ const syncPromise = require('../utils/syncPromise');
 const URL_RE = /^(?:url\s*\(\s*)?['"]?(?:[#/]|(?:https?:)?\/\/)/i;
 
 class StylusAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'css';
   }
 
   async parse(code) {
     // stylus should be installed locally in the module that's being required
     let stylus = await localRequire('stylus', this.name);
-    let opts =
-      this.package.stylus ||
-      (await this.getConfig(['.stylusrc', '.stylusrc.js']));
+    let opts = await this.getConfig(['.stylusrc', '.stylusrc.js'], {
+      packageKey: 'stylus'
+    });
     let style = stylus(code, opts);
     style.set('filename', this.name);
     style.set('include css', true);

--- a/src/assets/TOMLAsset.js
+++ b/src/assets/TOMLAsset.js
@@ -3,8 +3,8 @@ const toml = require('toml');
 const serializeObject = require('../utils/serializeObject');
 
 class TOMLAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/TypeScriptAsset.js
+++ b/src/assets/TypeScriptAsset.js
@@ -2,8 +2,8 @@ const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 
 class TypeScriptAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/VueAsset.js
+++ b/src/assets/VueAsset.js
@@ -4,8 +4,8 @@ const md5 = require('../utils/md5');
 const {minify} = require('uglify-es');
 
 class VueAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/assets/WebManifestAsset.js
+++ b/src/assets/WebManifestAsset.js
@@ -1,8 +1,8 @@
 const Asset = require('../Asset');
 
 class WebManifestAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'webmanifest';
   }
 

--- a/src/assets/YAMLAsset.js
+++ b/src/assets/YAMLAsset.js
@@ -3,8 +3,8 @@ const yaml = require('js-yaml');
 const serializeObject = require('../utils/serializeObject');
 
 class YAMLAsset extends Asset {
-  constructor(name, pkg, options) {
-    super(name, pkg, options);
+  constructor(name, options) {
+    super(name, options);
     this.type = 'js';
   }
 

--- a/src/transforms/htmlnano.js
+++ b/src/transforms/htmlnano.js
@@ -4,11 +4,10 @@ const htmlnano = require('htmlnano');
 module.exports = async function(asset) {
   await asset.parseIfNeeded();
 
-  const htmlNanoConfig =
-    asset.package.htmlnano ||
-    (await asset.getConfig(['.htmlnanorc', '.htmlnanorc.js'])) ||
-    {};
-
+  let htmlNanoConfig = await asset.getConfig(
+    ['.htmlnanorc', '.htmlnanorc.js'],
+    {packageKey: 'htmlnano'}
+  );
   let res = await posthtml([htmlnano(htmlNanoConfig)]).process(asset.ast, {
     skipParse: true
   });

--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -17,13 +17,10 @@ module.exports = async function(asset) {
 };
 
 async function getConfig(asset) {
-  let config =
-    asset.package.postcss ||
-    (await asset.getConfig([
-      '.postcssrc',
-      '.postcssrc.js',
-      'postcss.config.js'
-    ]));
+  let config = await asset.getConfig(
+    ['.postcssrc', '.postcssrc.js', 'postcss.config.js'],
+    {packageKey: 'postcss'}
+  );
 
   let enableModules =
     asset.options.rendition && asset.options.rendition.modules;

--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -15,13 +15,10 @@ module.exports = async function(asset) {
 };
 
 async function getConfig(asset) {
-  let config =
-    asset.package.posthtml ||
-    (await asset.getConfig([
-      '.posthtmlrc',
-      '.posthtmlrc.js',
-      'posthtml.config.js'
-    ]));
+  let config = await asset.getConfig(
+    ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
+    {packageKey: 'posthtml'}
+  );
   if (!config && !asset.options.minify) {
     return;
   }

--- a/src/visitors/fs.js
+++ b/src/visitors/fs.js
@@ -21,13 +21,7 @@ module.exports = {
   },
 
   CallExpression(path, asset) {
-    // See https://github.com/defunctzombie/node-browser-resolve#skip
-    let ignore =
-      asset.package &&
-      asset.package.browser &&
-      asset.package.browser.fs === false;
-
-    if (!ignore && referencesImport(path, 'fs', 'readFileSync')) {
+    if (referencesImport(path, 'fs', 'readFileSync')) {
       let vars = {
         __dirname: Path.dirname(asset.name),
         __filename: asset.basename

--- a/src/worker.js
+++ b/src/worker.js
@@ -15,10 +15,9 @@ function init(options, isLocal = false) {
   }
 }
 
-async function run(path, pkg, options, isWarmUp) {
+async function run(path, isWarmUp) {
   try {
-    options.isWarmUp = isWarmUp;
-    return await pipeline.process(path, pkg, options);
+    return await pipeline.process(path, isWarmUp);
   } catch (e) {
     e.fileName = path;
     throw e;

--- a/test/asset.js
+++ b/test/asset.js
@@ -30,6 +30,11 @@ describe('Asset', () => {
     assert(fs.existsSync(__dirname, `/dist/${outFile}`));
   });
 
+  it('should have backward compatibility for package field', function() {
+    let a = new Asset(__filename, {rootDir: '/root/dir'});
+    assert.equal(a.package.name, 'parcel-bundler');
+  });
+
   describe('addURLDependency', () => {
     const bundleName = 'xyz';
     const options = {

--- a/test/asset.js
+++ b/test/asset.js
@@ -5,7 +5,7 @@ const {bundle} = require('./utils');
 
 describe('Asset', () => {
   it('should include default implementations', async () => {
-    const a = new Asset(__filename, undefined, {rootDir: '/root/dir'});
+    const a = new Asset(__filename, {rootDir: '/root/dir'});
     Object.assign(a, {
       type: 'type',
       contents: 'contents'
@@ -42,7 +42,7 @@ describe('Asset', () => {
         }
       }
     };
-    const asset = new Asset('test', undefined, options);
+    const asset = new Asset('test', options);
 
     it('should ignore urls', () => {
       const url = 'https://parceljs.org/assets.html';


### PR DESCRIPTION
Previously, we would get the package.json from the resolver and pass it over the IPC to workers for use in assets along with the full bundler options object. These were fairly large objects, so passing them across the wire every time was slow.

We now no longer pass those things over the IPC. The package.json object is resolved as needed within the asset using the `getPackage` method. Additionally a `packageKey` option was added to the `getConfig` method. The options object is already passed to all of the workers during initialization, so doesn't need to be passed for every asset.