### PR TITLE
Always invalidate globAssets

### DIFF
--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -4,7 +4,7 @@ const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
 const pkg = require('../package.json');
 const logger = require('./Logger');
-const {isGlob, glob} = require('./utils/glob');
+const {isGlob} = require('./utils/glob');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target'];
@@ -32,20 +32,9 @@ class FSCache {
   }
 
   async getLastModified(filename) {
-    let mtime = 0;
-    if (isGlob(filename)) {
-      let files = await glob(filename, {
-        strict: true,
-        nodir: true
-      });
-      mtime = (await Promise.all(
-        files.map(file => fs.stat(file).then(({mtime}) => mtime.getTime()))
-      )).reduce((a, b) => Math.max(a, b), 0);
-    } else {
-      let stats = await fs.stat(filename);
-      mtime = stats.mtime.getTime();
-    }
-    return mtime;
+    if (isGlob(filename)) return 0;
+    let stats = await fs.stat(filename);
+    return stats.mtime.getTime();
   }
 
   async writeDepMtimes(data) {

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -38,12 +38,9 @@ class FSCache {
         strict: true,
         nodir: true
       });
-      for (let file of files) {
-        let fileStats = await fs.stat(file);
-        if (fileStats.mtime > mtime) {
-          mtime = fileStats.mtime.getTime();
-        }
-      }
+      mtime = (await Promise.all(
+        files.map(file => fs.stat(file).then(({mtime}) => mtime.getTime()))
+      )).reduce((a, b) => Math.max(a, b), 0);
     } else {
       let stats = await fs.stat(filename);
       mtime = stats.mtime.getTime();

--- a/src/FSCache.js
+++ b/src/FSCache.js
@@ -4,6 +4,7 @@ const md5 = require('./utils/md5');
 const objectHash = require('./utils/objectHash');
 const pkg = require('../package.json');
 const logger = require('./Logger');
+const {isGlob, glob} = require('./utils/glob');
 
 // These keys can affect the output, so if they differ, the cache should not match
 const OPTION_KEYS = ['publicURL', 'minify', 'hmr', 'target'];
@@ -30,16 +31,31 @@ class FSCache {
     return path.join(this.dir, hash + '.json');
   }
 
+  async getLastModified(filename) {
+    let mtime = 0;
+    if (isGlob(filename)) {
+      let files = await glob(filename, {
+        strict: true,
+        nodir: true
+      });
+      for (let file of files) {
+        let fileStats = await fs.stat(file);
+        if (fileStats.mtime > mtime) {
+          mtime = fileStats.mtime.getTime();
+        }
+      }
+    } else {
+      let stats = await fs.stat(filename);
+      mtime = stats.mtime.getTime();
+    }
+    return mtime;
+  }
+
   async writeDepMtimes(data) {
     // Write mtimes for each dependent file that is already compiled into this asset
     for (let dep of data.dependencies) {
       if (dep.includedInParent) {
-        let depPath = dep.name;
-        if (depPath[depPath.length - 1] === '*') {
-          depPath = path.dirname(depPath);
-        }
-        let stats = await fs.stat(depPath);
-        dep.mtime = stats.mtime.getTime();
+        dep.mtime = await this.getLastModified(dep.name);
       }
     }
   }
@@ -60,8 +76,8 @@ class FSCache {
     // If any of them changed, invalidate.
     for (let dep of data.dependencies) {
       if (dep.includedInParent) {
-        let stats = await fs.stat(dep.name);
-        if (stats.mtime > dep.mtime) {
+        let mtime = await this.getLastModified(dep.name);
+        if (mtime > dep.mtime) {
           return false;
         }
       }

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const RawAsset = require('./assets/RawAsset');
 const GlobAsset = require('./assets/GlobAsset');
-const glob = require('glob');
+const {isGlob} = require('./utils/glob');
 
 class Parser {
   constructor(options = {}) {
@@ -62,7 +62,7 @@ class Parser {
   }
 
   findParser(filename) {
-    if (/[*+{}]/.test(filename) && glob.hasMagic(filename)) {
+    if (isGlob(filename)) {
       return GlobAsset;
     }
 

--- a/src/assets/GlobAsset.js
+++ b/src/assets/GlobAsset.js
@@ -9,6 +9,10 @@ class GlobAsset extends Asset {
     this.type = null; // allows this asset to be included in any type bundle
   }
 
+  shouldInvalidate() {
+    return true;
+  }
+
   async load() {
     let regularExpressionSafeName = this.name;
     if (process.platform === 'win32')

--- a/src/assets/GlobAsset.js
+++ b/src/assets/GlobAsset.js
@@ -1,5 +1,5 @@
 const Asset = require('../Asset');
-const glob = require('glob');
+const {glob} = require('../utils/glob');
 const micromatch = require('micromatch');
 const path = require('path');
 
@@ -14,7 +14,7 @@ class GlobAsset extends Asset {
     if (process.platform === 'win32')
       regularExpressionSafeName = regularExpressionSafeName.replace(/\\/g, '/');
 
-    let files = glob.sync(regularExpressionSafeName, {
+    let files = await glob(regularExpressionSafeName, {
       strict: true,
       nodir: true
     });

--- a/src/utils/glob.js
+++ b/src/utils/glob.js
@@ -1,0 +1,7 @@
+const glob = require('glob');
+const promisify = require('./promisify');
+
+exports.isGlob = function(filename) {
+  return /[*+{}]/.test(filename) && glob.hasMagic(filename);
+};
+exports.glob = promisify(glob);

--- a/test/fs-cache.js
+++ b/test/fs-cache.js
@@ -140,18 +140,16 @@ describe('FSCache', () => {
     });
   });
 
-  it('should invalidate cache if a wildcard dependency changes', async () => {
+  it('Should not invalidate cache due to a glob Dependency', async () => {
     const cache = new FSCache({cacheDir: cachePath});
-    const wildcardPath = path.join(inputPath, 'wildcard');
-    await fs.mkdirp(wildcardPath);
-    await ncp(__dirname + '/integration/fs', wildcardPath);
-    const filePath = path.join(wildcardPath, 'test.txt');
+    await ncp(__dirname + '/integration/fs', inputPath);
+    const filePath = path.join(inputPath, 'test.txt');
 
     await cache.write(__filename, {
       dependencies: [
         {
           includedInParent: true,
-          name: path.join(wildcardPath, '*')
+          name: path.join(inputPath, '*')
         }
       ]
     });
@@ -164,6 +162,6 @@ describe('FSCache', () => {
     await fs.writeFile(filePath, 'world');
 
     cached = await cache.read(__filename);
-    assert.equal(cached, null);
+    assert(cached !== null);
   });
 });

--- a/test/fs-cache.js
+++ b/test/fs-cache.js
@@ -139,4 +139,31 @@ describe('FSCache', () => {
       });
     });
   });
+
+  it('should invalidate cache if a wildcard dependency changes', async () => {
+    const cache = new FSCache({cacheDir: cachePath});
+    const wildcardPath = path.join(inputPath, 'wildcard');
+    await fs.mkdirp(wildcardPath);
+    await ncp(__dirname + '/integration/fs', wildcardPath);
+    const filePath = path.join(wildcardPath, 'test.txt');
+
+    await cache.write(__filename, {
+      dependencies: [
+        {
+          includedInParent: true,
+          name: path.join(wildcardPath, '*')
+        }
+      ]
+    });
+
+    let cached = await cache.read(__filename);
+    assert(cached !== null);
+
+    // delay and update dependency
+    await sleep(1000);
+    await fs.writeFile(filePath, 'world');
+
+    cached = await cache.read(__filename);
+    assert.equal(cached, null);
+  });
 });


### PR DESCRIPTION
This PR is an alternative to #1417.

* Invalidate globAssets every time, as it takes just as long to check mtimes as to generate a new globAsset (but caching happens in master process, so actually even slows down the process)...
* Never invalidate a parent of globAsset, due to the glob Dependency (This should speed up builds, as before it always invalidated due to an error and globAsset deps don't really have an influence on the content of the parent asset)
* Makes glob generating async, might result in a minor performance improvement

Related to the comment by @devongovett on #1417 