### PR TITLE
Split cache into subdirs for faster fs

### DIFF
--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -32,7 +32,7 @@ class FSCache {
     // Create sub-directories for every possible hex value
     // This speeds up large caches on many file systems since there are fewer files in a single directory.
     for (let i = 0; i < 256; i++) {
-      await fs.mkdirp(path.join(this.dir, i.toString(16).padStart(2, '0')));
+      await fs.mkdirp(path.join(this.dir, ('00' + i.toString(16)).slice(-2)));
     }
 
     this.dirExists = true;

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -68,9 +68,8 @@ class FSCache {
   async write(filename, data) {
     try {
       await this.ensureDirExists();
-      let cacheFile = this.getCacheFile(filename);
       await this.writeDepMtimes(data);
-      await fs.writeFile(cacheFile, JSON.stringify(data));
+      await fs.writeFile(this.getCacheFile(filename), JSON.stringify(data));
       this.invalidated.delete(filename);
     } catch (err) {
       logger.error(`Error writing to cache: ${err.message}`);

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -22,14 +22,14 @@ class FSCache {
     );
   }
 
-  async ensureDirExists() {
-    await fs.mkdirp(this.dir);
+  async ensureDirExists(dir = this.dir) {
+    await fs.mkdirp(dir);
     this.dirExists = true;
   }
 
   getCacheFile(filename) {
     let hash = md5(this.optionsHash + filename);
-    return path.join(this.dir, hash + '.json');
+    return path.join(this.dir, hash.substring(0, 2), hash + '.json');
   }
 
   async getLastModified(filename) {
@@ -56,9 +56,10 @@ class FSCache {
 
   async write(filename, data) {
     try {
-      await this.ensureDirExists();
+      let cacheFile = this.getCacheFile(filename);
+      await this.ensureDirExists(path.dirname(cacheFile));
       await this.writeDepMtimes(data);
-      await fs.writeFile(this.getCacheFile(filename), JSON.stringify(data));
+      await fs.writeFile(cacheFile, JSON.stringify(data));
       this.invalidated.delete(filename);
     } catch (err) {
       logger.error(`Error writing to cache: ${err.message}`);


### PR DESCRIPTION
Splits cache dir structure into subdirectories for slightly faster fs if there are a lot of cache files