### PR TITLE
Also publish test results when any test fails

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -44,11 +44,13 @@ jobs:
     displayName: 'Lint'
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'
+    condition: succeededOrFailed()
     inputs:
       testResultsFiles: '**/junit-*.xml'
       testRunTitle: TestRun ${{ parameters.name }} $(node_version)
   - task: PublishCodeCoverageResults@1
     displayName: 'Publish code coverage results'
+    condition: succeededOrFailed()
     inputs: 
       codeCoverageTool: 'cobertura'
       summaryFileLocation: '**/coverage/cobertura-coverage.xml'


### PR DESCRIPTION
# ↪️ Pull Request

Currently when a test fails CI doesn't show which test, which is pretty inconvenient as that's the only time it matters to have a nice overview of the tests.