### PR TITLE
fix Watcher ignored regex

### DIFF
--- a/packages/core/watcher/src/Watcher.js
+++ b/packages/core/watcher/src/Watcher.js
@@ -19,7 +19,7 @@ class Watcher extends EventEmitter {
         process.platform === 'darwin' && process.env.NODE_ENV !== 'test',
       ignoreInitial: true,
       ignorePermissionErrors: true,
-      ignored: /\.cache|\.git/
+      ignored: /(^|[/\\])\.(git|cache)/
     }
   ) {
     super();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

**Solves issue of** auto-rebuild / hot-reloading not working for files/directories having `.git` (e.g. xyz.github.io) in it

**How?** So instead of ignoring any file/directories containing .git it will only ignore ones where .git appear at start of file/directories

Fixes 
https://github.com/parcel-bundler/parcel/issues/2231
https://github.com/parcel-bundler/parcel/issues/2093

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

Create file `hello.git.js`
```
console.log("hi from hello.git.js")
```

and run ` parcel hello.git.js` and make changes in file.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
