### PR TITLE
Fixing some tests that fail because of environment setups. 

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -10,6 +10,7 @@ const {
   ncp
 } = require('./utils');
 const {mkdirp} = require('@parcel/fs');
+const {symlinkPrivilegeWarning} = require('@parcel/utils').errorUtils;
 const {symlinkSync} = require('fs');
 
 describe('javascript', function() {
@@ -1290,21 +1291,28 @@ describe('javascript', function() {
       inputDir
     );
 
-    // Create the symlink here to prevent cross platform and git issues
-    symlinkSync(
-      path.join(inputDir, 'packages/foo'),
-      path.join(inputDir, 'node_modules/foo'),
-      'dir'
-    );
+    try {
+      // Create the symlink here to prevent cross platform and git issues
+      symlinkSync(
+        path.join(inputDir, 'packages/foo'),
+        path.join(inputDir, 'node_modules/foo'),
+        'dir'
+      );
 
-    await bundle(inputDir + '/index.js');
+      await bundle(inputDir + '/index.js');
 
-    let file = await fs.readFile(
-      path.join(__dirname, '/dist/index.js'),
-      'utf8'
-    );
-    assert(file.includes('function Foo'));
-    assert(file.includes('function Bar'));
+      let file = await fs.readFile(
+        path.join(__dirname, '/dist/index.js'),
+        'utf8'
+      );
+      assert(file.includes('function Foo'));
+      assert(file.includes('function Bar'));
+    } catch(e) {
+      if(e.perm == 'EPERM') {
+        symlinkPrivilegeWarning();
+        this.skip();
+      }
+    }
   });
 
   it('should not compile node_modules with a source field in package.json when not symlinked', async function() {

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -10,7 +10,7 @@ const {
   ncp
 } = require('./utils');
 const {mkdirp} = require('@parcel/fs');
-const {symlinkPrivilegeWarning} = require('@parcel/utils').errorUtils;
+const {symlinkPrivilegeWarning} = require('@parcel/test-utils');
 const {symlinkSync} = require('fs');
 
 describe('javascript', function() {

--- a/packages/core/integration-tests/test/kotlin.js
+++ b/packages/core/integration-tests/test/kotlin.js
@@ -1,7 +1,15 @@
 const assert = require('assert');
 const {bundle, assertBundleTree, run} = require('./utils');
+const commandExists = require('command-exists')
 
 describe('kotlin', function() {
+  if (!commandExists.sync('java')) {
+    console.log(
+      'Skipping Kotlin tests. Install https://www.java.com/download/ to run them.'
+    );
+    return;
+  }
+
   it('should produce a basic kotlin bundle', async function() {
     let b = await bundle(__dirname + '/integration/kotlin/index.js');
 

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -11,7 +11,7 @@ const {
   ncp
 } = require('./utils');
 const {sleep} = require('@parcel/test-utils');
-const {symlinkPrivilegeWarning} = require('@parcel/utils').errorUtils;
+const {symlinkPrivilegeWarning} = require('@parcel/test-utils');
 const {symlinkSync} = require('fs');
 
 const inputDir = path.join(__dirname, '/input');

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -11,6 +11,7 @@ const {
   ncp
 } = require('./utils');
 const {sleep} = require('@parcel/test-utils');
+const {symlinkPrivilegeWarning} = require('@parcel/utils').errorUtils;
 const {symlinkSync} = require('fs');
 
 const inputDir = path.join(__dirname, '/input');
@@ -274,29 +275,36 @@ describe('watcher', function() {
       inputDir
     );
 
-    // Create the symlink here to prevent cross platform and git issues
-    symlinkSync(
-      path.join(inputDir, 'local.js'),
-      path.join(inputDir, 'src/symlinked_local.js')
-    );
+    try {
+      // Create the symlink here to prevent cross platform and git issues
+      symlinkSync(
+        path.join(inputDir, 'local.js'),
+        path.join(inputDir, 'src/symlinked_local.js')
+      );
 
-    b = bundler(path.join(inputDir, '/src/index.js'), {
-      watch: true
-    });
+      b = bundler(path.join(inputDir, '/src/index.js'), {
+        watch: true
+      });
 
-    let bundle = await b.bundle();
-    let output = await run(bundle);
+      let bundle = await b.bundle();
+      let output = await run(bundle);
 
-    assert.equal(output(), 3);
+      assert.equal(output(), 3);
 
-    await sleep(100);
-    fs.writeFile(
-      path.join(inputDir, '/local.js'),
-      'exports.a = 5; exports.b = 5;'
-    );
+      await sleep(100);
+      fs.writeFile(
+        path.join(inputDir, '/local.js'),
+        'exports.a = 5; exports.b = 5;'
+      );
 
-    bundle = await nextBundle(b);
-    output = await run(bundle);
-    assert.equal(output(), 10);
+      bundle = await nextBundle(b);
+      output = await run(bundle);
+      assert.equal(output(), 10);
+    } catch(e) {
+      if(e.code == 'EPERM') {
+        symlinkPrivilegeWarning();
+        this.skip();
+      }
+    }
   });
 });

--- a/packages/core/parcel-bundler/test/resolver.js
+++ b/packages/core/parcel-bundler/test/resolver.js
@@ -3,33 +3,43 @@ const path = require('path');
 const assert = require('assert');
 const {rimraf, ncp} = require('./utils');
 const {mkdirp} = require('@parcel/fs');
+const {symlinkPrivilegeWarning} = require('@parcel/utils').errorUtils;
 const {symlinkSync} = require('fs');
 
 const rootDir = path.join(__dirname, 'input/resolver');
 
 describe('resolver', function() {
   let resolver;
+  let hasPrivilege = true;
+
   before(async function() {
     await rimraf(path.join(__dirname, '/input'));
     await mkdirp(rootDir);
     await ncp(path.join(__dirname, 'integration/resolver'), rootDir);
 
     // Create the symlinks here to prevent cross platform and git issues
-    symlinkSync(
-      path.join(rootDir, 'packages/source'),
-      path.join(rootDir, 'node_modules/source'),
-      'dir'
-    );
-    symlinkSync(
-      path.join(rootDir, 'packages/source-alias'),
-      path.join(rootDir, 'node_modules/source-alias'),
-      'dir'
-    );
-    symlinkSync(
-      path.join(rootDir, 'packages/source-alias-glob'),
-      path.join(rootDir, 'node_modules/source-alias-glob'),
-      'dir'
-    );
+    try {
+      symlinkSync(
+        path.join(rootDir, 'packages/source'),
+        path.join(rootDir, 'node_modules/source'),
+        'dir'
+      );
+      symlinkSync(
+        path.join(rootDir, 'packages/source-alias'),
+        path.join(rootDir, 'node_modules/source-alias'),
+        'dir'
+      );
+      symlinkSync(
+        path.join(rootDir, 'packages/source-alias-glob'),
+        path.join(rootDir, 'node_modules/source-alias-glob'),
+        'dir'
+      );
+    } catch (e) {
+      if (e.code == 'EPERM') {
+        symlinkPrivilegeWarning();
+        hasPrivilege = false;
+      }
+    }
 
     resolver = new Resolver({
       rootDir,
@@ -579,6 +589,8 @@ describe('resolver', function() {
 
   describe('source field', function() {
     it('should use the source field when symlinked', async function() {
+      if (!hasPrivilege) this.skip();
+
       let resolved = await resolver.resolve(
         'source',
         path.join(rootDir, 'foo.js')
@@ -591,6 +603,8 @@ describe('resolver', function() {
     });
 
     it('should not use the source field when not symlinked', async function() {
+      if (!hasPrivilege) this.skip();
+
       let resolved = await resolver.resolve(
         'source-not-symlinked',
         path.join(rootDir, 'foo.js')
@@ -603,6 +617,8 @@ describe('resolver', function() {
     });
 
     it('should use the source field as an alias when symlinked', async function() {
+      if (!hasPrivilege) this.skip();
+
       let resolved = await resolver.resolve(
         'source-alias/dist',
         path.join(rootDir, 'foo.js')
@@ -615,6 +631,8 @@ describe('resolver', function() {
     });
 
     it('should use the source field as a glob alias when symlinked', async function() {
+      if (!hasPrivilege) this.skip();
+
       let resolved = await resolver.resolve(
         'source-alias-glob',
         path.join(rootDir, 'foo.js')

--- a/packages/core/parcel-bundler/test/resolver.js
+++ b/packages/core/parcel-bundler/test/resolver.js
@@ -3,7 +3,7 @@ const path = require('path');
 const assert = require('assert');
 const {rimraf, ncp} = require('./utils');
 const {mkdirp} = require('@parcel/fs');
-const {symlinkPrivilegeWarning} = require('@parcel/utils').errorUtils;
+const {symlinkPrivilegeWarning} = require('@parcel/test-utils');
 const {symlinkSync} = require('fs');
 
 const rootDir = path.join(__dirname, 'input/resolver');

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -2,4 +2,13 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function symlinkPrivilegeWarning() {
+  console.error("-----------------------------------")
+  console.error("Skipping symbolic link test(s) because you don't have the privilege.");
+  console.error("Run tests with Administrator privilege.");
+  console.error("If you don't know how, check here: https://bit.ly/2UmWsbD");
+  console.error("-----------------------------------")
+}
+
 exports.sleep = sleep;
+exports.symlinkPrivilegeWarning = symlinkPrivilegeWarning;

--- a/packages/core/utils/src/errorUtils.js
+++ b/packages/core/utils/src/errorUtils.js
@@ -27,5 +27,14 @@ function jsonToError(json) {
   }
 }
 
+function symlinkPrivilegeWarning() {
+  console.error("-----------------------------------")
+  console.error("Skipping symbolic link test(s) because you don't have the privilege.");
+  console.error("Run tests with Administrator privilege.");
+  console.error("If you don't know how, check here: https://bit.ly/2UmWsbD");
+  console.error("-----------------------------------")
+}
+
 exports.errorToJson = errorToJson;
 exports.jsonToError = jsonToError;
+exports.symlinkPrivilegeWarning = symlinkPrivilegeWarning;

--- a/packages/core/utils/src/errorUtils.js
+++ b/packages/core/utils/src/errorUtils.js
@@ -27,14 +27,5 @@ function jsonToError(json) {
   }
 }
 
-function symlinkPrivilegeWarning() {
-  console.error("-----------------------------------")
-  console.error("Skipping symbolic link test(s) because you don't have the privilege.");
-  console.error("Run tests with Administrator privilege.");
-  console.error("If you don't know how, check here: https://bit.ly/2UmWsbD");
-  console.error("-----------------------------------")
-}
-
 exports.errorToJson = errorToJson;
 exports.jsonToError = jsonToError;
-exports.symlinkPrivilegeWarning = symlinkPrivilegeWarning;


### PR DESCRIPTION
# ↪️ Pull Request

Sometimes, we cannot pass some tests because:
* Java isn't installed or configured. Then, Kotlin test fails. (It's really rare for developers' computer to not have Java. Unfortunately, mine is one of them...)
* symlinkSync throws EPERM error. On Windows 10, [creating symlinks is disabled for security.](https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links) 

So, I changed these:
* Ignore Kotlin test when there is no Java. I borrowed structure and message from Rust.
* Show warning message and instruction link to the [`cmd` Admin article](https://bit.ly/2UmWsbD) when symlink fails. 

## 💻 Examples

None

## 🚨 Test instructions

1. `git clone https://github.com/parcel-bundler/parcel.git` on Windows 10.
2. `yarn test`
3. Test fails. 

## ✔️ PR Todo

- [V] Added/updated unit tests for this change
- [V] Filled out test instructions (In case there aren't any unit tests)
- [] Included links to related issues/PRs
