### PR TITLE
Parcel 2: Asset methods

### DIFF
--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -134,7 +134,7 @@ export default class Asset implements IAsset {
   }
 
   async getConfig(filePaths: Array<FilePath>) {
-    return config.load(filePaths);
+    return config.load(this.filePath, filePaths);
   }
 
   async getPackage() {

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -1,0 +1,150 @@
+// @flow
+import type {
+  Asset as IAsset,
+  TransformerResult,
+  DependencyOptions,
+  Dependency,
+  FilePath,
+  File,
+  Environment,
+  JSONObject,
+  AST,
+  AssetOutput
+} from '@parcel/types';
+import md5 from '@parcel/utils/md5';
+import config from '@parcel/utils/config';
+import createDependency from './createDependency';
+
+type AssetOptions = {
+  id?: string,
+  hash?: string,
+  filePath: FilePath,
+  type: string,
+  code?: string,
+  ast?: ?AST,
+  dependencies?: Array<Dependency>,
+  connectedFiles?: Array<File>,
+  output?: AssetOutput,
+  env: Environment,
+  meta?: JSONObject
+};
+
+export default class Asset implements IAsset {
+  id: string;
+  hash: string;
+  filePath: FilePath;
+  type: string;
+  code: string;
+  ast: ?AST;
+  dependencies: Array<Dependency>;
+  connectedFiles: Array<File>;
+  output: AssetOutput;
+  env: Environment;
+  meta: JSONObject;
+
+  constructor(options: AssetOptions) {
+    this.id =
+      options.id ||
+      md5(options.filePath + options.type + JSON.stringify(options.env));
+    this.hash = options.hash || '';
+    this.filePath = options.filePath;
+    this.type = options.type;
+    this.code = options.code || (options.output ? options.output.code : '');
+    this.ast = options.ast || null;
+    this.dependencies = options.dependencies
+      ? options.dependencies.slice()
+      : [];
+    this.connectedFiles = options.connectedFiles
+      ? options.connectedFiles.slice()
+      : [];
+    this.output = options.output || {code: this.code};
+    this.env = options.env;
+    this.meta = options.meta || {};
+  }
+
+  toJSON(): AssetOptions {
+    // Exclude `code` and `ast` from cache
+    return {
+      id: this.id,
+      hash: this.hash,
+      filePath: this.filePath,
+      type: this.type,
+      dependencies: this.dependencies,
+      connectedFiles: this.connectedFiles,
+      output: this.output,
+      env: this.env,
+      meta: this.meta
+    };
+  }
+
+  addDependency(opts: DependencyOptions) {
+    let dep = createDependency(
+      {
+        ...opts,
+        env: mergeEnvironment(this.env, opts.env)
+      },
+      this.filePath
+    );
+
+    this.dependencies.push(dep);
+    return dep.id;
+  }
+
+  async addConnectedFile(file: File) {
+    if (!file.hash) {
+      file.hash = await md5.file(file.filePath);
+    }
+
+    this.connectedFiles.push(file);
+  }
+
+  createChildAsset(result: TransformerResult) {
+    let code = result.code || (result.output && result.output.code) || '';
+    let opts: AssetOptions = {
+      hash: this.hash || md5(code),
+      filePath: this.filePath,
+      type: result.type,
+      code,
+      ast: result.ast,
+      env: mergeEnvironment(this.env, result.env),
+      dependencies: this.dependencies,
+      connectedFiles: this.connectedFiles,
+      meta: Object.assign({}, this.meta, result.meta)
+    };
+
+    let asset = new Asset(opts);
+
+    if (result.dependencies) {
+      for (let dep of result.dependencies) {
+        asset.addDependency(dep);
+      }
+    }
+
+    if (result.connectedFiles) {
+      for (let file of result.connectedFiles) {
+        asset.addConnectedFile(file);
+      }
+    }
+
+    return asset;
+  }
+
+  async getOutput() {
+    return this.output;
+  }
+
+  async getConfig(filePaths: Array<FilePath>) {
+    return config.load(filePaths);
+  }
+
+  async getPackage() {
+    return {
+      name: 'foo',
+      version: '1.2.3'
+    };
+  }
+}
+
+function mergeEnvironment(a: Environment, b: ?Environment): Environment {
+  return Object.assign({}, a, b);
+}

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -141,9 +141,8 @@ export default class Graph {
 
       edgesToRemove = edgesToRemove.filter(edge => edge.to !== toNode.id);
 
-      let edge = edgesBefore.find(edge => edge.to === toNode.id);
-      if (!edge) {
-        edge = {from: fromNode.id, to: toNode.id};
+      let edge = {from: fromNode.id, to: toNode.id};
+      if (!this.hasEdge(edge)) {
         this.addEdge(edge);
         added.addEdge(edge);
       }

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -1,18 +1,14 @@
 // @flow
 import type {
-  Asset,
+  Asset as IAsset,
   AssetOutput,
   CacheEntry,
-  Dependency,
-  Environment,
   File,
-  JSONObject,
   Transformer,
   TransformerRequest,
-  TransformerInput,
-  TransformerResult,
   CLIOptions
 } from '@parcel/types';
+import Asset from './Asset';
 import path from 'path';
 import clone from 'clone';
 import md5 from '@parcel/utils/md5';
@@ -26,15 +22,7 @@ type Opts = {
   cache?: Cache
 };
 
-type GenerateFunc = ?(input: TransformerInput) => Promise<AssetOutput>;
-type TransformContext = {
-  type: string,
-  hash?: string,
-  dependencies: Array<Dependency>,
-  connectedFiles: Array<File>,
-  generate?: GenerateFunc,
-  meta?: JSONObject
-};
+type GenerateFunc = ?(input: Asset) => Promise<AssetOutput>;
 
 class TransformerRunner {
   cliOpts: CLIOptions;
@@ -61,26 +49,21 @@ class TransformerRunner {
       return cacheEntry;
     }
 
-    let input: TransformerInput = {
+    let input = new Asset({
       filePath: req.filePath,
+      type: path.extname(req.filePath).slice(1),
       ast: null,
       code,
       env: req.env
-    };
-
-    let context = {
-      type: path.extname(req.filePath).slice(1),
-      dependencies: [],
-      connectedFiles: []
-    };
+    });
 
     let pipeline = await this.config.getTransformers(req.filePath);
     let {assets, initialAssets, connectedFiles} = await this.runPipeline(
       input,
       pipeline,
-      cacheEntry,
-      context
+      cacheEntry
     );
+
     cacheEntry = {
       filePath: req.filePath,
       env: req.env,
@@ -95,10 +78,10 @@ class TransformerRunner {
   }
 
   async runPipeline(
-    input: TransformerInput,
+    input: Asset,
     pipeline: Array<Transformer>,
     cacheEntry: ?CacheEntry,
-    context: TransformContext
+    previousGenerate: ?GenerateFunc
   ) {
     // Run the first transformer in the pipeline.
     let {
@@ -106,25 +89,17 @@ class TransformerRunner {
       connectedFiles,
       generate,
       postProcess
-    } = await this.runTransform(input, pipeline[0], context.generate);
+    } = await this.runTransform(input, pipeline[0], previousGenerate);
 
-    context.generate = generate;
-
-    let assets: Array<Asset> = [];
+    let assets: Array<IAsset> = [];
     for (let result of results) {
-      let asset;
-
-      // If this is the first transformer, create a hash for the asset.
-      if (!context.hash) {
-        asset = await transformerResultToAsset(input, result, context);
-        context.hash = asset.hash;
-      }
+      let asset = input.createChildAsset(result);
 
       // Check if any of the cached assets match the result.
       if (cacheEntry) {
         let cachedAssets = (
           cacheEntry.initialAssets || cacheEntry.assets
-        ).filter(child => child.hash === context.hash);
+        ).filter(child => child.hash === asset.hash);
 
         if (
           cachedAssets.length > 0 &&
@@ -136,20 +111,19 @@ class TransformerRunner {
       }
 
       // If the generated asset has the same type as the input...
-      if (result.type === context.type) {
+      // TODO: this is incorrect since multiple file types could map to the same pipeline. need to compare the pipelines.
+      if (result.type === input.type) {
         // If we have reached the last transform in the pipeline, then we are done.
         if (pipeline.length === 1) {
-          assets.push(
-            asset || (await transformerResultToAsset(input, result, context))
-          );
+          assets.push(await finalize(asset, generate));
         } else {
           // Recursively run the remaining transforms in the pipeline.
-          let nextInput = transformerResultToInput(input, result);
+          let nextInput = input.createChildAsset(result);
           let cacheEntry = await this.runPipeline(
             nextInput,
             pipeline.slice(1),
             null,
-            getNextContext(context, result)
+            generate
           );
 
           assets = assets.concat(cacheEntry.assets);
@@ -157,7 +131,7 @@ class TransformerRunner {
         }
       } else {
         // Jump to a different pipeline for the generated asset.
-        let nextInput = transformerResultToInput(input, result);
+        let nextInput = input.createChildAsset(result);
         let nextFilePath =
           input.filePath.slice(0, -path.extname(input.filePath).length) +
           '.' +
@@ -166,7 +140,7 @@ class TransformerRunner {
           nextInput,
           await this.config.getTransformers(nextFilePath),
           null,
-          getNextContext(context, result)
+          generate
         );
 
         assets = assets.concat(cacheEntry.assets);
@@ -175,7 +149,7 @@ class TransformerRunner {
     }
 
     // If the transformer has a postProcess function, execute that with the result of the pipeline.
-    let finalAssets = await postProcess(clone(assets), context);
+    let finalAssets = await postProcess(clone(assets));
 
     return {
       assets: finalAssets || assets,
@@ -185,7 +159,7 @@ class TransformerRunner {
   }
 
   async runTransform(
-    input: TransformerInput,
+    input: Asset,
     transformer: Transformer,
     previousGenerate: GenerateFunc
   ) {
@@ -222,7 +196,7 @@ class TransformerRunner {
     let results = await transformer.transform(input, config, this.cliOpts);
 
     // Create a generate function that can be called later to lazily generate
-    let generate = async (input: TransformerInput): Promise<AssetOutput> => {
+    let generate = async (input: Asset): Promise<AssetOutput> => {
       if (transformer.generate) {
         return await transformer.generate(input, config, this.cliOpts);
       }
@@ -234,8 +208,7 @@ class TransformerRunner {
 
     // Create a postProcess function that can be called later
     let postProcess = async (
-      assets: Array<Asset>,
-      context: TransformContext
+      assets: Array<IAsset>
     ): Promise<Array<Asset> | null> => {
       if (transformer.postProcess) {
         let results = await transformer.postProcess(
@@ -245,9 +218,7 @@ class TransformerRunner {
         );
 
         return Promise.all(
-          results.map(result =>
-            transformerResultToAsset(input, result, context)
-          )
+          results.map(result => input.createChildAsset(result))
         );
       }
 
@@ -258,92 +229,13 @@ class TransformerRunner {
   }
 }
 
-async function getOutput(
-  input: TransformerInput,
-  result: TransformerResult,
-  context: TransformContext
-): Promise<AssetOutput> {
-  let output: AssetOutput = result.output || {code: result.code || ''};
-  if (result.code) {
-    output = clone(output);
-    output.code = result.code || '';
+async function finalize(asset: Asset, generate: GenerateFunc): Promise<Asset> {
+  if (asset.ast && generate) {
+    asset.output = await generate(asset);
+    asset.ast = null;
   }
 
-  if (result.ast && context.generate) {
-    output = await context.generate(transformerResultToInput(input, result));
-  }
-
-  return output;
-}
-
-async function transformerResultToAsset(
-  input: TransformerInput,
-  result: TransformerResult,
-  context: TransformContext
-): Promise<Asset> {
-  let output = await getOutput(input, result, context);
-  let env = mergeEnvironment(input.env, result.env);
-  let dependencies = (result.dependencies || []).map(dep =>
-    toDependency(input, dep)
-  );
-
-  let connectedFiles = context.connectedFiles.concat(
-    result.connectedFiles || []
-  );
-  await Promise.all(
-    connectedFiles.map(async file => {
-      if (!file.hash) {
-        file.hash = await md5.file(file.filePath);
-      }
-    })
-  );
-
-  return {
-    id: md5(input.filePath + result.type + JSON.stringify(env)),
-    hash: context.hash || md5(output.code),
-    filePath: input.filePath,
-    type: result.type,
-    dependencies: context.dependencies.concat(dependencies),
-    connectedFiles,
-    output,
-    env,
-    meta: Object.assign({}, context.meta, result.meta)
-  };
-}
-
-function toDependency(input: TransformerInput, dep: Dependency): Dependency {
-  dep.env = mergeEnvironment(input.env, dep.env);
-  return dep;
-}
-
-function transformerResultToInput(
-  input: TransformerInput,
-  result: TransformerResult
-): TransformerInput {
-  return {
-    filePath: input.filePath,
-    code: result.code || (result.output && result.output.code) || '',
-    ast: result.ast,
-    env: mergeEnvironment(input.env, result.env)
-  };
-}
-
-function mergeEnvironment(a: Environment, b: ?Environment): Environment {
-  return Object.assign({}, a, b);
-}
-
-function getNextContext(
-  context: TransformContext,
-  result: TransformerResult
-): TransformContext {
-  return {
-    type: result.type,
-    generate: context.generate,
-    dependencies: context.dependencies.concat(result.dependencies || []),
-    connectedFiles: context.connectedFiles.concat(result.connectedFiles || []),
-    hash: context.hash,
-    meta: Object.assign({}, context.meta, result.meta)
-  };
+  return asset;
 }
 
 async function checkCacheEntry(cacheEntry: CacheEntry): Promise<boolean> {
@@ -355,7 +247,7 @@ async function checkCacheEntry(cacheEntry: CacheEntry): Promise<boolean> {
   return results.every(Boolean);
 }
 
-async function checkCachedAssets(assets: Array<Asset>): Promise<boolean> {
+async function checkCachedAssets(assets: Array<IAsset>): Promise<boolean> {
   let results = await Promise.all(
     assets.map(asset => checkConnectedFiles(asset.connectedFiles))
   );

--- a/packages/core/core/src/createDependency.js
+++ b/packages/core/core/src/createDependency.js
@@ -1,0 +1,14 @@
+// @flow
+import type {DependencyOptions, Dependency, FilePath} from '@parcel/types';
+import md5 from '@parcel/utils/md5';
+
+export default function createDependency(
+  opts: DependencyOptions,
+  sourcePath: FilePath
+): Dependency {
+  return {
+    ...opts,
+    sourcePath, // TODO: get this from the graph?
+    id: md5(`${sourcePath}:${opts.moduleSpecifier}:${JSON.stringify(opts.env)}`)
+  };
+}

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -85,8 +85,7 @@ export type SourceLocation = {
   end: {line: number, column: number}
 };
 
-export type Dependency = {
-  sourcePath: FilePath,
+export type DependencyOptions = {
   moduleSpecifier: ModuleSpecifier,
   isAsync?: boolean,
   isEntry?: boolean,
@@ -96,6 +95,16 @@ export type Dependency = {
   loc?: SourceLocation,
   env?: Environment,
   meta?: JSONObject
+};
+
+export type Dependency = {
+  ...DependencyOptions,
+  id: string,
+  env: Environment,
+
+  // TODO: get these from graph instead of storing them on dependencies
+  sourcePath: FilePath,
+  resolvedPath?: FilePath
 };
 
 export type File = {
@@ -108,17 +117,24 @@ export type TransformerRequest = {
   env: Environment
 };
 
-export type Asset = {
-  id: string,
-  filePath: FilePath,
-  type: string,
-  hash: string,
-  output: AssetOutput,
-  dependencies: Array<Dependency>,
-  connectedFiles: Array<File>,
-  env: Environment,
-  meta?: JSONObject
-};
+export interface Asset {
+  id: string;
+  hash: string;
+  filePath: FilePath;
+  type: string;
+  code: string;
+  ast: ?AST;
+  dependencies: Array<Dependency>;
+  connectedFiles: Array<File>;
+  output: AssetOutput;
+  env: Environment;
+  meta: JSONObject;
+
+  getConfig(filePaths: Array<FilePath>): Async<ConfigOutput>;
+  getPackage(): Async<PackageJSON>;
+  addDependency(dep: DependencyOptions): string;
+  createChildAsset(result: TransformerResult): Asset;
+}
 
 export type AssetOutput = {
   code: string,
@@ -129,27 +145,18 @@ export type AssetOutput = {
 export type AST = {
   type: string,
   version: string,
-  program: JSONObject
+  program: any
 };
 
 export type Config = JSONObject;
 export type SourceMap = JSONObject;
 export type Blob = string | Buffer;
 
-export type TransformerInput = {
-  filePath: FilePath,
-  code: string,
-  ast: ?AST,
-  env: Environment
-};
-
-export type TransformerOutput = {};
-
 export type TransformerResult = {
   type: string,
   code?: string,
   ast?: ?AST,
-  dependencies?: Array<Dependency>,
+  dependencies?: Array<DependencyOptions>,
   connectedFiles?: Array<File>,
   output?: AssetOutput,
   env?: Environment,
@@ -166,18 +173,14 @@ type Async<T> = T | Promise<T>;
 export type Transformer = {
   getConfig?: (filePath: FilePath, opts: CLIOptions) => Async<ConfigOutput>,
   canReuseAST?: (ast: AST, opts: CLIOptions) => boolean,
-  parse?: (
-    asset: TransformerInput,
-    config: ?Config,
-    opts: CLIOptions
-  ) => Async<?AST>,
+  parse?: (asset: Asset, config: ?Config, opts: CLIOptions) => Async<?AST>,
   transform(
-    asset: TransformerInput,
+    asset: Asset,
     config: ?Config,
     opts: CLIOptions
-  ): Async<Array<TransformerResult>>,
+  ): Async<Array<TransformerResult | Asset>>,
   generate?: (
-    asset: TransformerInput,
+    asset: Asset,
     config: ?Config,
     opts: CLIOptions
   ) => Async<AssetOutput>,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -171,7 +171,7 @@ export type ConfigOutput = {
 type Async<T> = T | Promise<T>;
 
 export type Transformer = {
-  getConfig?: (filePath: FilePath, opts: CLIOptions) => Async<ConfigOutput>,
+  getConfig?: (asset: Asset, opts: CLIOptions) => Async<ConfigOutput>,
   canReuseAST?: (ast: AST, opts: CLIOptions) => boolean,
   parse?: (asset: Asset, config: ?Config, opts: CLIOptions) => Async<?AST>,
   transform(

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -19,7 +19,9 @@ export default new Packager({
           let resolvedAsset = bundle.assets.find(
             a => a.filePath === dep.resolvedPath
           );
-          deps[dep.moduleSpecifier] = resolvedAsset.id;
+          if (resolvedAsset) {
+            deps[dep.moduleSpecifier] = resolvedAsset.id;
+          }
         }
 
         let wrapped = i === 0 ? '' : ',';

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -53,7 +53,7 @@ export default {
       types.isStringLiteral(args[0]);
 
     if (isDynamicImport) {
-      asset.dependencies.push({moduleSpecifier: '_bundle_loader'});
+      asset.addDependency({moduleSpecifier: '_bundle_loader'});
       addDependency(asset, args[0], {isAsync: true});
 
       node.callee = requireTemplate().expression;
@@ -71,7 +71,7 @@ export default {
       // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#avoid_changing_the_url_of_your_service_worker_script
       addURLDependency(asset, args[0], {
         isEntry: true,
-        context: 'serviceworker'
+        context: 'service-worker'
       });
       return;
     }
@@ -87,7 +87,7 @@ export default {
       types.isStringLiteral(args[0]);
 
     if (isWebWorker) {
-      addURLDependency(asset, args[0], {context: 'webworker'});
+      addURLDependency(asset, args[0], {context: 'web-worker'});
       return;
     }
   }
@@ -176,7 +176,7 @@ function addDependency(asset, node, opts = {}) {
     }
   }
 
-  asset.dependencies.push(
+  asset.addDependency(
     Object.assign(
       {
         moduleSpecifier: node.value,
@@ -190,10 +190,6 @@ function addDependency(asset, node, opts = {}) {
 function addURLDependency(asset, node, opts = {}) {
   opts.loc = node.loc && node.loc.start;
 
-  let assetPath = asset.addURLDependency(node.value, opts);
-  if (!isURL(assetPath)) {
-    assetPath = urlJoin(asset.options.publicURL, assetPath);
-  }
-  node.value = assetPath;
+  node.value = asset.addDependency({moduleSpecifier: node.value, ...opts});
   asset.ast.isDirty = true;
 }

--- a/packages/transformers/terser/src/TerserTransformer.js
+++ b/packages/transformers/terser/src/TerserTransformer.js
@@ -1,7 +1,6 @@
 // @flow
 import {minify} from 'terser';
 import {Transformer} from '@parcel/plugin';
-import config from '@parcel/utils/config';
 
 // TODO: extract SourceMap from parcel-bundler ?
 // Just using an empty class skeleton for now so that linting doesn't fail
@@ -11,8 +10,8 @@ class SourceMap {
 }
 
 export default new Transformer({
-  async getConfig(filePath /* , options */) {
-    return config.load(filePath, [
+  async getConfig(asset) {
+    return asset.getConfig([
       '.terserrc',
       '.uglifyrc',
       '.uglifyrc.js',
@@ -20,7 +19,7 @@ export default new Transformer({
     ]);
   },
 
-  async transform(module, config, options) {
+  async transform(asset, config, options) {
     let terserOptions = {
       warnings: true,
       mangle: {
@@ -55,10 +54,13 @@ export default new Transformer({
       terserOptions = Object.assign({}, terserOptions, config);
     }
 
-    let result = minify(module.code, terserOptions);
+    let result = minify(asset.code, terserOptions);
 
-    if (sourceMap && module.map) {
-      sourceMap = await new SourceMap().extendSourceMap(module.map, sourceMap);
+    if (sourceMap && asset.output.map) {
+      sourceMap = await new SourceMap().extendSourceMap(
+        asset.output.map,
+        sourceMap
+      );
     }
 
     if (result.error) {


### PR DESCRIPTION
This is an experiment with creating a mutable Asset class with some helper methods for transformers to use rather than only returning plain objects. The methods include things like `getConfig` and `getPackage` helpers, along with `addDependency`, `addConnectedFile, and `createChildAsset` mutation/factory methods. None of these are required - plain objects also work fine, and are converted on the fly by the transformer runner. I think it simplifies transformers quite a bit, and also simplifies the transformer runner.