### PR TITLE
Only send calls to remote workers if remote workers exist

### DIFF
--- a/src/workerfarm/WorkerFarm.js
+++ b/src/workerfarm/WorkerFarm.js
@@ -238,8 +238,9 @@ class WorkerFarm extends EventEmitter {
 
   shouldUseRemoteWorkers() {
     return (
-      !this.options.useLocalWorker ||
-      (this.warmWorkers >= this.workers.size || !this.options.warmWorkers)
+      this.shouldStartRemoteWorkers() &&
+      (!this.options.useLocalWorker ||
+        (this.warmWorkers >= this.workers.size || !this.options.warmWorkers))
     );
   }
 


### PR DESCRIPTION
This change fixes #1708 by ensuring `WorkerFarm#shouldUseRemoteWorkers()` only returns true if `this.shouldStartRemoteWorkers()` does as well.