### PR TITLE
Fixed watcher stop CI test on Windows. 

### DIFF
--- a/packages/core/watcher/test/fswatcher.js
+++ b/packages/core/watcher/test/fswatcher.js
@@ -25,8 +25,7 @@ describe('Watcher', function() {
     assert(!!watcher.child);
     assert(watcher.ready);
 
-    let time = Date.now();
     await watcher.stop();
-    assert.notEqual(time, Date.now());
+    assert(watcher.child.killed);
   });
 });


### PR DESCRIPTION
# ↪️ Pull Request

`watcher.stop()` test failed on Windows 10. Details on #2609. 

## 🤔 What is changed?

In the previous test, it compared the time to check if stop() is called successfully. 

After reading [child process document](https://nodejs.org/api/child_process.html#child_process_subprocess_kill_signal) and [some nodejs code](https://github.com/nodejs/node), it is a better solution to check `killed` rather than using time differences. 

Because `this.child.killed` is set to true when [`kill`](http://man7.org/linux/man-pages/man2/kill.2.html) or [`TerminateProcess`](https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-terminateprocess) finished their job correctly. 


## 💻 Examples

N/A

## 🚨 Test instructions

When added a pull request, it failed. 

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
