### PR TITLE
Handle invalidating cache if dependency is a globAsset

### DIFF
--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -69,8 +69,7 @@ class FSCache {
     // If any of them changed, invalidate.
     for (let dep of data.dependencies) {
       if (dep.includedInParent) {
-        let mtime = await this.getLastModified(dep.name);
-        if (mtime > dep.mtime) {
+        if ((await this.getLastModified(dep.name)) > dep.mtime) {
           return false;
         }
       }

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -32,20 +32,16 @@ class FSCache {
   }
 
   async getLastModified(filename) {
-    let mtime = 0;
     if (isGlob(filename)) {
       let files = await glob(filename, {
         strict: true,
         nodir: true
       });
-      mtime = (await Promise.all(
+      return (await Promise.all(
         files.map(file => fs.stat(file).then(({mtime}) => mtime.getTime()))
       )).reduce((a, b) => Math.max(a, b), 0);
-    } else {
-      let stats = await fs.stat(filename);
-      mtime = stats.mtime.getTime();
     }
-    return mtime;
+    return (await fs.stat(filename)).mtime.getTime();
   }
 
   async writeDepMtimes(data) {

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -38,12 +38,9 @@ class FSCache {
         strict: true,
         nodir: true
       });
-      for (let file of files) {
-        let fileStats = await fs.stat(file);
-        if (fileStats.mtime > mtime) {
-          mtime = fileStats.mtime.getTime();
-        }
-      }
+      mtime = (await Promise.all(
+        files.map(file => fs.stat(file).then(({mtime}) => mtime.getTime()))
+      )).reduce((a, b) => Math.max(a, b), 0);
     } else {
       let stats = await fs.stat(filename);
       mtime = stats.mtime.getTime();

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -4,7 +4,8 @@ const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
 const pkg = require('../package.json');
 const logger = require('./Logger');
-const {isGlob, glob} = require('./utils/glob');
+const glob = require('fast-glob');
+const isGlob = require('is-glob');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target', 'scopeHoist'];
@@ -34,9 +35,9 @@ class FSCache {
   async getLastModified(filename) {
     if (isGlob(filename)) {
       let files = await glob(filename, {
-        strict: true,
-        nodir: true
+        onlyFiles: true
       });
+
       return (await Promise.all(
         files.map(file => fs.stat(file).then(({mtime}) => mtime.getTime()))
       )).reduce((a, b) => Math.max(a, b), 0);

--- a/src/utils/glob.js
+++ b/src/utils/glob.js
@@ -1,7 +1,0 @@
-const glob = require('glob');
-const promisify = require('./promisify');
-
-exports.isGlob = function(filename) {
-  return /[*+{}]/.test(filename) && glob.hasMagic(filename);
-};
-exports.glob = promisify(glob);

--- a/src/utils/glob.js
+++ b/src/utils/glob.js
@@ -1,0 +1,7 @@
+const glob = require('glob');
+const promisify = require('./promisify');
+
+exports.isGlob = function(filename) {
+  return /[*+{}]/.test(filename) && glob.hasMagic(filename);
+};
+exports.glob = promisify(glob);

--- a/test/fs-cache.js
+++ b/test/fs-cache.js
@@ -136,4 +136,31 @@ describe('FSCache', () => {
       });
     });
   });
+
+  it('should invalidate cache if a wildcard dependency changes', async () => {
+    const cache = new FSCache({cacheDir: cachePath});
+    const wildcardPath = path.join(inputPath, 'wildcard');
+    await fs.mkdirp(wildcardPath);
+    await ncp(__dirname + '/integration/fs', wildcardPath);
+    const filePath = path.join(wildcardPath, 'test.txt');
+
+    await cache.write(__filename, {
+      dependencies: [
+        {
+          includedInParent: true,
+          name: path.join(wildcardPath, '*')
+        }
+      ]
+    });
+
+    let cached = await cache.read(__filename);
+    assert(cached !== null);
+
+    // delay and update dependency
+    await sleep(1000);
+    await fs.writeFile(filePath, 'world');
+
+    cached = await cache.read(__filename);
+    assert.equal(cached, null);
+  });
 });


### PR DESCRIPTION
Duplicate of #1414 

This is needed to properly invalidate and cache styl files as they allow glob requires.

But I kind of messed up a rebase, so here is a clean version

Closes #1546