### PR TITLE
Add support for `chrome-extension://` protocol to bundle-url.js

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/bundle-url.js
+++ b/packages/core/parcel-bundler/src/builtins/bundle-url.js
@@ -12,7 +12,7 @@ function getBundleURL() {
   try {
     throw new Error;
   } catch (err) {
-    var matches = ('' + err.stack).match(/(https?|file|ftp):\/\/[^)\n]+/g);
+    var matches = ('' + err.stack).match(/(https?|file|ftp|chrome-extension):\/\/[^)\n]+/g);
     if (matches) {
       return getBaseURL(matches[0]);
     }
@@ -22,7 +22,7 @@ function getBundleURL() {
 }
 
 function getBaseURL(url) {
-  return ('' + url).replace(/^((?:https?|file|ftp):\/\/.+)\/[^/]+$/, '$1') + '/';
+  return ('' + url).replace(/^((?:https?|file|ftp|chrome-extension):\/\/.+)\/[^/]+$/, '$1') + '/';
 }
 
 exports.getBundleURL = getBundleURLCached;


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds support for dynamic bundle loading (with code splitting) for the `chrome-extension://` protocol.

Usually, it's not necessary to use code-splitting with a chrome extension as the resources are loaded from disk. That said if you build your application for the web as well as a chrome extension, attempting to keep a unified code base and using code splitting to optimize the web build, you'll be forced to use code splitting for your chrome extension too.

This shouldn't be a problem; however, parcels logic for detecting bundle paths uses a regex that includes supported protocols. `file://`, `http://`, `https://` and `ftp://` are present, but not `chrome-extension://` which causes it to always load bundles relative to the root path when using `chrome-extension://`.