### PR TITLE
Fix: VSCode syntax highlight with PostCSS in Vue Component style tag

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -28,6 +28,7 @@ class Parser {
 
     this.registerExtension('css', './assets/CSSAsset');
     this.registerExtension('pcss', './assets/CSSAsset');
+    this.registerExtension('postcss', './assets/CSSAsset');
     this.registerExtension('styl', './assets/StylusAsset');
     this.registerExtension('stylus', './assets/StylusAsset');
     this.registerExtension('less', './assets/LESSAsset');


### PR DESCRIPTION
This fixes the issue #1894. Now it compiles the CSS file containing the parsed version of the PostCSS code within Vue Components inline style tags. As well as working with the VSCode Vetur extension for the syntax highlighting.