### PR TITLE
Avoid createBundleTree if same asset

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -648,7 +648,9 @@ class Bundler extends EventEmitter {
     parentBundles.add(bundle);
 
     for (let [dep, assetDep] of asset.depAssets) {
-      this.createBundleTree(assetDep, bundle, dep, parentBundles);
+      if (asset.name !== assetDep.name) {
+        this.createBundleTree(assetDep, bundle, dep, parentBundles);
+      }
     }
 
     parentBundles.delete(bundle);

--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -648,7 +648,7 @@ class Bundler extends EventEmitter {
     parentBundles.add(bundle);
 
     for (let [dep, assetDep] of asset.depAssets) {
-      if (asset.name !== assetDep.name) {
+      if (asset.id !== assetDep.id) {
         this.createBundleTree(assetDep, bundle, dep, parentBundles);
       }
     }


### PR DESCRIPTION
Thank you for great product.
I checkout master branch, and got Maximum call stack size exceeded in master branch when below code.

```
window.Buffer = require("buffer/").Buffer
```

```
Server running at http://localhost:1234
🚨  Maximum call stack size exceeded
    at Bundler.createBundleTree (/***/src/Bundler.js:583:19)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
    at Bundler.createBundleTree (/***/src/Bundler.js:652:12)
```

If my approach is not good, please close this PR.