### PR TITLE
use env port

### DIFF
--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -219,7 +219,7 @@ async function bundle(main, command) {
   command.target = command.target || 'browser';
   if (command.name() === 'serve' && command.target === 'browser') {
     const server = await bundler.serve(
-      command.port || 1234,
+      process.env.PORT || 1234,
       command.https,
       command.host
     );

--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -218,11 +218,8 @@ async function bundle(main, command) {
 
   command.target = command.target || 'browser';
   if (command.name() === 'serve' && command.target === 'browser') {
-    const server = await bundler.serve(
-      process.env.PORT || 1234,
-      command.https,
-      command.host
-    );
+    const port = command.port || process.env.PORT || 1234;
+    const server = await bundler.serve(port, command.https, command.host);
     if (server && command.open) {
       await require('./utils/openInBrowser')(
         `${command.https ? 'https' : 'http'}://localhost:${


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

#1126 
~~Replaces `command.port` with `process.env.PORT`~~
Adds `process.env.PORT` as additional default

I _think_ it's ok to just replace? 😅 

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->


## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

Don't think test are applicable here.

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
