### PR TITLE
Include indirect dependencies in bundle filename hash

### DIFF
--- a/packages/core/parcel-bundler/src/Bundle.js
+++ b/packages/core/parcel-bundler/src/Bundle.js
@@ -112,8 +112,8 @@ class Bundle {
     // Otherwise, use a hash of the filename so it remains consistent across builds.
     let ext = Path.extname(this.name);
     let hash = (contentHash
-      ? this.getHash()
-      : Path.basename(this.name, ext)
+        ? this.getHash()
+        : Path.basename(this.name, ext)
     ).slice(-8);
     let entryAsset = this.entryAsset || this.parentBundle.entryAsset;
     let name = Path.basename(entryAsset.name, Path.extname(entryAsset.name));
@@ -274,10 +274,15 @@ class Bundle {
 
   getHash() {
     let hash = crypto.createHash('md5');
-    for (let asset of this.assets) {
-      hash.update(asset.hash);
-    }
-
+    let visited = new Set();
+    let visit = asset => {
+      if (!visited.has(asset.id)) {
+        visited.add(asset.id);
+        hash.update(asset.hash);
+        Array.from(asset.depAssets.values()).forEach(visit);
+      }
+    };
+    this.assets.forEach(visit);
     return hash.digest('hex');
   }
 }

--- a/packages/core/parcel-bundler/test/contentHashing.js
+++ b/packages/core/parcel-bundler/test/contentHashing.js
@@ -71,4 +71,35 @@ describe('content hashing', function() {
 
     assert.notEqual(filename, newFilename);
   });
+
+  it('should update content hash when indirect dependency changes', async function () {
+    await ncp(
+      path.join(__dirname, '/integration/import-multilevel-html'),
+      path.join(__dirname, '/input')
+    );
+
+    await bundle(path.join(__dirname, '/input/index.html'), {
+      production: true
+    });
+
+    let html = await fs.readFile(path.join(__dirname, '/dist/index.html'), 'utf8');
+    let filename = html.match(/\/(input\.[0-9a-f]+\.js)/)[1];
+    assert(await fs.exists(path.join(__dirname, '/dist/', filename)));
+    let content = await fs.readFile(path.join(__dirname, '/dist/', filename));
+
+    await fs.writeFile(path.join(__dirname, '/input/test.txt'), 'hello world');
+
+    await bundle(path.join(__dirname, '/input/index.html'), {
+      production: true
+    });
+
+    html = await fs.readFile(path.join(__dirname, '/dist/index.html'), 'utf8');
+    let newFilename = html.match(/\/(input\.[0-9a-f]+\.js)/)[1];
+    assert(await fs.exists(path.join(__dirname, '/dist/', newFilename)));
+    let newContent = await fs.readFile(path.join(__dirname, '/dist/', newFilename));
+
+    assert.notEqual(content, newContent);
+    assert.notEqual(filename, newFilename);
+  });
+
 });

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/a.html
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/a.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+  <script src="./a.js"></script>
+</body>
+</html>

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/a.js
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/a.js
@@ -1,0 +1,2 @@
+module.exports.b_html = require('./b.html');
+module.exports.b = require('./b.js');

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/b.html
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/b.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+  <script src="./b.js"></script>
+</body>
+</html>

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/b.js
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/b.js
@@ -1,0 +1,1 @@
+require('./test.txt');

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/index.html
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/index.js
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/index.js
@@ -1,0 +1,1 @@
+module.exports.a_html = require('./a.html');

--- a/packages/core/parcel-bundler/test/integration/import-multilevel-html/test.txt
+++ b/packages/core/parcel-bundler/test/integration/import-multilevel-html/test.txt
@@ -1,0 +1,1 @@
+hi there

--- a/packages/core/parcel-bundler/test/integration/js-cyclic/a.js
+++ b/packages/core/parcel-bundler/test/integration/js-cyclic/a.js
@@ -1,0 +1,3 @@
+export let b = require('./b.js');
+export let a = 'a';
+

--- a/packages/core/parcel-bundler/test/integration/js-cyclic/b.js
+++ b/packages/core/parcel-bundler/test/integration/js-cyclic/b.js
@@ -1,0 +1,2 @@
+export let a = require('./a.js');
+export let b = 'b';

--- a/packages/core/parcel-bundler/test/integration/js-cyclic/index.js
+++ b/packages/core/parcel-bundler/test/integration/js-cyclic/index.js
@@ -1,0 +1,4 @@
+import {a, b as ab} from './a';
+import {a as ba, b} from './b';
+
+export default [a, b, ab.b, ba.a].join('');

--- a/packages/core/parcel-bundler/test/javascript.js
+++ b/packages/core/parcel-bundler/test/javascript.js
@@ -1584,6 +1584,12 @@ describe('javascript', function() {
     assert.equal(await module.default(), 'Hello Hello! Hello');
   });
 
+  it('should support cyclic dependencies', async function() {
+    let b = await bundle(path.join(__dirname, `/integration/js-cyclic/index.js`));
+    let module = await run(b);
+    assert.equal(module.default, 'abba');
+  });
+
   it('should support importing HTML from JS async', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/import-html-async/index.js'),


### PR DESCRIPTION
# ↪️ Pull Request

Changes bundle hash calculation to include all dependencies.

## 💻 Examples

Previously a change to a file that a bundle depended on, but did not include, would not affect the hash in its filename.  This could result in a situation where the filename would not change even though references to the bundle's dependencies would be updated in the file.

See https://github.com/parcel-bundler/parcel/issues/1481

This PR includes a test case that fails if the changes are reverted, and also serves as an example of the issue.

