### PR TITLE
Attempt to fix #2340

### DIFF
--- a/packages/core/parcel-bundler/src/Bundle.js
+++ b/packages/core/parcel-bundler/src/Bundle.js
@@ -89,6 +89,15 @@ class Bundle {
     return bundle;
   }
 
+  addChildBundle(bundle) {
+    this.childBundles.add(bundle);
+  }
+
+  addSiblingBundle(bundle) {
+    this.addChildBundle(bundle);
+    this.siblingBundles.add(bundle);
+  }
+
   get isEmpty() {
     return this.assets.size === 0;
   }

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -654,6 +654,7 @@ class Bundler extends EventEmitter {
     if ((dep && dep.dynamic) || !bundle.type) {
       // If the asset is already the entry asset of a bundle, don't create a duplicate.
       if (isEntryAsset) {
+        bundle.addChildBundle(asset.parentBundle);
         return;
       }
 
@@ -665,6 +666,7 @@ class Bundler extends EventEmitter {
     ) {
       // If the asset is already the entry asset of a bundle, don't create a duplicate.
       if (isEntryAsset) {
+        bundle.addSiblingBundle(asset.parentBundle);
         return;
       }
 

--- a/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index.css
+++ b/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index.html
+++ b/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport" />
+    <title></title>
+</head>
+<body>
+    <script src="./index.js"></script>
+    <h1>Index.html</h1>
+</body>
+</html>

--- a/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index.js
+++ b/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index2.html
+++ b/packages/core/parcel-bundler/test/integration/multiple-html-entry-points-sharing-asset/index2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport" />
+    <title></title>
+</head>
+<body>
+    <script src="./index.js"></script>
+    <h1>Index2.html</h1>
+</body>
+</html>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Today, before the bundler creates a child/sibling bundle for a certain asset, it's checked that the asset isn't already an entry point for an existing bundle. However, if it is, the bundle isn't added as an actual child/sibling bundle. That leads to the issue described in #2340.

I think it should be okay to just add the already created bundles as child/sibling to the new bundle, but I'm not so well versed in this codebase, so I cannot way that for sure. I'm also quite unsure how to add a good test case for it (how can I make assertions on the output?).

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
