### PR TITLE
WIP: Add PostCSS's SugarSS recognition by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "sinon": "^5.0.1",
     "sourcemap-validator": "^1.0.6",
     "stylus": "^0.54.5",
+    "sugarss": "^2.0.0",
     "typescript": "^3.0.0",
     "vue": "^2.5.16",
     "vue-template-compiler": "^2.5.16"

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -29,6 +29,7 @@ class Parser {
     this.registerExtension('css', './assets/CSSAsset');
     this.registerExtension('pcss', './assets/CSSAsset');
     this.registerExtension('postcss', './assets/CSSAsset');
+    this.registerExtension('sss', './assets/SSSAsset');
     this.registerExtension('styl', './assets/StylusAsset');
     this.registerExtension('stylus', './assets/StylusAsset');
     this.registerExtension('less', './assets/LESSAsset');

--- a/src/assets/Ast.js
+++ b/src/assets/Ast.js
@@ -1,0 +1,18 @@
+class CSSAst {
+  constructor(css, root) {
+    this.css = css;
+    this.root = root;
+    this.dirty = false;
+  }
+
+  render() {
+    if (this.dirty) {
+      this.css = '';
+      postcss.stringify(this.root, c => (this.css += c));
+    }
+
+    return this.css;
+  }
+}
+
+module.exports.CSSAst = CSSAst;

--- a/src/assets/Ast.js
+++ b/src/assets/Ast.js
@@ -1,3 +1,5 @@
+const postcss = require('postcss');
+
 class CSSAst {
   constructor(css, root) {
     this.css = css;

--- a/src/assets/CSSAsset.js
+++ b/src/assets/CSSAsset.js
@@ -3,6 +3,7 @@ const postcss = require('postcss');
 const valueParser = require('postcss-value-parser');
 const postcssTransform = require('../transforms/postcss');
 const CssSyntaxError = require('postcss/lib/css-syntax-error');
+const CSSAst = require('./Ast.js').CSSAst;
 
 const URL_RE = /url\s*\("?(?![a-z]+:)/;
 const IMPORT_RE = /@import/;
@@ -162,23 +163,6 @@ class CSSAsset extends Asset {
     }
 
     return err;
-  }
-}
-
-class CSSAst {
-  constructor(css, root) {
-    this.css = css;
-    this.root = root;
-    this.dirty = false;
-  }
-
-  render() {
-    if (this.dirty) {
-      this.css = '';
-      postcss.stringify(this.root, c => (this.css += c));
-    }
-
-    return this.css;
   }
 }
 

--- a/src/assets/SSSAsset.js
+++ b/src/assets/SSSAsset.js
@@ -1,10 +1,10 @@
 const postcss = require('postcss');
 
 const localRequire = require('../utils/localRequire');
-const CSSAsset = require('./CSSAsset.js');
+const Asset = require('../Asset');
 const CSSAst = require('./Ast.js').CSSAst;
 
-class SSSAsset extends CSSAsset {
+class SSSAsset extends Asset {
   constructor(name, options) {
     super(name, options);
     this.type = 'css';

--- a/src/assets/SSSAsset.js
+++ b/src/assets/SSSAsset.js
@@ -1,0 +1,21 @@
+const postcss = require('postcss');
+
+const localRequire = require('../utils/localRequire');
+const CSSAsset = require('./CSSAsset.js');
+const CSSAst = require('./Ast.js').CSSAst;
+
+class SSSAsset extends CSSAsset {
+  constructor(name, options) {
+    options.css_parser = "sugarss";
+    super(name, options);
+    this.type = 'css';
+  }
+
+  async parse(code) {
+    let sugarss = await localRequire('sugarss', this.name);
+    let root = postcss.parse(code, {from: this.name, to: this.name, parser: sugarss});
+    return new CSSAst(code, root);
+  }
+}
+
+module.exports = SSSAsset;

--- a/src/assets/SSSAsset.js
+++ b/src/assets/SSSAsset.js
@@ -6,7 +6,6 @@ const CSSAst = require('./Ast.js').CSSAst;
 
 class SSSAsset extends CSSAsset {
   constructor(name, options) {
-    options.css_parser = "sugarss";
     super(name, options);
     this.type = 'css';
   }

--- a/src/assets/SSSAsset.js
+++ b/src/assets/SSSAsset.js
@@ -15,6 +15,16 @@ class SSSAsset extends CSSAsset {
     let root = postcss.parse(code, {from: this.name, to: this.name, parser: sugarss});
     return new CSSAst(code, root);
   }
+  
+  generate() {
+    return [
+      {
+        type: 'css',
+        value: this.ast ? this.ast.render() : this.contents
+      }
+    ];
+  }
+
 }
 
 module.exports = SSSAsset;

--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -53,15 +53,6 @@ async function getConfig(asset) {
     config.plugins.push(postcssModules(postcssModulesConfig));
   }
 
-  if (config.parser === undefined && asset.options.css_parser !== undefined) {
-      const name = asset.options.css_parser;
-
-      if ((typeof name !== "string")) throw "Internal Error: Invalid PostCSS parser type. Should be string";
-
-      let parser = await localRequire(name, asset.name);
-      config.parser = parser;
-  }
-
   if (asset.options.minify) {
     let [cssnano, {version}] = await Promise.all(
       ['cssnano', 'cssnano/package.json'].map(name =>

--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -53,6 +53,15 @@ async function getConfig(asset) {
     config.plugins.push(postcssModules(postcssModulesConfig));
   }
 
+  if (config.parser === undefined && asset.options.css_parser !== undefined) {
+      const name = asset.options.css_parser;
+
+      if ((typeof name !== "string")) throw "Internal Error: Invalid PostCSS parser type. Should be string";
+
+      let parser = await localRequire(name, asset.name);
+      config.parser = parser;
+  }
+
   if (asset.options.minify) {
     let [cssnano, {version}] = await Promise.all(
       ['cssnano', 'cssnano/package.json'].map(name =>

--- a/test/integration/sugarss/index.js
+++ b/test/integration/sugarss/index.js
@@ -1,0 +1,5 @@
+require('./index.sss');
+
+module.exports = function () {
+  return 2;
+}

--- a/test/integration/sugarss/index.sss
+++ b/test/integration/sugarss/index.sss
@@ -1,0 +1,5 @@
+input.spoiler-input
+  display: none
+
+.spoiler_link
+  cursor: pointer

--- a/test/sugarss.js
+++ b/test/sugarss.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const {bundle, run, assertBundleTree} = require('./utils');
+
+describe('sugarss', function() {
+  it('should correctly parse SugarSS asset', async function() {
+    let b = await bundle(__dirname + '/integration/sugarss/index.js');
+
+    await assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js', 'index.sss'],
+      childBundles: [
+        {
+          type: 'map'
+        },
+        {
+          name: 'index.css',
+          assets: ['index.sss'],
+          childBundles: []
+        }
+      ]
+    });
+
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 2);
+
+  })
+})


### PR DESCRIPTION
Personally I find [SugarSS](https://github.com/postcss/sugarss) is pretty nice simplified version of CSS syntax.

Since its addition is configured by setting corresponding parse in PostCSS's config, I wonder if it would be ok to add its extension by default?