### PR TITLE
Inject content at beginning of stylus files

### DIFF
--- a/packages/core/parcel-bundler/src/assets/StylusAsset.js
+++ b/packages/core/parcel-bundler/src/assets/StylusAsset.js
@@ -5,6 +5,7 @@ const Resolver = require('../Resolver');
 const fs = require('@parcel/fs');
 const {dirname, resolve, relative} = require('path');
 const {isGlob, glob} = require('../utils/glob');
+const {EOL} = require('os');
 
 const URL_RE = /^(?:url\s*\(\s*)?['"]?(?:[#/]|(?:https?:)?\/\/)/i;
 
@@ -20,6 +21,10 @@ class StylusAsset extends Asset {
     let opts = await this.getConfig(['.stylusrc', '.stylusrc.js'], {
       packageKey: 'stylus'
     });
+    // inject content at beginning of stylus files
+    if (opts && opts.inject) {
+      code = opts.inject + EOL + code;
+    }
     let style = stylus(code, opts);
     style.set('filename', this.name);
     style.set('include css', true);

--- a/packages/core/parcel-bundler/src/assets/StylusAsset.js
+++ b/packages/core/parcel-bundler/src/assets/StylusAsset.js
@@ -30,7 +30,9 @@ class StylusAsset extends Asset {
     style.set('include css', true);
     // Setup a handler for the URL function so we add dependencies for linked assets.
     style.define('url', node => {
-      let filename = this.addURLDependency(node.val, node.filename);
+      let filename = /^=./.test(node.val)
+        ? node.val.slice(1)
+        : this.addURLDependency(node.val, node.filename);
       return new stylus.nodes.Literal(`url(${JSON.stringify(filename)})`);
     });
     style.set('Evaluator', await createEvaluator(code, this, style.options));

--- a/packages/core/parcel-bundler/src/assets/VueAsset.js
+++ b/packages/core/parcel-bundler/src/assets/VueAsset.js
@@ -17,6 +17,17 @@ class VueAsset extends Asset {
     );
     this.vue = await localRequire('@vue/component-compiler-utils', this.name);
 
+    // handle mighty vue (initial, pretty basic version)
+    const regx = /(?<=\n|^)(template|script|style)(?:.*\n)([\s\S]*?)(\n(?=\S)|$)/g;
+    const lang = {
+      template: 'pug',
+      script: 'coffee',
+      style: 'stylus'
+    };
+    code = code.replace(regx, function(...hits) {
+      return `<${hits[1]} lang='${lang[hits[1]]}'>\n${hits[2]}</${hits[1]}>\n`;
+    });
+
     return this.vue.parse({
       source: code,
       needMap: this.options.sourceMaps,


### PR DESCRIPTION
# ↪️ Pull Request

Allows content to be injected at the beginning of `stylus` files.

This is especially helpful if you have global variables (commonly used in themes or branded versions of the same site), that you need to define for your stylus files. Instead of having to type `@import "variables"` (or similar) at the beginning of each `*.styl` file, you can simple provide the content to inject in your `package.json` file.

It seems that this is a common and long-standing request (see #1725) that has never been addressed. Granted, this solution is pretty basic of just injecting to all `stylus` files, but if more elaborate use cases are needed, they could easy be added based on the same idea. Given that this will inject into every `stylus` file, it's best to use it to just define variables or mixins that don't have side effects.

## 💻 Examples

```
{ ... this is your package.json file ...

  "stylus": {
    "inject": "@import '~/src/styles/app.styl'"
  }
}
```

## 🚨 Test instructions

Add an `inject` key to your top-level `stylus` key in `package.json`, and verify that it's working.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
