### PR TITLE
Possibility to use `.postcssrc.json` as PostCSS config file

### DIFF
--- a/src/transforms/postcss.js
+++ b/src/transforms/postcss.js
@@ -18,7 +18,7 @@ module.exports = async function(asset) {
 
 async function getConfig(asset) {
   let config = await asset.getConfig(
-    ['.postcssrc', '.postcssrc.js', 'postcss.config.js'],
+    ['.postcssrc', '.postcssrc.json', '.postcssrc.js', 'postcss.config.js'],
     {packageKey: 'postcss'}
   );
 


### PR DESCRIPTION
## ↪️ Pull Request

I find defining PostCSS config in `.postcssrc.json` more consistent with another config files like `.eslintrc.json` and `.babelrc.json`. I prefer this way of naming because of transparency and conformity between the filename and content type.

Also, [postcss-load-config](https://github.com/michael-ciniawsky/postcss-load-config) package, which is widely using with PostCSS, supports this way of defining configs and enforces this naming [as recommended](https://github.com/michael-ciniawsky/postcss-load-config#postcssrc).

I think adding `.postcssrc.json` to resolvable configs makes parcel more smooth to switch from another bundler without much effort :slightly_smiling_face:

I didn't find any tests for PostCSS config files, so I'm not sure if I should add ones for this feature :confused: