### PR TITLE
Remove sass url loader, move url resolving to PostCSS

### DIFF
--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -40,13 +40,6 @@ class SASSAsset extends Asset {
         ? opts.indentedSyntax
         : type === 'sass';
 
-    opts.functions = Object.assign({}, opts.functions, {
-      'url($url)': url => {
-        let filename = this.addURLDependency(url.getValue());
-        return new sass.types.String(`url(${JSON.stringify(filename)})`);
-      }
-    });
-
     opts.importer = opts.importer || [];
     opts.importer = Array.isArray(opts.importer)
       ? opts.importer
@@ -83,8 +76,7 @@ class SASSAsset extends Asset {
     return [
       {
         type: 'css',
-        value: this.ast ? this.ast.css.toString() : '',
-        hasDependencies: false
+        value: this.ast ? this.ast.css.toString() : ''
       }
     ];
   }

--- a/test/integration/scss-url/index.scss
+++ b/test/integration/scss-url/index.scss
@@ -6,3 +6,7 @@
 .index {
   background: url("http://google.com");
 }
+
+.something {
+  background: url(./image.jpeg);
+}

--- a/test/sass.js
+++ b/test/sass.js
@@ -117,6 +117,11 @@ describe('sass', function() {
       assets: ['index.js', 'index.scss'],
       childBundles: [
         {
+          type: 'jpeg',
+          assets: ['image.jpeg'],
+          childBundles: []
+        },
+        {
           type: 'map'
         },
         {


### PR DESCRIPTION
This PR moves url resolving to PostCSS instead of relying on SASS to work.

Figured it might be worth it as it has been a pretty stale issue on the SASS end for a lil while now.

Closes #316