### PR TITLE
Update contributors broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Anyone can file an expense. If the expense makes sense for the development of th
 ### Contributors
 
 Thank you to all the people who have already contributed to parcel!
-<a href="graphs/contributors"><img src="https://opencollective.com/parcel/contributors.svg?width=890" /></a>
+<a href="https://github.com/parcel-bundler/parcel/graphs/contributors"><img src="https://opencollective.com/parcel/contributors.svg?width=890" /></a>
 
 ### Backers
 


### PR DESCRIPTION
# ↪️ Pull Request

The Previous link was redirecting to `https://github.com/parcel-bundler/parcel/blob/master/graphs/contributors` that doesn't exist. Replacing to the full link like we have in `README.md`.