### PR TITLE
Scope hoisting renaming after babel transforms

### DIFF
--- a/packages/core/parcel-bundler/src/scope-hoisting/hoist.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/hoist.js
@@ -51,6 +51,8 @@ function hasSideEffects(asset, {sideEffects} = asset._package) {
 module.exports = {
   Program: {
     enter(path, asset) {
+      path.scope.crawl();
+
       asset.cacheData.imports = asset.cacheData.imports || Object.create(null);
       asset.cacheData.exports = asset.cacheData.exports || Object.create(null);
       asset.cacheData.wildcards = asset.cacheData.wildcards || [];

--- a/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
@@ -3,31 +3,7 @@ function rename(scope, oldName, newName) {
     return;
   }
 
-  let binding = scope.getBinding(oldName);
-
-  // Rename all constant violations
-  for (let violation of binding.constantViolations) {
-    let bindingIds = violation.getBindingIdentifierPaths(true, false);
-    for (let name in bindingIds) {
-      if (name === oldName) {
-        for (let idPath of bindingIds[name]) {
-          idPath.node.name = newName;
-        }
-      }
-    }
-  }
-
-  // Rename all references
-  for (let path of binding.referencePaths) {
-    if (path.node.name === oldName) {
-      path.node.name = newName;
-    }
-  }
-
-  // Rename binding identifier, and update scope.
-  binding.identifier.name = newName;
-  scope.bindings[newName] = binding;
-  delete scope.bindings[oldName];
+  scope.rename(oldName, newName);
 }
 
 module.exports = rename;

--- a/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
@@ -3,7 +3,31 @@ function rename(scope, oldName, newName) {
     return;
   }
 
-  scope.rename(oldName, newName);
+  let binding = scope.getBinding(oldName);
+
+  // Rename all constant violations
+  for (let violation of binding.constantViolations) {
+    let bindingIds = violation.getBindingIdentifierPaths(true, false);
+    for (let name in bindingIds) {
+      if (name === oldName) {
+        for (let idPath of bindingIds[name]) {
+          idPath.node.name = newName;
+        }
+      }
+    }
+  }
+
+  // Rename all references
+  for (let path of binding.referencePaths) {
+    if (path.node.name === oldName) {
+      path.node.name = newName;
+    }
+  }
+
+  // Rename binding identifier, and update scope.
+  scope.removeOwnBinding(oldName);
+  scope.bindings[newName] = binding;
+  binding.identifier.name = newName;
 }
 
 module.exports = rename;

--- a/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/jsx-pragma/.babelrc
+++ b/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/jsx-pragma/.babelrc
@@ -1,0 +1,3 @@
+{
+	"plugins": ["@babel/plugin-transform-react-jsx"]
+}

--- a/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/jsx-pragma/a.js
+++ b/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/jsx-pragma/a.js
@@ -1,0 +1,3 @@
+import React from "./react.js";
+
+output = <span>Test</span>;

--- a/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/jsx-pragma/react.js
+++ b/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/jsx-pragma/react.js
@@ -1,0 +1,9 @@
+// mock for React.createElement
+
+export default {
+	createElement(type, props, children){
+		return {
+			type, props, children
+		};
+	}
+}

--- a/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/rename-superclass/a.js
+++ b/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/rename-superclass/a.js
@@ -1,0 +1,5 @@
+import Superclass from './b';
+
+class Test extends Superclass {}
+
+output = new Test().parentMethod();

--- a/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/rename-superclass/b.js
+++ b/packages/core/parcel-bundler/test/integration/scope-hoisting/es6/rename-superclass/b.js
@@ -1,0 +1,5 @@
+export default class Superclass {
+	parentMethod(){
+		return 2;
+	}
+}

--- a/packages/core/parcel-bundler/test/scope-hoisting.js
+++ b/packages/core/parcel-bundler/test/scope-hoisting.js
@@ -457,6 +457,19 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'bar');
     });
 
+    it('should support the jsx pragma', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/scope-hoisting/es6/jsx-pragma/a.js')
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, {
+        children: 'Test',
+        props: null,
+        type: 'span'
+      });
+    });
+
     it('should not nameclash with internal variables', async function() {
       let b = await bundle(
         path.join(__dirname, '/integration/scope-hoisting/es6/name-clash/a.js')

--- a/packages/core/parcel-bundler/test/scope-hoisting.js
+++ b/packages/core/parcel-bundler/test/scope-hoisting.js
@@ -89,6 +89,17 @@ describe('scope hoisting', function() {
       assert.equal(output, 2);
     });
 
+    it('supports renaming superclass identifiers', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/rename-superclass/a.js'
+        )
+      );
+      let output = await run(b);
+      assert.equal(output, 2);
+    });
+
     it('supports renaming imports', async function() {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
# ↪️ Pull Request

With this change the renaming part of scope-hoisting seems to work with other babel-transforms as well. E.g.:
1. Superclass identifiers get renamed correctly (closes #2204)
2. `<span>Test</span>` gets transpiled to `React.createElement("span", null, "Test")`, but React isn't getting renamed (same for `h` of preact, hyperapp). (closes #1699, closes #2084)
3. `babel-plugin-lodash` transforms the ast just like jsx (closes #1821)
5. most things regarding `constantViolations undefined`: with `styled-jsx` - closes #1538, with `plugin-transform-runtime` - closes #2255

I've added test for jsx and superclasses to the scope-hoisting/es6 folder.

Is a reason for the custom renaming logic? All scope-hoisting tests still pass with simply `scope.rename(oldName, newName)`. 

## 💻 Examples

Previously, scope-hoisting didn't correctly rename the superclass identifier (same problem with jsx)

src:
```js
import Component from "./x.js";

console.log(Component);

class App extends Component {}
```
Before hoisting:
```js
// ...

import Component from "./x.js";
console.log(Component);

var App =
/*#__PURE__*/
function (_Component) {
  _inherits(App, _Component);

  function App() {
    _classCallCheck(this, App);

    return _possibleConstructorReturn(this, _getPrototypeOf(App).apply(this, arguments));
  }

  return App;
}(Component);
```

After hoisting:

```js
// ...

import $Focm$import$Component from "./x.js";
console.log($Focm$import$Component);

var App =
/*#__PURE__*/
function (_Component) {
  _inherits(App, _Component);

  function App() {
    _classCallCheck(this, App);

    return _possibleConstructorReturn(this, _getPrototypeOf(App).apply(this, arguments));
  }

  return App;
}(Component); // <--- Problem
```
