### PR TITLE
Fix dotenv package error

### DIFF
--- a/src/visitors/env.js
+++ b/src/visitors/env.js
@@ -7,10 +7,13 @@ module.exports = {
     if (matchesPattern(node.object, 'process.env')) {
       let key = types.toComputedKey(node);
       if (types.isStringLiteral(key)) {
-        let val = types.valueToNode(process.env[key.value]);
-        morph(node, val);
-        asset.isAstDirty = true;
-        asset.cacheData.env[key.value] = process.env[key.value];
+        let prop = process.env[key.value];
+        if (typeof prop !== 'function') {
+          let value = types.valueToNode(prop);
+          morph(node, value);
+          asset.isAstDirty = true;
+          asset.cacheData.env[key.value] = process.env[key.value];
+        }
       }
     }
   }


### PR DESCRIPTION
This fixes #1440. Package "dotenv" does something like "process.env.hasOwnProperty( ... )".
Parcel expects a value property lookup on process.env, not a function call. So valueToNode fails if it was called with a function like "hasOwnProperty". 