### PR TITLE
fix .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-packages/core/parcel/src/builtins
-packages/core/parcel/test/integration
-packages/core/parcel/test/input
-packages/core/parcel/test/dist
+packages/core/parcel-bundler/src/builtins
+packages/core/parcel-bundler/test/integration
+packages/core/parcel-bundler/test/input
+packages/core/parcel-bundler/test/dist


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Looks like `.prettierignore` didn't get updated when you changed `parcel` -> `parcel-bundler`
