### PR TITLE
Watch PostHTML plugins dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "node-sass": "^4.7.2",
     "nyc": "^11.1.0",
     "postcss-modules": "^1.1.0",
+    "posthtml-extend": "^0.2.1",
     "posthtml-include": "^1.1.0",
     "prettier": "^1.13.0",
     "pug": "^2.0.3",

--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -112,7 +112,20 @@ class HTMLAsset extends Asset {
   }
 
   collectDependencies() {
-    this.ast.walk(node => {
+    let {ast} = this;
+
+    // Add bundled dependencies from plugins like posthtml-extend or posthtml-include, if any
+    if (ast.messages) {
+      ast.messages.forEach(message => {
+        if (message.type === 'dependency') {
+          this.addDependency(message.file, {
+            includedInParent: true
+          });
+        }
+      });
+    }
+
+    ast.walk(node => {
       if (node.attrs) {
         if (node.tag === 'meta') {
           if (

--- a/src/transforms/posthtml.js
+++ b/src/transforms/posthtml.js
@@ -38,6 +38,8 @@ async function getConfig(asset) {
   config = config || {};
   const plugins = config.plugins;
   if (typeof plugins === 'object') {
+    // This is deprecated in favor of result messages but kept for compatibility
+    // See https://github.com/posthtml/posthtml-include/blob/e4f2a57c2e52ff721eed747b65eddf7d7a1451e3/index.js#L18-L26
     const depConfig = {
       addDependencyTo: {
         addDependency: name =>

--- a/test/html.js
+++ b/test/html.js
@@ -116,6 +116,19 @@ describe('html', function() {
     assert(asset.dependencies.get(other).includedInParent);
   });
 
+  it('should add dependencies referenced by plugins', async () => {
+    const b = await bundle(
+      __dirname + '/integration/posthtml-plugin-deps/index.html'
+    );
+    const asset = b.assets.values().next().value;
+    const other = path.join(
+      __dirname,
+      '/integration/posthtml-plugin-deps/base.html'
+    );
+    assert(asset.dependencies.has(other));
+    assert(asset.dependencies.get(other).includedInParent);
+  });
+
   it('should insert sibling CSS bundles for JS files in the HEAD', async function() {
     let b = await bundle(__dirname + '/integration/html-css/index.html');
 

--- a/test/integration/posthtml-plugin-deps/base.html
+++ b/test/integration/posthtml-plugin-deps/base.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>Parcel</title>
+    </head>
+    <body>
+        <div class="content"></div>
+    </body>
+</html>

--- a/test/integration/posthtml-plugin-deps/index.html
+++ b/test/integration/posthtml-plugin-deps/index.html
@@ -1,0 +1,3 @@
+<extends src='base.html'>
+    <p>Hello</p>
+</extends>

--- a/test/integration/posthtml-plugin-deps/posthtml.config.js
+++ b/test/integration/posthtml-plugin-deps/posthtml.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+    plugins: [
+        require('posthtml-extend')({
+            root: __dirname
+        })
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5756,6 +5756,13 @@ postcss@^6.0.1, postcss@^6.0.19, postcss@^6.0.20:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+posthtml-extend@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/posthtml-extend/-/posthtml-extend-0.2.1.tgz#d023ce7ce4dd6071071b50e315dfefa87da8a979"
+  dependencies:
+    posthtml "^0.11.3"
+    posthtml-parser "^0.3.0"
+
 posthtml-include@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/posthtml-include/-/posthtml-include-1.1.0.tgz#6a11efff05dfba4e9f29788dea1d17248f04f1e1"
@@ -5768,7 +5775,7 @@ posthtml-parser@^0.1.1:
   dependencies:
     htmlparser2 "^3.8.3"
 
-posthtml-parser@^0.3.3:
+posthtml-parser@^0.3.0, posthtml-parser@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.3.3.tgz#3fe986fca9f00c0f109d731ba590b192f26e776d"
   dependencies:


### PR DESCRIPTION
Fixes #1670

I didn't find much about `tree.messages`, it is in [`posthtml` tests](https://github.com/posthtml/posthtml/blob/788a306b33b6930b9bbfbcb659484e75cf3ee940/test/messages.js).

Also found in `posthtml-include` :
https://github.com/posthtml/posthtml-include/blob/e4f2a57c2e52ff721eed747b65eddf7d7a1451e3/index.js#L18-L26