### PR TITLE
refactor: JSON.stringify replacer can not be boolean

### DIFF
--- a/packages/core/parcel-bundler/src/assets/CSSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/CSSAsset.js
@@ -122,7 +122,7 @@ class CSSAsset extends Asset {
 
     if (this.cssModules) {
       js +=
-        'module.exports = ' + JSON.stringify(this.cssModules, false, 2) + ';';
+        'module.exports = ' + JSON.stringify(this.cssModules, null, 2) + ';';
     }
 
     return [

--- a/packages/core/parcel-bundler/src/assets/GraphqlAsset.js
+++ b/packages/core/parcel-bundler/src/assets/GraphqlAsset.js
@@ -60,7 +60,7 @@ class GraphqlAsset extends Asset {
   }
 
   generate() {
-    return `module.exports=${JSON.stringify(this.ast, false, 2)};`;
+    return `module.exports=${JSON.stringify(this.ast, null, 2)};`;
   }
 }
 

--- a/packages/core/parcel-bundler/src/assets/VueAsset.js
+++ b/packages/core/parcel-bundler/src/assets/VueAsset.js
@@ -100,7 +100,7 @@ class VueAsset extends Asset {
     supplemental += this.compileCSSModules(generated, optsVar);
     supplemental += this.compileHMR(generated, optsVar);
 
-    if (this.options.minify && !this.options.scopeHoist && supplemental) {
+    if (this.options.minify && !this.options.scopeHoist) {
       let {code, error} = minify(supplemental, {toplevel: true});
       if (error) {
         throw error;


### PR DESCRIPTION
1. Use correct type parameter for JSON.stringify.
2. Remove `supplemental` not null checking which will never be empty.