### PR TITLE
re-exporting and renaming when scopehoisting

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed/a.js
@@ -1,0 +1,3 @@
+import { x } from './b.js';
+
+output = x;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed/b.js
@@ -1,0 +1,3 @@
+export const x = 'foobar';
+
+export { x as y } from './c.js'

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed/c.js
@@ -1,0 +1,1 @@
+export const x = 'xyz';

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -321,6 +321,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'foobar');
     });
 
+    it('supports requiring a re-exported and renamed ES6 import', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-renamed/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'foobar');
+    });
+
     it('keeps side effects by default', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
@@ -1,3 +1,5 @@
+const t = require('@babel/types');
+
 function rename(scope, oldName, newName) {
   if (oldName === newName) {
     return;
@@ -19,6 +21,9 @@ function rename(scope, oldName, newName) {
 
   // Rename all references
   for (let path of binding.referencePaths) {
+    if (t.isExportSpecifier(path.parent) && path.parentPath.parent.source) {
+      continue;
+    }
     if (path.node.name === oldName) {
       path.node.name = newName;
     }


### PR DESCRIPTION
# ↪️ Pull Request

Renaming an identifier incorrectly renaming the local identifier of re-export+rename statements as well. (i.e. a function named `x` and `export {x as func) from "...";`)

This is fixing https://github.com/babel/babel/issues/9266 manually, because parcel doesn't use babel's `scope.rename`. Maybe we should wait for the babel team to respond there
Closes #2284

## 💻 Examples

Described in https://github.com/babel/babel/issues/9266

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs


