### PR TITLE
Support `--no-autoinstall` for `build`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -122,6 +122,7 @@ program
   .option('--no-minify', 'disable minification')
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
+  .option('--no-autoinstall', 'disable autoinstall')
   .option(
     '-t, --target <target>',
     'set the runtime environment, either "node", "browser" or "electron". defaults to "browser"',


### PR DESCRIPTION
When running `build` you might want to disable autoinstall.