### PR TITLE
Add support for Firefox's 'moz-extension://' protocol, to bundle-url.js

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/bundle-url.js
+++ b/packages/core/parcel-bundler/src/builtins/bundle-url.js
@@ -12,7 +12,7 @@ function getBundleURL() {
   try {
     throw new Error;
   } catch (err) {
-    var matches = ('' + err.stack).match(/(https?|file|ftp|chrome-extension):\/\/[^)\n]+/g);
+    var matches = ('' + err.stack).match(/(https?|file|ftp|chrome-extension|moz-extension):\/\/[^)\n]+/g);
     if (matches) {
       return getBaseURL(matches[0]);
     }
@@ -22,7 +22,7 @@ function getBundleURL() {
 }
 
 function getBaseURL(url) {
-  return ('' + url).replace(/^((?:https?|file|ftp|chrome-extension):\/\/.+)\/[^/]+$/, '$1') + '/';
+  return ('' + url).replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\/\/.+)\/[^/]+$/, '$1') + '/';
 }
 
 exports.getBundleURL = getBundleURLCached;


### PR DESCRIPTION
# ↪️ Pull Request
Add support for code splitting, in locally loaded Firefox extensions.
With the `moz-extension://` protocol.

This has already been added for `chrome-extension://`, which is used by chromium based browsers, but not Firefox. See #2434 