### PR TITLE
Improve reported bundle times

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -37,6 +37,8 @@ class Asset {
     this.parentBundle = null;
     this.bundles = new Set();
     this.cacheData = {};
+    this.startTime = 0;
+    this.endTime = 0;
     this.buildTime = 0;
     this.bundledSize = 0;
   }

--- a/src/Bundle.js
+++ b/src/Bundle.js
@@ -196,10 +196,17 @@ class Bundle {
 
     await packager.end();
 
-    this.bundleTime = Date.now() - startTime;
-    for (let asset of this.assets) {
-      this.bundleTime += asset.buildTime;
-    }
+    let assetArray = Array.from(this.assets);
+    let assetStartTime =
+      this.type === 'map'
+        ? 0
+        : assetArray.sort((a, b) => a.startTime - b.startTime)[0].startTime;
+    let assetEndTime =
+      this.type === 'map'
+        ? 0
+        : assetArray.sort((a, b) => b.endTime - a.endTime)[0].endTime;
+    let packagingTime = Date.now() - startTime;
+    this.bundleTime = assetEndTime - assetStartTime + packagingTime;
   }
 
   async _addDeps(asset, packager, included) {

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -495,7 +495,7 @@ class Bundler extends EventEmitter {
     asset.processed = true;
 
     // First try the cache, otherwise load and compile in the background
-    let startTime = Date.now();
+    asset.startTime = Date.now();
     let processed = this.cache && (await this.cache.read(asset.name));
     let cacheMiss = false;
     if (!processed || asset.shouldInvalidate(processed.cacheData)) {
@@ -503,7 +503,8 @@ class Bundler extends EventEmitter {
       cacheMiss = true;
     }
 
-    asset.buildTime = Date.now() - startTime;
+    asset.endTime = Date.now();
+    asset.buildTime = asset.endTime - asset.startTime;
     asset.generated = processed.generated;
     asset.hash = processed.hash;
 


### PR DESCRIPTION
Previously the bundleTime, was all asset's build times totalled. This indicator was incorrect as we use workers and it might be misleading for performance benchmarking.

So I've changed it in this PR to a more accurate indicator, taking the first starting time of the assets and the last ending time of the assets of the bundle and differencing those and adding the time the packager takes.

This PR also changes the map build times to represent the actual mapping instead of also including asset build times

So this will change this output (Totals to 3.06minutes 🤯):
<img width="455" alt="screen shot 2018-05-11 at 10 52 43" src="https://user-images.githubusercontent.com/2175521/39915910-7629a4aa-5509-11e8-9e10-b52c24b633d1.png">

Into this output (Totals to 7.77seconds 🚀):
<img width="417" alt="screen shot 2018-05-11 at 10 53 43" src="https://user-images.githubusercontent.com/2175521/39915953-9760ac54-5509-11e8-91f7-9be61e028d55.png">
