### PR TITLE
Fix autoinstall of cssnano

### DIFF
--- a/packages/core/parcel-bundler/src/transforms/postcss.js
+++ b/packages/core/parcel-bundler/src/transforms/postcss.js
@@ -54,11 +54,8 @@ async function getConfig(asset) {
   }
 
   if (asset.options.minify) {
-    let [cssnano, {version}] = await Promise.all(
-      ['cssnano', 'cssnano/package.json'].map(name =>
-        localRequire(name, asset.name).catch(() => require(name))
-      )
-    );
+    let cssnano = await localRequire('cssnano', asset.name);
+    let {version} = await localRequire('cssnano/package.json', asset.name);
     config.plugins.push(
       cssnano(
         (await asset.getConfig(['cssnano.config.js'])) || {


### PR DESCRIPTION
# ↪️ Pull Request

Fixes autoinstalling of cssnano (previously, parcel tried to install the package "cssnano/package.json". 
Fixes #2290, this seems to be a cleaner/easier fix than what was proposed there.

With this change, `localrequire("cssnano/package.json")` never fails, because it will only run after cssnano is installed.

Should there be a test for this? If yes, how should that look like?

## 💻 Examples
## 🚨 Test instructions

Building any html file which imports a css file.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
