### PR TITLE
Fix sourceMappingURL for bundles with multiple entry points

### DIFF
--- a/packages/core/integration-tests/test/integration/sourcemap-sourcemappingurl-multiple-entrypoints/a/index.js
+++ b/packages/core/integration-tests/test/integration/sourcemap-sourcemappingurl-multiple-entrypoints/a/index.js
@@ -1,0 +1,1 @@
+console.log('hello1');

--- a/packages/core/integration-tests/test/integration/sourcemap-sourcemappingurl-multiple-entrypoints/b/index.js
+++ b/packages/core/integration-tests/test/integration/sourcemap-sourcemappingurl-multiple-entrypoints/b/index.js
@@ -1,0 +1,1 @@
+console.log('hello2');

--- a/packages/core/integration-tests/test/integration/sourcemap-sourcemappingurl/index.js
+++ b/packages/core/integration-tests/test/integration/sourcemap-sourcemappingurl/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -314,4 +314,34 @@ describe('sourcemaps', function() {
     );
     mapValidator(jsOutput, map);
   });
+
+  it('should create correct sourceMappingURL', async function() {
+    const b = await bundle(
+      path.join(__dirname, '/integration/sourcemap-sourcemappingurl/index.js')
+    );
+
+    const jsOutput = await fs.readFile(b.name, 'utf8');
+    assert(jsOutput.includes('//# sourceMappingURL=/index.js.map'));
+  });
+
+  it('should create correct sourceMappingURL with multiple entrypoints', async function() {
+    const b = await bundle([
+      path.join(
+        __dirname,
+        '/integration/sourcemap-sourcemappingurl-multiple-entrypoints/a/index.js'
+      ),
+      path.join(
+        __dirname,
+        '/integration/sourcemap-sourcemappingurl-multiple-entrypoints/b/index.js'
+      )
+    ]);
+
+    const bundle1 = [...b.childBundles][0];
+    const bundle2 = [...b.childBundles][1];
+    const jsOutput1 = await fs.readFile(bundle1.name, 'utf8');
+    const jsOutput2 = await fs.readFile(bundle2.name, 'utf8');
+
+    assert(jsOutput1.includes('//# sourceMappingURL=/a/index.js.map'));
+    assert(jsOutput2.includes('//# sourceMappingURL=/b/index.js.map'));
+  });
 });

--- a/packages/core/parcel-bundler/src/packagers/JSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSPackager.js
@@ -239,7 +239,7 @@ class JSPackager extends Packager {
       if (mapBundle) {
         let mapUrl = urlJoin(
           this.options.publicURL,
-          path.basename(mapBundle.name)
+          path.relative(this.options.outDir, mapBundle.name)
         );
         await this.write(`\n//# sourceMappingURL=${mapUrl}`);
       }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

sourceMappingURL is not correct for bundles with multiple entry points

## 💻 Examples

Taken from #2607 

```
parcel build src/a/index.js src/b/index.js
```

The two output files should contains these sourcemap comments:

```
a/index.js: `//# sourceMappingURL=/a/index.js.map`
b/index.js: `//# sourceMappingURL=/b/index.js.map`
```

but in reality `/a/` and `/b/` are not there.

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

See #2607 for detailed instructions. For tldr, see Examples 👆 

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
