### PR TITLE
Don't dedupe assets that are depended on in more than one bundle

### DIFF
--- a/test/integration/js-dedup-hoist/a.js
+++ b/test/integration/js-dedup-hoist/a.js
@@ -1,0 +1,3 @@
+import hello2 from './hello2'
+
+export default `${hello2}`

--- a/test/integration/js-dedup-hoist/hello1.js
+++ b/test/integration/js-dedup-hoist/hello1.js
@@ -1,0 +1,2 @@
+const value = 'Hello'
+export default value

--- a/test/integration/js-dedup-hoist/hello2.js
+++ b/test/integration/js-dedup-hoist/hello2.js
@@ -1,0 +1,2 @@
+const value = 'Hello'
+export default value

--- a/test/integration/js-dedup-hoist/index.js
+++ b/test/integration/js-dedup-hoist/index.js
@@ -1,7 +1,8 @@
 import hello1 from './hello1'
 import hello2 from './hello2'
 
-export default async function () {
-  let a = await import('./a');
-  return `${hello1} ${hello2}! ${a.default}`;
+export default function () {
+  return import('./a').then(function (a) {
+    return `${hello1} ${hello2}! ${a.default}`;
+  });
 }

--- a/test/integration/js-dedup-hoist/index.js
+++ b/test/integration/js-dedup-hoist/index.js
@@ -1,0 +1,7 @@
+import hello1 from './hello1'
+import hello2 from './hello2'
+
+export default async function () {
+  let a = await import('./a');
+  return `${hello1} ${hello2}! ${a.default}`;
+}

--- a/test/integration/js-dedup-hoist/package.json
+++ b/test/integration/js-dedup-hoist/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": ["last 1 Chrome version"]
+}

--- a/test/javascript.js
+++ b/test/javascript.js
@@ -1520,22 +1520,40 @@ describe('javascript', function() {
       }
     );
     const {rootDir} = b.entryAsset.options;
-    const dedupedAssets = Array.from(b.offsets.keys()).map(asset => asset.name);
-    assert.equal(dedupedAssets.length, 2);
-    assert(dedupedAssets.includes(path.join(rootDir, 'index.js')));
+    const writtenAssets = Array.from(b.offsets.keys()).map(asset => asset.name);
+    assert.equal(writtenAssets.length, 2);
+    assert(writtenAssets.includes(path.join(rootDir, 'index.js')));
     assert(
-      dedupedAssets.includes(path.join(rootDir, 'hello1.js')) ||
-        dedupedAssets.includes(path.join(rootDir, 'hello2.js'))
+      writtenAssets.includes(path.join(rootDir, 'hello1.js')) ||
+        writtenAssets.includes(path.join(rootDir, 'hello2.js'))
     );
     assert(
       !(
-        dedupedAssets.includes(path.join(rootDir, 'hello1.js')) &&
-        dedupedAssets.includes(path.join(rootDir, 'hello2.js'))
+        writtenAssets.includes(path.join(rootDir, 'hello1.js')) &&
+        writtenAssets.includes(path.join(rootDir, 'hello2.js'))
       )
     );
 
     let module = await run(b);
     assert.equal(module.default, 'Hello Hello!');
+  });
+
+  it('should not dedupe assets that exist in more than one bundle', async function() {
+    let b = await bundle(
+      path.join(__dirname, `/integration/js-dedup-hoist/index.js`),
+      {
+        hmr: false // enable asset dedupe in JSPackager
+      }
+    );
+    const {rootDir} = b.entryAsset.options;
+    const writtenAssets = Array.from(b.offsets.keys()).map(asset => asset.name);
+    assert(
+      writtenAssets.includes(path.join(rootDir, 'hello1.js')) &&
+        writtenAssets.includes(path.join(rootDir, 'hello2.js'))
+    );
+
+    let module = await run(b);
+    assert.equal(await module.default(), 'Hello Hello! Hello');
   });
 
   it('should support importing HTML from JS async', async function() {


### PR DESCRIPTION
# ↪️ Pull Request

Assets that are depended on in more than one bundle (e.g. hoisted) shouldn't be deduped in the parent bundle or the asset ids will be incorrect. The child bundle has no way of accessing the parent deduped id. This PR disables deduping for modules which are accessed by an external bundle.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
