### PR TITLE
Add a buildError event to bundler

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -300,7 +300,11 @@ class Bundler extends EventEmitter {
       return this.mainBundle;
     } catch (err) {
       this.error = err;
+
       logger.error(err);
+
+      this.emit('bundle-error', err);
+
       if (this.hmr) {
         this.hmr.emitError(err);
       }

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -303,7 +303,7 @@ class Bundler extends EventEmitter {
 
       logger.error(err);
 
-      this.emit('bundle-error', err);
+      this.emit('buildError', err);
 
       if (this.hmr) {
         this.hmr.emitError(err);


### PR DESCRIPTION
This PR adds a buildError event to the bundler, which is very usefull, when using the parcel API