### PR TITLE
pug Deprecated pretty

### DIFF
--- a/packages/core/parcel-bundler/src/assets/PugAsset.js
+++ b/packages/core/parcel-bundler/src/assets/PugAsset.js
@@ -18,7 +18,7 @@ class PugAsset extends Asset {
       compileDebug: false,
       filename: this.name,
       basedir: path.dirname(this.name),
-      pretty: !this.options.minify,
+      pretty: config.pretty || false,
       templateName: path.basename(this.basename, path.extname(this.basename)),
       filters: config.filters,
       filterOptions: config.filterOptions,


### PR DESCRIPTION

see https://pugjs.org/api/reference.html#options

pretty: boolean | string

[Deprecated.] Adds whitespace to the resulting HTML to make it easier for a human to read using '  ' as indentation. If a string is specified, that will be used as indentation instead (e.g. '\t'). We strongly recommend against using this option. Too often, it creates subtle bugs in your templates because of the way it alters the interpretation and rendering of whitespace, and so this feature is going to be removed. Defaults to false.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
