### PR TITLE
Add support for Cargo workspaces in Rust integration

### DIFF
--- a/src/assets/RustAsset.js
+++ b/src/assets/RustAsset.js
@@ -152,7 +152,12 @@ class RustAsset extends Asset {
     await exec('cargo', args, {cwd: cargoDir});
 
     // Get output file paths
-    let outDir = path.join(cargoDir, 'target', RUST_TARGET, 'release');
+    let [stdout] = await exec('cargo', ['metadata', '--format-version', '1'], {
+      cwd: cargoDir
+    });
+    const cargoMetadata = JSON.parse(stdout);
+    const cargoTargetDir = cargoMetadata.target_directory;
+    let outDir = path.join(cargoTargetDir, RUST_TARGET, 'release');
 
     // Rust converts '-' to '_' when outputting files.
     let rustName = cargoConfig.package.name.replace(/-/g, '_');

--- a/test/integration/rust-cargo-workspace/.eslintrc
+++ b/test/integration/rust-cargo-workspace/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "../.eslintrc.json",
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/test/integration/rust-cargo-workspace/Cargo.toml
+++ b/test/integration/rust-cargo-workspace/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+  "member"
+]

--- a/test/integration/rust-cargo-workspace/member/Cargo.toml
+++ b/test/integration/rust-cargo-workspace/member/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "member"
+version = "0.1.0"
+authors = ["josealbizures <albizures3601@gmail.com>"]
+
+[dependencies]
+
+[lib]
+crate-type = ["cdylib"]

--- a/test/integration/rust-cargo-workspace/member/src/index.js
+++ b/test/integration/rust-cargo-workspace/member/src/index.js
@@ -1,0 +1,3 @@
+module.exports = import('./lib.rs').then(function ({add}) {
+  return add(2, 3);
+});

--- a/test/integration/rust-cargo-workspace/member/src/lib.rs
+++ b/test/integration/rust-cargo-workspace/member/src/lib.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub fn add(a: i32, b: i32) -> i32 {
+    return a + b
+}

--- a/test/rust.js
+++ b/test/rust.js
@@ -133,6 +133,36 @@ describe('rust', function() {
     assert.equal(res, 5);
   });
 
+  it('should generate a wasm file from a rust file in cargo workspace', async function() {
+    this.timeout(500000);
+    let b = await bundle(
+      __dirname + '/integration/rust-cargo-workspace/member/src/index.js'
+    );
+
+    await assertBundleTree(b, {
+      name: 'index.js',
+      assets: [
+        'bundle-loader.js',
+        'bundle-url.js',
+        'index.js',
+        'wasm-loader.js'
+      ],
+      childBundles: [
+        {
+          type: 'map'
+        },
+        {
+          type: 'wasm',
+          assets: ['lib.rs'],
+          childBundles: []
+        }
+      ]
+    });
+
+    var res = await run(b);
+    assert.equal(res, 5);
+  });
+
   it('should use wasm-gc to minify output', async function() {
     this.timeout(500000);
 


### PR DESCRIPTION
Without the PR Parcel tries to infer the output directory for a cargo build in a less flexible way. However, since the project structure of Cargo projects that make use of workspaces feature is slightly different from the normal one, that fails.

This PR uses the `cargo metadata` command to infer the correct target directory, which is should be fairly robust.