### PR TITLE
Fix Vue asset supplemental code concatenation

### DIFF
--- a/src/assets/VueAsset.js
+++ b/src/assets/VueAsset.js
@@ -87,6 +87,10 @@ class VueAsset extends Asset {
       supplemental = code;
     }
 
+    if (supplemental) {
+      supplemental = `(function(){${supplemental}})();`;
+    }
+
     js += supplemental;
 
     if (js) {

--- a/src/assets/VueAsset.js
+++ b/src/assets/VueAsset.js
@@ -88,7 +88,7 @@ class VueAsset extends Asset {
     }
 
     if (supplemental) {
-      supplemental = `(function(){${supplemental}})();`;
+      supplemental = `\n(function(){${supplemental}})();`;
     }
 
     js += supplemental;


### PR DESCRIPTION
This PR is intended to fix #1350 and probably also #1344.

Without this fix, the user's code is minified just fine; however, supplemental code is minified separately, then appended to the user's code in the same scope. This can cause a symbol naming clash which breaks the user's code.