### PR TITLE
add dependencies referenced by posthtml-include

### DIFF
--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -23,14 +23,18 @@ async function getConfig(asset) {
     return;
   }
 
-  if (config && config.plugins && config.plugins['posthtml-include']) {
-    config.plugins['posthtml-include'].addDependencyTo = {
-      addDependency: src => asset.addDependency(src, {includedInParent: true})
-    };
-  }
-
   config = Object.assign({}, config);
-  config.plugins = await loadPlugins(config.plugins, asset.name);
+  const plugins = config.plugins;
+  if (typeof plugins === 'object') {
+    const depConfig = {
+      addDependencyTo: {
+        addDependency: name =>
+          asset.addDependency(name, {includedInParent: true})
+      }
+    };
+    Object.keys(plugins).forEach(p => Object.assign(plugins[p], depConfig));
+  }
+  config.plugins = await loadPlugins(plugins, asset.name);
   config.skipParse = true;
   return config;
 }

--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -23,6 +23,12 @@ async function getConfig(asset) {
     return;
   }
 
+  if (config && config.plugins && config.plugins['posthtml-include']) {
+    config.plugins['posthtml-include'].addDependencyTo = {
+      addDependency: src => asset.addDependency(src, {includedInParent: true})
+    };
+  }
+
   config = Object.assign({}, config);
   config.plugins = await loadPlugins(config.plugins, asset.name);
   config.skipParse = true;

--- a/test/html.js
+++ b/test/html.js
@@ -102,6 +102,16 @@ describe('html', function() {
     });
   });
 
+  it('should add dependencies referenced by posthtml-include', async () => {
+    const b = await bundle(
+      __dirname + '/integration/posthtml-assets/index.html'
+    );
+    const asset = b.assets.values().next().value;
+    const other = __dirname + '/integration/posthtml-assets/other.html';
+    assert(asset.dependencies.has(other));
+    assert(asset.dependencies.get(other).includedInParent);
+  });
+
   it('should insert sibling CSS bundles for JS files in the HEAD', async function() {
     let b = await bundle(__dirname + '/integration/html-css/index.html');
 


### PR DESCRIPTION
fixes #488 
closes #1226

:rotating_light: note: works with config like this:
https://github.com/parcel-bundler/parcel/blob/e7df99decb2484d08b4f613ec6dc2ebe4bf9e969/test/integration/posthtml-assets/.posthtmlrc.js#L1-L7

not like this:
https://github.com/parcel-bundler/parcel/blob/e7df99decb2484d08b4f613ec6dc2ebe4bf9e969/test/integration/posthtml/.posthtmlrc.js#L1-L7
