### PR TITLE
get only existing package main

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -295,9 +295,10 @@ class Resolver {
         continue;
       }
       try {
-        // else, check if the file main exists/is accessible. if it does, break the loop.
-        await fs.access(path.resolve(pkg.pkgdir, main));
-        break;
+        // else, check if the file main exists/is accessible. if it does, return the path of the file.
+        const resolvedPath = path.resolve(pkg.pkgdir, main);
+        await fs.access(resolvedPath);
+        return resolvedPath;
       } catch (e) {
         // keep looking for an accessible file
       }

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -235,9 +235,8 @@ class Resolver {
         }
         if (file == '.' || file == './') {
           file = 'index';
-        } else {
-          file = path.resolve(pkg.pkgdir, file);
         }
+        file = path.resolve(pkg.pkgdir, file);
 
         const res =
           (await this.loadAsFile(file, extensions, pkg)) ||

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -7,8 +7,16 @@ exports.writeFile = promisify(fs.writeFile);
 exports.stat = promisify(fs.stat);
 exports.readdir = promisify(fs.readdir);
 exports.unlink = promisify(fs.unlink);
-exports.realpath = promisify(fs.realpath);
-exports.access = promisify(fs.access);
+exports.realpath = async function(path) {
+  const realpath = promisify(fs.realpath);
+  try {
+    path = await realpath(path);
+  } catch (e) {
+    // do nothing
+  }
+  return path;
+};
+exports.lstat = promisify(fs.lstat);
 
 exports.exists = function(filename) {
   return new Promise(resolve => {

--- a/src/utils/fs.js
+++ b/src/utils/fs.js
@@ -7,16 +7,8 @@ exports.writeFile = promisify(fs.writeFile);
 exports.stat = promisify(fs.stat);
 exports.readdir = promisify(fs.readdir);
 exports.unlink = promisify(fs.unlink);
-exports.realpath = async function(path) {
-  const realpath = promisify(fs.realpath);
-  try {
-    path = await realpath(path);
-  } catch (e) {
-    // do nothing
-  }
-  return path;
-};
-exports.lstat = promisify(fs.lstat);
+exports.realpath = promisify(fs.realpath);
+exports.access = promisify(fs.access);
 
 exports.exists = function(filename) {
   return new Promise(resolve => {

--- a/test/integration/resolver/node_modules/package-module-fallback/package.json
+++ b/test/integration/resolver/node_modules/package-module-fallback/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package-module-fallback",
+  "main": "main.js",
+  "module": "module.js"
+}

--- a/test/resolver.js
+++ b/test/resolver.js
@@ -176,6 +176,18 @@ describe('resolver', function() {
       assert.equal(resolved.pkg.name, 'package-browser');
     });
 
+    it('should fall back to package.main when package.module does not exist', async function() {
+      let resolved = await resolver.resolve(
+        'package-module-fallback',
+        path.join(rootDir, 'foo.js')
+      );
+      assert.equal(
+        resolved.path,
+        path.join(rootDir, 'node_modules', 'package-module-fallback', 'main.js')
+      );
+      assert.equal(resolved.pkg.name, 'package-module-fallback');
+    });
+
     it('should not resolve a node_modules package.browser main field with --target=node', async function() {
       let resolver = new Resolver({
         rootDir,


### PR DESCRIPTION
Sometimes a package has in his package.json a source field, but the package is already bundled/compiled, so there isn't any source file inside that package. Now, before returning any package file, parcel checks if the file exists. If it doesn't exists, parcel tries to use another file, until a real file is found. fixes #1568 

I still need to fix the error...
