### PR TITLE
Fix and reenable windows scope-hoisting tests

### DIFF
--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -7,15 +7,6 @@ const bundle = (name, opts = {}) =>
   _bundle(name, Object.assign({scopeHoist: true}, opts));
 
 describe('scope hoisting', function() {
-  if (process.platform === 'win32') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'WARNING: Scope hoisting tests are disabled on windows due to ' +
-        'filesystem errors. Feel free to look into this and contribute a fix!'
-    );
-    return;
-  }
-
   describe('es6', function() {
     it('supports default imports and exports of expressions', async function() {
       let b = await bundle(

--- a/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js
@@ -513,36 +513,42 @@ class JSConcatPackager extends Packager {
       `);
     }
 
-    let ast = t.file(t.program(this.statements));
-    let {code: output} = concat(this, ast);
+    try {
+      let ast = t.file(t.program(this.statements));
+      let {code: output} = concat(this, ast);
 
-    if (!this.options.minify) {
-      output = '\n' + output + '\n';
-    }
-
-    let preludeCode = this.options.minify ? prelude.minified : prelude.source;
-    if (this.needsPrelude) {
-      output = preludeCode + '(function (require) {' + output + '});';
-    } else {
-      output = '(function () {' + output + '})();';
-    }
-
-    this.size = output.length;
-
-    let {sourceMaps} = this.options;
-    if (sourceMaps) {
-      // Add source map url if a map bundle exists
-      let mapBundle = this.bundle.siblingBundlesMap.get('map');
-      if (mapBundle) {
-        let mapUrl = urlJoin(
-          this.options.publicURL,
-          path.basename(mapBundle.name)
-        );
-        output += `\n//# sourceMappingURL=${mapUrl}`;
+      if (!this.options.minify) {
+        output = '\n' + output + '\n';
       }
-    }
 
-    await super.write(output);
+      let preludeCode = this.options.minify ? prelude.minified : prelude.source;
+      if (this.needsPrelude) {
+        output = preludeCode + '(function (require) {' + output + '});';
+      } else {
+        output = '(function () {' + output + '})();';
+      }
+
+      this.size = output.length;
+
+      let {sourceMaps} = this.options;
+      if (sourceMaps) {
+        // Add source map url if a map bundle exists
+        let mapBundle = this.bundle.siblingBundlesMap.get('map');
+        if (mapBundle) {
+          let mapUrl = urlJoin(
+            this.options.publicURL,
+            path.basename(mapBundle.name)
+          );
+          output += `\n//# sourceMappingURL=${mapUrl}`;
+        }
+      }
+
+      await super.write(output);
+    } catch (e) {
+      throw e;
+    } finally {
+      await super.end();
+    }
   }
 
   resolveModule(id, name) {


### PR DESCRIPTION
# ↪️ Pull Request

The scopehoisting test on Windows were disabled because the `afterEach` test hook deleting the `dist` folder failed with a permissions error.
This was because `JSConcatPackager.end()` didn't call `super.end()` to close the file handle (no issues on macOS / Linux).

I also wrapped the call to `concat` and everything thereafter in a try-catch, because `let {code: output} = concat(this, ast);` can throw because of e.g. a missing import, meaning `super.end()` would never be called.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
