### PR TITLE
Fix hoisting of "var" variables on wrapped modules

### DIFF
--- a/test/integration/scope-hoisting/commonjs/hoist-vars/a.js
+++ b/test/integration/scope-hoisting/commonjs/hoist-vars/a.js
@@ -1,0 +1,3 @@
+const foo = require('./b')
+
+output = foo()

--- a/test/integration/scope-hoisting/commonjs/hoist-vars/b.js
+++ b/test/integration/scope-hoisting/commonjs/hoist-vars/b.js
@@ -1,3 +1,13 @@
 if(process.env.NODE_ENV === 'test') {
-    module.exports = require('./c')
+    var c = require('./c')()
+
+    for(var i = 0, {length} = c, out = ''; i < length; i++) {
+        out += c[i]
+    }
+
+    module.exports = function() {
+        if(c != out) throw new Error()
+
+        return out
+    }
 }

--- a/test/integration/scope-hoisting/commonjs/hoist-vars/b.js
+++ b/test/integration/scope-hoisting/commonjs/hoist-vars/b.js
@@ -1,0 +1,3 @@
+if(process.env.NODE_ENV === 'test') {
+    module.exports = require('./c')
+}

--- a/test/integration/scope-hoisting/commonjs/hoist-vars/c.js
+++ b/test/integration/scope-hoisting/commonjs/hoist-vars/c.js
@@ -1,0 +1,12 @@
+module.exports = doFoo
+  
+function doFoo() {
+  return foo
+}
+
+if(process.env.NODE_ENV === 'test') {
+  var foo = 'bar'
+}
+else {
+  foo = 'foo'
+}

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -842,5 +842,14 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 9);
     });
+
+    it('should correctly hoist "var" on wrapped modules', async function() {
+      let b = await bundle(
+        __dirname + '/integration/scope-hoisting/commonjs/hoist-vars/a.js'
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'bar');
+    });
   });
 });


### PR DESCRIPTION
Part of the fixes for #1699

Fix issues with some React apps. One of the problematic files (`loggedTypeFailures`) : 
https://github.com/facebook/prop-types/blob/cfc7f43af3d74978ec82052fe6bb8212f09daca0/checkPropTypes.js
