### PR TITLE
Use async modules when possibles

### DIFF
--- a/src/assets/GlobAsset.js
+++ b/src/assets/GlobAsset.js
@@ -1,5 +1,6 @@
 const Asset = require('../Asset');
-const glob = require('glob');
+const promisify = require('../utils/promisify');
+const glob = promisify(require('glob'));
 const micromatch = require('micromatch');
 const path = require('path');
 
@@ -14,7 +15,7 @@ class GlobAsset extends Asset {
     if (process.platform === 'win32')
       regularExpressionSafeName = regularExpressionSafeName.replace(/\\/g, '/');
 
-    let files = glob.sync(regularExpressionSafeName, {
+    let files = await glob(regularExpressionSafeName, {
       strict: true,
       nodir: true
     });

--- a/src/utils/localRequire.js
+++ b/src/utils/localRequire.js
@@ -1,5 +1,6 @@
 const {dirname} = require('path');
-const resolve = require('resolve');
+const promisify = require('../utils/promisify');
+const resolve = promisify(require('resolve'));
 const worker = require('../worker');
 
 const cache = new Map();
@@ -10,7 +11,7 @@ async function localRequire(name, path, triedInstall = false) {
   let resolved = cache.get(key);
   if (!resolved) {
     try {
-      resolved = resolve.sync(name, {basedir});
+      resolved = await resolve(name, {basedir}).then(([name]) => name);
     } catch (e) {
       if (e.code === 'MODULE_NOT_FOUND' && !triedInstall) {
         await worker.addCall({


### PR DESCRIPTION
- Use the async version of `glob` in `GlobAsset`
- Use the async version of `resolve` in `localRequire`