### PR TITLE
Remove physical-cpu-count

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "node-forge": "^0.7.1",
     "node-libs-browser": "^2.0.0",
     "opn": "^5.1.0",
-    "physical-cpu-count": "^2.0.0",
     "postcss": "^6.0.19",
     "postcss-value-parser": "^3.3.0",
     "posthtml": "^0.11.2",
@@ -62,9 +61,9 @@
     "serve-static": "^1.12.4",
     "source-map": "0.6.1",
     "strip-ansi": "^4.0.0",
+    "terser": "^3.7.3",
     "toml": "^2.3.3",
     "tomlify-j0.4": "^3.0.0",
-    "terser": "^3.7.3",
     "v8-compile-cache": "^2.0.0",
     "ws": "^5.1.1"
   },

--- a/src/workerfarm/WorkerFarm.js
+++ b/src/workerfarm/WorkerFarm.js
@@ -268,13 +268,7 @@ class WorkerFarm extends EventEmitter {
       return parseInt(process.env.PARCEL_WORKERS, 10);
     }
 
-    let cores;
-    try {
-      cores = require('physical-cpu-count');
-    } catch (err) {
-      cores = os.cpus().length;
-    }
-    return cores || 1;
+    return os.cpus().length || 1;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5001,10 +5001,6 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
-physical-cpu-count@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz#18de2f97e4bf7a9551ad7511942b5496f7aba660"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"


### PR DESCRIPTION
<!-- Brainfart of the day -->
As noted in #1554 `physical-cpu-count` has some overhead.

Is there any motivation behind not using the number of logical cores? Parcel benefits from HyperThreading, on all my i7 machines I get slightly better performance.

---

Closes #1554 