### PR TITLE
LESS: Fix relative paths and node module conflict 

### DIFF
--- a/src/assets/LESSAsset.js
+++ b/src/assets/LESSAsset.js
@@ -4,6 +4,7 @@ const promisify = require('../utils/promisify');
 const Resolver = require('../Resolver');
 const fs = require('../utils/fs');
 const path = require('path');
+const parseCSSImport = require('../utils/parseCSSImport');
 
 class LESSAsset extends Asset {
   constructor(name, options) {
@@ -80,6 +81,7 @@ function getFileManager(less, options) {
     }
 
     async loadFile(filename, currentDirectory) {
+      filename = parseCSSImport(filename);
       let resolved = await resolver.resolve(
         filename,
         path.join(currentDirectory, 'index')

--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -4,6 +4,7 @@ const promisify = require('../utils/promisify');
 const path = require('path');
 const os = require('os');
 const Resolver = require('../Resolver');
+const parseCSSImport = require('../utils/parseCSSImport');
 
 class SASSAsset extends Asset {
   constructor(name, options) {
@@ -50,11 +51,7 @@ class SASSAsset extends Asset {
       ? opts.importer
       : [opts.importer];
     opts.importer.push((url, prev, done) => {
-      if (!/^(~|\.\/|\/)/.test(url)) {
-        url = './' + url;
-      } else if (!/^(~\/|\.\/|\/)/.test(url)) {
-        url = url.substring(1);
-      }
+      url = parseCSSImport(url);
       resolver
         .resolve(url, prev === 'stdin' ? this.name : prev)
         .then(resolved => resolved.path)

--- a/src/utils/parseCSSImport.js
+++ b/src/utils/parseCSSImport.js
@@ -1,0 +1,10 @@
+function parseCSSImport(url) {
+  if (!/^(~|\.\/|\/)/.test(url)) {
+    url = './' + url;
+  } else if (!/^(~\/|\.\/|\/)/.test(url)) {
+    url = url.substring(1);
+  }
+  return url;
+}
+
+module.exports = parseCSSImport;

--- a/test/integration/less-import/base.less
+++ b/test/integration/less-import/base.less
@@ -1,3 +1,5 @@
+@import '~external-less/a.less';
+
 @base: #f938ab;
 
 .base {

--- a/test/integration/less-import/node_modules/external-less/a.less
+++ b/test/integration/less-import/node_modules/external-less/a.less
@@ -1,0 +1,3 @@
+.external {
+  background: red;
+}

--- a/test/integration/less-import/node_modules/external-less/package.json
+++ b/test/integration/less-import/node_modules/external-less/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "external-less",
+  "private": true
+}


### PR DESCRIPTION
This fixes relative paths being seen as a node_module, works identical to how sass gets processed.

Closes #1541 