### PR TITLE
Defer throwing asset errors until after dependencies are handled.

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -593,6 +593,13 @@ class Bundler extends EventEmitter {
       })
     );
 
+    // If there was a processing error, re-throw now that we've set up
+    // depdenency watchers. This keeps reloading working if there is an
+    // error in a dependency not directly handled by Parcel.
+    if (processed.error !== null) {
+      throw processed.error;
+    }
+
     // Store resolved assets in their original order
     dependencies.forEach((dep, i) => {
       asset.dependencies.set(dep.name, dep);

--- a/packages/core/parcel-bundler/src/Pipeline.js
+++ b/packages/core/parcel-bundler/src/Pipeline.js
@@ -17,16 +17,23 @@ class Pipeline {
     }
 
     let asset = this.parser.getAsset(path, options);
-    let generated = await this.processAsset(asset);
+    let error = null;
     let generatedMap = {};
-    for (let rendition of generated) {
-      generatedMap[rendition.type] = rendition.value;
+    try {
+      let generated = await this.processAsset(asset);
+      for (let rendition of generated) {
+        generatedMap[rendition.type] = rendition.value;
+      }
+    } catch (err) {
+      error = err;
+      error.fileName = path;
     }
 
     return {
       id: asset.id,
       dependencies: Array.from(asset.dependencies.values()),
       generated: generatedMap,
+      error: error,
       hash: asset.hash,
       cacheData: asset.cacheData
     };

--- a/packages/core/parcel-bundler/src/assets/ElmAsset.js
+++ b/packages/core/parcel-bundler/src/assets/ElmAsset.js
@@ -44,12 +44,7 @@ class ElmAsset extends Asset {
       options.optimize = true;
     }
 
-    let compiled = await this.elm.compileToString(this.name, options);
-    this.contents = compiled.toString();
-    if (this.options.hmr) {
-      let {inject} = await localRequire('elm-hot', this.name);
-      this.contents = inject(this.contents);
-    }
+    this.elmOpts = options;
   }
 
   async collectDependencies() {
@@ -76,6 +71,13 @@ class ElmAsset extends Asset {
   }
 
   async generate() {
+    let compiled = await this.elm.compileToString(this.name, this.elmOpts);
+    this.contents = compiled.toString();
+    if (this.options.hmr) {
+      let {inject} = await localRequire('elm-hot', this.name);
+      this.contents = inject(this.contents);
+    }
+
     let output = this.contents;
 
     if (this.options.minify) {
@@ -128,6 +130,10 @@ class ElmAsset extends Asset {
 
       return result.code;
     }
+  }
+
+  generateErrorMessage(err) {
+    return err.message;
   }
 }
 

--- a/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
+++ b/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
@@ -8,10 +8,10 @@ function Module(moduleName) {
     data: module.bundle.hotData,
     _acceptCallbacks: [],
     _disposeCallbacks: [],
-    accept: function (fn) {
-      this._acceptCallbacks.push(fn || function () {});
+    accept: function(fn) {
+      this._acceptCallbacks.push(fn || function() {});
     },
-    dispose: function (fn) {
+    dispose: function(fn) {
       this._disposeCallbacks.push(fn);
     }
   };
@@ -25,18 +25,20 @@ var parent = module.bundle.parent;
 if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
   var hostname = process.env.HMR_HOSTNAME || location.hostname;
   var protocol = location.protocol === 'https:' ? 'wss' : 'ws';
-  var ws = new WebSocket(protocol + '://' + hostname + ':' + process.env.HMR_PORT + '/');
+  var ws = new WebSocket(
+    protocol + '://' + hostname + ':' + process.env.HMR_PORT + '/'
+  );
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);
 
     if (data.type === 'update') {
       console.clear();
 
-      data.assets.forEach(function (asset) {
+      data.assets.forEach(function(asset) {
         hmrApply(global.parcelRequire, asset);
       });
 
-      data.assets.forEach(function (asset) {
+      data.assets.forEach(function(asset) {
         if (!asset.isNew) {
           hmrAccept(global.parcelRequire, asset.id);
         }
@@ -45,9 +47,9 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
 
     if (data.type === 'reload') {
       ws.close();
-      ws.onclose = function () {
+      ws.onclose = function() {
         location.reload();
-      }
+      };
     }
 
     if (data.type === 'error-resolved') {
@@ -57,7 +59,9 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
     }
 
     if (data.type === 'error') {
-      console.error('[parcel] 🚨  ' + data.error.message + '\n' + data.error.stack);
+      console.error(
+        '[parcel] 🚨  ' + data.error.message + '\n' + (data.error.stack || '')
+      );
 
       removeErrorOverlay();
 
@@ -82,19 +86,21 @@ function createErrorOverlay(data) {
   var message = document.createElement('div');
   var stackTrace = document.createElement('pre');
   message.innerText = data.error.message;
-  stackTrace.innerText = data.error.stack;
+  stackTrace.innerText = data.error.stack || '';
 
-  overlay.innerHTML = (
+  overlay.innerHTML =
     '<div style="background: black; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; opacity: 0.85; font-family: Menlo, Consolas, monospace; z-index: 9999;">' +
-      '<span style="background: red; padding: 2px 4px; border-radius: 2px;">ERROR</span>' +
-      '<span style="top: 2px; margin-left: 5px; position: relative;">🚨</span>' +
-      '<div style="font-size: 18px; font-weight: bold; margin-top: 20px;">' + message.innerHTML + '</div>' +
-      '<pre>' + stackTrace.innerHTML + '</pre>' +
-    '</div>'
-  );
+    '<span style="background: red; padding: 2px 4px; border-radius: 2px;">ERROR</span>' +
+    '<span style="top: 2px; margin-left: 5px; position: relative;">🚨</span>' +
+    '<div style="font-size: 18px; font-weight: bold; margin-top: 20px;">' +
+    message.innerHTML +
+    '</div>' +
+    '<pre>' +
+    stackTrace.innerHTML +
+    '</pre>' +
+    '</div>';
 
   return overlay;
-
 }
 
 function getParents(bundle, id) {
@@ -154,7 +160,7 @@ function hmrAccept(bundle, id) {
   }
 
   if (cached && cached.hot && cached.hot._disposeCallbacks.length) {
-    cached.hot._disposeCallbacks.forEach(function (cb) {
+    cached.hot._disposeCallbacks.forEach(function(cb) {
       cb(bundle.hotData);
     });
   }
@@ -164,13 +170,13 @@ function hmrAccept(bundle, id) {
 
   cached = bundle.cache[id];
   if (cached && cached.hot && cached.hot._acceptCallbacks.length) {
-    cached.hot._acceptCallbacks.forEach(function (cb) {
+    cached.hot._acceptCallbacks.forEach(function(cb) {
       cb();
     });
     return true;
   }
 
-  return getParents(global.parcelRequire, id).some(function (id) {
-    return hmrAccept(global.parcelRequire, id)
+  return getParents(global.parcelRequire, id).some(function(id) {
+    return hmrAccept(global.parcelRequire, id);
   });
 }


### PR DESCRIPTION
# ↪️ Pull Request


This allows compiled langauges like Elm that handle their own dependency
compilation to set up watchers for dependencies so that hot-reload
continues to work due to errors in new depdenencies. Fixes #2147.

There are also a few tweaks to `ElmAsset` to make sure compilation errors
are thrown after dependency collection

## 💻 Examples

Main.elm:
```elm
module Main exposing (main)

import Html exposing (text)


main =
    text "Hello World"
```

Broken.elm:
```elm
module Broken exposing (anError)

{- This module causes a compiler error -}


anError : String
anError =
    2
```

## 🚨 Test instructions

Using the files above, start the parcel server, and navigate to localhost:1234.

Add a line in `Main.elm` to import `Broken.elm`:
```
import Broken
```

Notice that the build fails

Update `Broken.elm` by changing the value `2` to `"foo"`.

In current parcel: no rebuild is triggered
In this branch: the error is resolved


## ✔️ PR Todo

If anybody knows of a good unit test strategy for this, I'm open to suggestions. 

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
