### PR TITLE
Fix babel config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "babylon-walk": "^1.0.2",
     "browserslist": "^3.2.6",
     "chalk": "^2.1.0",
+    "clone": "^2.1.1",
     "command-exists": "^1.2.6",
     "commander": "^2.11.0",
     "cross-spawn": "^6.0.4",

--- a/src/Asset.js
+++ b/src/Asset.js
@@ -1,5 +1,6 @@
 const URL = require('url');
 const path = require('path');
+const clone = require('clone');
 const fs = require('./utils/fs');
 const objectHash = require('./utils/objectHash');
 const md5 = require('./utils/md5');
@@ -136,7 +137,7 @@ class Asset {
     if (opts.packageKey) {
       let pkg = await this.getPackage();
       if (pkg && pkg[opts.packageKey]) {
-        return pkg[opts.packageKey];
+        return clone(pkg[opts.packageKey]);
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,6 +1328,10 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
+clone@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+
 clones@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/clones/-/clones-1.1.0.tgz#87e904132d6140c5c0b72006c08c0d05bd7b63b3"


### PR DESCRIPTION
I figured out #927.

Babel seems to mutate config. More specifically, presets seem to append plugins every time babel is run. Because the asset caches `asset.package`, when using a package config like `asset.package.babel`, babel mutates the cached package config. Next time it needs the config it gets the same config, and mutates it again.

Instead, if loading config using a packageKey, clone the config before returning so mutations won't be persisted on the cached copy.