### PR TITLE
Generate source map files with long extentions (e.g. .js.map)

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -12,7 +12,7 @@ describe('css', function() {
       assets: ['index.js', 'index.css', 'local.js', 'local.css'],
       childBundles: [
         {
-          name: 'index.map'
+          name: 'index.js.map'
         },
         {
           name: 'index.css',
@@ -88,7 +88,7 @@ describe('css', function() {
           childBundles: []
         },
         {
-          name: 'index.map',
+          name: 'index.js.map',
           type: 'map'
         }
       ]

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -14,7 +14,7 @@ describe('sourcemaps', function() {
       assets: ['index.js'],
       childBundles: [
         {
-          name: 'index.map',
+          name: 'index.js.map',
           type: 'map'
         }
       ]
@@ -24,7 +24,7 @@ describe('sourcemaps', function() {
       path.join(__dirname, '/dist/index.js')
     )).toString();
     let map = (await fs.readFile(
-      path.join(__dirname, '/dist/index.map')
+      path.join(__dirname, '/dist/index.js.map')
     )).toString();
     mapValidator(raw, map);
     let mapObject = JSON.parse(map);
@@ -59,7 +59,7 @@ describe('sourcemaps', function() {
       assets: ['index.ts'],
       childBundles: [
         {
-          name: 'index.map',
+          name: 'index.js.map',
           type: 'map'
         }
       ]
@@ -69,7 +69,7 @@ describe('sourcemaps', function() {
       path.join(__dirname, '/dist/index.js')
     )).toString();
     let map = (await fs.readFile(
-      path.join(__dirname, '/dist/index.map')
+      path.join(__dirname, '/dist/index.js.map')
     )).toString();
     mapValidator(raw, map);
 
@@ -88,7 +88,7 @@ describe('sourcemaps', function() {
       assets: ['index.ts', 'local.ts'],
       childBundles: [
         {
-          name: 'index.map',
+          name: 'index.js.map',
           type: 'map'
         }
       ]
@@ -98,7 +98,7 @@ describe('sourcemaps', function() {
       path.join(__dirname, '/dist/index.js')
     )).toString();
     let map = (await fs.readFile(
-      path.join(__dirname, '/dist/index.map')
+      path.join(__dirname, '/dist/index.js.map')
     )).toString();
     mapValidator(raw, map);
 
@@ -117,7 +117,7 @@ describe('sourcemaps', function() {
       assets: ['index.js', 'local.js', 'util.js'],
       childBundles: [
         {
-          name: 'index.map',
+          name: 'index.js.map',
           type: 'map'
         }
       ]
@@ -127,7 +127,7 @@ describe('sourcemaps', function() {
       path.join(__dirname, '/dist/index.js')
     )).toString();
     let map = (await fs.readFile(
-      path.join(__dirname, '/dist/index.map')
+      path.join(__dirname, '/dist/index.js.map')
     )).toString();
     mapValidator(raw, map);
 
@@ -149,7 +149,7 @@ describe('sourcemaps', function() {
       assets: ['index.js', 'local.js', 'util.js'],
       childBundles: [
         {
-          name: 'index.map',
+          name: 'index.js.map',
           type: 'map'
         }
       ]
@@ -159,7 +159,7 @@ describe('sourcemaps', function() {
       path.join(__dirname, '/dist/index.js')
     )).toString();
     let map = (await fs.readFile(
-      path.join(__dirname, '/dist/index.map')
+      path.join(__dirname, '/dist/index.js.map')
     )).toString();
     mapValidator(raw, map);
 

--- a/packages/core/parcel-bundler/src/Bundle.js
+++ b/packages/core/parcel-bundler/src/Bundle.js
@@ -64,7 +64,11 @@ class Bundle {
         type,
         Path.join(
           Path.dirname(this.name),
-          Path.basename(this.name, Path.extname(this.name)) + '.' + type
+          // keep the original extension for source map files, so we have
+          // .js.map instead of just .map
+          type === 'map'
+            ? Path.basename(this.name) + '.' + type
+            : Path.basename(this.name, Path.extname(this.name)) + '.' + type
         ),
         this
       );
@@ -110,7 +114,14 @@ class Bundle {
   getHashedBundleName(contentHash) {
     // If content hashing is enabled, generate a hash from all assets in the bundle.
     // Otherwise, use a hash of the filename so it remains consistent across builds.
-    let ext = Path.extname(this.name);
+    let basename = Path.basename(this.name);
+
+    let ext = Path.extname(basename);
+    if (this.type === 'map') {
+      // Using this instead of Path.extname because the source map files have long
+      // extensions like '.js.map' but extname only return the last piece (.map).
+      ext = basename.substring(basename.indexOf('.'));
+    }
     let hash = (contentHash
       ? this.getHash()
       : Path.basename(this.name, ext)


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Closes #2460.

What I do here is preserve the original file extension before appending `.map` to the source map files.

Instead of `index.map` it would generate `index.js.map`. According to the [spec](https://sourcemaps.info/spec.html) it's the recommended convention. It also solves a real issue for debugging Javascript in VSCode.

While it solves the issue, I don't like the tech debt I introduce. Specifically, I don't like the conditionals about specific types of bundles in the otherwise abstract code.

@DeMoorJasper please, take a look and let me know if you can think of a more pleasing solution architecture-wise. This is my first peek at the internals of Parcel, so I don't have the whole context yet.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->