### PR TITLE
Fix absolute and tilde paths

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -91,8 +91,8 @@ class Asset {
     }
 
     const parsed = URL.parse(url);
-    let depName = null;
-    let resolved = null;
+    let depName;
+    let resolved;
     let dir = path.dirname(from);
     const filename = decodeURIComponent(parsed.pathname);
 

--- a/test/asset.js
+++ b/test/asset.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const fs = require('fs');
+const path = require('path');
 const Asset = require('../src/Asset');
 const {bundle} = require('./utils');
 
@@ -75,6 +76,20 @@ describe('Asset', () => {
         asset.addURLDependency('foo?bar#baz'),
         `${bundleName}?bar#baz`
       );
+    });
+
+    it('should resolve slash', () => {
+      asset.dependencies.clear();
+      assert.strictEqual(asset.addURLDependency('/foo'), bundleName);
+      const key = path.resolve('/root/dir/foo');
+      assert(asset.dependencies.has(key));
+    });
+
+    it('should resolve tilde', () => {
+      asset.dependencies.clear();
+      assert.strictEqual(asset.addURLDependency('~/foo'), bundleName);
+      const key = path.normalize('/root/dir/foo');
+      assert(asset.dependencies.has(key));
     });
   });
 });


### PR DESCRIPTION
Fix addURLDependency resolution in Asset.js

Minimal reproducible repo: https://github.com/marcosbozzani/parcel-bug-tilde-abs-paths

Just clone the repo, `yarn install` and `yarn tilde` or `yarn slash`

Tilde error: `Cannot resolve dependency './~\style.css'`
Slash error: `Cannot resolve dependency './..\..\..\..\..\..\`