### PR TITLE
Ensure css files are written before hmr is triggered

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -298,11 +298,6 @@ class Bundler extends EventEmitter {
         asset.replaceBundleNames(this.bundleNameMap);
       }
 
-      // Emit an HMR update if this is not the initial bundle.
-      if (this.hmr && !isInitialBundle) {
-        this.hmr.emitUpdate(changedAssets);
-      }
-
       logger.progress(`Packaging...`);
 
       // Package everything up
@@ -310,6 +305,11 @@ class Bundler extends EventEmitter {
         this,
         this.bundleHashes
       );
+
+      // Emit an HMR update if this is not the initial bundle.
+      if (this.hmr && !isInitialBundle) {
+        this.hmr.emitUpdate(changedAssets);
+      }
 
       // Unload any orphaned assets
       this.unloadOrphanedAssets();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

The project I am building is generating a big CSS file (~20k lines of code/ 500kb file).
When generating this file in development the hot reload is triggered before the file is completely generated, it will only load the first ~2000 lines of the code. Triggering the update again by hand (finding the link tag within the dom and updating the number after the `?` parameter) is working.

Moving the emit of the hot reload after `this.mainBundle.package` call solves the issue.

## 💻 Examples

I cannot really show an example because I don't have a public project with that many lines of code. I guess it also depends on the filesystem speed to reproduce this (my filesystem is actually slow because of Windows/ WSL).

## 🚨 Test instructions

My setup uses SCSS, CSS Modules and Typescript. Let me know if there are more things you are interested in.

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
