### PR TITLE
Fix htmlnano tests

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -289,7 +289,7 @@ describe('html', function() {
       'utf8'
     );
     assert(html.includes('Other page'));
-    assert(!html.includes('\n'));
+    assert.equal(html.split('\n').length, 2);
   });
 
   it('should read .htmlnanorc and minify HTML in production mode', async function() {
@@ -338,7 +338,7 @@ describe('html', function() {
       'utf8'
     );
     assert(html.includes('<input type="text">'));
-    assert(!html.includes('\n'));
+    assert.equal(html.split('\n').length, 2);
   });
 
   it('should not prepend the public path to assets with remote URLs', async function() {

--- a/packages/core/parcel-bundler/test/sourcemaps.js
+++ b/packages/core/parcel-bundler/test/sourcemaps.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const fs = require('@parcel/fs');
 const SourceMap = require('../src/SourceMap');
 
 describe('sourcemaps', function() {


### PR DESCRIPTION
# ↪️ Pull Request

The version upgrade in https://github.com/parcel-bundler/parcel/pull/2506 seems to have changed the output regarding `collapseWhitespace`. Setting that htmlnano option to `all`  would make current tests pass, but is not always safe ([see here](https://github.com/posthtml/htmlnano#collapsewhitespace))


## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs