### PR TITLE
Support html5 history mode routing

### DIFF
--- a/src/Server.js
+++ b/src/Server.js
@@ -36,6 +36,7 @@ function enableCors(res) {
 function middleware(bundler) {
   const serve = serveStatic(bundler.options.outDir, {
     index: false,
+    redirect: false,
     setHeaders: setHeaders
   });
 


### PR DESCRIPTION
While developing my first Parcel project I noticed that html5 history urls/routes were not working when reloading the page or changing the url manually. This is due to a default setting in `serve-static` which redirects directory urls to `/`. I made this simple change to my locally installed parcel-bundler and all works as expected 🎉 