### PR TITLE
Fix typo in uglify.js (fixes #1353)

### DIFF
--- a/src/transforms/uglify.js
+++ b/src/transforms/uglify.js
@@ -16,7 +16,7 @@ module.exports = async function(asset) {
   };
 
   let sourceMap;
-  if (asset.options.sourceMap) {
+  if (asset.options.sourceMaps) {
     sourceMap = new SourceMap();
     options.output = {
       source_map: {


### PR DESCRIPTION
Fix a typo that prevented source maps from being carried over when minifying.

Would be awesome to get this out in a `1.8.2` release.