### PR TITLE
use npm for auto-install by default

### DIFF
--- a/src/utils/installPackage.js
+++ b/src/utils/installPackage.js
@@ -82,14 +82,11 @@ async function determinePackageManager(filepath) {
   const hasYarn = await checkForYarnCommand();
 
   /**
-   * There is package-lock.json -> Use npm
-   * There is yarn.lock & yarn command -> Use Yarn
-   * Otherwise -> Use npm
+   * The only situation Parcel should use yarn is
+   * there is yarn command AND there is yarn.lock AND there is NO package-lock.json
+   * Otherwise, it uses npm
    */
-  if (npmLockFile) {
-    return 'npm';
-  }
-  if (hasYarn && yarnLockFile) {
+  if (hasYarn && yarnLockFile && !npmLockFile) {
     return 'yarn';
   }
   return 'npm';

--- a/src/utils/installPackage.js
+++ b/src/utils/installPackage.js
@@ -75,11 +75,11 @@ async function installPeerDependencies(filepath, name, options) {
 }
 
 async function determinePackageManager(filepath) {
-  const [npmLockFile, yarnLockFile] = await Promise.all([
+  const [npmLockFile, yarnLockFile, hasYarn] = await Promise.all([
     config.resolve(filepath, [PACKAGE_LOCK]),
-    config.resolve(filepath, [YARN_LOCK])
+    config.resolve(filepath, [YARN_LOCK]),
+    checkForYarnCommand()
   ]);
-  const hasYarn = await checkForYarnCommand();
 
   /**
    * The only situation Parcel should use yarn is

--- a/src/utils/installPackage.js
+++ b/src/utils/installPackage.js
@@ -75,10 +75,9 @@ async function installPeerDependencies(filepath, name, options) {
 }
 
 async function determinePackageManager(filepath) {
-  const [npmLockFile, yarnLockFile, hasYarn] = await Promise.all([
+  const [npmLockFile, yarnLockFile] = await Promise.all([
     config.resolve(filepath, [PACKAGE_LOCK]),
-    config.resolve(filepath, [YARN_LOCK]),
-    checkForYarnCommand()
+    config.resolve(filepath, [YARN_LOCK])
   ]);
 
   /**
@@ -86,9 +85,16 @@ async function determinePackageManager(filepath) {
    * there is yarn command AND there is yarn.lock AND there is NO package-lock.json
    * Otherwise, it uses npm
    */
-  if (hasYarn && yarnLockFile && !npmLockFile) {
+
+  if (!yarnLockFile || npmLockFile) {
+    return 'npm';
+  }
+
+  const hasYarn = await checkForYarnCommand();
+  if (hasYarn) {
     return 'yarn';
   }
+
   return 'npm';
 }
 

--- a/src/utils/installPackage.js
+++ b/src/utils/installPackage.js
@@ -10,7 +10,6 @@ const fs = require('./fs');
 const WorkerFarm = require('../workerfarm/WorkerFarm');
 
 const YARN_LOCK = 'yarn.lock';
-const PACKAGE_LOCK = 'package-lock.json';
 
 async function install(modules, filepath, options = {}) {
   let {installPeers = true, saveDev = true, packageManager} = options;
@@ -75,18 +74,13 @@ async function installPeerDependencies(filepath, name, options) {
 }
 
 async function determinePackageManager(filepath) {
-  const [npmLockFile, yarnLockFile] = await Promise.all([
-    config.resolve(filepath, [PACKAGE_LOCK]),
-    config.resolve(filepath, [YARN_LOCK])
-  ]);
+  const yarnLockFile = await config.resolve(filepath, [YARN_LOCK]);
 
   /**
-   * The only situation Parcel should use yarn is
-   * there is yarn command AND there is yarn.lock AND there is NO package-lock.json
-   * Otherwise, it uses npm
+   * no yarn.lock => use npm
+   * yarn.lock => Use yarn, fallback to npm
    */
-
-  if (!yarnLockFile || npmLockFile) {
+  if (!yarnLockFile) {
     return 'npm';
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Changed the logic to determine which package manager to use during auto-installation.

The only situation Parcel should use yarn is when it satisfies
- There is `yarn` command available
AND
- There is `yarn.lock` file
AND
- There is NOT `package-lock.json`

Otherwise, it uses npm.

Fixes #2117 

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Setup a testing directory with different setups (package-lock existence, yarn.lock existence, yarn command existence).
The only situation Parcel should use yarn is when
- There is `yarn` command available
AND
- There is `yarn.lock` file
AND
- There is NOT `package-lock.json`

## ✔️ PR Todo

~~- [ ] Added/updated unit tests for this change~~
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->

## Side note

There is a situation where there are both package-lock.json and yarn.lock. Having npm as default package manager means that it should use npm in this situation.

That's why there is only one situation where Parcel should use yarn.
