### PR TITLE
Typescript 3.0.0 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "sinon": "^5.0.1",
     "sourcemap-validator": "^1.0.6",
     "stylus": "^0.54.5",
-    "typescript": "^2.9.0",
+    "typescript": "^3.0.0",
     "vue": "^2.5.16",
     "vue-template-compiler": "^2.5.16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7184,9 +7184,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.9.0:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+typescript@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 uglify-es@^3.3.9:
   version "3.3.9"


### PR DESCRIPTION
Update to typescript 3.0.0, it's just so the tests run the latest version.
There appears to be no breaking changes.