### PR TITLE
Added new --host option and updated relevant tests

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -711,8 +711,8 @@ class Bundler extends EventEmitter {
     return Server.middleware(this);
   }
 
-  async serve(port = 1234, https = false) {
-    this.server = await Server.serve(this, port, https);
+  async serve(port = 1234, host = 'localhost', https = false) {
+    this.server = await Server.serve(this, port, host, https);
     this.bundle();
     return this.server;
   }

--- a/src/Server.js
+++ b/src/Server.js
@@ -88,7 +88,7 @@ function middleware(bundler) {
   };
 }
 
-async function serve(bundler, port, useHTTPS = false) {
+async function serve(bundler, port, host, useHTTPS = false) {
   let handler = middleware(bundler);
   let server;
   if (!useHTTPS) {
@@ -100,7 +100,7 @@ async function serve(bundler, port, useHTTPS = false) {
   }
 
   let freePort = await getPort({port});
-  server.listen(freePort);
+  server.listen(freePort, host);
 
   return new Promise((resolve, reject) => {
     server.on('error', err => {
@@ -115,10 +115,13 @@ async function serve(bundler, port, useHTTPS = false) {
               `configured port ${port} could not be used.`
             )}`
           : '';
+      const hostAddress = host || 'localhost';
 
       logger.persistent(
         `Server running at ${logger.chalk.cyan(
-          `${useHTTPS ? 'https' : 'http'}://localhost:${server.address().port}`
+          `${useHTTPS ? 'https' : 'http'}://${hostAddress}:${
+            server.address().port
+          }`
         )} ${addon}`
       );
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ program
     'set the port to serve on. defaults to 1234',
     parseInt
   )
+  .option('--host <host>', 'set the host to listen to. defaults to localhost')
   .option(
     '--hmr-port <port>',
     'set the port to serve HMR websockets, defaults to random',
@@ -186,10 +187,15 @@ async function bundle(main, command) {
 
   command.target = command.target || 'browser';
   if (command.name() === 'serve' && command.target === 'browser') {
-    const server = await bundler.serve(command.port || 1234, command.https);
+    const hostAddress = command.host || 'localhost';
+    const server = await bundler.serve(
+      command.port || 1234,
+      hostAddress,
+      command.https
+    );
     if (server && command.open) {
       await require('./utils/openInBrowser')(
-        `${command.https ? 'https' : 'http'}://localhost:${
+        `${command.https ? 'https' : 'http'}://${hostAddress}:${
           server.address().port
         }`,
         command.open

--- a/test/server.js
+++ b/test/server.js
@@ -96,7 +96,7 @@ describe('server', function() {
 
   it('should support HTTPS', async function() {
     let b = bundler(__dirname + '/integration/commonjs/index.js');
-    server = await b.serve(0, true);
+    server = await b.serve(0, undefined, true);
 
     let data = await get('/index.js', https);
     assert.equal(data, await fs.readFile(__dirname + '/dist/index.js', 'utf8'));
@@ -104,7 +104,7 @@ describe('server', function() {
 
   it('should support HTTPS via custom certificate', async function() {
     let b = bundler(__dirname + '/integration/commonjs/index.js');
-    server = await b.serve(0, {
+    server = await b.serve(0, undefined, {
       key: __dirname + '/integration/https/private.pem',
       cert: __dirname + '/integration/https/primary.crt'
     });


### PR DESCRIPTION
Hello! This PR should add the new option --host as requested on [1412](https://github.com/parcel-bundler/parcel/issues/1412). Based on the comments I assumed perhaps ```HMRServer.js``` had to be updated but after testing, that change seems unecessary.

## Rundown of my changes
- A new cli option called --host which receives the host to listen on (defaults to localhost)
- Updated server tests

## How I tested
1. Created an Ubuntu guest virtual machine
2. Run ```yarn build``` in the host machine after changing the code
3. Run ```bin\cli.js -p 999 --host <LOCAL_INTERFACE_IP> <SOME_LOCAL_ENTRY_POINT>``` in the host machine
4. Connected successfully from the guest machine to the host machine via <LOCAL_INTERFACE_IP>:999