### PR TITLE
Validate if PostCSS config is an object

### DIFF
--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -29,6 +29,11 @@ async function getConfig(asset) {
   }
 
   config = config || {};
+
+  if (typeof config !== 'object') {
+    throw new Error('PostCSS config should be an object.');
+  }
+
   let postcssModulesConfig = {
     getJSON: (filename, json) => (asset.cssModules = json)
   };


### PR DESCRIPTION
This just throws a simple error if postCSS config is not an object.

Closes #749