### PR TITLE
Added dotenv-expand to expand env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cssnano": "^4.0.0",
     "deasync": "^0.1.13",
     "dotenv": "^5.0.0",
+    "dotenv-expand": "^4.2.0",
     "fast-glob": "^2.2.2",
     "filesize": "^3.6.0",
     "fswatcher-child": "^1.0.5",

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,5 +1,6 @@
 const config = require('./config');
 const dotenv = require('dotenv');
+const variableExpansion = require('dotenv-expand');
 
 async function loadEnv(filepath) {
   const NODE_ENV = process.env.NODE_ENV || 'development';
@@ -17,7 +18,8 @@ async function loadEnv(filepath) {
     dotenvFiles.map(async dotenvFile => {
       const envPath = await config.resolve(filepath, [dotenvFile]);
       if (envPath) {
-        dotenv.config({path: envPath});
+        const envs = dotenv.config({path: envPath});
+        variableExpansion(envs)
       }
     })
   );


### PR DESCRIPTION
If you're not familiar with dotenv-expand it adds to dotenv to expand vars like this:

```
MONGOLAB_DATABASE=heroku_db
MONGOLAB_USER=username
MONGOLAB_PASSWORD=password
MONGOLAB_DOMAIN=abcd1234.mongolab.com
MONGOLAB_PORT=12345
MONGOLAB_URI=mongodb://${MONGOLAB_USER}:${MONGOLAB_PASSWORD}@${MONGOLAB_DOMAIN}:${MONGOLAB_PORT}/${MONGOLAB_DATABASE}
```