### PR TITLE
Use babel-core bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/types": "^7.0.0",
     "ansi-to-html": "^0.6.4",
     "babel-code-frame": "^6.26.0",
-    "babel-core": "^6.25.0",
+    "babel-core": "^7.0.0-bridge.0",
     "babel-generator": "^6.25.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",

--- a/src/transforms/babel.js
+++ b/src/transforms/babel.js
@@ -226,7 +226,7 @@ async function findBabelRc(asset) {
   });
 }
 
-function shouldIgnoreBabelrc(filename, babelrc) {
+function shouldIgnoreBabelrc(/* filename, babelrc */) {
   return false;
   // Determine if we should ignore this babelrc file. We do this here instead of
   // letting @babel/core handle it because this config might be merged with our


### PR DESCRIPTION
`babel-core@7.0.0-bridge.0` should be used instead of `babel-core@6.25.0` for babel7 compatibility.

https://babeljs.io/blog/2017/12/27/nearing-the-7.0-release#peer-dependencies-integrations