### PR TITLE
Don't resolve slash and tilde paths twice

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -107,7 +107,7 @@ class Asset {
       depName = './' + path.relative(path.dirname(this.name), resolved);
     }
 
-    this.addDependency(depName, Object.assign({dynamic: true}, opts));
+    this.addDependency(depName, Object.assign({dynamic: true, resolved}, opts));
 
     parsed.pathname = this.options.parser
       .getAsset(resolved, this.options)


### PR DESCRIPTION
Fix "Cannot resolve dependency" errors for valid slash and tilde paths.

Before:

    /src/js/index.js
      -> /home/user/my-project/src/js/index.js
      -> /home/user/my-project/home/user/my-project/src/js/index.js

Error:

    Cannot resolve dependency /home/user/my-project/src/js/index.js

After:

    /src/js/index.js
      -> /home/user/my-project/src/js/index.js

The code already has a way for asset-handlers to signal to the bundler that a dependency has been resolved to an absolute path, but it isn't being used.

fixes #1555
fixes #1986