### PR TITLE
Prioritize browser field over module

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -273,9 +273,9 @@ class Resolver {
     }
 
     // libraries like d3.js specifies node.js specific files in the "main" which breaks the build
-    // we use the "module" or "browser" field to get the full dependency tree if available.
+    // we use the "browser" or "module" field to get the full dependency tree if available.
     // If this is a linked module with a `source` field, use that as the entry point.
-    let main = [pkg.source, pkg.module, browser, pkg.main].find(
+    let main = [pkg.source, browser, pkg.module, pkg.main].find(
       entry => typeof entry === 'string'
     );
 


### PR DESCRIPTION
It's what webpack does - [link](https://webpack.js.org/configuration/resolve/#resolve-mainfields).

IMHO it's really important to be consistent about this across bundlers, because otherwise the library authoring process is unclear and impossible to satisfy all bundlers with a single `package.json` description.

It also only make sense to use *more* specific field (`"browser"`) with higher priority than less specific one (`"module"`). Latter only recommends using ESM modules over CJS, former doesn't actually say anything about module format but it's way more specific about targeting environment and this can be leveraged to produce more optimized bundles.

Keep in mind that `"browser"` is also an alias field and can be used like this:
```json
{
  "main": "dist/module.cjs.node.js",
  "module": "dist/module.esm.node.js",
  "browser": {
    "dist/module.cjs.node.js": "dist/module.cjs.browser.js",
    "dist/module.esm.node.js": "dist/module.esm.browser.js"
  }
}
```