### PR TITLE
Exit process on error if it's just a single build

### DIFF
--- a/src/Bundler.js
+++ b/src/Bundler.js
@@ -335,7 +335,7 @@ class Bundler extends EventEmitter {
 
       if (this.options.throwErrors && !this.hmr) {
         throw err;
-      } else if (process.env.NODE_ENV === 'production' || !initialised) {
+      } else if (!this.options.watch || !initialised) {
         await this.stop();
         process.exit(1);
       }


### PR DESCRIPTION
As Parcel now supports single dev builds, it makes no sense to check for production env, changed the line to be checking if it's watching for changes. (It should have probably been like that all along)