### PR TITLE
[WIP] Babel Autoinstall 

### DIFF
--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -115,6 +115,13 @@ async function getBabelConfig(asset) {
         }
       }
 
+      // Autoinstall any missing babel presets
+      if(babelrc.presets){
+        for(let preset of babelrc.presets){
+          await localRequire(`babel-preset-${preset}`, asset.name)
+        }
+      }
+
       // Filter out presets that are already applied by babel-preset-env
       if (Array.isArray(babelrc.presets)) {
         babelrc.presets = babelrc.presets.filter(preset => {

--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -107,6 +107,14 @@ async function getBabelConfig(asset) {
   // Merge the babel-preset-env config and the babelrc if needed
   if (babelrc && !shouldIgnoreBabelrc(asset.name, babelrc)) {
     if (envConfig) {
+      // Auto Install any missing babel plugins
+      if(babelrc.plugins){
+        for(let plugin of babelrc.plugins){
+          let pluginName = getPluginName(plugin);
+          await localRequire(`babel-plugin-${pluginName}`, asset.name)
+        }
+      }
+
       // Filter out presets that are already applied by babel-preset-env
       if (Array.isArray(babelrc.presets)) {
         babelrc.presets = babelrc.presets.filter(preset => {


### PR DESCRIPTION
Based on [this twitter thread]( https://twitter.com/JasperDeMoor/status/1020326259723649029) and [point #3 of my comment on the auto install part 2 RFC](https://github.com/parcel-bundler/parcel/issues/376#issuecomment-361129052)
 
The idea is to automatically install any missing babel preset/plugins by `localrequire`ing them. `localrequire` will automatically handle resolving the modules and installing anything that's missing, so adding this feature is relatively trivial.

I didn't have too much time to finish everything so I'm opening this up as a WIP PR so we can discuss in the meantime. 

@DeMoorJasper You mentioned in your tweet that you had some concerns about security... Just wondering what you meant by that, because this should pretty much come with the same exact security side problems as the normal auto install we have now (which we try to improve btw, but that's a separate issue). Is there anything about Babel plugins/presets in particular that could be a cause for concern?

Progress
- [x] Support babel plugins
- [x] Support babel presets
- [ ] Add Unit Tests
- [ ] Fix duplicate install bug (looks like it's installing the same module multiple times because of workers)