### PR TITLE
Don't lowercase attributes in html files

### DIFF
--- a/packages/core/parcel-bundler/src/transforms/posthtml.js
+++ b/packages/core/parcel-bundler/src/transforms/posthtml.js
@@ -7,7 +7,6 @@ async function parse(code, asset) {
   if (!config) {
     config = {};
   }
-  config = Object.assign({lowerCaseAttributeNames: true}, config);
   return posthtmlParse(code, config);
 }
 

--- a/packages/core/parcel-bundler/test/html.js
+++ b/packages/core/parcel-bundler/test/html.js
@@ -320,7 +320,7 @@ describe('html', function() {
     // minifySvg is false
     assert(
       html.includes(
-        '<svg version="1.1" baseprofile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="red"></rect><circle cx="150" cy="100" r="80" fill="green"></circle><text x="150" y="125" font-size="60" text-anchor="middle" fill="white">SVG</text></svg>'
+        '<svg version="1.1" baseProfile="full" width="300" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="red"></rect><circle cx="150" cy="100" r="80" fill="green"></circle><text x="150" y="125" font-size="60" text-anchor="middle" fill="white">SVG</text></svg>'
       )
     );
   });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Lowercasing html attributes breaks inline svg.

This PR changes the default to the posthtml default which is to not lowercase attributes.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
