### PR TITLE
Fix unintended Vue asset supplemental code insertion

### DIFF
--- a/src/assets/VueAsset.js
+++ b/src/assets/VueAsset.js
@@ -85,7 +85,9 @@ class VueAsset extends Asset {
         }
       }
     } else {
-      supplemental += `var ${optsVar} = exports.default || module.exports;`;
+      supplemental += `
+        var ${optsVar} = exports.default || module.exports;
+      `;
     }
 
     supplemental += `


### PR DESCRIPTION
This PR fixes the first line of supplemental code being [accidentally commented out](https://github.com/parcel-bundler/parcel/blob/v1.9.1/src/assets/VueAsset.js#L112) when the generated JS code (the `js` variable) was ended with `//`.

![screen shot 2018-06-18 at 20 14 20](https://user-images.githubusercontent.com/9481405/41533572-39fc91a4-7336-11e8-997e-22154a158219.png)