### PR TITLE
@parcel/register slight refactoring

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -91,7 +91,7 @@ export default class Parcel {
   }
 
   async init() {
-    Cache.createCacheDir(this.options.cliOpts.cacheDir);
+    await Cache.createCacheDir(this.options.cliOpts.cacheDir);
 
     if (!this.options.env) {
       await loadEnv(path.join(this.rootDir, 'index'));

--- a/packages/core/integration-tests/test/utils.js
+++ b/packages/core/integration-tests/test/utils.js
@@ -1,4 +1,4 @@
-const Parcel = require('@parcel/core');
+const Parcel = require('@parcel/core').default;
 const assert = require('assert');
 const vm = require('vm');
 const fs = require('@parcel/fs');

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@parcel/core": "^2.0.0",
     "@parcel/utils": "^1.10.3",
-    "pirates": "^4.0.0",
-    "resolve-from": "^4.0.0"
+    "pirates": "^4.0.0"
   }
 }

--- a/packages/core/register/src/hook.js
+++ b/packages/core/register/src/hook.js
@@ -1,13 +1,9 @@
 import Module from 'module';
 import process from 'process';
 import path from 'path';
-import fs from 'fs';
 import {addHook} from 'pirates';
-import resolveFrom from 'resolve-from';
-
-import Parcel, {Asset, Dependency, Environment} from '@parcel/core';
+import Parcel, {Dependency, Environment} from '@parcel/core';
 import syncPromise from '@parcel/utils/lib/syncPromise';
-import {loadConfig} from '@parcel/utils/lib/config';
 
 const originalRequire = Module.prototype.require;
 const DEFAULT_CLI_OPTS = {
@@ -15,49 +11,6 @@ const DEFAULT_CLI_OPTS = {
 };
 
 let hooks = {};
-let parcelModuleDirs = [];
-
-function getPkgUp(filename) {
-  return syncPromise(loadConfig(filename, ['package.json']));
-}
-
-function getModuleDir(filename) {
-  let pkg = getPkgUp(filename);
-  if (!pkg || !pkg.files[0]) {
-    return null;
-  }
-
-  return path.dirname(pkg.files[0].filePath);
-}
-
-function isParcelModule(filename) {
-  return !!parcelModuleDirs.find(moduleDir => filename.startsWith(moduleDir));
-}
-
-function isParcelDep(filename) {
-  if (isParcelModule(filename)) {
-    return true;
-  }
-
-  let loadedConfig = getPkgUp(filename);
-  if (loadedConfig === null) {
-    return false;
-  }
-
-  let pkg = loadedConfig.config;
-  return pkg && (pkg.name.includes('@parcel') || pkg.name.includes('parcel-'));
-}
-
-function addParcelModuleDir(filename) {
-  if (!filename) {
-    return;
-  }
-
-  let moduleDir = getModuleDir(filename);
-  if (!parcelModuleDirs.includes(moduleDir)) {
-    parcelModuleDirs.push(moduleDir);
-  }
-}
 
 export default function register(opts = DEFAULT_CLI_OPTS) {
   // Replace old hook, as this one likely contains options.
@@ -81,13 +34,18 @@ export default function register(opts = DEFAULT_CLI_OPTS) {
 
   syncPromise(parcel.init());
 
+  let inParcelRequire = false;
+  let isProcessing = false;
+  let isParcelModule = new WeakSet();
+
   // As Parcel is pretty much fully asynchronous, create an async function and wrap it in a syncPromise later...
   async function fileProcessor(code, filename) {
-    if (isParcelDep(filename)) {
+    if (inParcelRequire) {
       return code;
     }
 
     try {
+      isProcessing = true;
       let result = await parcel.runTransform({
         filePath: filename,
         env: environment
@@ -104,6 +62,8 @@ export default function register(opts = DEFAULT_CLI_OPTS) {
     } catch (e) {
       console.error('@parcel/register failed to process: ', filename);
       console.error(e);
+    } finally {
+      isProcessing = false;
     }
 
     return '';
@@ -112,20 +72,12 @@ export default function register(opts = DEFAULT_CLI_OPTS) {
   let hookFunction = (...args) => syncPromise(fileProcessor(...args));
 
   function resolveFile(currFile, targetFile) {
-    let resolvedTargetFile;
     try {
-      resolvedTargetFile = resolveFrom(path.dirname(currFile), targetFile);
-    } catch (e) {
-      resolvedTargetFile = e;
-    }
-
-    if (
-      !isParcelDep(currFile) &&
-      (resolvedTargetFile instanceof Error || !isParcelDep(resolvedTargetFile))
-    ) {
+      isProcessing = true;
       let dep = new Dependency({
         moduleSpecifier: targetFile,
-        sourcePath: currFile
+        sourcePath: currFile,
+        env: environment
       });
 
       targetFile = syncPromise(parcel.resolverRunner.resolve(dep));
@@ -137,23 +89,31 @@ export default function register(opts = DEFAULT_CLI_OPTS) {
           ignoreNodeModules: false
         });
       }
-    } else {
-      if (resolvedTargetFile instanceof Error) {
-        throw resolvedTargetFile;
-      }
 
-      addParcelModuleDir(currFile);
-      addParcelModuleDir(resolvedTargetFile);
+      return targetFile;
+    } finally {
+      isProcessing = false;
     }
-
-    return targetFile;
   }
 
   Module.prototype.require = function(filePath, ...args) {
-    return originalRequire.bind(this)(
-      resolveFile(this.filename, filePath),
-      ...args
-    );
+    let wasInParcelRequire = inParcelRequire;
+
+    // If this is a require while Parcel is processing, don't process it or any of its deps.
+    if (isProcessing || (this.parent && isParcelModule.has(this.parent))) {
+      inParcelRequire = true;
+      isParcelModule.add(this);
+    }
+
+    let resolved = filePath;
+    if (!inParcelRequire) {
+      resolved = resolveFile(this.filename, filePath);
+    }
+
+    let res = originalRequire.call(this, resolved, ...args);
+
+    inParcelRequire = wasInParcelRequire;
+    return res;
   };
 }
 

--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -38,6 +38,10 @@ class Worker extends EventEmitter {
 
     this.child = childProcess.fork(childModule, process.argv, options);
 
+    // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
+    this.child.unref();
+    this.child.channel.unref();
+
     this.child.on('message', data => this.receive(data));
 
     this.child.once('exit', code => {


### PR DESCRIPTION
I played around a bit with `@parcel/register` on #2399 to see if I could simplify it a little. Basically, instead of tracking things by filename and needing to do multiple resolves + package.json lookups, I take advantage of the fact that `require` is synchronous in Node. This means that only one require can be processed at a time. Using this, we can set a flag right as we are about to process a file in Parcel's resolver or transformer, and unset it at the end. Any `require` calls that happen while that flag is set are internal to Parcel or one of its deps and should use the default node require implementation.

Additionally, I added `unref` calls to the child processes and their IPC channels so that they don't keep the main process running. I'm not totally sure this won't break anything else, but the other tests seem to pass ok so seems like maybe it'll work.

Let me know what you think!