### PR TITLE
Fix ES6 re-export of CommonJS modules

### DIFF
--- a/test/integration/scope-hoisting/es6/re-export-commonjs/a.js
+++ b/test/integration/scope-hoisting/es6/re-export-commonjs/a.js
@@ -1,0 +1,3 @@
+import {foo} from './b'
+
+output = foo()

--- a/test/integration/scope-hoisting/es6/re-export-commonjs/b.js
+++ b/test/integration/scope-hoisting/es6/re-export-commonjs/b.js
@@ -1,0 +1,1 @@
+export {default as foo} from './c'

--- a/test/integration/scope-hoisting/es6/re-export-commonjs/c.js
+++ b/test/integration/scope-hoisting/es6/re-export-commonjs/c.js
@@ -1,0 +1,6 @@
+Object.defineProperty(exports, '__esModule', {
+    value: true
+})
+Object.defineProperty(exports, 'default', {
+    value: () => 'foo'
+})

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -292,6 +292,15 @@ describe('scope hoisting', function() {
       assert(contents.includes('foo'));
       assert(!contents.includes('bar'));
     });
+
+    it('support exporting a ES6 module exported as CommonJS', async function() {
+      let b = await bundle(
+        __dirname + '/integration/scope-hoisting/es6/re-export-commonjs/a.js'
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'foo');
+    });
   });
 
   describe('commonjs', function() {


### PR DESCRIPTION
Affects `material-ui@next`

Fixes #1540