### PR TITLE
use RootDir for localrequire of compilers

### DIFF
--- a/packages/core/parcel-bundler/src/assets/CoffeeScriptAsset.js
+++ b/packages/core/parcel-bundler/src/assets/CoffeeScriptAsset.js
@@ -1,5 +1,6 @@
 const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
+const path = require('path');
 
 class CoffeeScriptAsset extends Asset {
   constructor(name, options) {
@@ -9,7 +10,10 @@ class CoffeeScriptAsset extends Asset {
 
   async generate() {
     // require coffeescript, installed locally in the app
-    let coffee = await localRequire('coffeescript', this.name);
+    let coffee = await localRequire(
+      'coffeescript',
+      path.join(this.options.rootDir, 'index')
+    );
 
     // Transpile Module using CoffeeScript and parse result as ast format through babylon
     let transpiled = coffee.compile(this.contents, {

--- a/packages/core/parcel-bundler/src/assets/ElmAsset.js
+++ b/packages/core/parcel-bundler/src/assets/ElmAsset.js
@@ -21,7 +21,7 @@ class ElmAsset extends Asset {
     try {
       await commandExists('elm');
     } catch (err) {
-      await localRequire('elm', this.name);
+      await localRequire('elm', path.join(this.options.rootDir, 'index'));
       options.pathToElm = path.join(
         path.dirname(require.resolve('elm')),
         'bin',
@@ -29,7 +29,10 @@ class ElmAsset extends Asset {
       );
     }
 
-    this.elm = await localRequire('node-elm-compiler', this.name);
+    this.elm = await localRequire(
+      'node-elm-compiler',
+      path.join(this.options.rootDir, 'index')
+    );
 
     // Ensure that an elm.json file exists, and initialize one if not.
     let elmConfig = await this.getConfig(['elm.json'], {load: false});

--- a/packages/core/parcel-bundler/src/assets/GLSLAsset.js
+++ b/packages/core/parcel-bundler/src/assets/GLSLAsset.js
@@ -11,7 +11,10 @@ class GLSLAsset extends Asset {
   }
 
   async parse() {
-    const glslifyDeps = await localRequire('glslify-deps', this.name);
+    const glslifyDeps = await localRequire(
+      'glslify-deps',
+      path.join(this.options.rootDir, 'index')
+    );
 
     // Use the Parcel resolver rather than the default glslify one.
     // This adds support for parcel features like aliases, and tilde paths.

--- a/packages/core/parcel-bundler/src/assets/GraphqlAsset.js
+++ b/packages/core/parcel-bundler/src/assets/GraphqlAsset.js
@@ -50,7 +50,10 @@ class GraphqlAsset extends Asset {
   }
 
   async parse(code) {
-    let gql = await localRequire('graphql-tag', this.name);
+    let gql = await localRequire(
+      'graphql-tag',
+      path.join(this.options.rootDir, 'index')
+    );
 
     await this.traverseImports(this.name, code);
 

--- a/packages/core/parcel-bundler/src/assets/LESSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/LESSAsset.js
@@ -14,7 +14,10 @@ class LESSAsset extends Asset {
 
   async parse(code) {
     // less should be installed locally in the module that's being required
-    let less = await localRequire('less', this.name);
+    let less = await localRequire(
+      'less',
+      path.join(this.options.rootDir, 'index')
+    );
     let render = promisify(less.render.bind(less));
 
     let opts =

--- a/packages/core/parcel-bundler/src/assets/PugAsset.js
+++ b/packages/core/parcel-bundler/src/assets/PugAsset.js
@@ -10,7 +10,10 @@ class PugAsset extends Asset {
   }
 
   async generate() {
-    const pug = await localRequire('pug', this.name);
+    const pug = await localRequire(
+      'pug',
+      path.join(this.options.rootDir, 'index')
+    );
     const config =
       (await this.getConfig(['.pugrc', '.pugrc.js', 'pug.config.js'])) || {};
 

--- a/packages/core/parcel-bundler/src/assets/ReasonAsset.js
+++ b/packages/core/parcel-bundler/src/assets/ReasonAsset.js
@@ -9,7 +9,10 @@ class ReasonAsset extends Asset {
   }
 
   async generate() {
-    const bsb = await localRequire('bsb-js', this.name);
+    const bsb = await localRequire(
+      'bsb-js',
+      path.join(this.options.rootDir, 'index')
+    );
 
     // This runs BuckleScript - the Reason to JS compiler.
     // Other Asset types use `localRequire` but the `bsb-js` package already

--- a/packages/core/parcel-bundler/src/assets/SASSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/SASSAsset.js
@@ -14,7 +14,7 @@ class SASSAsset extends Asset {
 
   async parse(code) {
     // node-sass or dart-sass should be installed locally in the module that's being required
-    let sass = await getSassRuntime(this.name);
+    let sass = await getSassRuntime(path.join(this.options.rootDir, 'index'));
     let render = promisify(sass.render.bind(sass));
     const resolver = new Resolver({
       extensions: ['.scss', '.sass'],

--- a/packages/core/parcel-bundler/src/assets/SSSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/SSSAsset.js
@@ -9,7 +9,10 @@ class SSSAsset extends Asset {
   }
 
   async generate() {
-    let sugarss = await localRequire('sugarss', this.name);
+    let sugarss = await localRequire(
+      'sugarss',
+      path.join(this.options.rootDir, 'index')
+    );
 
     await this.loadIfNeeded();
 

--- a/packages/core/parcel-bundler/src/assets/StylusAsset.js
+++ b/packages/core/parcel-bundler/src/assets/StylusAsset.js
@@ -16,7 +16,10 @@ class StylusAsset extends Asset {
 
   async parse(code) {
     // stylus should be installed locally in the module that's being required
-    let stylus = await localRequire('stylus', this.name);
+    let stylus = await localRequire(
+      'stylus',
+      path.join(this.options.rootDir, 'index')
+    );
     let opts = await this.getConfig(['.stylusrc', '.stylusrc.js'], {
       packageKey: 'stylus'
     });
@@ -171,7 +174,7 @@ async function createEvaluator(code, asset, options) {
   const deps = await getDependencies(code, asset.name, asset, options);
   const Evaluator = await localRequire(
     'stylus/lib/visitor/evaluator',
-    asset.name
+    path.join(asset.options.rootDir, 'index')
   );
 
   // This is a custom stylus evaluator that extends stylus with support for the node

--- a/packages/core/parcel-bundler/src/assets/TypeScriptAsset.js
+++ b/packages/core/parcel-bundler/src/assets/TypeScriptAsset.js
@@ -9,7 +9,10 @@ class TypeScriptAsset extends Asset {
 
   async generate() {
     // require typescript, installed locally in the app
-    let typescript = await localRequire('typescript', this.name);
+    let typescript = await localRequire(
+      'typescript',
+      path.join(this.options.rootDir, 'index')
+    );
     let transpilerOptions = {
       compilerOptions: {
         module: this.options.scopeHoist

--- a/packages/core/parcel-bundler/src/assets/VueAsset.js
+++ b/packages/core/parcel-bundler/src/assets/VueAsset.js
@@ -13,9 +13,12 @@ class VueAsset extends Asset {
     // Is being used in component-compiler-utils, errors if not installed...
     this.vueTemplateCompiler = await localRequire(
       'vue-template-compiler',
-      this.name
+      path.join(this.options.rootDir, 'index')
     );
-    this.vue = await localRequire('@vue/component-compiler-utils', this.name);
+    this.vue = await localRequire(
+      '@vue/component-compiler-utils',
+      path.join(this.options.rootDir, 'index')
+    );
 
     return this.vue.parse({
       source: code,

--- a/packages/core/parcel-bundler/src/transforms/babel/babel6.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babel6.js
@@ -2,7 +2,10 @@ const localRequire = require('../../utils/localRequire');
 const {babel6toBabel7} = require('./astConverter');
 
 async function babel6(asset, options) {
-  let babel = await localRequire('babel-core', asset.name);
+  let babel = await localRequire(
+    'babel-core',
+    path.join(asset.options.rootDir, 'index')
+  );
 
   let config = options.config;
   config.code = false;

--- a/packages/core/parcel-bundler/src/transforms/babel/babel7.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babel7.js
@@ -7,7 +7,10 @@ async function babel7(asset, options) {
   // otherwise require a local version from the package we're compiling.
   let babel = options.internal
     ? require('@babel/core')
-    : await localRequire('@babel/core', asset.name);
+    : await localRequire(
+        '@babel/core',
+        path.join(asset.options.rootDir, 'index')
+      );
 
   let pkg = await asset.getPackage();
 

--- a/packages/core/parcel-bundler/src/transforms/postcss.js
+++ b/packages/core/parcel-bundler/src/transforms/postcss.js
@@ -49,14 +49,19 @@ async function getConfig(asset) {
   config.plugins = await loadPlugins(config.plugins, asset.name);
 
   if (config.modules || enableModules) {
-    let postcssModules = await localRequire('postcss-modules', asset.name);
+    let postcssModules = await localRequire(
+      'postcss-modules',
+      path.join(asset.options.rootDir, 'index')
+    );
     config.plugins.push(postcssModules(postcssModulesConfig));
   }
 
   if (asset.options.minify) {
     let [cssnano, {version}] = await Promise.all(
       ['cssnano', 'cssnano/package.json'].map(name =>
-        localRequire(name, asset.name).catch(() => require(name))
+        localRequire(name, path.join(asset.options.rootDir, 'index')).catch(
+          () => require(name)
+        )
       )
     );
     config.plugins.push(


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR ensures Parcel installls all compiler libraries for asset types in the same project (the root project).

This is for file structures where a project has multiple package.json's or a file outside of the project dir is required. (which would both resolve in re-installing the package)

This is a work in progress, still need to test this a little bit and make sure the current tests pass again

Fixes #2318

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
