### PR TITLE
Fix tree-shaking DCE

### DIFF
--- a/test/integration/scope-hoisting/commonjs/export-local/a.js
+++ b/test/integration/scope-hoisting/commonjs/export-local/a.js
@@ -1,0 +1,1 @@
+module.exports = require('./b').foo;

--- a/test/integration/scope-hoisting/commonjs/export-local/b.js
+++ b/test/integration/scope-hoisting/commonjs/export-local/b.js
@@ -1,0 +1,1 @@
+var x = exports.foo = exports.bar = 3;

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -766,5 +766,17 @@ describe('scope hoisting', function() {
       assert(contents.includes('foo'));
       assert(!contents.includes('bar'));
     });
+
+    it('supports removing an unused inline export with uglify minification', async function() {
+      // Uglify does strange things to multiple assignments in a line.
+      // See https://github.com/parcel-bundler/parcel/issues/1549
+      let b = await bundle(
+        __dirname + '/integration/scope-hoisting/commonjs/export-local/a.js',
+        {minify: true}
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 3);
+    });
   });
 });


### PR DESCRIPTION
Fixes #1549. Tiny refactor of the node removal part of the DCE to handle more wild cases and do the removal recursively on parents.

Did this before going to work, will update later to fix/add tests.
Feedback appreciated, fixes `keycode` and `material-ui` (build, didn't had time to runtime test, cc @oliviertassinari).

It breaks DCE on babel-minify but not on Uglify.