### PR TITLE
Add amp-* tag to HTMLAsset to parse its own src attribute

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -18,7 +18,9 @@ const ATTRS = {
     'source',
     'track',
     'iframe',
-    'embed'
+    'embed',
+    'amp-img',
+    'amp-anim'
   ],
   href: ['link', 'a', 'use'],
   srcset: ['img', 'source'],


### PR DESCRIPTION
Currently, `amp-*` tag's src does not be parsed by `HTMLAsset`. 