### PR TITLE
Prevent nameclashes with internal variables

### DIFF
--- a/src/scope-hoisting/concat.js
+++ b/src/scope-hoisting/concat.js
@@ -7,7 +7,7 @@ const treeShake = require('./shake');
 const mangleScope = require('./mangler');
 const {getName, getIdentifier} = require('./utils');
 
-const EXPORTS_RE = /^\$(.+?)\$exports$/;
+const EXPORTS_RE = /^\$([^$]+)\$exports$/;
 
 const DEFAULT_INTEROP_TEMPLATE = template(
   'var NAME = $parcel$interopDefault(MODULE)'

--- a/src/scope-hoisting/hoist.js
+++ b/src/scope-hoisting/hoist.js
@@ -121,7 +121,7 @@ module.exports = {
         // Rename each binding in the top-level scope to something unique.
         for (let name in scope.bindings) {
           if (!name.startsWith('$' + t.toIdentifier(asset.id))) {
-            let newName = getName(asset, 'var', name, '$');
+            let newName = getName(asset, 'var', name);
             rename(scope, name, newName);
           }
         }

--- a/src/scope-hoisting/hoist.js
+++ b/src/scope-hoisting/hoist.js
@@ -121,7 +121,7 @@ module.exports = {
         // Rename each binding in the top-level scope to something unique.
         for (let name in scope.bindings) {
           if (!name.startsWith('$' + t.toIdentifier(asset.id))) {
-            let newName = getName(asset, 'var', name);
+            let newName = getName(asset, 'var', name, '$');
             rename(scope, name, newName);
           }
         }

--- a/src/scope-hoisting/shake.js
+++ b/src/scope-hoisting/shake.js
@@ -1,6 +1,6 @@
 const t = require('babel-types');
 
-const EXPORTS_RE = /^\$(.+?)\$exports$/;
+const EXPORTS_RE = /^\$([^$]+)\$exports$/;
 
 /**
  * This is a small small implementation of dead code removal specialized to handle

--- a/test/integration/scope-hoisting/es6/name-clash/a.js
+++ b/test/integration/scope-hoisting/es6/name-clash/a.js
@@ -1,0 +1,3 @@
+import {foo} from './b'
+
+output = foo()

--- a/test/integration/scope-hoisting/es6/name-clash/b.js
+++ b/test/integration/scope-hoisting/es6/name-clash/b.js
@@ -1,0 +1,3 @@
+var $exports = module.exports = {}
+
+$exports.foo = () => 'bar'

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -330,6 +330,15 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 'bar');
     });
+
+    it('should not nameclash with internal variables', async function() {
+      let b = await bundle(
+        __dirname + '/integration/scope-hoisting/es6/name-clash/a.js'
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'bar');
+    });
   });
 
   describe('commonjs', function() {


### PR DESCRIPTION
Fixes #1699

Found in [`core-js` code](https://cdn.jsdelivr.net/npm/core-js/modules/_wks.js) 
```js
var $exports = module.exports = function (name) {
  return store[name] || (store[name] =
    USE_SYMBOL && Symbol[name] || (USE_SYMBOL ? Symbol : uid)('Symbol.' + name));
};

$exports.store = store;
```