### PR TITLE
Prevent postcss-modules plugin config from being deleted after first run

### DIFF
--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -28,7 +28,15 @@ async function getConfig(asset) {
     return;
   }
 
-  config = Object.assign({}, config);
+  config = Object.assign(
+    {},
+    config,
+    config && {
+      plugins: Array.isArray(config.plugins)
+        ? [].concat(config.plugins)
+        : Object.assign({}, config.plugins)
+    }
+  );
 
   let postcssModulesConfig = {
     getJSON: (filename, json) => (asset.cssModules = json)

--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -28,16 +28,7 @@ async function getConfig(asset) {
     return;
   }
 
-  config = Object.assign(
-    {},
-    config,
-    config && {
-      plugins: Array.isArray(config.plugins)
-        ? [].concat(config.plugins)
-        : Object.assign({}, config.plugins)
-    }
-  );
-
+  config = config || {};
   let postcssModulesConfig = {
     getJSON: (filename, json) => (asset.cssModules = json)
   };

--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -35,7 +35,7 @@ async function getConfig(asset) {
     return;
   }
 
-  config = Object.assign({}, config);
+  config = config || {};
   const plugins = config.plugins;
   if (typeof plugins === 'object') {
     const depConfig = {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,5 +1,6 @@
 const fs = require('./fs');
 const path = require('path');
+const clone = require('clone');
 
 const PARSERS = {
   json: require('json5').parse,
@@ -36,7 +37,7 @@ async function load(filepath, filenames, root = path.parse(filepath).root) {
     try {
       let extname = path.extname(configFile).slice(1);
       if (extname === 'js') {
-        return require(configFile);
+        return clone(require(configFile));
       }
 
       let configContent = (await fs.readFile(configFile)).toString();

--- a/test/css.js
+++ b/test/css.js
@@ -218,6 +218,15 @@ describe('css', function() {
     assert(css.includes(`.${cssClass}`));
   });
 
+  it('should support transforming with postcss twice with the same result', async function() {
+    let b = await bundle(__dirname + '/integration/postcss-plugins/index.js');
+    let c = await bundle(__dirname + '/integration/postcss-plugins/index2.js');
+
+    let [run1, run2] = await Promise.all([await run(b), await run(c)]);
+
+    assert.equal(run1(), run2());
+  });
+
   it('should minify CSS in production mode', async function() {
     let b = await bundle(__dirname + '/integration/cssnano/index.js', {
       production: true

--- a/test/integration/postcss-plugins/.postcssrc.js
+++ b/test/integration/postcss-plugins/.postcssrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  modules: true,
+  plugins: {
+    'postcss-modules': {
+      generateScopedName: "_[name]__[local]"
+    }
+  }
+};

--- a/test/integration/postcss-plugins/index.css
+++ b/test/integration/postcss-plugins/index.css
@@ -1,0 +1,3 @@
+.index {
+  color: red;
+}

--- a/test/integration/postcss-plugins/index.js
+++ b/test/integration/postcss-plugins/index.js
@@ -1,0 +1,5 @@
+var map = require('./index.css');
+
+module.exports = function () {
+  return map.index;
+};

--- a/test/integration/postcss-plugins/index2.js
+++ b/test/integration/postcss-plugins/index2.js
@@ -1,0 +1,5 @@
+var map = require('./index.css');
+
+module.exports = function () {
+  return map.index;
+};


### PR DESCRIPTION
When the postcss config object is being copied with `Object.assign`, the nested `plugins` array or object remains as a reference and not a copy.

As the postcss transform deletes the plugins config for `postcss-modules` each time, it inadvertently deletes the original config by reference.

As a result, postcss transforms that occur after the first time have no `postcss-modules` plugins config and therefore parcel produces a different result for all subsequent transforms.

Related: #809 