### PR TITLE
Fix env not defined in worker

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -5,7 +5,7 @@ const WorkerFarm = require('./workerfarm/WorkerFarm');
 
 let pipeline;
 
-function init(options, isLocal = false) {
+function init(options = {}, isLocal = false) {
   pipeline = new Pipeline(options || {});
   Object.assign(process.env, options.env || {});
   process.env.HMR_PORT = options.hmrPort;


### PR DESCRIPTION
This should fix the undefined options, as it defaults to an empty object in this pr.

Closes #1277 