### PR TITLE
Process array of assets for JSON-LD

### DIFF
--- a/packages/core/integration-tests/test/integration/schema-jsonld/index.html
+++ b/packages/core/integration-tests/test/integration/schema-jsonld/index.html
@@ -21,7 +21,7 @@
       "width": 180,
       "height": 120
     },
-  "image": "images/image.jpeg"
+  "image": ["images/image.jpeg", "images/image.jpeg"]
 }
 </script>
 

--- a/packages/core/parcel-bundler/src/assets/JSONLDAsset.js
+++ b/packages/core/parcel-bundler/src/assets/JSONLDAsset.js
@@ -59,6 +59,10 @@ class JSONLDAsset extends Asset {
         assetPath = urlJoin(this.options.publicURL, assetPath);
       }
       schema[schemaKey] = assetPath;
+    } else if (Array.isArray(schema[schemaKey])) {
+      Object.keys(schema[schemaKey]).forEach(i => {
+        this.collectFromKey(schema[schemaKey], i);
+      });
     } else {
       this.collectFromKey(schema[schemaKey], 'url');
     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This pull request implemented processing of multiple assets in JSON-LD.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

Before this PR, JSON-LD like below wouldn't get processed correctly, which `image` array would get ignored:

```html
<script type="application/ld+json">
{
  "@context": "http://schema.org",
  "@type": "LocalBusiness",
  "description": "This is your business description.",
  "name": "Parcel's parcel",
  "telephone": "555-111-2345",
  "openingHours": "Mo,Tu,We,Th,Fr 09:00-17:00",
  "logo": {
      "@type": "ImageObject",
      "url": "images/logo.png",
      "width": 180,
      "height": 120
    },
  "image": ["images/image.jpeg", "images/image.jpeg"]
}
</script>
```
<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

Please just check updated test case.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->