### PR TITLE
fix 'Cannot read property 'posthtml' of null

### DIFF
--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -26,7 +26,7 @@ async function transform(asset) {
 
 async function getConfig(asset) {
   let config =
-    (await asset.getPackage()).posthtml ||
+    ((await asset.getPackage()) || {}).posthtml ||
     (await asset.getConfig([
       '.posthtmlrc',
       '.posthtmlrc.js',


### PR DESCRIPTION
fixes #1574 