### PR TITLE
Fix debug log files for certain locales

### DIFF
--- a/packages/core/logger/src/Logger.js
+++ b/packages/core/logger/src/Logger.js
@@ -75,10 +75,7 @@ class Logger {
     if (this.logLevel > 4) {
       if (!this.logFile) {
         this.logFile = fs.createWriteStream(
-          path.join(
-            process.cwd(),
-            `parcel-debug-${currDate.toLocaleDateString()}@${currDate.toLocaleTimeString()}.log`
-          )
+          path.join(process.cwd(), `parcel-debug-${currDate.toISOString()}.log`)
         );
       }
       this.logFile.write(stripAnsi(message) + '\n');


### PR DESCRIPTION
When using `--log-level 5` on a system with US locale the command failed because the name of the log file to be created contained slashes (eg. `2018/11/16`).

I replaced `Date.toLocaleString()` with `Date.toISOString()` to fix that and provide consistent results.