### PR TITLE
Parcel 2: BundleGraph and Default Bundler plugin

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -1,18 +1,213 @@
 // @flow
+import type {Asset, Bundle} from '@parcel/types';
 import {Bundler} from '@parcel/plugin';
+
+const ISOLATED_ENVS = new Set(['web-worker', 'service-worker']);
+const OPTIONS = {
+  minBundleSize: 30000,
+  maxParallelRequests: 5
+};
 
 export default new Bundler({
   async bundle(graph) {
-    let assets = Array.from(graph.nodes.values())
-      .filter(node => node.type === 'asset')
-      .map(node => node.value);
+    // RULES
+    // 1. If dep.isAsync or dep.isEntry, start a new bundle.
+    // 2. If an asset has been seen before in a different bundle:
+    //    a. If the asset is already in a parent bundle in the same entry point, exclude from the current bundle.
+    //    b. If the asset is only in separate isolated entry points (e.g. workers, different HTML pages), duplicate it.
+    //    c. If the sub-graph from this asset is >= 30kb, and the number of parallel requests at the current entry point is < 5, create a new bundle containing the sub-graph.
+    //    d. Else, hoist the asset to the nearest common ancestor.
 
-    return [
-      {
-        type: 'js',
-        filePath: 'bundle.js',
-        assets
+    // graph.walkAssets((asset, currentBundle) => {
+    //   let deps = graph.getIncomingDeps(asset);
+    //   let isIsolated = ISOLATED_ENVS.has(asset.env);
+
+    //   // if (bundleAssetMap.has(asset)) {
+    //   //   let commonBundle = findCommonBundle()
+    //   // }
+
+    //   let isAsync = deps.some(dep => dep.isAsync || dep.isEntry);
+    //   let isSync = deps.some(dep => !dep.isSync && !dep.isEntry);
+    //   if (isAsync || currentBundle.type !== asset.type) {
+    //     // create new bundle
+    //     let subGraph = graph.getSubGraph(asset);
+    //   }
+
+    //   if (isSync) {
+
+    //   }
+    // });
+    let bundles = [];
+    // function createBundle(type) {
+    //   let bundle = {
+    //     type: type,
+    //     filePath: 'bundle.' + bundles.length + '.js',
+    //     assets: []
+    //   };
+
+    //   bundles.push(bundle);
+    //   return bundle;
+    // }
+
+    let bundleAssetMap = new Map();
+    let bundleTree = null;
+
+    graph.dfs((node, currentBundle) => {
+      // if (node.type === 'asset') {
+      //   // console.log(node.value.filePath, context && context.filePath)
+      //   // return node.value;
+      //   let asset: Asset = node.value;
+
+      //   let deps = graph.getIncomingDependencies(asset);
+      //   // console.log(asset.filePath, deps);
+
+      //   let isAsync = deps.some(dep => dep.isAsync || dep.isEntry);
+      //   if (isAsync) {
+      //     // currentBundle = createBundle(asset.type);
+      //     let bundle = graph.getSubGraph(node);
+      //     currentBundle && currentBundle.removeNode(node);
+      //     currentBundle = bundle;
+      //     bundles.push(currentBundle);
+
+      //     for (let node of currentBundle.nodes.values()) {
+      //       if (node.type === 'asset') {
+      //         if (!bundleAssetMap.has(node.value)) {
+      //           bundleAssetMap.set(node.value, new Set);
+      //         }
+
+      //         bundleAssetMap.get(node.value).add(currentBundle);
+      //       }
+      //     }
+      //   }
+
+      //   // currentBundle.assets.push(asset);
+      //   return currentBundle;
+      // }
+
+      if (node.type === 'dependency') {
+        let dep = node.value;
+        if (dep.isAsync || dep.isEntry) {
+          let bundle = graph.getSubGraph(node);
+          if (currentBundle) {
+            // currentBundle.removeEdges(node);
+
+            for (let req of graph.getNodesConnectedFrom(node)) {
+              let bundleNode = {
+                id: 'bundle:' + req.id,
+                type: 'bundle',
+                value: bundle
+              };
+
+              let b = currentBundle;
+              while (b) {
+                // b.addNode(bundleNode);
+                // for (let node of b.getNodesConnectedTo(req)) {
+                //   b.addEdge({from: node.id, to: bundleNode.id});
+                // }
+
+                // b.removeNode(req);
+                b.bundle.replaceNodesConnectedTo(node, [bundleNode]);
+                b = b.parent;
+                // b.replaceNode()
+              }
+            }
+          }
+
+          let newBundleNode = {
+            bundle,
+            parent: currentBundle,
+            children: []
+          };
+
+          if (!bundleTree) {
+            bundleTree = newBundleNode;
+          } else {
+            currentBundle.children.push(newBundleNode);
+          }
+
+          currentBundle = bundleTree;
+          bundles.push(bundle);
+        }
       }
-    ];
+
+      return currentBundle;
+    });
+
+    let queue = [bundleTree];
+    while (queue.length > 0) {
+      let currentBundle = queue.shift();
+
+      if (currentBundle.parent) {
+        let dep = currentBundle.bundle.getRootNode().value;
+        let isIsolated = dep.isEntry || ISOLATED_ENVS.has(dep.env.context);
+        if (!isIsolated) {
+          for (let node of currentBundle.bundle.nodes.values()) {
+            // if (node.type === 'transformer_request') { console.log(currentBundle, node)}
+            if (
+              node.type === 'transformer_request' &&
+              hasNode(currentBundle.parent, node)
+            ) {
+              console.log('dup', node);
+              currentBundle.removeNode(node);
+            }
+          }
+        }
+      }
+
+      queue.push(...currentBundle.children);
+    }
+
+    function hasNode(treeNode, node) {
+      while (treeNode) {
+        if (treeNode.bundle.hasNode(node)) {
+          return true;
+        }
+
+        treeNode = treeNode.parent;
+      }
+
+      return false;
+    }
+
+    // console.log(bundleTree)
+
+    // for (let bundle of bundles) {
+    //   for (let node of bundle.nodes.values()) {
+    //     if (node.type === 'asset') {
+    //       if (!bundleAssetMap.has(node)) {
+    //         bundleAssetMap.set(node, new Set);
+    //       }
+
+    //       bundleAssetMap.get(node).add(bundle);
+    //     }
+    //   }
+    // }
+
+    // for (let [asset, bundles] of bundleAssetMap) {
+    //   if (bundles.size > 1) {
+    //     console.log(asset.value.filePath)
+    //   }
+    // }
+
+    for (let bundle of bundles) {
+      // console.log(bundle.nodes)
+      bundle.dumpGraphViz();
+    }
+
+    // console.log(bundles);
+    throw 'stop';
+    return bundles;
+
+    // let assets = Array.from(graph.nodes.values())
+    //   .filter(node => node.type === 'asset')
+    //   .map(node => node.value);
+
+    // return [
+    //   {
+    //     type: 'js',
+    //     filePath: 'bundle.js',
+    //     assets
+    //   }
+    // ];
   }
 });

--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -1,7 +1,7 @@
 // @flow
 import type {Asset, Bundle} from '@parcel/types';
 import {Bundler} from '@parcel/plugin';
-import Graph from '@parcel/core/src/AssetGraph';
+import BundleGraph from '@parcel/core/src/BundleGraph';
 
 const ISOLATED_ENVS = new Set(['web-worker', 'service-worker']);
 const OPTIONS = {
@@ -9,103 +9,6 @@ const OPTIONS = {
   minBundleSize: 10000,
   maxParallelRequests: 5
 };
-
-class BundleGraph extends Graph {
-  constructor() {
-    super();
-    this.setRootNode({
-      type: 'root',
-      id: 'root',
-      value: null
-    });
-  }
-
-  addBundleGroup(parentBundleNode, dep) {
-    let bundleGroup = {
-      id: 'bundle_group:' + dep.id,
-      type: 'bundle_group',
-      value: null
-    };
-
-    // Add a connection from the dependency to the new bundle group in all bundles
-    this.traverse(bundle => {
-      if (bundle.type === 'bundle') {
-        let depNode = bundle.value.assetGraph.getNode(dep.id);
-        if (depNode) {
-          bundle.value.assetGraph.replaceNodesConnectedTo(depNode, [
-            bundleGroup
-          ]);
-        }
-      }
-    });
-
-    this.addNode(bundleGroup);
-    this.addEdge({
-      from: !parentBundleNode ? 'root' : parentBundleNode.id,
-      to: bundleGroup.id
-    });
-
-    return bundleGroup;
-  }
-
-  addBundle(bundleGroup, bundle, id) {
-    let bundleNode = {
-      id: id,
-      type: 'bundle',
-      value: bundle
-    };
-
-    this.addNode(bundleNode);
-    this.addEdge({
-      from: bundleGroup.id,
-      to: bundleNode.id
-    });
-
-    // Add a connection from the bundle group to the bundle in all bundles
-    this.traverse(node => {
-      if (
-        node.type === 'bundle' &&
-        node.value.assetGraph.hasNode(bundleGroup.id)
-      ) {
-        node.value.assetGraph.addNode(bundleNode);
-        node.value.assetGraph.addEdge({
-          from: bundleGroup.id,
-          to: bundleNode.id
-        });
-      }
-    });
-
-    return bundleNode;
-  }
-
-  isAssetInAncestorBundle(bundle, asset) {
-    let ret = null;
-    this.traverseAncestors(bundle, (node, context, traversal) => {
-      // Skip starting node
-      if (node === bundle) {
-        return;
-      }
-
-      // If this is the first bundle we've seen, initialize result to true
-      if (node.type === 'bundle' && ret === null) {
-        ret = true;
-      }
-
-      if (node.type === 'bundle' && !node.value.assetGraph.hasNode(asset.id)) {
-        ret = false;
-        traversal.stop();
-      }
-    });
-
-    return !!ret;
-  }
-
-  findBundlesWithAsset(asset) {
-    return Array.from(this.nodes.values()).filter(
-      node => node.type === 'bundle' && node.value.assetGraph.hasNode(asset.id)
-    );
-  }
-}
 
 export default new Bundler({
   async bundle(graph) {

--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -64,7 +64,6 @@ export default new Bundler({
       let assetGraph = bundle.assetGraph;
       assetGraph.traverseAssets(asset => {
         if (bundleGraph.isAssetInAncestorBundle(bundle, asset)) {
-          console.log('dup', asset);
           assetGraph.removeAsset(asset);
         }
       });
@@ -79,8 +78,6 @@ export default new Bundler({
       // If this asset is duplicated in the minimum number of bundles, it is a candidate to be separated into its own bundle.
       let bundles = bundleGraph.findBundlesWithAsset(asset);
       if (bundles.length > OPTIONS.minBundles) {
-        console.log('dup', asset.filePath);
-
         let bundle = assetGraph.createBundle(asset);
         let size = bundle.assetGraph.getTotalSize();
 

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -41,6 +41,7 @@ export default class Asset implements IAsset {
   dependencies: Array<Dependency>;
   connectedFiles: Array<File>;
   output: AssetOutput;
+  outputSize: number;
   env: Environment;
   meta: JSONObject;
 
@@ -60,6 +61,7 @@ export default class Asset implements IAsset {
       ? options.connectedFiles.slice()
       : [];
     this.output = options.output || {code: this.code};
+    this.outputSize = this.output.code.length;
     this.env = options.env;
     this.meta = options.meta || {};
   }
@@ -74,6 +76,7 @@ export default class Asset implements IAsset {
       dependencies: this.dependencies,
       connectedFiles: this.connectedFiles,
       output: this.output,
+      outputSize: this.outputSize,
       env: this.env,
       meta: this.meta
     };

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -286,7 +286,7 @@ export default class AssetGraph extends Graph {
     return size;
   }
 
-  getEntryAssets() {
+  getEntryAssets(): Array<Asset> {
     return this.getNodesConnectedFrom(this.getRootNode()).map(
       node => node.value
     );

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -340,7 +340,7 @@ export default class AssetGraph extends Graph {
         if (node.value.isOptional) parts.push('optional');
         if (parts.length) label += ' (' + parts.join(', ') + ')';
         if (node.value.env) label += ` (${getEnvDescription(node.value.env)})`;
-      } else if (node.type === 'asset') {
+      } else if (node.type === 'asset' || node.type === 'asset_reference') {
         label += path.basename(node.value.filePath) + '#' + node.value.type;
       } else if (node.type === 'file') {
         label += path.basename(node.value.filePath);
@@ -349,7 +349,20 @@ export default class AssetGraph extends Graph {
           path.basename(node.value.filePath) +
           ` (${getEnvDescription(node.value.env)})`;
       } else if (node.type === 'bundle') {
-        label += node.id;
+        let rootAssets = node.value.assetGraph.getNodesConnectedFrom(
+          node.value.assetGraph.getRootNode()
+        );
+        label += rootAssets
+          .map(asset => {
+            let parts = asset.value.filePath.split(path.sep);
+            let index = parts.lastIndexOf('node_modules');
+            if (index >= 0) {
+              return parts[index + 1];
+            }
+
+            return path.basename(asset.value.filePath);
+          })
+          .join(', ');
       } else {
         // label += node.id;
         label = node.type;

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -11,7 +11,7 @@ import type {
   Target,
   Environment,
   Bundle,
-  TraversalContext
+  GraphTraversalCallback
 } from '@parcel/types';
 import path from 'path';
 import md5 from '@parcel/utils/md5';
@@ -244,10 +244,7 @@ export default class AssetGraph extends Graph {
     }
   }
 
-  traverseAssets(
-    visit: (node: Asset, context?: any, traversal: TraversalContext) => any,
-    startNode: ?Node
-  ) {
+  traverseAssets(visit: GraphTraversalCallback<Asset>, startNode: ?Node) {
     return this.traverse((node, ...args) => {
       if (node.type === 'asset') {
         return visit(node.value, ...args);
@@ -270,6 +267,7 @@ export default class AssetGraph extends Graph {
 
     graph.addEdge({from: 'root', to: assetNode.id});
     return {
+      id: 'bundle:' + asset.id,
       type: asset.type,
       assetGraph: graph,
       filePath: 'bundle.' + BUNDLECOUNT++ + '.js'

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -285,6 +285,8 @@ export default class AssetGraph extends Graph {
         label +=
           path.basename(node.value.filePath) +
           ` (${getEnvDescription(node.value.env)})`;
+      } else if (node.type === 'bundle') {
+        label += node.id;
       } else {
         // label += node.id;
         label = node.type;

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1,3 +1,4 @@
+// @flow
 import AssetGraph from './AssetGraph';
 
 export default class BundleGraph extends AssetGraph {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1,0 +1,98 @@
+import AssetGraph from './AssetGraph';
+
+export default class BundleGraph extends AssetGraph {
+  constructor() {
+    super();
+    this.setRootNode({
+      type: 'root',
+      id: 'root',
+      value: null
+    });
+  }
+
+  addBundleGroup(parentBundleNode, dep) {
+    let bundleGroup = {
+      id: 'bundle_group:' + dep.id,
+      type: 'bundle_group',
+      value: null
+    };
+
+    // Add a connection from the dependency to the new bundle group in all bundles
+    this.traverse(bundle => {
+      if (bundle.type === 'bundle') {
+        let depNode = bundle.value.assetGraph.getNode(dep.id);
+        if (depNode) {
+          bundle.value.assetGraph.replaceNodesConnectedTo(depNode, [
+            bundleGroup
+          ]);
+        }
+      }
+    });
+
+    this.addNode(bundleGroup);
+    this.addEdge({
+      from: !parentBundleNode ? 'root' : parentBundleNode.id,
+      to: bundleGroup.id
+    });
+
+    return bundleGroup;
+  }
+
+  addBundle(bundleGroup, bundle, id) {
+    let bundleNode = {
+      id: id,
+      type: 'bundle',
+      value: bundle
+    };
+
+    this.addNode(bundleNode);
+    this.addEdge({
+      from: bundleGroup.id,
+      to: bundleNode.id
+    });
+
+    // Add a connection from the bundle group to the bundle in all bundles
+    this.traverse(node => {
+      if (
+        node.type === 'bundle' &&
+        node.value.assetGraph.hasNode(bundleGroup.id)
+      ) {
+        node.value.assetGraph.addNode(bundleNode);
+        node.value.assetGraph.addEdge({
+          from: bundleGroup.id,
+          to: bundleNode.id
+        });
+      }
+    });
+
+    return bundleNode;
+  }
+
+  isAssetInAncestorBundle(bundle, asset) {
+    let ret = null;
+    this.traverseAncestors(bundle, (node, context, traversal) => {
+      // Skip starting node
+      if (node === bundle) {
+        return;
+      }
+
+      // If this is the first bundle we've seen, initialize result to true
+      if (node.type === 'bundle' && ret === null) {
+        ret = true;
+      }
+
+      if (node.type === 'bundle' && !node.value.assetGraph.hasNode(asset.id)) {
+        ret = false;
+        traversal.stop();
+      }
+    });
+
+    return !!ret;
+  }
+
+  findBundlesWithAsset(asset) {
+    return Array.from(this.nodes.values()).filter(
+      node => node.type === 'bundle' && node.value.assetGraph.hasNode(asset.id)
+    );
+  }
+}

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -1,7 +1,11 @@
+// @flow
 import path from 'path';
-import Config from './Config';
+import type Config from './Config';
+import BundleGraph from './BundleGraph';
 
 export default class BundlerRunner {
+  config: Config;
+
   constructor(opts) {
     this.config = opts.config;
   }
@@ -9,6 +13,8 @@ export default class BundlerRunner {
   async bundle(graph /* , opts */) {
     let bundler = await this.config.getBundler();
 
-    return bundler.bundle(graph);
+    let bundleGraph = new BundleGraph();
+    bundler.bundle(graph, bundleGraph);
+    return bundleGraph;
   }
 }

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -194,7 +194,34 @@ export default class Graph {
     return {removed, added};
   }
 
-  dfs(visit: (node: Node, context?: any) => any, startNode: ?Node): ?Node {
+  traverse(visit: (node: Node, context?: any) => any, startNode?: Node) {
+    return this.dfs({
+      visit,
+      startNode,
+      getChildren: this.getNodesConnectedFrom.bind(this)
+    });
+  }
+
+  traverseAncestors(
+    startNode: Node,
+    visit: (node: Node, context?: any) => any
+  ) {
+    return this.dfs({
+      visit,
+      startNode,
+      getChildren: this.getNodesConnectedTo.bind(this)
+    });
+  }
+
+  dfs({
+    visit,
+    startNode,
+    getChildren
+  }: {
+    visit(node: Node, context?: any): any,
+    getChildren(node: Node): Array<Node>,
+    startNode?: Node
+  }): ?Node {
     let root = startNode || this.getRootNode();
     if (!root) {
       return null;
@@ -210,7 +237,7 @@ export default class Graph {
         context = newContext;
       }
 
-      for (let child of this.getNodesConnectedFrom(node)) {
+      for (let child of getChildren(node)) {
         if (visited.has(child)) {
           continue;
         }
@@ -257,7 +284,7 @@ export default class Graph {
     let graph = new this.constructor();
     graph.setRootNode(node);
 
-    this.dfs(node => {
+    this.traverse(node => {
       graph.addNode(node);
 
       let edges = Array.from(this.edges).filter(edge => edge.from === node.id);

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -1,6 +1,6 @@
 // @flow
 'use strict';
-import {TraversalContext} from '@parcel/types';
+import type {TraversalContext} from '@parcel/types';
 
 export type NodeId = string;
 

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -228,13 +228,32 @@ export default class Graph {
     }
 
     let visited = new Set<Node>();
+    let stopped = false;
+    let skipped = false;
+    let ctx = {
+      skipChildren() {
+        skipped = true;
+      },
+      stop() {
+        stopped = true;
+      }
+    };
 
     let walk = (node, context) => {
       visited.add(node);
 
-      let newContext = visit(node, context);
+      skipped = false;
+      let newContext = visit(node, context, ctx);
       if (typeof newContext !== 'undefined') {
         context = newContext;
+      }
+
+      if (skipped) {
+        return;
+      }
+
+      if (stopped) {
+        return context;
       }
 
       for (let child of getChildren(node)) {
@@ -244,7 +263,7 @@ export default class Graph {
 
         visited.add(child);
         let result = walk(child, context);
-        if (result) {
+        if (stopped) {
           return result;
         }
       }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -7,6 +7,7 @@ import AssetGraph from './AssetGraph';
 import {Node} from './Graph';
 import type {
   Bundle,
+  BundleGraph,
   CLIOptions,
   Dependency,
   File,
@@ -218,12 +219,10 @@ export default class Parcel {
     return this.bundlerRunner.bundle(this.graph);
   }
 
-  package(bundleGraph: any) {
+  package(bundleGraph: BundleGraph) {
     let promises = [];
-    bundleGraph.traverse(bundle => {
-      if (bundle.type === 'bundle') {
-        promises.push(this.runPackage(bundle.value));
-      }
+    bundleGraph.traverseBundles(bundle => {
+      promises.push(this.runPackage(bundle));
     });
 
     return Promise.all(promises);

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -128,8 +128,8 @@ export default class Parcel {
       await this.updateGraph({signal});
       await this.completeGraph({signal});
       await this.graph.dumpGraphViz();
-      let bundles = await this.bundle();
-      await this.package(bundles);
+      let bundleGraph = await this.bundle();
+      await this.package(bundleGraph);
 
       if (!this.watcher) {
         await this.farm.end();
@@ -218,8 +218,14 @@ export default class Parcel {
     return this.bundlerRunner.bundle(this.graph);
   }
 
-  // TODO: implement bundle types
-  package(bundles: any[]) {
-    return Promise.all(bundles.map(bundle => this.runPackage(bundle)));
+  package(bundleGraph: any) {
+    let promises = [];
+    bundleGraph.traverse(bundle => {
+      if (bundle.type === 'bundle') {
+        promises.push(this.runPackage(bundle.value));
+      }
+    });
+
+    return Promise.all(promises);
   }
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -97,8 +97,6 @@ export type DependencyOptions = {
   isAsync?: boolean,
   isEntry?: boolean,
   isOptional?: boolean,
-  isIncluded?: boolean,
-  isConfig?: boolean,
   loc?: SourceLocation,
   env?: Environment,
   meta?: JSONObject
@@ -205,7 +203,9 @@ export type CacheEntry = {
 };
 
 // TODO: what do we want to expose here?
-interface AssetGraph {}
+interface AssetGraph {
+  filterAssets((asset: Asset) => boolean): AssetGraph;
+}
 
 export type Bundle = {
   type: string,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -214,7 +214,13 @@ interface AssetGraph {
   ): any;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
+  getEntryAssets(): Array<Asset>;
+  removeAsset(asset: Asset): void;
 }
+
+export type BundleGroup = {
+  dependency: Dependency
+};
 
 export type Bundle = {
   type: string,
@@ -222,8 +228,15 @@ export type Bundle = {
   filePath?: FilePath
 };
 
+interface BundleGraph {
+  addBundleGroup(parentBundle: ?Bundle, dep: Dependency): void;
+  addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
+  isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;
+  findBundlesWithAsset(asset: Asset): Array<Bundle>;
+}
+
 export type Bundler = {
-  bundle(graph: AssetGraph, opts: CLIOptions): Array<Bundle>
+  bundle(graph: AssetGraph, bundleGraph: BundleGraph, opts: CLIOptions): void
 };
 
 export type Namer = {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -207,11 +207,15 @@ export interface TraversalContext {
   stop(): void;
 }
 
+export type GraphTraversalCallback<T> = (
+  asset: T,
+  context?: any,
+  traversal: TraversalContext
+) => any;
+
 // TODO: what do we want to expose here?
 interface AssetGraph {
-  traverseAssets(
-    visit: (node: Asset, context?: any, traversal: TraversalContext) => any
-  ): any;
+  traverseAssets(visit: GraphTraversalCallback<Asset>): any;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
   getEntryAssets(): Array<Asset>;
@@ -223,16 +227,20 @@ export type BundleGroup = {
 };
 
 export type Bundle = {
+  id: string,
   type: string,
   assetGraph: AssetGraph,
   filePath?: FilePath
 };
 
-interface BundleGraph {
-  addBundleGroup(parentBundle: ?Bundle, dep: Dependency): void;
+export interface BundleGraph {
+  addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
   addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
   isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;
   findBundlesWithAsset(asset: Asset): Array<Bundle>;
+  getBundles(bundleGroup: BundleGroup): Array<Bundle>;
+  getBundleGroups(bundle: Bundle): Array<BundleGroup>;
+  traverseBundles(visit: GraphTraversalCallback<Bundle>): any;
 }
 
 export type Bundler = {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -202,14 +202,23 @@ export type CacheEntry = {
   initialAssets: ?Array<Asset> // Initial assets, pre-post processing
 };
 
+export interface TraversalContext {
+  skipChildren(): void;
+  stop(): void;
+}
+
 // TODO: what do we want to expose here?
 interface AssetGraph {
-  filterAssets((asset: Asset) => boolean): AssetGraph;
+  traverseAssets(
+    visit: (node: Asset, context?: any, traversal: TraversalContext) => any
+  ): any;
+  createBundle(asset: Asset): Bundle;
+  getTotalSize(asset?: Asset): number;
 }
 
 export type Bundle = {
   type: string,
-  assets: Array<Asset>,
+  assetGraph: AssetGraph,
   filePath?: FilePath
 };
 

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -102,8 +102,7 @@ export type DependencyOptions = {
   meta?: JSONObject
 };
 
-export type Dependency = {
-  ...DependencyOptions,
+export type Dependency = DependencyOptions & {
   id: string,
   env: Environment,
 
@@ -142,6 +141,7 @@ export interface Asset {
   getPackage(): Promise<PackageJSON | null>;
   addDependency(dep: DependencyOptions): string;
   createChildAsset(result: TransformerResult): Asset;
+  getOutput(): AssetOutput;
 }
 
 export type AssetOutput = {
@@ -213,13 +213,24 @@ export type GraphTraversalCallback<T> = (
   traversal: TraversalContext
 ) => any;
 
+interface Graph {
+  merge(graph: Graph): void;
+}
+
+export type DependencyResolution = {
+  asset?: Asset,
+  bundles?: Array<Bundle>
+};
+
 // TODO: what do we want to expose here?
-interface AssetGraph {
+interface AssetGraph extends Graph {
   traverseAssets(visit: GraphTraversalCallback<Asset>): any;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
   getEntryAssets(): Array<Asset>;
   removeAsset(asset: Asset): void;
+  getDependencies(asset: Asset): Array<Dependency>;
+  getDependencyResolution(dependency: Dependency): DependencyResolution;
 }
 
 export type BundleGroup = {

--- a/packages/dev/babel-preset/common.js
+++ b/packages/dev/babel-preset/common.js
@@ -1,5 +1,6 @@
 const flow = require('@babel/preset-flow');
 
 module.exports = {
-  presets: [flow]
+  presets: [flow],
+  plugins: [require('@babel/plugin-proposal-class-properties')]
 };

--- a/packages/dev/babel-preset/legacy.js
+++ b/packages/dev/babel-preset/legacy.js
@@ -11,5 +11,6 @@ module.exports = () => ({
       }
     ],
     ...common.presets
-  ]
+  ],
+  plugins: common.plugins
 });

--- a/packages/dev/babel-preset/modern.js
+++ b/packages/dev/babel-preset/modern.js
@@ -11,5 +11,6 @@ module.exports = () => ({
       }
     ],
     ...common.presets
-  ]
+  ],
+  plugins: common.plugins
 });

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "license": "MIT",
   "dependencies": {
+    "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-flow": "^7.0.0"
   },

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -10,16 +10,8 @@
     "@parcel/babel-register": "^2.0.0",
     "@parcel/core": "^2.0.0"
   },
-  "browser": "dist/browser.js",
   "browserModern": "dist/modern.js",
   "targets": {
-    "browser": {
-      "engines": {
-        "browsers": [
-          "> 1%"
-        ]
-      }
-    },
     "browserModern": {
       "engines": {
         "browsers": [

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -19,5 +19,10 @@
         ]
       }
     }
+  },
+  "dependencies": {
+    "lodash": "^4.17.11",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3"
   }
 }

--- a/packages/examples/simple/src/async.js
+++ b/packages/examples/simple/src/async.js
@@ -1,0 +1,1 @@
+console.log(require('./message'));

--- a/packages/examples/simple/src/async.js
+++ b/packages/examples/simple/src/async.js
@@ -1,1 +1,2 @@
-console.log(require('./message'));
+console.log(require('react'));
+require('lodash');

--- a/packages/examples/simple/src/async2.js
+++ b/packages/examples/simple/src/async2.js
@@ -1,0 +1,1 @@
+console.log(require('./message'));

--- a/packages/examples/simple/src/async2.js
+++ b/packages/examples/simple/src/async2.js
@@ -1,1 +1,2 @@
-console.log(require('./message'));
+console.log(require('react'));
+require('lodash');

--- a/packages/examples/simple/src/index.js
+++ b/packages/examples/simple/src/index.js
@@ -1,6 +1,8 @@
 import('./async');
 import('./async2');
 
+new Worker('./worker.js');
+
 // const message = require('./message');
 // const fs = require('fs');
 

--- a/packages/examples/simple/src/index.js
+++ b/packages/examples/simple/src/index.js
@@ -1,7 +1,7 @@
 import('./async');
 import('./async2');
 
-const message = require('./message');
+// const message = require('./message');
 // const fs = require('fs');
 
 // console.log(message); // eslint-disable-line no-console

--- a/packages/examples/simple/src/index.js
+++ b/packages/examples/simple/src/index.js
@@ -1,7 +1,10 @@
-const message = require('./message');
-const fs = require('fs');
+import('./async');
+import('./async2');
 
-console.log(message); // eslint-disable-line no-console
-console.log(fs.readFileSync(__dirname + '/test.txt', 'utf8'));
+const message = require('./message');
+// const fs = require('fs');
+
+// console.log(message); // eslint-disable-line no-console
+// console.log(fs.readFileSync(__dirname + '/test.txt', 'utf8'));
 
 class Test {}

--- a/packages/examples/simple/src/worker.js
+++ b/packages/examples/simple/src/worker.js
@@ -1,0 +1,1 @@
+module.exports = 'worker';

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -24,19 +24,12 @@ export default new Packager({
 
       let dependencies = bundle.assetGraph.getNodesConnectedFrom(asset);
       for (let dep of dependencies) {
-        let node = bundle.assetGraph.getNodesConnectedFrom(dep)[0];
-        if (node.type === 'transformer_request') {
-          let assetNode = bundle.assetGraph
-            .getNodesConnectedFrom(node)
-            .find(
-              node => node.type === 'asset' || node.type === 'asset_reference'
-            );
-          if (assetNode) {
-            deps[dep.value.moduleSpecifier] = assetNode.value.id;
-          }
-        } else if (node.type === 'bundle_group') {
-          let bundles = bundle.assetGraph.getNodesConnectedFrom(node);
+        let resolved = bundle.assetGraph.getDependencyResolution(dep);
+        if (resolved.type === 'bundle_group') {
+          let bundles = bundle.assetGraph.getNodesConnectedFrom(resolved);
           deps[dep.value.moduleSpecifier] = bundles.map(b => b.id);
+        } else {
+          deps[dep.value.moduleSpecifier] = resolved.value.id;
         }
       }
 

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -52,9 +52,7 @@ export default new Packager({
       assets +
       '},{},' +
       JSON.stringify(
-        bundle.assetGraph
-          .getNodesConnectedFrom(bundle.assetGraph.getRootNode())
-          .map(node => node.id)
+        bundle.assetGraph.getEntryAssets().map(asset => asset.id)
       ) +
       ', ' +
       'null' +

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -22,14 +22,13 @@ export default new Packager({
     bundle.assetGraph.traverseAssets(asset => {
       let deps = {};
 
-      let dependencies = bundle.assetGraph.getNodesConnectedFrom(asset);
+      let dependencies = bundle.assetGraph.getDependencies(asset);
       for (let dep of dependencies) {
         let resolved = bundle.assetGraph.getDependencyResolution(dep);
-        if (resolved.type === 'bundle_group') {
-          let bundles = bundle.assetGraph.getNodesConnectedFrom(resolved);
-          deps[dep.value.moduleSpecifier] = bundles.map(b => b.id);
-        } else {
-          deps[dep.value.moduleSpecifier] = resolved.value.id;
+        if (resolved.bundles) {
+          deps[dep.moduleSpecifier] = resolved.bundles.map(b => b.id);
+        } else if (resolved.asset) {
+          deps[dep.moduleSpecifier] = resolved.asset.id;
         }
       }
 

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -63,17 +63,17 @@ export default new Transformer({
       return [asset];
     }
 
+    // Inline environment variables
+    if (asset.env.context === 'browser' && ENV_RE.test(asset.code)) {
+      walk.simple(asset.ast.program, envVisitor, asset);
+    }
+
     // Collect dependencies
     if (canHaveDependencies(asset.code)) {
       walk.ancestor(asset.ast.program, collectDependencies, asset);
     }
 
     if (asset.env.context === 'browser') {
-      // Inline environment variables
-      if (ENV_RE.test(asset.code)) {
-        walk.simple(asset.ast.program, envVisitor, asset);
-      }
-
       // Inline fs calls
       let fsDep = asset.dependencies.find(dep => dep.moduleSpecifier === 'fs');
       if (fsDep && FS_RE.test(asset.code)) {
@@ -89,9 +89,9 @@ export default new Transformer({
       }
 
       // Insert node globals
-      if (GLOBAL_RE.test(asset.code)) {
-        walk.ancestor(asset.ast.program, insertGlobals, asset);
-      }
+      // if (GLOBAL_RE.test(asset.code)) {
+      //   walk.ancestor(asset.ast.program, insertGlobals, asset);
+      // }
     }
 
     // Do some transforms

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -53,12 +53,12 @@ export default {
       types.isStringLiteral(args[0]);
 
     if (isDynamicImport) {
-      asset.addDependency({moduleSpecifier: '_bundle_loader'});
+      // asset.addDependency({moduleSpecifier: '_bundle_loader'});
       addDependency(asset, args[0], {isAsync: true});
 
-      node.callee = requireTemplate().expression;
-      node.arguments[0] = argTemplate({MODULE: args[0]}).expression;
-      asset.ast.isDirty = true;
+      // node.callee = requireTemplate().expression;
+      // node.arguments[0] = argTemplate({MODULE: args[0]}).expression;
+      // asset.ast.isDirty = true;
       return;
     }
 

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -71,7 +71,7 @@ export default {
       // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#avoid_changing_the_url_of_your_service_worker_script
       addURLDependency(asset, args[0], {
         isEntry: true,
-        context: 'service-worker'
+        env: {context: 'service-worker'}
       });
       return;
     }
@@ -87,7 +87,7 @@ export default {
       types.isStringLiteral(args[0]);
 
     if (isWebWorker) {
-      addURLDependency(asset, args[0], {context: 'web-worker'});
+      addURLDependency(asset, args[0], {env: {context: 'web-worker'}});
       return;
     }
   }
@@ -190,6 +190,10 @@ function addDependency(asset, node, opts = {}) {
 function addURLDependency(asset, node, opts = {}) {
   opts.loc = node.loc && node.loc.start;
 
-  node.value = asset.addDependency({moduleSpecifier: node.value, ...opts});
+  node.value = asset.addDependency({
+    moduleSpecifier: node.value,
+    isAsync: true,
+    ...opts
+  });
   asset.ast.isDirty = true;
 }

--- a/packages/transformers/js/src/visitors/env.js
+++ b/packages/transformers/js/src/visitors/env.js
@@ -11,7 +11,7 @@ export default {
           let value = types.valueToNode(prop);
           morph(node, value);
           asset.ast.isDirty = true;
-          asset.meta.env[key.value] = process.env[key.value];
+          // asset.meta.env[key.value] = process.env[key.value];
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -252,6 +252,18 @@
     "@babel/helper-remap-async-to-generator" "^7.1.0"
     "@babel/plugin-syntax-async-generators" "^7.0.0"
 
+"@babel/plugin-proposal-class-properties@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.1.0.tgz#9af01856b1241db60ec8838d84691aa0bd1e8df4"
+  integrity sha512-/PCJWN+CKt5v1xcGn4vnuu13QDoV+P7NcICP44BoonAJoPSGwVkgrXihFIQGiEjjPlUDBIw1cM7wYFLARS2/hw==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.1.0"
+    "@babel/plugin-syntax-class-properties" "^7.0.0"
+
 "@babel/plugin-proposal-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.0.0.tgz#3b4d7b5cf51e1f2e70f52351d28d44fc2970d01e"
@@ -289,6 +301,13 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0.tgz#bf0891dcdbf59558359d0c626fdc9490e20bc13c"
   integrity sha512-im7ged00ddGKAjcZgewXmp1vxSZQQywuQXe2B1A7kajjZmDeY/ekMPmWr9zJgveSaQH0k7BcGrojQhcK06l0zA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0.tgz#e051af5d300cbfbcec4a7476e37a803489881634"
+  integrity sha512-cR12g0Qzn4sgkjrbrzWy2GE7m9vMl/sFkqZ3gIpAQdrvPDnLM8180i+ANDFIXfjHo9aqp0ccJlQ0QNZcFUbf9w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
This is an implementation of the default bundler plugin for Parcel 2, along with the infrastructure in core necessary to support it. It implements code splitting, splitting by asset type, asset deduping, and bundle splitting.

Closes #2139. Related to #885.

* Adds a `BundleGraph` to core, and changes the Bundler plugin API to return one. Bundler plugins accept the complete asset graph, along with an empty bundle graph instance to fill in. This way we don't need to expose the constructor to plugins. A `BundleGraph` contains nodes of type `bundle_group` and `bundle`.
* Each `Bundle` object now has an `AssetGraph` in it instead of just an array of assets. This gives packagers access to the dependencies and other information in the graph for that bundle.
* Adds a bunch of helper methods that will be useful for bundler plugins to `BundleGraph` and `AssetGraph`, along with some traversal methods to `Graph` itself.
* Changes existing JS packager to use the AssetGraph within the bundle to write its assets. This also included changing the way asset outputs were read from the cache to do it within the packager via `asset.getOutput()` rather than beforehand in the PackagerRunner.

The default bundler traverses the asset graph and creates a node of type `bundle_group` for every entry point and async dependency. Connected to these are `bundle` nodes, which each contain a subset of the full asset graph. The point of the `bundle_group` nodes is to group things that would be loaded in parallel, e.g. JS + CSS, or JS and other bundle split JS.

Child bundle groups can share dependencies with their parents, so assets that would be duplicated are removed from children. When a dependency with an isolated environment (e.g. a web worker) is hit where it would be impossible to access parent dependencies, it is connected to the root of the bundle graph instead. This way it will have no parents and thus not share anything with other bundles.

![graph](https://user-images.githubusercontent.com/19409/49852491-1b05f900-fd99-11e8-94d2-10bc68c92c32.png)

Within each `bundle` node is a sub asset graph containing only the assets in that bundle. These asset graphs inside bundles start from one or more assets and point to the rest of the subgraph for those assets. When an async dependency is hit that creates a separate bundle, the dependency resolution is replaced with the `bundle_group` node from the bundle graph for this dependency, which gives packagers access to the referenced bundles that should be loaded.

![graph copy](https://user-images.githubusercontent.com/19409/49852809-070ec700-fd9a-11e8-9b4b-0fdc9d35599b.png)

The above example shows three async dependencies, two of which depend on react and lodash. Since those are large libraries and they are shared, they are extracted out into their own separate bundle which is added to the original bundle groups to be loaded in parallel. This allows them to be cached independently of the original bundles, decreasing the overall application size.

Within those async bundles, the separated assets which are no longer in the original bundles are replaced with `asset_reference` nodes, which give packagers access to the original assets without including them or their dependencies in the bundle.

![graph](https://user-images.githubusercontent.com/19409/49852942-708ed580-fd9a-11e8-8569-c8f02b324336.png)

The full rules for the default bundler are as follows:

1. If an async or entry dependency is seen, start a new bundle group.
2. If an asset is a different type than the current bundle, make a parallel bundle in the same bundle group.
3. If an asset is already in a parent bundle in the same entry point, exclude from child bundles.
4. If an asset is only in separate isolated entry points (e.g. workers, different HTML pages), duplicate it.
5. If the sub-graph from an asset is >= 30kb, and the number of parallel requests in the bundle group is < 5, create a new bundle containing the sub-graph.
6. If two assets are always seen together, put them in the same extracted bundle.
7. Consider larger split bundles before smaller ones.

Feedback on the API for AssetGraph and BundleGraph would be appreciated! One idea I had was to make bundler plugins composable, but I will explore that in a future PR. 😄 