### PR TITLE
Add support for vue-i18n single-file components

### DIFF
--- a/src/assets/VueAsset.js
+++ b/src/assets/VueAsset.js
@@ -30,6 +30,11 @@ class VueAsset extends Asset {
     let descriptor = this.ast;
     let parts = [];
 
+    let i18nBlock = descriptor.customBlocks.find(r => r.type === 'i18n');
+    if (i18nBlock) {
+      this.i18nData = JSON.parse(i18nBlock.content);
+    }
+
     if (descriptor.script) {
       parts.push({
         type: descriptor.script.lang || 'js',
@@ -95,6 +100,15 @@ class VueAsset extends Asset {
         ${optsVar} = ${optsVar}.options;
       }
     `;
+
+    if (this.i18nData) {
+      supplemental += `
+        ${optsVar}.__i18n = ${optsVar}.__i18n || [];
+        ${optsVar}.__i18n.push(${JSON.stringify(
+        JSON.stringify(this.i18nData)
+      )});
+      `;
+    }
 
     supplemental += this.compileTemplate(generated, scopeId, optsVar);
     supplemental += this.compileCSSModules(generated, optsVar);


### PR DESCRIPTION
Hi! I'm in a project where we use `vue-i18n` for localization. In particular, we're taking advantage of the single-file feature where you can include a `<i18n>` tag in a particular component rather than using global localization sheets. Typically, with webpack, you would use `vue-i18n-loader`, [as documented here](https://kazupon.github.io/vue-i18n/guide/sfc.html#installing-vue-i18n-loader), to inject the `<i18n></i18n>` tags into the Vue component.

After digging into the `vue-i18n` package a bit, it seems like it's able to detect the existence of an `__i18n` option on the component and automatically load the injected content, which is what [`vue-i18n-loader` is doing](https://github.com/kazupon/vue-i18n-loader/blob/dev/src/index.js). I figured since there isn't even a dependency problem, this could be implemented relatively easily into parcel as well.

Let me know if there's anything else that's needed or if this isn't the right place to discuss things. Thanks!