### PR TITLE
Use this.write and super.end for JSPackager

### DIFF
--- a/src/packagers/JSPackager.js
+++ b/src/packagers/JSPackager.js
@@ -226,7 +226,7 @@ class JSPackager extends Packager {
       entry.push(this.bundle.entryAsset.id);
     }
 
-    await this.dest.write(
+    await this.write(
       '},{},' +
         JSON.stringify(entry) +
         ', ' +
@@ -244,7 +244,7 @@ class JSPackager extends Packager {
         await this.write(`\n//# sourceMappingURL=${mapUrl}`);
       }
     }
-    await this.dest.end();
+    await super.end();
   }
 }
 


### PR DESCRIPTION
Very small change, but I noticed how these were calling `this.dest` directly over using the Packager's methods.