### PR TITLE
Pass compiler of @vue/component-compiler-utils to parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ws": "^5.1.1"
   },
   "devDependencies": {
-    "@vue/component-compiler-utils": "^1.0.0",
+    "@vue/component-compiler-utils": "^2.0.0",
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-async-super": "^1.0.0",
     "babel-polyfill": "^6.26.0",

--- a/src/assets/VueAsset.js
+++ b/src/assets/VueAsset.js
@@ -21,7 +21,8 @@ class VueAsset extends Asset {
       source: code,
       needMap: this.options.sourceMaps,
       filename: this.relativeName, // Used for sourcemaps
-      sourceRoot: '' // Used for sourcemaps. Override so it doesn't use cwd
+      sourceRoot: '', // Used for sourcemaps. Override so it doesn't use cwd
+      compiler: this.vueTemplateCompiler
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,9 +38,9 @@
   dependencies:
     "@types/babel-types" "*"
 
-"@vue/component-compiler-utils@^1.0.0":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-1.2.1.tgz#3d543baa75cfe5dab96e29415b78366450156ef6"
+"@vue/component-compiler-utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-2.0.0.tgz#ea2e46d04c521afbce91a011ae2eb09460362a4b"
   dependencies:
     consolidate "^0.15.1"
     hash-sum "^1.0.2"
@@ -48,7 +48,7 @@
     merge-source-map "^1.1.0"
     postcss "^6.0.20"
     postcss-selector-parser "^3.1.1"
-    prettier "^1.11.1"
+    prettier "^1.13.0"
     source-map "^0.5.6"
     vue-template-es2015-compiler "^1.6.0"
 
@@ -5354,10 +5354,6 @@ prepend-http@^1.0.0:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
-
-prettier@^1.11.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
 
 prettier@^1.13.0:
   version "1.13.0"


### PR DESCRIPTION
Seems like this bug https://github.com/parcel-bundler/parcel/issues/1490 appeared, after the change made in this commit https://github.com/vuejs/component-compiler-utils/commit/caa1538960ab97b70e4fff8ce84d446a7431226c#diff-3bebbbb54c7d798b4200eb324ebd4500R17

Tested for older version of vuejs/component-compiler-utils, works pretty fine.