### PR TITLE
Allow dotfiles to be served

### DIFF
--- a/packages/core/parcel-bundler/src/Server.js
+++ b/packages/core/parcel-bundler/src/Server.js
@@ -36,7 +36,8 @@ function middleware(bundler) {
   const serve = serveStatic(bundler.options.outDir, {
     index: false,
     redirect: false,
-    setHeaders: setHeaders
+    setHeaders: setHeaders,
+    dotfiles: 'allow'
   });
 
   return function(req, res, next) {


### PR DESCRIPTION
# ↪️ Pull Request

Requesting output files starting with a dot would result in them being handled as missing.

As documented: https://github.com/expressjs/serve-static#dotfiles

Closes #2628


## 💻 Examples

```
dist
 |- .mybundle.213fasd.js
 |- index.html (includes .mybundle.213fasd.js)
```
## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->