### PR TITLE
Only disable shouldWatchDirs on MacOS

### DIFF
--- a/src/Watcher.js
+++ b/src/Watcher.js
@@ -12,7 +12,8 @@ class Watcher {
     // FS events on macOS are flakey in the tests, which write lots of files very quickly
     // See https://github.com/paulmillr/chokidar/issues/612
     this.shouldWatchDirs =
-      process.platform === 'darwin' && process.env.NODE_ENV !== 'test';
+      process.platform === 'darwin' ? process.env.NODE_ENV !== 'test' : true;
+
     this.watcher = new FSWatcher({
       useFsEvents: this.shouldWatchDirs,
       ignoreInitial: true,


### PR DESCRIPTION
# ↪️ Pull Request

Fix watching files on Linux. Currently only the first change gets noticed.

This is a fix for 57f4c4592dcfc008bbdc107386f3448c2e75e820 which was a workaround for OS X that affected all platforms.

## 💻 Examples

On my Ubuntu machine parcel only noticed the first time a file was updated:

```
$ yarn run parcel serve index.html --log-level 4             
yarn run v1.12.3
warning package.json: No license field
$ /home/tomek/tests/parcel-hangs/node_modules/.bin/parcel serve index.html --log-level 4
[17:50:03]: Server running at http://localhost:1234 
[17:50:03]: Building...
[17:50:03]: Building index.html...
[17:50:04]: Building index.js...
[17:50:04]: Built index.js...
[17:50:04]: Built index.html...
[17:50:04]: Producing bundles...
[17:50:04]: Packaging...
[17:50:04]: Building hmr-runtime.js...
[17:50:04]: Built ../../parcel/src/builtins/hmr-runtime.js...
[17:50:04]: ✨  Built in 779ms.
## Here I change index.js, and Parcel notices ##
[17:50:08]: Building index.js...
[17:50:08]: Building...
[17:50:08]: Building index.js...
[17:50:08]: Built index.js...
[17:50:08]: Producing bundles...
[17:50:08]: Packaging...
[17:50:08]: ✨  Built in 31ms.
## That's the end of the log - any further changes to index.js were not noticed. ##
```

After the change in this PR it works:
```
$ yarn run parcel serve index.html --log-level 4             
yarn run v1.12.3
warning package.json: No license field
$ /home/tomek/tests/parcel-hangs/node_modules/.bin/parcel serve index.html --log-level 4
[17:57:30]: Server running at http://localhost:1234 
[17:57:30]: Building...
[17:57:30]: Building index.html...
[17:57:30]: Building index.js...
[17:57:30]: Built index.js...
[17:57:30]: Built index.html...
[17:57:30]: Producing bundles...
[17:57:30]: Packaging...
[17:57:30]: Building hmr-runtime.js...
[17:57:31]: Built ../../parcel/src/builtins/hmr-runtime.js...
[17:57:31]: ✨  Built in 787ms.
## Here I change index.js, and Parcel notices ##
[17:57:36]: Building index.js...
[17:57:36]: Building...
[17:57:36]: Building index.js...
[17:57:36]: Built index.js...
[17:57:36]: Producing bundles...
[17:57:36]: Packaging...
[17:57:36]: ✨  Built in 29ms.
## Here I change index.js again, and Parcel notices ##
[17:57:38]: Building index.js...
[17:57:38]: Building...
[17:57:38]: Building index.js...
[17:57:38]: Built index.js...
[17:57:38]: Producing bundles...
[17:57:38]: Packaging...
[17:57:38]: ✨  Built in 11ms.
[17:57:40]: Building index.js...
[17:57:41]: Building...
[17:57:41]: Building index.js...
[17:57:41]: Built index.js...
[17:57:41]: Producing bundles...
[17:57:41]: Packaging...
[17:57:41]: ✨  Built in 16ms.
```

## 🚨 Test instructions

* Run parcel in watch or serve mode on Linux
* Change a watched file, notice that Parcel has rebuilt the bundle
* Change the same file again, notice that Parcel hasn't reacted in any way (no rebuild, no new logs)

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
