### PR TITLE
fix build not exiting in dev env

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -177,7 +177,7 @@ async function bundle(main, command) {
   const Bundler = require('../');
 
   if (command.name() === 'build') {
-    command.watch = false;
+    command.production = true;
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';
   } else {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';

--- a/src/cli.js
+++ b/src/cli.js
@@ -177,6 +177,7 @@ async function bundle(main, command) {
   const Bundler = require('../');
 
   if (command.name() === 'build') {
+    command.watch = false;
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';
   } else {
     process.env.NODE_ENV = process.env.NODE_ENV || 'development';


### PR DESCRIPTION
When NODE_ENV is set to something else instead of `production` build was
not exiting. This bug was introduced in 1b6a93f3efa1d8a4e9e04beda1a5545770e9fb07

Closes #1626