### PR TITLE
Fix to resovle dependencies with paths option in tsconfig #202

### DIFF
--- a/packages/core/parcel-bundler/src/Asset.js
+++ b/packages/core/parcel-bundler/src/Asset.js
@@ -45,6 +45,7 @@ class Asset {
     this.buildTime = 0;
     this.bundledSize = 0;
     this.resolver = new Resolver(options);
+    this.resolvePaths = {};
   }
 
   shouldInvalidate() {

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -419,8 +419,8 @@ class Bundler extends EventEmitter {
     return asset;
   }
 
-  async resolveAsset(name, parent) {
-    let {path} = await this.resolver.resolve(name, parent);
+  async resolveAsset(name, parent, resolvePaths) {
+    let {path} = await this.resolver.resolve(name, parent, resolvePaths);
     return this.getLoadedAsset(path);
   }
 
@@ -471,7 +471,7 @@ class Bundler extends EventEmitter {
         return this.getLoadedAsset(dep.resolved);
       }
 
-      return await this.resolveAsset(dep.name, asset.name);
+      return await this.resolveAsset(dep.name, asset.name, asset.resolvePaths);
     } catch (err) {
       // If the dep is optional, return before we throw
       if (dep.optional) {
@@ -574,6 +574,7 @@ class Bundler extends EventEmitter {
     asset.generated = processed.generated;
     asset.hash = processed.hash;
     asset.cacheData = processed.cacheData;
+    asset.resolvePaths = processed.resolvePaths;
 
     // Call the delegate to get implicit dependencies
     let dependencies = processed.dependencies;

--- a/packages/core/parcel-bundler/src/Pipeline.js
+++ b/packages/core/parcel-bundler/src/Pipeline.js
@@ -36,7 +36,8 @@ class Pipeline {
       generated: generatedMap,
       error: error,
       hash: asset.hash,
-      cacheData: asset.cacheData
+      cacheData: asset.cacheData,
+      resolvePaths: asset.resolvePaths
     };
   }
 
@@ -70,6 +71,7 @@ class Pipeline {
         subAsset.contents = value;
         subAsset.dependencies = asset.dependencies;
         subAsset.cacheData = Object.assign(asset.cacheData, subAsset.cacheData);
+        subAsset.resolvePaths = asset.resolvePaths;
 
         let processed = await this.processAsset(subAsset);
         if (rendition.meta) {

--- a/packages/core/parcel-bundler/src/assets/TypeScriptAsset.js
+++ b/packages/core/parcel-bundler/src/assets/TypeScriptAsset.js
@@ -62,6 +62,8 @@ class TypeScriptAsset extends Asset {
       );
     }
 
+    this.resolvePaths = transpilerOptions.compilerOptions.paths;
+
     return [
       {
         type: 'js',

--- a/packages/core/parcel-bundler/test/integration/resolve-paths/app/foo.ts
+++ b/packages/core/parcel-bundler/test/integration/resolve-paths/app/foo.ts
@@ -1,0 +1,1 @@
+exports.getMessage = () => './app/foo.ts';

--- a/packages/core/parcel-bundler/test/integration/resolve-paths/core/util/foo.ts
+++ b/packages/core/parcel-bundler/test/integration/resolve-paths/core/util/foo.ts
@@ -1,0 +1,1 @@
+exports.getMessage = () => './core/util/foo.ts';

--- a/packages/core/parcel-bundler/test/integration/resolve-paths/index.ts
+++ b/packages/core/parcel-bundler/test/integration/resolve-paths/index.ts
@@ -1,0 +1,7 @@
+import app_foo from '@app/foo';
+import core_util_foo from '@core/foo';
+import src_foo from '@src/foo';
+
+app_foo.getMessage();
+core_util_foo.getMessage();
+src_foo.getMessage();

--- a/packages/core/parcel-bundler/test/integration/resolve-paths/package.json
+++ b/packages/core/parcel-bundler/test/integration/resolve-paths/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "resolve-paths",
+  "version": "1.0.0",
+  "main": "index.ts"
+}

--- a/packages/core/parcel-bundler/test/integration/resolve-paths/src/foo.ts
+++ b/packages/core/parcel-bundler/test/integration/resolve-paths/src/foo.ts
@@ -1,0 +1,1 @@
+exports.getMessage = () => './src/foo.js';

--- a/packages/core/parcel-bundler/test/integration/resolve-paths/tsconfig.json
+++ b/packages/core/parcel-bundler/test/integration/resolve-paths/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["esnext"],
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["./app/*"],
+      "@core/*": ["./core/**"],
+      "@src/*": ["./src"]
+    }
+  }
+}

--- a/packages/core/parcel-bundler/test/resolvePaths.js
+++ b/packages/core/parcel-bundler/test/resolvePaths.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const Path = require('path');
+const Bundler = require('../src/Bundler');
+
+describe('typescript asset', () => {
+  it('should be resolved with tsconfig paths when bundled', async () => {
+    const filename = Path.normalize(
+      Path.join(__dirname, '/integration/resolve-paths/index.ts')
+    );
+
+    const options = {
+      outDir: Path.join(__dirname, './integration/resolve-paths/dist'),
+      outFile: 'index.js',
+      cache: false,
+      hmr: false
+    };
+
+    const bundler = new Bundler(filename, options);
+    const bundle = await bundler.bundle();
+
+    const loadedAssets = [...bundle.assets.values()].map(asset => asset.id);
+
+    assert.equal(loadedAssets.includes('index.ts'), true);
+    assert.equal(loadedAssets.includes('app/foo.ts'), true);
+    assert.equal(loadedAssets.includes('core/util/foo.ts'), true);
+    assert.equal(loadedAssets.includes('src/foo.ts'), true);
+  });
+});


### PR DESCRIPTION
# ↪️ Pull Request

Paths option in tsconfig.json doesn't work.
This commit fix that #202 issue.


## 💻 Examples

```
.
├── app
│   └── foo.ts
├── core
│   └── util
│       └── foo.ts
├── src
│   └── foo.ts
├── index.ts
├── package.json
├── tsconfig.json
```

```ts
import app_foo from '@app/foo';
import core_util_foo from '@core/foo';
import src_foo from '@src/foo';
```

```js
{
  "compilerOptions": {
    // ...
    "paths": {
      "@app/*": ["./app/*"],
      "@core/*": ["./core/**"],
      "@src/*": ["./src"]
    }
  }
}
```

## 🚨 Test instructions

```
$ cd parcel/paackages/core/parcel-bundler && yarn
$ yarn test
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

