### PR TITLE
Cross-platform deterministic asset ids

### DIFF
--- a/src/Asset.js
+++ b/src/Asset.js
@@ -21,7 +21,7 @@ class Asset {
     this.id = null;
     this.name = name;
     this.basename = path.basename(this.name);
-    this.relativeName = path.relative(options.rootDir, this.name);
+    this.relativeName = path.relative(options.rootDir, this.name).replace(/\\/g, "/");
     this.options = options;
     this.encoding = 'utf8';
     this.type = path.extname(this.name).slice(1);


### PR DESCRIPTION
Makes the deterministic asset ids introduced in #1694 not dependant on platform.

On windows, `path.relative` uses `\`, whereas on other systems it uses `/`. Because of this, the hashes were different.

## 💻 Examples

For a file at `<root>/src/index.js`, `Asset::relativeName` would be transformed into `src\index.js` on windows, giving the identifier `"2gen"`.

On other platforms, where the platform seperator is `/`, `Asset::relativeName` would be `src/index.js` as expected, with the identifier `"H99C"`.

This is causing unwanted build failures for my project when `dist` is committed to master, which I am doing to allow my typescript project to be used as an npm module directly from github. See Levertion/mcfunction-langserver#69

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change

I haven't added any tests as #1694 did not change any tests and was included in a patch release => asset identifiers are not guaranteed to be backwards compatible. 

Additionally, I am not sure how I would actually test this behaviour, given that it uses the platform specific `path` module directly.