### PR TITLE
added fix for typescript asset invalidation

### DIFF
--- a/packages/core/parcel-bundler/src/assets/JSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/JSAsset.js
@@ -16,6 +16,7 @@ const hoist = require('../scope-hoisting/hoist');
 const path = require('path');
 const fs = require('@parcel/fs');
 const logger = require('@parcel/logger');
+const isAccessedVarChanged = require('../utils/isAccessedVarChanged');
 
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
 const ENV_RE = /\b(?:process\.env)\b/;
@@ -40,13 +41,7 @@ class JSAsset extends Asset {
   }
 
   shouldInvalidate(cacheData) {
-    for (let key in cacheData.env) {
-      if (cacheData.env[key] !== process.env[key]) {
-        return true;
-      }
-    }
-
-    return false;
+    return isAccessedVarChanged(cacheData);
   }
 
   mightHaveDependencies() {

--- a/packages/core/parcel-bundler/src/assets/TypeScriptAsset.js
+++ b/packages/core/parcel-bundler/src/assets/TypeScriptAsset.js
@@ -1,10 +1,16 @@
 const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
+const isAccessedVarChanged = require('../utils/isAccessedVarChanged');
 
 class TypeScriptAsset extends Asset {
   constructor(name, options) {
     super(name, options);
     this.type = 'js';
+    this.cacheData.env = {};
+  }
+
+  shouldInvalidate(cacheData) {
+    return isAccessedVarChanged(cacheData);
   }
 
   async generate() {

--- a/packages/core/parcel-bundler/src/utils/isAccessedVarChanged.js
+++ b/packages/core/parcel-bundler/src/utils/isAccessedVarChanged.js
@@ -1,0 +1,14 @@
+/*
+  Checks if any of the used variable from process.env is changed
+*/
+function isAccessedVarChanged(cacheData) {
+  for (let key in cacheData.env) {
+    if (cacheData.env[key] !== process.env[key]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+module.exports = isAccessedVarChanged;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
**What?** Invalidate `TypeScriptAsset` when inline process.env is updated. 

Also, we are using same code for `JSAsset`, So extracted common code as utility.

Solves https://github.com/parcel-bundler/parcel/issues/2480

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
See https://github.com/parcel-bundler/parcel/issues/2480


## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
See Code Sample here https://github.com/parcel-bundler/parcel/issues/2480

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
