### PR TITLE
Make dynamic import name relative to the file importing it

### DIFF
--- a/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js
@@ -372,7 +372,7 @@ class JSConcatPackager extends Packager {
   }
 
   getBundleSpecifier(bundle) {
-    let name = path.basename(bundle.name);
+    let name = path.relative(path.dirname(this.bundle.name), bundle.name);
     if (bundle.entryAsset) {
       return [name, bundle.entryAsset.id];
     }

--- a/packages/core/parcel-bundler/src/packagers/JSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSPackager.js
@@ -94,7 +94,7 @@ class JSPackager extends Packager {
   }
 
   getBundleSpecifier(bundle) {
-    let name = path.basename(bundle.name);
+    let name = path.relative(path.dirname(this.bundle.name), bundle.name);
     if (bundle.entryAsset) {
       return [name, bundle.entryAsset.id];
     }


### PR DESCRIPTION
As talked about with @devongovett, when the entrypoint is in a subdirectory it would not require the correct path to the dynamic import