### PR TITLE
Parcel 2:  Add connected file support to asset graph

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -96,7 +96,7 @@ export default class AssetGraph extends Graph {
       })
     );
 
-    this.updateDownStreamNodes(rootNode, depNodes);
+    this.replaceNodesConnectedTo(rootNode, depNodes);
     for (let depNode of depNodes) {
       this.incompleteNodes.set(depNode.id, depNode);
     }
@@ -116,7 +116,7 @@ export default class AssetGraph extends Graph {
     this.invalidNodes.delete(depNode.id);
 
     let fileNode = nodeFromFile(file);
-    let {added, removed} = this.updateDownStreamNodes(depNode, [fileNode]);
+    let {added, removed} = this.replaceNodesConnectedTo(depNode, [fileNode]);
 
     if (added.nodes.size) {
       newFile = file;
@@ -145,7 +145,7 @@ export default class AssetGraph extends Graph {
     }
 
     let assetNodes = cacheEntry.assets.map(asset => nodeFromAsset(asset));
-    let {added, removed} = this.updateDownStreamNodes(fileNode, [
+    let {added, removed} = this.replaceNodesConnectedTo(fileNode, [
       ...assetNodes,
       ...fileNodes
     ]);
@@ -159,7 +159,7 @@ export default class AssetGraph extends Graph {
         dep.sourcePath = file.filePath;
         return nodeFromDep(dep);
       });
-      let {removed, added} = this.updateDownStreamNodes(assetNode, depNodes);
+      let {removed, added} = this.replaceNodesConnectedTo(assetNode, depNodes);
       removedFiles = removedFiles.concat(getFilesFromGraph(removed));
       newDepNodes = newDepNodes.concat(getDepNodesFromGraph(added));
     }

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -37,6 +37,10 @@ export default class Graph {
     return this.nodes.has(id);
   }
 
+  getNode(id: string) {
+    return this.nodes.get(id);
+  }
+
   addEdge(edge: Edge) {
     this.edges.add(edge);
     return edge;
@@ -50,6 +54,12 @@ export default class Graph {
     }
 
     return false;
+  }
+
+  getConnectedNodes(node: Node): Array<Node> {
+    let edges = Array.from(this.edges).filter(edge => edge.to === node.id);
+
+    return edges.map(edge => this.nodes.get(edge.from));
   }
 
   merge(graph: Graph) {

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -56,10 +56,14 @@ export default class Graph {
     return false;
   }
 
-  getConnectedNodes(node: Node): Array<Node> {
+  getNodesConnectedTo(node: Node): Array<Node> {
     let edges = Array.from(this.edges).filter(edge => edge.to === node.id);
-
     return edges.map(edge => this.nodes.get(edge.from));
+  }
+
+  getNodesConnectedFrom(node: Node): Array<Node> {
+    let edges = Array.from(this.edges).filter(edge => edge.from === node.id);
+    return edges.map(edge => this.nodes.get(edge.to));
   }
 
   merge(graph: Graph) {
@@ -117,7 +121,7 @@ export default class Graph {
 
   // Update a node's downstream nodes making sure to prune any orphaned branches
   // Also keeps track of all added and removed edges and nodes
-  updateDownStreamNodes(fromNode: Node, toNodes: Array<Node>): GraphUpdates {
+  replaceNodesConnectedTo(fromNode: Node, toNodes: Array<Node>): GraphUpdates {
     let removed = new Graph();
     let added = new Graph();
 

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -4,6 +4,7 @@ import Cache from '@parcel/cache';
 import {mkdirp, writeFile} from '@parcel/fs';
 import path from 'path';
 import type {Bundle, CLIOptions, Blob, FilePath} from '@parcel/types';
+import clone from 'clone';
 
 type Opts = {
   config: Config,
@@ -45,6 +46,9 @@ export default class PackagerRunner {
   async package(bundle: Bundle): Promise<Blob> {
     let packager = await this.config.getPackager(bundle.filePath);
 
+    // Read the contents of each asset in the bundle from the cache.
+    // This mutates the assets, so clone the bundle first.
+    bundle = clone(bundle);
     await Promise.all(
       bundle.assets.map(async asset => {
         await this.cache.readBlobs(asset);

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -213,7 +213,7 @@ export default class Parcel {
 
     if (node.type === 'connected_file') {
       // Invalidate all file nodes connected to this node.
-      for (let connectedNode of this.graph.getConnectedNodes(node)) {
+      for (let connectedNode of this.graph.getNodesConnectedTo(node)) {
         if (connectedNode.type === 'file') {
           this.graph.invalidateNode(connectedNode);
         }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -88,7 +88,7 @@ export default class Parcel {
       this.watcher.on('change', filePath => {
         if (this.graph.hasNode(filePath)) {
           controller.abort();
-          this.handleChange(filePath);
+          this.graph.invalidateFile(filePath);
 
           controller = new AbortController();
           signal = controller.signal;
@@ -199,25 +199,5 @@ export default class Parcel {
   // TODO: implement bundle types
   package(bundles: any[]) {
     return Promise.all(bundles.map(bundle => this.runPackage(bundle)));
-  }
-
-  handleChange(filePath: string) {
-    let node = this.graph.getNode(filePath);
-    if (!node) {
-      return;
-    }
-
-    if (node.type === 'file') {
-      this.graph.invalidateNode(node);
-    }
-
-    if (node.type === 'connected_file') {
-      // Invalidate all file nodes connected to this node.
-      for (let connectedNode of this.graph.getNodesConnectedTo(node)) {
-        if (connectedNode.type === 'file') {
-          this.graph.invalidateNode(connectedNode);
-        }
-      }
-    }
   }
 }

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -77,7 +77,7 @@ describe('Graph', () => {
     let nodeD = {id: 'd', value: 'd'};
     let edgeAD = {from: 'a', to: 'd'};
 
-    let {removed} = graph.updateDownStreamNodes(nodeA, [nodeB, nodeD]);
+    let {removed} = graph.replaceNodesConnectedTo(nodeA, [nodeB, nodeD]);
 
     assert(graph.nodes.has('a'));
     assert(graph.nodes.has('b'));

--- a/packages/core/plugin/index.js.flow
+++ b/packages/core/plugin/index.js.flow
@@ -1,1 +1,2 @@
-export * from './src'
+// @flow
+export * from './src';

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -47,7 +47,8 @@ export type Target = {
 
 export type Environment = {
   target: Target,
-  browserContext: 'browser' | 'worker' | 'serviceworker'
+  context: 'browser' | 'webWorker' | 'serviceWorker' | 'node' | 'electron',
+  includeNodeModules?: boolean
 };
 
 export type PackageJSON = {
@@ -93,7 +94,8 @@ export type Dependency = {
 };
 
 export type File = {
-  filePath: FilePath
+  filePath: FilePath,
+  hash?: string
 };
 
 export type Asset = {
@@ -103,6 +105,7 @@ export type Asset = {
   hash: string,
   output: AssetOutput,
   dependencies: Array<Dependency>,
+  connectedFiles: Array<File>,
   env: Environment,
   meta?: JSONObject
 };
@@ -137,6 +140,7 @@ export type TransformerResult = {
   code?: string,
   ast?: ?AST,
   dependencies?: Array<Dependency>,
+  connectedFiles?: Array<File>,
   output?: AssetOutput,
   env?: Environment,
   meta?: JSONObject
@@ -144,7 +148,7 @@ export type TransformerResult = {
 
 export type ConfigOutput = {
   config: Config,
-  dependencies: Array<Dependency>
+  files: Array<File>
 };
 
 type Async<T> = T | Promise<T>;
@@ -176,11 +180,10 @@ export type Transformer = {
 
 export type CacheEntry = {
   filePath: FilePath,
-  env: Environment,
   hash: string,
   assets: Array<Asset>,
   initialAssets: ?Array<Asset>, // Initial assets, pre-post processing
-  dependencies: Array<Dependency> // File-level dependencies, e.g. config files.
+  connectedFiles: Array<File> // File-level dependencies, e.g. config files.
 };
 
 // TODO: what do we want to expose here?

--- a/packages/core/utils/config.js
+++ b/packages/core/utils/config.js
@@ -39,7 +39,7 @@ async function load(filepath, filenames, root = path.parse(filepath).root) {
       if (extname === 'js') {
         return {
           config: clone(require(configFile)),
-          dependencies: [{name: configFile}]
+          files: [{filePath: configFile}]
         };
       }
 
@@ -48,7 +48,7 @@ async function load(filepath, filenames, root = path.parse(filepath).root) {
       let config = configContent ? parse(configContent) : null;
       return {
         config: config,
-        dependencies: [{name: configFile}]
+        files: [{filePath: configFile}]
       };
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND' || err.code === 'ENOENT') {

--- a/packages/examples/simple/src/index.js
+++ b/packages/examples/simple/src/index.js
@@ -1,3 +1,5 @@
 const message = require('./message');
+const fs = require('fs');
 
 console.log(message); // eslint-disable-line no-console
+console.log(fs.readFileSync(__dirname + '/test.txt', 'utf8'));

--- a/packages/examples/simple/src/test.txt
+++ b/packages/examples/simple/src/test.txt
@@ -1,0 +1,1 @@
+hello world

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -4,7 +4,10 @@
 import {Packager} from '@parcel/plugin';
 import fs from 'fs';
 
-const PRELUDE = fs.readFileSync(__dirname + '/prelude.js');
+const PRELUDE = fs
+  .readFileSync(__dirname + '/prelude.js', 'utf8')
+  .trim()
+  .replace(/;$/, '');
 
 export default new Packager({
   async package(bundle) {

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -6,7 +6,9 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@parcel/plugin": "^2.0.0"
+  },
   "devDependencies": {
     "@parcel/eslint-config": "1.10.3"
   }

--- a/packages/transformers/js/src/index.js
+++ b/packages/transformers/js/src/index.js
@@ -3,47 +3,62 @@ import semver from 'semver';
 import generate from 'babel-generator';
 import {Transformer} from '@parcel/plugin';
 import collectDependencies from './visitors/dependencies';
-
-// Can't import these
-const babylon = require('babylon');
-const walk = require('babylon-walk');
+import envVisitor from './visitors/env';
+import fsVisitor from './visitors/fs';
+import insertGlobals from './visitors/globals';
+import {parse} from '@babel/parser';
+import traverse from '@babel/traverse';
+import * as walk from 'babylon-walk';
 
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
+const ENV_RE = /\b(?:process\.env)\b/;
+const GLOBAL_RE = /\b(?:process|__dirname|__filename|global|Buffer|define)\b/;
+const FS_RE = /\breadFileSync\b/;
 const SW_RE = /\bnavigator\s*\.\s*serviceWorker\s*\.\s*register\s*\(/;
-const WORKER_RE = /\bnew\s*Worker\s*\(/;
+const WORKER_RE = /\bnew\s*(?:Shared)?Worker\s*\(/;
 
 // Sourcemap extraction
 // const SOURCEMAP_RE = /\/\/\s*[@#]\s*sourceMappingURL\s*=\s*([^\s]+)/;
 // const DATA_URL_RE = /^data:[^;]+(?:;charset=[^;]+)?;base64,(.*)/;
 
 function canHaveDependencies(code) {
-  return IMPORT_RE.test(code) || SW_RE.test(code) || WORKER_RE.test(code);
+  return (
+    IMPORT_RE.test(code) ||
+    GLOBAL_RE.test(code) ||
+    SW_RE.test(code) ||
+    WORKER_RE.test(code)
+  );
 }
 
 export default new Transformer({
   canReuseAST(ast) {
-    return ast.type === 'babel' && semver.satisfies(ast.version, '^6.0.0');
+    return ast.type === 'babel' && semver.satisfies(ast.version, '^7.0.0');
   },
 
   async parse(asset /*, config , options */) {
-    if (!canHaveDependencies(asset.code)) return null;
+    if (
+      !canHaveDependencies(asset.code) &&
+      !ENV_RE.test(asset.code) &&
+      !FS_RE.test(asset.code)
+    ) {
+      return null;
+    }
+
     return {
       type: 'babel',
-      version: '6.0.0',
-      program: babylon.parse(asset.code, {
-        filename: this.filePath,
+      version: '7.0.0',
+      isDirty: false,
+      program: parse(asset.code, {
+        filename: this.name,
         allowReturnOutsideFunction: true,
-        allowHashBang: true,
-        ecmaVersion: Infinity,
         strictMode: false,
         sourceType: 'module',
-        locations: true,
-        plugins: ['exportExtensions', 'dynamicImport']
+        plugins: ['exportDefaultFrom', 'exportNamespaceFrom', 'dynamicImport']
       })
     };
   },
 
-  async transform(asset, config /*, options */) {
+  async transform(asset, config, options) {
     if (!asset.ast) {
       return [
         {
@@ -56,21 +71,57 @@ export default new Transformer({
 
     let module = {
       type: 'js',
+      filePath: asset.filePath,
       dependencies: [],
+      connectedFiles: [],
       code: asset.code,
-      ast: asset.ast
+      ast: asset.ast,
+      env: asset.env
     };
 
-    walk.ancestor(module.ast.program, collectDependencies, {
-      module,
-      config
-    });
+    // Collect dependencies
+    if (canHaveDependencies(asset.code)) {
+      walk.ancestor(module.ast.program, collectDependencies, module);
+    }
+
+    if (asset.env.context === 'browser') {
+      // Inline environment variables
+      if (ENV_RE.test(asset.code)) {
+        walk.simple(module.ast.program, envVisitor, module);
+      }
+
+      // Inline fs calls
+      let fsDep = module.dependencies.find(dep => dep.moduleSpecifier === 'fs');
+      if (fsDep && FS_RE.test(asset.code)) {
+        // Check if we should ignore fs calls
+        // See https://github.com/defunctzombie/node-browser-resolve#skip
+        // let pkg = await this.getPackage();
+        // let ignore = pkg && pkg.browser && pkg.browser.fs === false;
+        let ignore;
+
+        if (!ignore) {
+          traverse(module.ast.program, fsVisitor, null, module);
+        }
+      }
+
+      // Insert node globals
+      if (GLOBAL_RE.test(asset.code)) {
+        walk.ancestor(module.ast.program, insertGlobals, module);
+      }
+    }
 
     // Do some transforms
     return [module];
   },
 
   async generate(module, config, options) {
+    if (!module.ast.isDirty) {
+      return {
+        code: module.code
+        // TODO: sourcemaps
+      };
+    }
+
     let generated = generate(
       module.ast.program,
       {

--- a/packages/transformers/js/src/visitors/env.js
+++ b/packages/transformers/js/src/visitors/env.js
@@ -1,0 +1,30 @@
+import * as types from '@babel/types';
+
+export default {
+  MemberExpression(node, asset) {
+    // Inline environment variables accessed on process.env
+    if (types.matchesPattern(node.object, 'process.env')) {
+      let key = types.toComputedKey(node);
+      if (types.isStringLiteral(key)) {
+        let prop = process.env[key.value];
+        if (typeof prop !== 'function') {
+          let value = types.valueToNode(prop);
+          morph(node, value);
+          asset.ast.isDirty = true;
+          asset.meta.env[key.value] = process.env[key.value];
+        }
+      }
+    }
+  }
+};
+
+// replace object properties
+function morph(object, newProperties) {
+  for (let key in object) {
+    delete object[key];
+  }
+
+  for (let key in newProperties) {
+    object[key] = newProperties[key];
+  }
+}

--- a/packages/transformers/js/src/visitors/fs.js
+++ b/packages/transformers/js/src/visitors/fs.js
@@ -1,0 +1,198 @@
+import * as t from '@babel/types';
+import Path from 'path';
+import fs from 'fs';
+import template from '@babel/template';
+import logger from '@parcel/logger';
+
+const bufferTemplate = template('Buffer(CONTENT, ENC)');
+
+export default {
+  AssignmentExpression(path) {
+    if (!isRequire(path.node.right, 'fs', 'readFileSync')) {
+      return;
+    }
+
+    for (let name in path.getBindingIdentifiers()) {
+      const binding = path.scope.getBinding(name);
+      if (!binding) continue;
+
+      binding.path.setData('__require', path.node);
+    }
+  },
+
+  CallExpression(path, asset) {
+    if (referencesImport(path, 'fs', 'readFileSync')) {
+      let vars = {
+        __dirname: Path.dirname(asset.filePath),
+        __filename: Path.basename(asset.filePath)
+      };
+      let filename, args, res;
+
+      try {
+        [filename, ...args] = path
+          .get('arguments')
+          .map(arg => evaluate(arg, vars));
+
+        filename = Path.resolve(filename);
+        res = fs.readFileSync(filename, ...args);
+      } catch (err) {
+        if (err instanceof NodeNotEvaluatedError) {
+          // Warn using a code frame
+          err.fileName = asset.filePath;
+          asset.generateErrorMessage(err);
+          logger.warn(err);
+          return;
+        }
+
+        // Add location info so we log a code frame with the error
+        err.loc =
+          path.node.arguments.length > 0
+            ? path.node.arguments[0].loc.start
+            : path.node.loc.start;
+        throw err;
+      }
+
+      let replacementNode;
+      if (Buffer.isBuffer(res)) {
+        replacementNode = bufferTemplate({
+          CONTENT: t.stringLiteral(res.toString('base64')),
+          ENC: t.stringLiteral('base64')
+        });
+      } else {
+        replacementNode = t.stringLiteral(res);
+      }
+
+      asset.connectedFiles.push({
+        filePath: filename
+      });
+
+      path.replaceWith(replacementNode);
+      asset.ast.isDirty = true;
+    }
+  }
+};
+
+function isRequire(node, name, method) {
+  // e.g. require('fs').readFileSync
+  if (t.isMemberExpression(node) && node.property.name === method) {
+    node = node.object;
+  }
+
+  if (!t.isCallExpression(node)) {
+    return false;
+  }
+
+  let {callee, arguments: args} = node;
+  let isRequire =
+    t.isIdentifier(callee) &&
+    callee.name === 'require' &&
+    args.length === 1 &&
+    t.isStringLiteral(args[0]);
+
+  if (!isRequire) {
+    return false;
+  }
+
+  if (name && args[0].value !== name) {
+    return false;
+  }
+
+  return true;
+}
+
+function referencesImport(path, name, method) {
+  let callee = path.node.callee;
+  let bindingPath;
+
+  // e.g. readFileSync()
+  if (t.isIdentifier(callee)) {
+    bindingPath = getBindingPath(path, callee.name);
+  } else if (t.isMemberExpression(callee)) {
+    if (callee.property.name !== method) {
+      return false;
+    }
+
+    // e.g. fs.readFileSync()
+    if (t.isIdentifier(callee.object)) {
+      bindingPath = getBindingPath(path, callee.object.name);
+
+      // require('fs').readFileSync()
+    } else if (isRequire(callee.object, name)) {
+      return true;
+    }
+  } else {
+    return false;
+  }
+
+  if (!bindingPath) {
+    return;
+  }
+
+  let bindingNode = bindingPath.getData('__require') || bindingPath.node;
+  let parent = bindingPath.parentPath;
+
+  // e.g. import fs from 'fs';
+  if (parent.isImportDeclaration()) {
+    if (
+      bindingPath.isImportSpecifier() &&
+      bindingPath.node.imported.name !== method
+    ) {
+      return false;
+    }
+
+    return parent.node.source.value === name;
+
+    // e.g. var fs = require('fs');
+  } else if (
+    t.isVariableDeclarator(bindingNode) ||
+    t.isAssignmentExpression(bindingNode)
+  ) {
+    let left = bindingNode.id || bindingNode.left;
+    let right = bindingNode.init || bindingNode.right;
+
+    // e.g. var {readFileSync} = require('fs');
+    if (t.isObjectPattern(left)) {
+      let prop = left.properties.find(p => p.value.name === callee.name);
+      if (!prop || prop.key.name !== method) {
+        return false;
+      }
+    } else if (!t.isIdentifier(left)) {
+      return false;
+    }
+
+    return isRequire(right, name, method);
+  }
+
+  return false;
+}
+
+function getBindingPath(path, name) {
+  let binding = path.scope.getBinding(name);
+  return binding && binding.path;
+}
+
+function NodeNotEvaluatedError(node) {
+  this.message = 'Cannot statically evaluate fs argument';
+  this.node = node;
+  this.loc = node.loc.start;
+}
+
+function evaluate(path, vars) {
+  // Inline variables
+  path.traverse({
+    Identifier: function(ident) {
+      let key = ident.node.name;
+      if (key in vars) {
+        ident.replaceWith(t.valueToNode(vars[key]));
+      }
+    }
+  });
+
+  let res = path.evaluate();
+
+  if (!res.confident) {
+    throw new NodeNotEvaluatedError(path.node);
+  }
+
+  return res.value;
+}

--- a/packages/transformers/js/src/visitors/globals.js
+++ b/packages/transformers/js/src/visitors/globals.js
@@ -1,0 +1,57 @@
+import Path from 'path';
+import * as types from '@babel/types';
+
+const VARS = {
+  process: asset => {
+    asset.dependencies.push({moduleSpecifier: 'process'});
+    return 'var process = require("process");';
+  },
+  global: asset =>
+    `var global = arguments[${asset.options.scopeHoist ? 0 : 3}];`,
+  __dirname: asset =>
+    `var __dirname = ${JSON.stringify(Path.dirname(asset.filePath))};`,
+  __filename: asset => `var __filename = ${JSON.stringify(asset.filePath)};`,
+  Buffer: asset => {
+    asset.dependencies.push({moduleSpecifier: 'buffer'});
+    return 'var Buffer = require("buffer").Buffer;';
+  },
+  // Prevent AMD defines from working when loading UMD bundles.
+  // Ideally the CommonJS check would come before the AMD check, but many
+  // existing modules do the checks the opposite way leading to modules
+  // not exporting anything to Parcel.
+  define: () => 'var define;'
+};
+
+export default {
+  Identifier(node, asset, ancestors) {
+    let parent = ancestors[ancestors.length - 2];
+    if (
+      VARS.hasOwnProperty(node.name) &&
+      !asset.meta.globals.has(node.name) &&
+      types.isReferenced(node, parent)
+    ) {
+      asset.meta.globals.set(node.name, VARS[node.name](asset));
+    }
+  },
+
+  Declaration(node, asset, ancestors) {
+    // If there is a global declaration of one of the variables, remove our declaration
+    let identifiers = types.getBindingIdentifiers(node);
+    for (let id in identifiers) {
+      if (VARS.hasOwnProperty(id) && !inScope(ancestors)) {
+        // Don't delete entirely, so we don't add it again when the declaration is referenced
+        asset.meta.globals.set(id, '');
+      }
+    }
+  }
+};
+
+function inScope(ancestors) {
+  for (let i = ancestors.length - 2; i >= 0; i--) {
+    if (types.isScope(ancestors[i]) && !types.isProgram(ancestors[i])) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
This adds a new node type to the asset graph: `connected_file`. This node is like a cross between a normal `file` node and a `dependency` node. Connected files are returned by transformers like dependencies, but are fully resolved to absolute paths in the transformer, and do not get transformed like normal files. Connected files are watched, however, and trigger a rebuild of any file nodes that are connected to them.

Connected files are useful in two cases: 

1. As a part of assets for compilers that include external files as part of their builds. This is the case for stylus, sass, etc. which have their own `@import` syntax that they process themselves. The output of the compilation will include all imported files in the built asset, so we have no need to resolve and transform them. We do want to watch the included files though, so we return a connected file to represent that.

2. At the top-level, connected directly to a file to represent dependencies like config files (e.g. `.babelrc`). When a config file changes, we need to recompile all files that it affects.

In the graph, `connected_file` nodes are always connected to a `file` node, not an `asset`. This makes it easy to determine which files to invalidate when the connected file changes. However, in the cache we store a separate list of connected files on each asset with a hash on each one to determine when they changed. This allows us to only invalidate a single asset inside a file, e.g. stylus inside vue. If a the JS part of a vue file does not change but an included stylus file does, only the stylus part will be recompiled.

I added support for `fs.readFileSync` inlining to the parcel 2 JS transform, which uses connected files to ensure the files that it reads are watched. Updating the simple example to read a text file produces the following graph:

![graph](https://user-images.githubusercontent.com/19409/47959393-40386800-dfa0-11e8-8703-a8eccc43050a.png)