### PR TITLE
Fix server when there is a dot in the path

### DIFF
--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -217,6 +217,19 @@ describe('server', function() {
     );
   });
 
+  it('should work with paths that contain a dot', async function() {
+    let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
+      publicUrl: '/'
+    });
+    server = await b.serve(0);
+
+    let data = await get('/bar.baz');
+    assert.equal(
+      data,
+      await fs.readFile(path.join(__dirname, '/dist/index.html'), 'utf8')
+    );
+  });
+
   it('should not log dev server access for log level <= 3', async function() {
     let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
       publicUrl: '/'

--- a/packages/core/parcel-bundler/src/Server.js
+++ b/packages/core/parcel-bundler/src/Server.js
@@ -63,7 +63,7 @@ function middleware(bundler) {
       } else {
         // Otherwise, serve the file from the dist folder
         req.url = pathname.slice(bundler.options.publicURL.length);
-        return serve(req, res, send404);
+        return serve(req, res, sendIndex);
       }
     }
 


### PR DESCRIPTION
# ↪️ Pull Request

This fixes an issue where a 404 would be returned if there was a dot in the path. Instead, now it serves the `index.html` page if an actual file doesn't exist.

Fixes #1684.