### PR TITLE
Ignore permission errors on watch

### DIFF
--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -13,6 +13,7 @@ class Watcher {
     this.watcher = new FSWatcher({
       useFsEvents: this.shouldWatchDirs,
       ignoreInitial: true,
+      ignorePermissionErrors: true,
       ignored: /\.cache|\.git/
     });
 


### PR DESCRIPTION
This PR adds `ignorePermissionErrors: true` to the watcher, this will prevent it from throwing permission errors, when trying to watch system files.

Unfortunately one of the side-effects apparently is that it takes long to build if the folder contains this kind of files. (Might be related to temporary system files updating a lot?)

Closes #1308 