### PR TITLE
Support sideEffect: false with CommonJS

### DIFF
--- a/src/scope-hoisting/hoist.js
+++ b/src/scope-hoisting/hoist.js
@@ -280,8 +280,9 @@ module.exports = {
     }
 
     if (t.isIdentifier(callee, {name: 'require'})) {
+      let source = args[0].value;
       // Ignore require calls that were ignored earlier.
-      if (!asset.dependencies.has(args[0].value)) {
+      if (!asset.dependencies.has(source)) {
         return;
       }
 
@@ -296,8 +297,10 @@ module.exports = {
           p.isSequenceExpression()
       );
       if (!parent.isProgram() || bail) {
-        asset.dependencies.get(args[0].value).shouldWrap = true;
+        asset.dependencies.get(source).shouldWrap = true;
       }
+
+      asset.cacheData.imports['$require$' + source] = [source, '*'];
 
       // Generate a variable name based on the current asset id and the module name to require.
       // This will be replaced by the final variable name of the resolved asset in the packager.

--- a/test/integration/scope-hoisting/commonjs/side-effects-false/a.js
+++ b/test/integration/scope-hoisting/commonjs/side-effects-false/a.js
@@ -1,0 +1,1 @@
+output = require('bar').foo(3)

--- a/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/bar.js
+++ b/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/bar.js
@@ -1,0 +1,3 @@
+export default function bar() {
+  return 2;
+}

--- a/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/foo.js
+++ b/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/foo.js
@@ -1,0 +1,3 @@
+export default function foo(a) {
+  return a * a;
+}

--- a/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/index.js
+++ b/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/index.js
@@ -1,0 +1,2 @@
+export foo from './foo';
+export bar from './bar';

--- a/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/package.json
+++ b/test/integration/scope-hoisting/commonjs/side-effects-false/node_modules/bar/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bar",
+  "sideEffects": false
+}

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -816,5 +816,15 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 3);
     });
+
+    it('should support sideEffects: false', async function() {
+      let b = await bundle(
+        __dirname +
+          '/integration/scope-hoisting/commonjs/side-effects-false/a.js'
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 9);
+    });
   });
 });


### PR DESCRIPTION
Part of the fixes for #1699.

We currently can't `require` a module with `sideEffects: false`. This PR adds a `$require$NAME` entry to `cacheData.import` so we can treat both `require` like it is a wildcard import.