### PR TITLE
Fix glob import/require in Stylus assets

### DIFF
--- a/test/integration/stylus-glob-import/index.js
+++ b/test/integration/stylus-glob-import/index.js
@@ -1,0 +1,5 @@
+require('./index.styl');
+
+module.exports = function () {
+  return 2;
+};

--- a/test/integration/stylus-glob-import/index.styl
+++ b/test/integration/stylus-glob-import/index.styl
@@ -1,0 +1,4 @@
+@require 'subdir/**/*'
+
+.index
+  color: red

--- a/test/integration/stylus-glob-import/subdir/bar/bar.styl
+++ b/test/integration/stylus-glob-import/subdir/bar/bar.styl
@@ -1,0 +1,2 @@
+.bar
+  color: green

--- a/test/integration/stylus-glob-import/subdir/foo/foo.styl
+++ b/test/integration/stylus-glob-import/subdir/foo/foo.styl
@@ -1,0 +1,2 @@
+.foo
+  color: blue

--- a/test/integration/stylus-glob-import/subdir/main.styl
+++ b/test/integration/stylus-glob-import/subdir/main.styl
@@ -1,0 +1,2 @@
+.main
+  color: yellow

--- a/test/stylus.js
+++ b/test/stylus.js
@@ -124,4 +124,35 @@ describe('stylus', function() {
     let css = await fs.readFile(__dirname + '/dist/index.css', 'utf8');
     assert(css.includes('._index_g9mqo_1'));
   });
+
+  it('should support requiring stylus files with glob dependencies', async function() {
+    let b = await bundle(
+      __dirname + '/integration/stylus-glob-import/index.js'
+    );
+
+    await assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js', 'index.styl'],
+      childBundles: [
+        {
+          type: 'map'
+        },
+        {
+          name: 'index.css',
+          assets: ['index.styl'],
+          childBundles: []
+        }
+      ]
+    });
+
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 2);
+
+    let css = await fs.readFile(__dirname + '/dist/index.css', 'utf8');
+    assert(css.includes('.index'));
+    assert(css.includes('.main'));
+    assert(css.includes('.foo'));
+    assert(css.includes('.bar'));
+  });
 });


### PR DESCRIPTION
As said in #1816, Parcel currently overrides the Stylus resolver with its own, namely to support importing from `node_modules` and root imports. However, it currently fails to resolve glob imports, trying to resolve to files literally named `**/*` (which obviously don't exist, throwing `ENOENT`).

This PR works around the issue by detecting glob imports in the ahead-of-time Stylus `ImportVisitor`, applying `fast-glob` on the given path, and then associating multiple paths to the import instead of a single one.
During evaluation time, it will then replace the glob import statement with multiple ones (one for each resolved file) before passing them to Stylus, and then merging all the resulting node blocks into one.

This PR also adds a test case for Stylus glob import, to prevent future regressions.

This should fix #1816.

(Comments are obviously welcome, considering I don't really know the Parcel codebase there might be issues here and there.)