### PR TITLE
Only watch directories on macOS

### DIFF
--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -2,14 +2,17 @@ const FSWatcher = require('fswatcher-child');
 const Path = require('path');
 
 /**
- * This watcher wraps chokidar so that we watch directories rather than individual files.
+ * This watcher wraps chokidar so that we watch directories rather than individual files on macOS.
  * This prevents us from hitting EMFILE errors when running out of file descriptors.
+ * Chokidar does not have support for watching directories on non-macOS platforms, so we disable
+ * this behavior in order to prevent watching more individual files than necessary (e.g. node_modules).
  */
 class Watcher {
   constructor() {
     // FS events on macOS are flakey in the tests, which write lots of files very quickly
     // See https://github.com/paulmillr/chokidar/issues/612
-    this.shouldWatchDirs = process.env.NODE_ENV !== 'test';
+    this.shouldWatchDirs =
+      process.platform === 'darwin' && process.env.NODE_ENV !== 'test';
     this.watcher = new FSWatcher({
       useFsEvents: this.shouldWatchDirs,
       ignoreInitial: true,


### PR DESCRIPTION
Fixes #1557.
Closes #1559.

We switched to watching directories instead of files in #1279 because of EMFILE errors (running out of file descriptors) when watching individual files. This was especially seen on macOS. However, it seems that watching directories is not supported on Linux, so Chokidar is recursively watching all individual files in node_modules. This is likely more files than just the ones we were watching individually before, since it will include things in node_modules that aren't in the build (e.g. tests, etc.).

This PR changes the behavior of the watcher to only watch directories on macOS, where Chokidar has special support via fs-events. Long term, we should consider moving off of Chokidar but this should "solve" the problem temporarily.

