### PR TITLE
Fix hoist of modules with multiple aliases

### DIFF
--- a/src/packagers/JSConcatPackager.js
+++ b/src/packagers/JSConcatPackager.js
@@ -217,8 +217,10 @@ class JSConcatPackager extends Packager {
 
     let depAsts = new Map();
     for (let depAsset of asset.depAssets.values()) {
-      let depAst = this.addDeps(depAsset, included);
-      depAsts.set(depAsset, depAst);
+      if (!depAsts.has(depAsset)) {
+        let depAst = this.addDeps(depAsset, included);
+        depAsts.set(depAsset, depAst);
+      }
     }
 
     let statements;

--- a/test/integration/scope-hoisting/commonjs/wrap-aliases/a.js
+++ b/test/integration/scope-hoisting/commonjs/wrap-aliases/a.js
@@ -1,0 +1,6 @@
+try {
+    output = require('foo')
+}
+catch(_) {
+    output = require('foo-bar')
+}

--- a/test/integration/scope-hoisting/commonjs/wrap-aliases/node_modules/foo-bar/index.js
+++ b/test/integration/scope-hoisting/commonjs/wrap-aliases/node_modules/foo-bar/index.js
@@ -1,0 +1,1 @@
+module.exports = 42

--- a/test/integration/scope-hoisting/commonjs/wrap-aliases/package.json
+++ b/test/integration/scope-hoisting/commonjs/wrap-aliases/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "a",
+    "browser": {
+        "foo": "foo-bar"
+    }
+}

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -1065,7 +1065,7 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 42);
     });
-    
+
     it('should support optional requires', async function() {
       let b = await bundle(
         path.join(

--- a/test/scope-hoisting.js
+++ b/test/scope-hoisting.js
@@ -1053,5 +1053,17 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 9);
     });
+
+    it('should support two aliases to the same module', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/wrap-aliases/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 42);
+    });
   });
 });


### PR DESCRIPTION


---
name: Fix hoist of modules with multiple aliases
---

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->
## ↪️ Pull Request
When a module has multiple aliases it can get trimmed from the output, triggering reference errors at runtime.

## 💻 Examples

`parcel build a.js --experimental-scope-hoist && node dist/a.js`

- `a.js`
```js
require('to-function')
```

- output
```
  output = ($BDJ7$init(), {});
  ^

ReferenceError: $BDJ7$init is not defined
```

<!-- Examples help us understand the requested feature better -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions
- [ ] Included links to related issues/PRs
<!-- Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate -->
