### PR TITLE
add missing --no-autoinstall flag to build command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -132,6 +132,7 @@ program
   .option('--no-minify', 'disable minification')
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
+  .option('--no-autoinstall', 'disable autoinstall')
   .option('--no-content-hash', 'disable content hashing')
   .option(
     '--experimental-scope-hoisting',


### PR DESCRIPTION
Was running `parcel build` and the auto installer started running, I went to disable it and found that the option was not available here