### PR TITLE
Fix worker environment variable

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -195,7 +195,7 @@ function stringWidth(string) {
 // If we are in a worker, make a proxy class which will
 // send the logger calls to the main process via IPC.
 // These are handled in WorkerFarm and directed to handleMessage above.
-if (process.send && process.env.WORKER_TYPE === 'parcel-worker') {
+if (process.send && process.env.PARCEL_WORKER_TYPE === 'remote-worker') {
   const worker = require('./worker');
   class LoggerProxy {}
   for (let method of Object.getOwnPropertyNames(Logger.prototype)) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,18 +1,21 @@
 require('v8-compile-cache');
 const Pipeline = require('./Pipeline');
-const child = require('./workerfarm/child');
 const WorkerFarm = require('./workerfarm/WorkerFarm');
 
 let pipeline;
+let child;
 
-function init(options, isLocal = false) {
+function setChildReference(childReference) {
+  child = childReference;
+}
+
+function init(options) {
   pipeline = new Pipeline(options || {});
-  Object.assign(process.env, options.env || {});
+  Object.assign(process.env, options.env || {}, {
+    PARCEL_WORKER_TYPE: child ? 'remote-worker' : 'local-worker'
+  });
   process.env.HMR_PORT = options.hmrPort;
   process.env.HMR_HOSTNAME = options.hmrHostname;
-  if (isLocal) {
-    process.env.WORKER_TYPE = 'parcel-worker';
-  }
 }
 
 async function run(path, isWarmUp) {
@@ -26,7 +29,7 @@ async function run(path, isWarmUp) {
 
 // request.location is a module path relative to src or lib
 async function addCall(request, awaitResponse = true) {
-  if (process.send && process.env.WORKER_TYPE === 'parcel-worker') {
+  if (process.send && process.env.PARCEL_WORKER_TYPE === 'remote-worker') {
     return child.addCall(request, awaitResponse);
   } else {
     return WorkerFarm.getShared().processRequest(request);
@@ -36,3 +39,4 @@ async function addCall(request, awaitResponse = true) {
 exports.init = init;
 exports.run = run;
 exports.addCall = addCall;
+exports.setChildReference = setChildReference;

--- a/src/workerfarm/WorkerFarm.js
+++ b/src/workerfarm/WorkerFarm.js
@@ -205,7 +205,7 @@ class WorkerFarm extends EventEmitter {
   }
 
   init(options) {
-    this.localWorker.init(options, true);
+    this.localWorker.init(options);
     this.initRemoteWorkers(options);
   }
 

--- a/src/workerfarm/child.js
+++ b/src/workerfarm/child.js
@@ -9,6 +9,8 @@ class Child {
     this.responseQueue = new Map();
     this.responseId = 0;
     this.maxConcurrentCalls = 10;
+
+    process.env.PARCEL_WORKER_TYPE = 'remote-worker';
   }
 
   messageListener(data) {


### PR DESCRIPTION
This PR fixes a bug with the workerfarm, related to the workers not properly setting the env variable `PARCEL_WORKER_TYPE`