### PR TITLE
Skip external import's from processing

### DIFF
--- a/packages/core/parcel-bundler/src/visitors/dependencies.js
+++ b/packages/core/parcel-bundler/src/visitors/dependencies.js
@@ -54,6 +54,8 @@ module.exports = {
       types.isStringLiteral(args[0]);
 
     if (isDynamicImport) {
+      if (isURL(args[0].value)) return;
+
       asset.addDependency('_bundle_loader');
       addDependency(asset, args[0], {dynamic: true});
 

--- a/packages/core/parcel-bundler/test/integration/dynamic-external/index.js
+++ b/packages/core/parcel-bundler/test/integration/dynamic-external/index.js
@@ -1,0 +1,5 @@
+const lodash = import('https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js');
+
+export default function () {
+  return lodash.then(() => _);
+};

--- a/packages/core/parcel-bundler/test/javascript.js
+++ b/packages/core/parcel-bundler/test/javascript.js
@@ -342,6 +342,25 @@ describe('javascript', function() {
     assert.equal(await output(), 3);
   });
 
+  it('Should not run parcel over external modules', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/dynamic-external/index.js'),
+      {
+        target: 'browser'
+      }
+    );
+
+    await assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js'],
+      childBundles: [
+        {
+          type: 'map'
+        }
+      ]
+    });
+  });
+
   it('should support bundling workers', async function() {
     let b = await bundle(path.join(__dirname, '/integration/workers/index.js'));
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Closes #2374 Fixes #2358

Future work: Rewrite url imports to use parcel's bundle loader for IE support.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

```Javascript
const lodash = import('https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.11/lodash.min.js');

lodash.then(() => console.log(_.VERSION));
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Run the example or experiment a lil with this branch.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
