### PR TITLE
Upgrade Typescript to 2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,9 @@
     "serve-static": "^1.12.4",
     "source-map": "0.6.1",
     "strip-ansi": "^4.0.0",
+    "terser": "^3.7.3",
     "toml": "^2.3.3",
     "tomlify-j0.4": "^3.0.0",
-    "terser": "^3.7.3",
     "v8-compile-cache": "^2.0.0",
     "ws": "^5.1.1"
   },
@@ -99,7 +99,7 @@
     "sinon": "^5.0.1",
     "sourcemap-validator": "^1.0.6",
     "stylus": "^0.54.5",
-    "typescript": "^2.7.0",
+    "typescript": "^2.9.0",
     "vue": "^2.5.16",
     "vue-template-compiler": "^2.5.16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6685,9 +6685,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.7.0:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^2.9.0:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
 uglify-es@^3.3.9:
   version "3.3.9"


### PR DESCRIPTION
This pull request upgrades the default version of Typescript from 2.7 to 2.9