### PR TITLE
Attempt to fix importing URLs, #2358

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -20,6 +20,7 @@ const bundleReport = require('./utils/bundleReport');
 const prettifyTime = require('./utils/prettifyTime');
 const getRootDir = require('./utils/getRootDir');
 const {glob} = require('./utils/glob');
+const isURL = require('./utils/is-url');
 
 /**
  * The Bundler is the main entry point. It resolves and loads assets,
@@ -496,6 +497,8 @@ class Bundler extends EventEmitter {
   }
 
   async installDep(asset, dep) {
+    // Check if module is a URL, skip trying to resolve
+    if (isURL(dep.name)) return;
     // Check if module exists, prevents useless installs
     let resolved = await this.resolver.resolveModule(dep.name, asset.name);
 


### PR DESCRIPTION
# ↪️ Pull Request

Followed @DeMoorJasper's advice in [2358](https://github.com/parcel-bundler/parcel/issues/2358#issuecomment-444819406). That fixes the error I was seeing at the CLI, but when I navigate to the local server, I see this error in the Chrome console:

> test.e31bb0bc.js:39 Uncaught (in promise) Error: Cannot find module 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js'
    at newRequire (test.e31bb0bc.js:39)
    at newRequire (test.e31bb0bc.js:23)
    at localRequire (test.e31bb0bc.js:55)
    at bundle-loader.js:17

## 🚨 Test instructions

See #2358. Running the CLI succeeded, the browser failed.

![image](https://user-images.githubusercontent.com/33569/49680374-8e7dd280-fa48-11e8-859a-7a6187e7271f.png)


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs