### PR TITLE
Don't cache dynamic bundles that had a network error

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/bundle-loader.js
+++ b/packages/core/parcel-bundler/src/builtins/bundle-loader.js
@@ -59,6 +59,10 @@ function loadBundle(bundle) {
         }
 
         return resolved;
+      }).catch(function(e) {
+        delete bundles[bundle];
+        
+        throw e;
       });
   }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

If a network error occurs while loading a dynamic bundle, remove the cached promise as this will always result in the same network error. This will allow users to retry fetching this bundle.

Fixes #2326 

Based on the fix by @diem98

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
