### PR TITLE
[WIP] Improve logging user experience

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -6,6 +6,7 @@ const md5 = require('./utils/md5');
 const isURL = require('./utils/is-url');
 const config = require('./utils/config');
 const syncPromise = require('./utils/syncPromise');
+const emoji = require('./utils/emoji');
 const logger = require('./Logger');
 const Resolver = require('./Resolver');
 
@@ -51,6 +52,7 @@ class Asset {
 
   async loadIfNeeded() {
     if (this.contents == null) {
+      logger.status(emoji.progress, `Loading ${this.relativeName}...`);
       this.contents = await this.load();
     }
   }
@@ -58,6 +60,7 @@ class Asset {
   async parseIfNeeded() {
     await this.loadIfNeeded();
     if (!this.ast) {
+      logger.status(emoji.progress, `Parsing ${this.relativeName}...`);
       this.ast = await this.parse(this.contents);
     }
   }
@@ -189,9 +192,15 @@ class Asset {
   async process() {
     if (!this.generated) {
       await this.loadIfNeeded();
+
+      logger.status(emoji.progress, `Analyzing ${this.relativeName}...`);
+
       await this.pretransform();
       await this.getDependencies();
       await this.transform();
+
+      logger.status(emoji.progress, `Generating ${this.relativeName}...`);
+
       this.generated = await this.generate();
       this.hash = await this.generateHash();
     }

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -491,10 +491,6 @@ class Bundler extends EventEmitter {
       return;
     }
 
-    if (!this.errored) {
-      logger.status(emoji.progress, `Building ${asset.basename}...`);
-    }
-
     // Mark the asset processed so we don't load it twice
     asset.processed = true;
 
@@ -503,6 +499,10 @@ class Bundler extends EventEmitter {
     let processed = this.cache && (await this.cache.read(asset.name));
     let cacheMiss = false;
     if (!processed || asset.shouldInvalidate(processed.cacheData)) {
+      if (!this.errored) {
+        logger.status(emoji.progress, `Queuing ${asset.relativeName}...`);
+      }
+
       processed = await this.farm.run(asset.name);
       cacheMiss = true;
     }


### PR DESCRIPTION
Just an idea, I opened this PR prematurely to get some feedback.

- [x] Use relative name instead of base name (`Building index.js` isn't really expressive)
  - [ ] Use a npm based name instead (`@tensorflow/tfjs-core/dist-es6/kernels/backend_webgl.js` instead of `../node_modules/@tensorflow/tfjs-core/dist-es6/kernels/backend_webgl.js`)
- [ ] Improve emojis (⚡️ for transform, 💥 for generate)
- [ ] Batch logger calls (no need to render 400 lines/seconds)

**Before**

![http://g.recordit.co/TaP0aA6RIQ.gif](http://g.recordit.co/TaP0aA6RIQ.gif)

The logger shows `Building quad.ts` for two seconds, given its content I highly doubt it's representative : 

- `quad.ts`
```ts
import {StaticBuffer} from '../objects/buffer'

const BufferData = new Float32Array([
    // (x, y)

    // Vertices
    -1,  1,
    -1, -1,
     1,  1,
     1, -1,
     1,  1,
     1, -1,
     1,  1,
     1, -1,

     // Texture coordinates
     0,  0,
     0,  1,
     1,  0,
     1,  1,
     0,  0,
     0,  1,
     1,  0,
     1,  1,
])

export class QuadGeometry extends StaticBuffer {
    public readonly position = 0
    public readonly texture = 16 * Float32Array.BYTES_PER_ELEMENT

    constructor(gl: WebGLRenderingContext) {
        super(gl, BufferData)
    }
}
```

**After**

![http://g.recordit.co/iv4XJgXCcg.gif](http://g.recordit.co/iv4XJgXCcg.gif)