### PR TITLE
Update help message for public-url option

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -39,7 +39,7 @@ program
   )
   .option(
     '--public-url <url>',
-    'set the public URL to serve on. defaults to the same as the --out-dir option'
+    'set the public URL to serve on. defaults to "/"'
   )
   .option('--global <variable>', 'expose your module through a global variable')
   .option('--no-hmr', 'disable hot module replacement')
@@ -77,7 +77,7 @@ program
   )
   .option(
     '--public-url <url>',
-    'set the public URL to serve on. defaults to the same as the --out-dir option'
+    'set the public URL to serve on. defaults to "/"'
   )
   .option('--global <variable>', 'expose your module through a global variable')
   .option(
@@ -126,7 +126,7 @@ program
   )
   .option(
     '--public-url <url>',
-    'set the public URL to serve on. defaults to the same as the --out-dir option'
+    'set the public URL to serve on. defaults to "/"'
   )
   .option('--global <variable>', 'expose your module through a global variable')
   .option('--no-minify', 'disable minification')


### PR DESCRIPTION
Just a small documentation change -- as of #1040, the default value for `--public-url` is `/`, not the `--out-dir` option anymore.