### PR TITLE
Use Buffer.from instead of new Buffer()

### DIFF
--- a/packages/core/integration-tests/test/integration/globals/index.js
+++ b/packages/core/integration-tests/test/integration/globals/index.js
@@ -2,7 +2,7 @@ module.exports = function () {
   return {
     dir: __dirname,
     file: __filename,
-    buf: new Buffer(process.title).toString('base64'),
+    buf: Buffer.from(process.title).toString('base64'),
     global: !!global.document
   };
 };

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -802,7 +802,7 @@ describe('javascript', function() {
     assert.deepEqual(output(), {
       dir: path.join(__dirname, '/integration/globals'),
       file: path.join(__dirname, '/integration/globals/index.js'),
-      buf: new Buffer('browser').toString('base64'),
+      buf: Buffer.from('browser').toString('base64'),
       global: true
     });
   });


### PR DESCRIPTION
# ↪️ Pull Request

Removes some warnings when running the tests
Based on https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1

## 💻 Examples

<!-- Examples help us understand the requested feature better -->


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs