### PR TITLE
Option to leave certain filenames untouched

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -140,6 +140,7 @@ class Bundler extends EventEmitter {
           ? options.autoinstall
           : !isProduction,
       scopeHoist: scopeHoist,
+      copyPaths: Array.isArray(options.copyPaths) ? options.copyPaths : [],
       contentHash:
         typeof options.contentHash === 'boolean'
           ? options.contentHash
@@ -291,7 +292,8 @@ class Bundler extends EventEmitter {
 
       // Generate the final bundle names, and replace references in the built assets.
       this.bundleNameMap = this.mainBundle.getBundleNameMap(
-        this.options.contentHash
+        this.options.contentHash,
+        this.options.copyPaths
       );
 
       for (let asset of changedAssets) {

--- a/packages/core/parcel-bundler/test/contentHashing.js
+++ b/packages/core/parcel-bundler/test/contentHashing.js
@@ -71,4 +71,20 @@ describe('content hashing', function() {
 
     assert.notEqual(filename, newFilename);
   });
+
+  it('should keep the original filename when a matching copyPath is found', async function() {
+    await ncp(
+      path.join(__dirname, '/integration/import-raw'),
+      path.join(__dirname, '/input')
+    );
+
+    await bundle(path.join(__dirname, '/input/index.js'), {
+      production: true,
+      copyPaths: [/\.txt$/]
+    });
+
+    let js = await fs.readFile(path.join(__dirname, '/dist/index.js'), 'utf8');
+    let filename = js.match(/test\.txt/g);
+    assert.equal(filename.length, 3);
+  });
 });


### PR DESCRIPTION
# ↪️ Pull Request
adds functionality to leave filenames untouched for certain paths
this is useful for legacy projects where certain parts depend on predictable filenames instead of content hashes. This is an issue we ran into at the agency I am currently employed at.

Implementation wise, this adds an additional configuration option to the bundler called `copyPaths` which is an array of relative paths or regexes. If an asset matches the one of the `copyPaths` the filename will not receive a hash even if it isn't an entry file.

## 💻 Examples
In the example below all `.jpg` files will not receive a hash in the final filename.
```
const bundler = new Bundler(entryFiles, {
    copyPaths: [
        /\.jpg$/
    ]
});
```

## ✔️ PR Todo

- [ x] Added/updated unit tests for this change
- [ x] Filled out test instructions (In case there aren't any unit tests)
- [ x] Included links to related issues/PRs
