### PR TITLE
fixed watch not working when NODE_ENV is production

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -188,6 +188,10 @@ async function bundle(main, command) {
   // Require bundler here so the help command is fast
   const Bundler = require('../');
 
+  if (command.name() === 'watch') {
+    command.watch = true;
+  }
+
   if (command.name() === 'build') {
     command.production = true;
     process.env.NODE_ENV = process.env.NODE_ENV || 'production';


### PR DESCRIPTION
---
name: 🙋 fix for watch not working when NODE_ENV is 'production'
about: fixes issue #2011 
---

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->
## ↪️ Pull Request
<!---
Provide a general summary of the pull request here
Does this address an existing issue?
-->
I understand that Parcel should watch changes every time the watch command is being used.
Previously, watch was enabled on dev environment only, while the watch command inserted by users was completely ignored.

With this modification, watch is always enabled if the user passes the command in CLI. 
## 💻 Examples

There is an example in #2011 - first post

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions
- [ ] Included links to related issues/PRs
<!-- Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate -->
