### PR TITLE
Fix Sass dependencies can not be watched when includePaths is a relative path

### DIFF
--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -24,9 +24,10 @@ class SASSAsset extends Asset {
     let opts =
       (await this.getConfig(['.sassrc', '.sassrc.js'], {packageKey: 'sass'})) ||
       {};
-    opts.includePaths = (opts.includePaths || []).concat(
-      path.dirname(this.name)
-    );
+    opts.includePaths = (opts.includePaths
+      ? opts.includePaths.map(includePath => path.resolve(includePath))
+      : []
+    ).concat(path.dirname(this.name));
     opts.data = opts.data ? opts.data + os.EOL + code : code;
     let type = this.options.rendition
       ? this.options.rendition.type


### PR DESCRIPTION
For #1613 
I have reviewed the contributing guidelines and glad to give a pr to fix it.
Hope this is a suitable solution.