### PR TITLE
Set user provided NODE_ENV if provided with build command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -174,7 +174,7 @@ async function bundle(main, command) {
   const Bundler = require('../');
 
   if (command.name() === 'build') {
-    process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = process.env.NODE_ENV || 'production';
   } else {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';
   }


### PR DESCRIPTION
Like others in #702, there are times when I need a development build. This change remedies that by using the `NODE_ENV` set by a user in the build command, but will default to `production` is none is provided.