### PR TITLE
generate unique certificate serial numbers

### DIFF
--- a/src/utils/generateCertificate.js
+++ b/src/utils/generateCertificate.js
@@ -27,7 +27,7 @@ function generateCertificate(options = {}) {
   const cert = pki.createCertificate();
 
   cert.publicKey = keys.publicKey;
-  cert.serialNumber = '01';
+  cert.serialNumber = Date.now().toString();
   cert.validity.notBefore = new Date();
   cert.validity.notAfter = new Date();
   cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);


### PR DESCRIPTION
Fixes browser errors thrown due to multiple certificates using the same issuer and serial number.  Occurs when a self-signed certificate has already been stored in the browser and new certificate is generated; either in the same project or across project installations.