### PR TITLE
Enable Object Rest Spread by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-core": "^6.25.0",
     "babel-generator": "^6.25.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.7.0",
     "babel-template": "^6.26.0",

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -70,7 +70,7 @@ class JSAsset extends Asset {
       strictMode: false,
       sourceType: 'module',
       locations: true,
-      plugins: ['exportExtensions', 'dynamicImport', 'objectRestSpread']
+      plugins: ['exportExtensions', 'dynamicImport']
     };
 
     // Check if there is a babel config file. If so, determine which parser plugins to enable

--- a/src/assets/JSAsset.js
+++ b/src/assets/JSAsset.js
@@ -70,7 +70,7 @@ class JSAsset extends Asset {
       strictMode: false,
       sourceType: 'module',
       locations: true,
-      plugins: ['exportExtensions', 'dynamicImport']
+      plugins: ['exportExtensions', 'dynamicImport', 'objectRestSpread']
     };
 
     // Check if there is a babel config file. If so, determine which parser plugins to enable

--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -265,6 +265,14 @@ async function getEnvPlugins(targets, useBuiltIns = false) {
     {},
     {targets, modules: false, useBuiltIns: useBuiltIns ? 'entry' : false}
   ).plugins;
+
+  // babel-preset-env version 6.x does not cover object-rest-spread so always
+  // add it.
+  plugins.push([
+    require('babel-plugin-transform-object-rest-spread'),
+    {useBuiltIns}
+  ]);
+
   envCache.set(key, plugins);
   return plugins;
 }

--- a/test/integration/object-rest-spread/object-rest-spread.js
+++ b/test/integration/object-rest-spread/object-rest-spread.js
@@ -1,0 +1,7 @@
+var x = {a: 'a', b: 'b'};
+var {a: y, ...ys} = x;
+var z = {y, ...ys};
+
+export default function () {
+  return {x, y, z, ys};
+}

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -28,6 +28,21 @@ describe('javascript', function() {
     assert.equal(output.default(), 3);
   });
 
+  it('should produce a basic JS bundle with object rest spread support', async function() {
+    let b = await bundle(__dirname + '/integration/es6/object-rest-spread.js');
+
+    assert.equal(b.assets.size, 1);
+
+    let output = await run(b);
+    assert.equal(typeof output, 'object');
+    assert.equal(typeof output.default, 'function');
+
+    let res = output.default();
+    assert.equal(res.y, 'a');
+    assert.deepEqual(res.z, {y: 'a', b: 'b'});
+    assert.deepEqual(res.ys, {b: 'b'});
+  });
+
   it('should bundle node_modules on --target=browser', async function() {
     let b = await bundle(__dirname + '/integration/node_require/main.js', {
       target: 'browser'

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -29,7 +29,9 @@ describe('javascript', function() {
   });
 
   it('should produce a basic JS bundle with object rest spread support', async function() {
-    let b = await bundle(__dirname + '/integration/object-rest-spread/object-rest-spread.js');
+    let b = await bundle(
+      __dirname + '/integration/object-rest-spread/object-rest-spread.js'
+    );
 
     assert.equal(b.assets.size, 1);
 

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -29,7 +29,7 @@ describe('javascript', function() {
   });
 
   it('should produce a basic JS bundle with object rest spread support', async function() {
-    let b = await bundle(__dirname + '/integration/es6/object-rest-spread.js');
+    let b = await bundle(__dirname + '/integration/object-rest-spread/object-rest-spread.js');
 
     assert.equal(b.assets.size, 1);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,6 +543,10 @@ babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-syntax-trailing-function-commas@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
@@ -736,6 +740,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-react-jsx@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
This uses Babel's plugin:
https://babeljs.io/docs/en/babel-plugin-transform-object-rest-spread

Spec:
https://tc39.github.io/ecma262/#sec-object-initializer-runtime-semantics-propertydefinitionevaluation

Fixes #1221, #1422