### PR TITLE
Add unit tests for line counter

### DIFF
--- a/test/lineCounter.js
+++ b/test/lineCounter.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const assert = require('assert');
 const lineCounter = require('../src/utils/lineCounter');
 
-describe.only('line counter', () => {
+describe('line counter', () => {
   it('counts number of lines of a string', () => {
     const input = ` line 1
       line 2

--- a/test/lineCounter.js
+++ b/test/lineCounter.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const assert = require('assert');
+const lineCounter = require('../src/utils/lineCounter');
+
+describe.only('line counter', () => {
+  it('counts number of lines of a string', () => {
+    const input = ` line 1
+      line 2
+      line 3`;
+
+    assert(lineCounter(input) === 3);
+  });
+
+  it('counts number of lines of a file from disk', () => {
+    const input = fs.readFileSync('./test/lineCounter.js').toString();
+    assert(lineCounter(input) === 19);
+  });
+});


### PR DESCRIPTION
I'm curious if not using `require('os').EOL` for splitting lines in lineCounter is problematic or not. Since I don't have a Windows machine I'm testing this in your CI! :D 