### PR TITLE
support for sass specific import syntax

### DIFF
--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -43,9 +43,9 @@ class SASSAsset extends Asset {
     opts.importer = (url, prev, done) => {
       let resolved;
       try {
-        if (!url.match(/^(~|\.\/|\/)/)) {
+        if (!url.test(/^(~|\.\/|\/)/)) {
           url = './' + url;
-        } else if (!url.match(/^(~\/|\.\/|\/)/)) {
+        } else if (!url.test(/^(~\/|\.\/|\/)/)) {
           url = url.substring(1);
         }
         resolved = syncPromise(

--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -43,6 +43,11 @@ class SASSAsset extends Asset {
     opts.importer = (url, prev, done) => {
       let resolved;
       try {
+        if (!url.match(/^(~|\.\/|\/)/)) {
+          url = './' + url;
+        } else if (!url.match(/^(~\/|\.\/|\/)/)) {
+          url = url.substring(1);
+        }
         resolved = syncPromise(
           resolver.resolve(url, prev === 'stdin' ? this.name : prev)
         ).path;

--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -43,9 +43,9 @@ class SASSAsset extends Asset {
     opts.importer = (url, prev, done) => {
       let resolved;
       try {
-        if (!url.test(/^(~|\.\/|\/)/)) {
+        if (!/^(~|\.\/|\/)/.test(url)) {
           url = './' + url;
-        } else if (!url.test(/^(~\/|\.\/|\/)/)) {
+        } else if (!/^(~\/|\.\/|\/)/.test(url)) {
           url = url.substring(1);
         }
         resolved = syncPromise(

--- a/test/integration/sass-advanced-import/bar.sass
+++ b/test/integration/sass-advanced-import/bar.sass
@@ -1,0 +1,2 @@
+.bar
+  color: green;

--- a/test/integration/sass-advanced-import/foo.sass
+++ b/test/integration/sass-advanced-import/foo.sass
@@ -1,0 +1,2 @@
+.foo
+  color: blue;

--- a/test/integration/sass-advanced-import/hello.sass
+++ b/test/integration/sass-advanced-import/hello.sass
@@ -1,2 +1,0 @@
-.hello
-  color: blue;

--- a/test/integration/sass-advanced-import/index.sass
+++ b/test/integration/sass-advanced-import/index.sass
@@ -1,4 +1,4 @@
-@import '~/hello.sass';
+@import '~/hello';
 
 .index
   background: #ffffff;

--- a/test/integration/sass-advanced-import/index.sass
+++ b/test/integration/sass-advanced-import/index.sass
@@ -1,4 +1,5 @@
-@import '~/hello';
+@import '~/foo';
+@import '~/bar.sass';
 
 .index
   background: #ffffff;

--- a/test/integration/scss-import/bar.scss
+++ b/test/integration/scss-import/bar.scss
@@ -1,0 +1,5 @@
+$bar: #f8a93b;
+
+.bar {
+  color: $bar;
+}

--- a/test/integration/scss-import/base.scss
+++ b/test/integration/scss-import/base.scss
@@ -1,5 +1,0 @@
-$base: #f938ab;
-
-.base {
-  color: $base;
-}

--- a/test/integration/scss-import/foo.scss
+++ b/test/integration/scss-import/foo.scss
@@ -1,0 +1,5 @@
+$foo: #f938ab;
+
+.foo {
+  color: $foo;
+}

--- a/test/integration/scss-import/index.scss
+++ b/test/integration/scss-import/index.scss
@@ -1,5 +1,7 @@
-@import 'base';
+@import 'foo';
+@import './bar.scss';
 
 .index {
-  color: $base;
+  color: $foo;
+  background-color: $bar;
 }

--- a/test/integration/scss-import/index.scss
+++ b/test/integration/scss-import/index.scss
@@ -1,4 +1,4 @@
-@import './base.scss';
+@import 'base';
 
 .index {
   color: $base;

--- a/test/sass.js
+++ b/test/sass.js
@@ -79,7 +79,8 @@ describe('sass', function() {
 
     let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
     assert(css.includes('.index'));
-    assert(css.includes('.base'));
+    assert(css.includes('.foo'));
+    assert(css.includes('.bar'));
   });
 
   it('should support requiring empty scss files', async function() {
@@ -183,7 +184,10 @@ describe('sass', function() {
       assets: ['index.sass']
     });
 
-    let css = fs.readFileSync(__dirname + '/dist/index.css', 'utf8');
-    assert(css.includes('color: blue;'));
+    let css = fs
+      .readFileSync(__dirname + '/dist/index.css', 'utf8')
+      .replace(/\s+/g, ' ');
+    assert(css.includes('.foo { color: blue;'));
+    assert(css.includes('.bar { color: green;'));
   });
 });


### PR DESCRIPTION
I'm not sure if this is a good idea, but I guess this has sort of become the standard in css imports?

This PR changes import syntax for sass:
Node modules:
`~some-node-module/...`
Files:
`some-file` or `./some-file`
Parcel's custom resolver:
`~/some-file` or `/some-file`

Closes #1329 Closes #1402