### PR TITLE
Support array in package.json's sideEffects property

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -125,7 +125,7 @@ class Asset {
 
   async getPackage() {
     if (!this._package) {
-      this._package = await this.getConfig(['package.json']);
+      this._package = await this.resolver.findPackage(path.dirname(this.name));
     }
 
     return this._package;

--- a/src/packagers/JSConcatPackager.js
+++ b/src/packagers/JSConcatPackager.js
@@ -141,8 +141,8 @@ class JSConcatPackager extends Packager {
     this.addedAssets.add(asset);
     let {js} = asset.generated;
 
-    // If the asset's package has the sideEffects: false flag set, and there are no used
-    // exports marked, exclude the asset from the bundle.
+    // If the asset has no side effects according to the its package's sideEffects flag,
+    // and there are no used exports marked, exclude the asset from the bundle.
     if (
       asset.cacheData.sideEffects === false &&
       (!asset.usedExports || asset.usedExports.size === 0)

--- a/test/graphql.js
+++ b/test/graphql.js
@@ -31,7 +31,6 @@ describe('graphql', function() {
           firstName
           lastName
         }
-
       `.definitions
     );
   });

--- a/test/integration/scope-hoisting/es6/side-effects-array/a.js
+++ b/test/integration/scope-hoisting/es6/side-effects-array/a.js
@@ -1,0 +1,3 @@
+import {foo} from 'bar';
+
+output = foo(2);

--- a/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/bar.js
+++ b/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/bar.js
@@ -1,0 +1,5 @@
+sideEffect('bar');
+
+export default function bar() {
+  return 2;
+}

--- a/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/foo.js
+++ b/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/foo.js
@@ -1,0 +1,5 @@
+sideEffect('foo');
+
+export default function foo(a) {
+  return a * a;
+}

--- a/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/index.js
+++ b/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/index.js
@@ -1,0 +1,2 @@
+export foo from './foo';
+export bar from './bar';

--- a/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/package.json
+++ b/test/integration/scope-hoisting/es6/side-effects-array/node_modules/bar/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bar",
+  "sideEffects": ["./foo.js"]
+}

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -281,6 +281,22 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'bar');
     });
 
+    it('supports the package.json sideEffects flag with an array', async function() {
+      let b = await bundle(
+        __dirname + '/integration/scope-hoisting/es6/side-effects-array/a.js'
+      );
+
+      let calls = [];
+      let output = await run(b, {
+        sideEffect: caller => {
+          calls.push(caller);
+        }
+      });
+
+      assert(calls.toString() == 'foo', "side effect called for 'foo'");
+      assert.deepEqual(output, 4);
+    });
+
     it('missing exports should be replaced with an empty object', async function() {
       let b = await bundle(
         __dirname + '/integration/scope-hoisting/es6/empty-module/a.js'


### PR DESCRIPTION
This pull request implements array support for the `package.json`'s `sideEffects` property, like webpack does. Example:
```json
"sideEffects": ["./a.js"]
```
Fixes #1566.