### PR TITLE
refactor: declare variable in for to avoid pollution

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
+++ b/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
@@ -106,8 +106,8 @@ function getParents(bundle, id) {
   var parents = [];
   var k, d, dep;
 
-  for (k in modules) {
-    for (d in modules[k][1]) {
+  for (var k in modules) {
+    for (var d in modules[k][1]) {
       dep = modules[k][1][d];
       if (dep === id || (Array.isArray(dep) && dep[dep.length - 1] === id)) {
         parents.push(k);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Add `var` for the variables in for-loop to avoid global variables pollution.

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
