### PR TITLE
Fix tree-shaking named import on wrapped module

### DIFF
--- a/src/scope-hoisting/concat.js
+++ b/src/scope-hoisting/concat.js
@@ -339,7 +339,7 @@ module.exports = (packager, ast) => {
           let {identifier} = findExportModule(match[1], name, path);
 
           // Check if $id$export$name exists and if so, replace the node by it.
-          if (identifier) {
+          if (identifier && path.scope.hasBinding(identifier)) {
             path.replaceWith(t.identifier(identifier));
           }
         }

--- a/src/scope-hoisting/concat.js
+++ b/src/scope-hoisting/concat.js
@@ -339,7 +339,7 @@ module.exports = (packager, ast) => {
           let {identifier} = findExportModule(match[1], name, path);
 
           // Check if $id$export$name exists and if so, replace the node by it.
-          if (identifier && path.scope.hasBinding(identifier)) {
+          if (identifier) {
             path.replaceWith(t.identifier(identifier));
           }
         }

--- a/src/scope-hoisting/hoist.js
+++ b/src/scope-hoisting/hoist.js
@@ -110,6 +110,7 @@ module.exports = {
           ])
         );
 
+        asset.cacheData.exports = {};
         asset.cacheData.isCommonJS = true;
         asset.cacheData.isES6Module = false;
       } else {

--- a/test/integration/scope-hoisting/es6/import-wrapped/a.js
+++ b/test/integration/scope-hoisting/es6/import-wrapped/a.js
@@ -1,0 +1,3 @@
+import {foo} from './b'
+
+output = foo

--- a/test/integration/scope-hoisting/es6/import-wrapped/b.js
+++ b/test/integration/scope-hoisting/es6/import-wrapped/b.js
@@ -1,0 +1,1 @@
+export const foo = eval("'bar'")

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -301,6 +301,15 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 'foo');
     });
+
+    it('should support named imports on wrapped modules', async function() {
+      let b = await bundle(
+        __dirname + '/integration/scope-hoisting/es6/import-wrapped/a.js'
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'bar');
+    });
   });
 
   describe('commonjs', function() {


### PR DESCRIPTION
Fixes de-optimized modules like `redux-bundler`