### PR TITLE
Deterministic asset ids

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -525,8 +525,7 @@ class Bundler extends EventEmitter {
     let processed = this.cache && (await this.cache.read(asset.name));
     let cacheMiss = false;
     if (!processed || asset.shouldInvalidate(processed.cacheData)) {
-      processed = await this.farm.run(asset.name, asset.id);
-      processed.id = asset.id;
+      processed = await this.farm.run(asset.name);
       cacheMiss = true;
     }
 

--- a/src/Pipeline.js
+++ b/src/Pipeline.js
@@ -11,15 +11,13 @@ class Pipeline {
     this.parser = new Parser(options);
   }
 
-  async process(path, id, isWarmUp) {
+  async process(path, isWarmUp) {
     let options = this.options;
     if (isWarmUp) {
       options = Object.assign({isWarmUp}, options);
     }
 
     let asset = this.parser.getAsset(path, options);
-    asset.id = id;
-
     let generated = await this.processAsset(asset);
     let generatedMap = {};
     for (let rendition of generated) {
@@ -27,6 +25,7 @@ class Pipeline {
     }
 
     return {
+      id: asset.id,
       dependencies: Array.from(asset.dependencies.values()),
       generated: generatedMap,
       hash: asset.hash,

--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -110,7 +110,7 @@ function getParents(bundle, id) {
     for (d in modules[k][1]) {
       dep = modules[k][1][d];
       if (dep === id || (Array.isArray(dep) && dep[dep.length - 1] === id)) {
-        parents.push(+k);
+        parents.push(k);
       }
     }
   }

--- a/src/packagers/JSConcatPackager.js
+++ b/src/packagers/JSConcatPackager.js
@@ -6,6 +6,7 @@ const urlJoin = require('../utils/urlJoin');
 const walk = require('babylon-walk');
 const babylon = require('babylon');
 const t = require('babel-types');
+const {getName, getIdentifier} = require('../scope-hoisting/utils');
 
 const prelude = fs
   .readFileSync(path.join(__dirname, '../builtins/prelude2.min.js'), 'utf8')
@@ -119,9 +120,9 @@ class JSConcatPackager extends Packager {
   }
 
   getExportIdentifier(asset) {
-    let id = '$' + asset.id + '$exports';
+    let id = getName(asset, 'exports');
     if (this.shouldWrap(asset)) {
-      return `($${asset.id}$init(), ${id})`;
+      return `(${getName(asset, 'init')}(), ${id})`;
     }
 
     return id;
@@ -311,13 +312,13 @@ class JSConcatPackager extends Packager {
       }
     }
 
-    let executed = `$${asset.id}$executed`;
+    let executed = getName(asset, 'executed');
     decls.push(
       t.variableDeclarator(t.identifier(executed), t.booleanLiteral(false))
     );
 
     let init = t.functionDeclaration(
-      t.identifier(`$${asset.id}$init`),
+      getIdentifier(asset, 'init'),
       [],
       t.blockStatement([
         t.ifStatement(t.identifier(executed), t.returnStatement()),
@@ -498,7 +499,7 @@ class JSConcatPackager extends Packager {
           );
         }
 
-        exposed.push(`${m.id}: ${this.getExportIdentifier(m)}`);
+        exposed.push(`"${m.id}": ${this.getExportIdentifier(m)}`);
       }
 
       this.write(`
@@ -538,12 +539,12 @@ class JSConcatPackager extends Packager {
   }
 
   resolveModule(id, name) {
-    let module = this.assets.get(+id);
+    let module = this.assets.get(id);
     return module.depAssets.get(module.dependencies.get(name));
   }
 
   findExportModule(id, name, replacements) {
-    let asset = this.assets.get(+id);
+    let asset = this.assets.get(id);
     let exp =
       asset &&
       Object.prototype.hasOwnProperty.call(asset.cacheData.exports, name)
@@ -571,7 +572,7 @@ class JSConcatPackager extends Packager {
 
     // If this is a wildcard import, resolve to the exports object.
     if (asset && name === '*') {
-      exp = `$${id}$exports`;
+      exp = getName(asset, 'exports');
     }
 
     if (replacements && replacements.has(exp)) {

--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -106,7 +106,10 @@ class JSPackager extends Packager {
   async writeModule(id, code, deps = {}, map) {
     let wrapped = this.first ? '' : ',';
     wrapped +=
-      id + ':[function(require,module,exports) {\n' + (code || '') + '\n},';
+      JSON.stringify(id) +
+      ':[function(require,module,exports) {\n' +
+      (code || '') +
+      '\n},';
     wrapped += JSON.stringify(deps);
     wrapped += ']';
 
@@ -154,7 +157,7 @@ class JSPackager extends Packager {
     }
 
     // Generate a module to register the bundle loaders that are needed
-    let loads = 'var b=require(' + bundleLoader.id + ');';
+    let loads = 'var b=require(' + JSON.stringify(bundleLoader.id) + ');';
     for (let bundleType of this.bundleLoaders) {
       let loader = this.options.bundleLoaders[bundleType];
       if (loader) {
@@ -165,7 +168,7 @@ class JSPackager extends Packager {
           'b.register(' +
           JSON.stringify(bundleType) +
           ',require(' +
-          asset.id +
+          JSON.stringify(asset.id) +
           '));';
       }
     }
@@ -183,7 +186,9 @@ class JSPackager extends Packager {
 
       loads += 'b.load(' + JSON.stringify(preload) + ')';
       if (this.bundle.entryAsset) {
-        loads += `.then(function(){require(${this.bundle.entryAsset.id});})`;
+        loads += `.then(function(){require(${JSON.stringify(
+          this.bundle.entryAsset.id
+        )});})`;
       }
 
       loads += ';';

--- a/src/scope-hoisting/shake.js
+++ b/src/scope-hoisting/shake.js
@@ -1,6 +1,6 @@
 const t = require('babel-types');
 
-const EXPORTS_RE = /^\$([\d]+)\$exports$/;
+const EXPORTS_RE = /^\$(.+?)\$exports$/;
 
 /**
  * This is a small small implementation of dead code removal specialized to handle

--- a/src/scope-hoisting/utils.js
+++ b/src/scope-hoisting/utils.js
@@ -1,0 +1,28 @@
+const t = require('babel-types');
+
+function getName(asset, type, ...rest) {
+  return (
+    '$' +
+    t.toIdentifier(asset.id) +
+    '$' +
+    type +
+    (rest.length
+      ? '$' +
+        rest
+          .map(name => (name === 'default' ? name : t.toIdentifier(name)))
+          .join('$')
+      : '')
+  );
+}
+
+function getIdentifier(asset, type, ...rest) {
+  return t.identifier(getName(asset, type, ...rest));
+}
+
+function getExportIdentifier(asset, name) {
+  return getIdentifier(asset, 'export', name);
+}
+
+exports.getName = getName;
+exports.getIdentifier = getIdentifier;
+exports.getExportIdentifier = getExportIdentifier;

--- a/src/utils/md5.js
+++ b/src/utils/md5.js
@@ -1,11 +1,11 @@
 const crypto = require('crypto');
 const fs = require('fs');
 
-function md5(string) {
+function md5(string, encoding = 'hex') {
   return crypto
     .createHash('md5')
     .update(string)
-    .digest('hex');
+    .digest(encoding);
 }
 
 md5.file = function(filename) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -10,9 +10,9 @@ function init(options) {
   process.env.HMR_HOSTNAME = options.hmrHostname;
 }
 
-async function run(path, id, isWarmUp) {
+async function run(path, isWarmUp) {
   try {
-    return await pipeline.process(path, id, isWarmUp);
+    return await pipeline.process(path, isWarmUp);
   } catch (e) {
     e.fileName = path;
     throw e;


### PR DESCRIPTION
Closes #780. Fixes #735. Fixes #1656.

Before this change, asset ids were integers that were dependent on resolution order. There were two problems with this:

1. Builds were not deterministic (#735). This meant that if you did two builds without changing any files, the output might be different, since the asset ids might change. This is not great for long-term cachability, build verification, etc.
2. Since scope hoisting was merged, we started depending on the asset ids as part of variable identifiers. We started caching these asset ids so that references between modules were kept the same if you rebuilt from cache. The problem with caching asset ids is that if you actually changed a file and it was invalidated in the cache, a new asset id was generated. Then, references using the old ids would be invalid, and id collisions were also possible. This caused issues like #1656 to appear.

This PR changes asset ids to be deterministic, based on the relative path to that file from the root project directory. There are two cases:

* In production, we use a short 4-character base64 md5 hash as the id. While slightly longer than the numeric ids of the past, this should provide enough uniqueness for fairly large apps. 
* In development, we simply use the relative path as the id without modification. This avoids the cost of hashing, and also could help with debugging bundles since you can see the original filenames right in the output.

I **think** I changed all the places where we assumed asset ids were numbers and not strings, and it passes all tests, but this could use a bit of real world testing.