### PR TITLE
Bug fix. Only resolve env vars on bundling when --target=browser.

### DIFF
--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -97,7 +97,7 @@ class JSAsset extends Asset {
     await babel(this);
 
     // Inline environment variables
-    if (ENV_RE.test(this.contents)) {
+    if (this.options.target === 'browser' && ENV_RE.test(this.contents)) {
       await this.parseIfNeeded();
       this.traverseFast(envVisitor);
     }

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -415,10 +415,33 @@ describe('javascript', function() {
     assert.deepEqual(output(), false);
   });
 
-  it('should insert environment variables', async function() {
-    let b = await bundle(__dirname + '/integration/env/index.js');
+  it('should not insert environment variables on --target=node', async function() {
+    let b = await bundle(__dirname + '/integration/env/index.js', {
+      target: 'node'
+    });
 
     let output = run(b);
+    assert.ok(output.toString().indexOf('process.env') > -1);
+    assert.equal(output(), 'test:test');
+  });
+
+  it('should not insert environment variables on --target=electron', async function() {
+    let b = await bundle(__dirname + '/integration/env/index.js', {
+      target: 'electron'
+    });
+
+    let output = run(b);
+    assert.ok(output.toString().indexOf('process.env') > -1);
+    assert.equal(output(), 'test:test');
+  });
+
+  it('should insert environment variables on --target=browser', async function() {
+    let b = await bundle(__dirname + '/integration/env/index.js', {
+      target: 'browser'
+    });
+
+    let output = run(b);
+    assert.ok(output.toString().indexOf('process.env') === -1);
     assert.equal(output(), 'test:test');
   });
 


### PR DESCRIPTION
This fix checks if target is browser before replacing process.env with the value of the environment variable. 

When targeting node parcel should not replace process.env with value of variable in code at bundle time. Node needs to do this at runtime.

I've assumed that electron is the same way but haven't built any electron apps myself yet so.. not sure. If my assumption was incorrect the pull request needs a little tweak. 
