### PR TITLE
Lookup correct generated output for bundle type in RawPackager

### DIFF
--- a/src/packagers/RawPackager.js
+++ b/src/packagers/RawPackager.js
@@ -8,7 +8,7 @@ class RawPackager extends Packager {
   setup() {}
 
   async addAsset(asset) {
-    let contents = asset.generated[asset.type];
+    let contents = asset.generated[this.bundle.type];
     if (!contents || (contents && contents.path)) {
       contents = await fs.readFile(contents ? contents.path : asset.name);
     }


### PR DESCRIPTION
When an `Asset` generates multiple assets with different types, `RawPackager` would give the same output for every entry in `asset.generated` even if they have different types and values.  This is because it used the asset's primary type `asset.type` instead of the type for the bundle it is actually generating (`this.bundle.type`).

This fixes it so that `RawPackager` uses the bundle type so that the correct entry in `generated` is read for each bundle.