### PR TITLE
Add autorun for NodeJS builds

### DIFF
--- a/packages/core/parcel-bundler/src/AutoRun.js
+++ b/packages/core/parcel-bundler/src/AutoRun.js
@@ -31,6 +31,9 @@ class AutoRun {
   }
 
   run(bundle) {
+    if (!bundle.name) {
+      return;
+    }
     this.prog = spawn('node', [bundle.name], {
       stdio: [process.stdin, process.stdout, process.stderr],
       detached: false

--- a/packages/core/parcel-bundler/src/AutoRun.js
+++ b/packages/core/parcel-bundler/src/AutoRun.js
@@ -1,50 +1,24 @@
-const {spawn} = require('child_process');
+const {fork} = require('child_process');
 
 class AutoRun {
   constructor(bundler) {
     this.bundler = bundler;
-    this.prog = null;
-
-    this.selfStoppedPIDs = {};
 
     bundler.on('bundled', async bundle => {
-      await this.clearPrevious();
+      if (this.previousRun) {
+        this.previousRun.kill();
+      }
       this.run(bundle);
     });
 
     bundler.bundle();
   }
 
-  async clearPrevious() {
-    if (this.prog) {
-      this.prog.kill();
-      this.selfStoppedPIDs[this.prog.pid] = true;
-      await new Promise(resolve => {
-        const intervalID = setInterval(() => {
-          if (this.prog.killed) {
-            resolve(clearInterval(intervalID));
-          }
-        }, 50);
-      });
-      return;
-    }
-  }
-
   run(bundle) {
     if (!bundle.name) {
       return;
     }
-    this.prog = spawn('node', [bundle.name], {
-      stdio: [process.stdin, process.stdout, process.stderr],
-      detached: false
-    });
-    this.prog.on('close', code => {
-      if (this.selfStoppedPIDs[this.prog.pid]) {
-        delete this.selfStoppedPIDs[this.prog.pid];
-      } else {
-        process.exit(code);
-      }
-    });
+    this.previousRun = fork(bundle.name);
   }
 }
 

--- a/packages/core/parcel-bundler/src/AutoRun.js
+++ b/packages/core/parcel-bundler/src/AutoRun.js
@@ -1,0 +1,48 @@
+const {spawn} = require('child_process');
+
+class AutoRun {
+  constructor(bundler) {
+    this.bundler = bundler;
+    this.prog = null;
+
+    this.selfStoppedPIDs = {};
+
+    bundler.on('bundled', async bundle => {
+      await this.clearPrevious();
+      this.run(bundle);
+    });
+
+    bundler.bundle();
+  }
+
+  async clearPrevious() {
+    if (this.prog) {
+      this.prog.kill();
+      this.selfStoppedPIDs[this.prog.pid] = true;
+      await new Promise(resolve => {
+        const intervalID = setInterval(() => {
+          if (this.prog.killed) {
+            resolve(clearInterval(intervalID));
+          }
+        }, 50);
+      });
+      return;
+    }
+  }
+
+  run(bundle) {
+    this.prog = spawn('node', [bundle.name], {
+      stdio: [process.stdin, process.stdout, process.stderr],
+      detached: false
+    });
+    this.prog.on('close', code => {
+      if (this.selfStoppedPIDs[this.prog.pid]) {
+        delete this.selfStoppedPIDs[this.prog.pid];
+      } else {
+        process.exit(code);
+      }
+    });
+  }
+}
+
+module.exports = AutoRun;

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -8,6 +8,7 @@ const Watcher = require('@parcel/watcher');
 const FSCache = require('./FSCache');
 const HMRServer = require('./HMRServer');
 const Server = require('./Server');
+const AutoRun = require('./AutoRun');
 const {EventEmitter} = require('events');
 const logger = require('@parcel/logger');
 const PackagerRegistry = require('./packagers');
@@ -844,6 +845,10 @@ class Bundler extends EventEmitter {
       // ignore: server can still work with errored bundler
     }
     return this.server;
+  }
+
+  autorun() {
+    new AutoRun(this);
   }
 }
 

--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -247,6 +247,8 @@ async function bundle(main, command) {
         command.open
       );
     }
+  } else if (command.name() === 'serve' && command.target === 'node') {
+    await bundler.autorun();
   } else {
     bundler.bundle();
   }


### PR DESCRIPTION
# ↪️ Pull Request

Currently, if you want to create a plain NodeJS build, parcel is only building the JS files, not running them.

This PR adds the equivalent of `serve` but for NodeJS env.

And the script will be restarted at every build if `watch` is enabled.

## 💻 Examples

`parcel index.js --target=node` will also run index.js

## 🚨 Test instructions

I don't know how to test that the build is indeed run after the building phase.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
