### PR TITLE
Surface Bundler error to browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "index.js"
   ],
   "dependencies": {
+    "ansi-to-html": "^0.6.4",
     "babel-code-frame": "^6.26.0",
     "babel-core": "^6.25.0",
     "babel-generator": "^6.25.0",

--- a/test/integration/bundler-error-syntax-error/index.html
+++ b/test/integration/bundler-error-syntax-error/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+
+<head>
+</head>
+
+<body>
+    <h1>Hello world</h1>
+    <script src="./index.js"></script>
+</body>
+
+</html>

--- a/test/integration/bundler-error-syntax-error/index.js
+++ b/test/integration/bundler-error-syntax-error/index.js
@@ -1,0 +1,1 @@
+.invalid_js

--- a/test/server.js
+++ b/test/server.js
@@ -27,7 +27,7 @@ describe('server', function() {
           let data = '';
           res.on('data', c => (data += c));
           res.on('end', () => {
-            if (Math.floor(res.statusCode / 100) !== 2) {
+            if (res.statusCode !== 200) {
               return reject(data);
             }
             resolve(data);

--- a/test/server.js
+++ b/test/server.js
@@ -23,14 +23,13 @@ describe('server', function() {
           rejectUnauthorized: false
         },
         res => {
-          if (res.statusCode !== 200) {
-            return reject(new Error('Request failed: ' + res.statusCode));
-          }
-
           res.setEncoding('utf8');
           let data = '';
           res.on('data', c => (data += c));
           res.on('end', () => {
+            if (Math.floor(res.statusCode / 100) !== 2) {
+              return reject(data);
+            }
             resolve(data);
           });
         }
@@ -85,13 +84,63 @@ describe('server', function() {
 
     try {
       await get('/');
-      throw new Error('GET / responded with 200');
     } catch (err) {
       assert.equal(err.message, 'Request failed: 500');
     }
 
     b.errored = false;
     await get('/');
+  });
+
+  it('should serve a 500 response with error stack trace when bundler has errors', async function() {
+    let b = bundler(
+      __dirname + '/integration/bundler-error-syntax-error/index.html'
+    );
+
+    server = await b.serve(0);
+    let resp;
+    try {
+      await get('/');
+    } catch (e) {
+      resp = e;
+    }
+
+    assert(resp.includes('<title>🚨 Build Error</title>'), 'has title');
+    assert(resp.includes('<h1>🚨 Build Error</h1>'), 'has h1');
+    assert(
+      resp.includes('<div style="background: black; padding: 1rem;">'),
+      'has code frame'
+    );
+    assert(resp.includes('invalid_js'), 'code frame has invalid code');
+  });
+
+  it('should serve a 500 response without stack trace when bundler has errors in production', async function() {
+    let NODE_ENV = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    let b = bundler(
+      __dirname + '/integration/bundler-error-syntax-error/index.html'
+    );
+
+    server = await b.serve(0);
+    let resp;
+    try {
+      await get('/');
+    } catch (e) {
+      resp = e;
+    }
+
+    assert(resp.includes('<title>🚨 Build Error</title>'), 'has title');
+    assert(resp.includes('<h1>🚨 Build Error</h1>'), 'has h1');
+    assert(
+      resp.includes('<p><b>Check the console for details.</b></p>'),
+      'has description'
+    );
+    assert(
+      !resp.includes('<div style="background: black; padding: 1rem;">'),
+      'do not have code frame'
+    );
+    assert(!resp.includes('invalid_js'), 'source code is not shown');
+    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should support HTTPS', async function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,6 +145,12 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
+ansi-to-html@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/ansi-to-html/-/ansi-to-html-0.6.4.tgz#8b14ace87f8b3d25367d03cd5300d60be17cf9e0"
+  dependencies:
+    entities "^1.1.1"
+
 any-observable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"


### PR DESCRIPTION

Instead of sending a generic error with the 500 response, print the error message and stack trace in the response HTML payload. 

Feel free to comment. 


<img width="817" alt="screen shot 2018-05-31 at 4 23 03 am" src="https://user-images.githubusercontent.com/543633/40779600-649f3ba6-648a-11e8-8c7b-8ed291358b17.png">