### PR TITLE
Pass .posthtmlrc options to posthtml-parse

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -1,5 +1,4 @@
 const Asset = require('../Asset');
-const parse = require('posthtml-parser');
 const api = require('posthtml/lib/api');
 const urlJoin = require('../utils/urlJoin');
 const render = require('posthtml-render');
@@ -79,8 +78,8 @@ class HTMLAsset extends Asset {
     this.isAstDirty = false;
   }
 
-  parse(code) {
-    let res = parse(code, {lowerCaseAttributeNames: true});
+  async parse(code) {
+    let res = await posthtmlTransform.parse(code, this);
     res.walk = api.walk;
     res.match = api.match;
     return res;
@@ -151,7 +150,7 @@ class HTMLAsset extends Asset {
   }
 
   async pretransform() {
-    await posthtmlTransform(this);
+    await posthtmlTransform.transform(this);
   }
 
   async transform() {

--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -1,7 +1,17 @@
 const loadPlugins = require('../utils/loadPlugins');
 const posthtml = require('posthtml');
+const posthtmlParse = require('posthtml-parser');
 
-module.exports = async function(asset) {
+async function parse(code, asset) {
+  var config = await getConfig(asset);
+  if (!config) {
+    config = {};
+  }
+  config = Object.assign({lowerCaseAttributeNames: true}, config);
+  return posthtmlParse(code, config);
+}
+
+async function transform(asset) {
   let config = await getConfig(asset);
   if (!config) {
     return;
@@ -12,13 +22,16 @@ module.exports = async function(asset) {
 
   asset.ast = res.tree;
   asset.isAstDirty = true;
-};
+}
 
 async function getConfig(asset) {
-  let config = await asset.getConfig(
-    ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
-    {packageKey: 'posthtml'}
-  );
+  let config =
+    (await asset.getPackage()).posthtml ||
+    (await asset.getConfig([
+      '.posthtmlrc',
+      '.posthtmlrc.js',
+      'posthtml.config.js'
+    ]));
   if (!config && !asset.options.minify) {
     return;
   }
@@ -38,3 +51,5 @@ async function getConfig(asset) {
   config.skipParse = true;
   return config;
 }
+
+module.exports = {parse, transform};


### PR DESCRIPTION
This pull request makes HTML parsing options configurable, so HTMLAsset parsing / transform behavior can be more consistent.

With this change we can config `.posthtmlrc` with the following options (they are consumed by posthtml-parse, then htmlparser2. See also https://github.com/fb55/htmlparser2/wiki/Parser-options )

- `xmlMode: true`
- `lowerCaseAttributeNames: false`
- `lowerCaseTags: false`
- `recognizeSelfClosing: true`
- ...

If we config `recognizeSelfClosing: true` in `.posthtmlrc`,  we can also fix #1103 

Allow setting `false` to lower case options maybe can also fix #1123 . (not tested yet)
