### PR TITLE
Fix dependency list parsing in RustAsset for paths on Windows

### DIFF
--- a/packages/core/parcel-bundler/src/assets/RustAsset.js
+++ b/packages/core/parcel-bundler/src/assets/RustAsset.js
@@ -176,7 +176,7 @@ class RustAsset extends Asset {
       .slice(1);
 
     for (let dep of deps) {
-      dep = path.resolve(dir, dep.slice(0, dep.indexOf(':')));
+      dep = path.resolve(dir, dep.slice(0, dep.indexOf(': ')));
       if (dep !== this.name) {
         this.addDependency(dep, {includedInParent: true});
       }


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #2184

When importing a Rust asset on Windows, an error like this occurs:
```
×  Error writing to cache: ENOENT: no such file or directory, stat 'C:\Users\lmorc\devel\rust-wasm-play\src\C'
```

This appears to be an issue with how RustAsset [attempts to parse a deps file](https://github.com/parcel-bundler/parcel/blob/31bd420580e68ae82dfb88a7926364ec1fdac800/packages/core/parcel-bundler/src/assets/RustAsset.js#L179) using ":" - which fails on Windows because ":" is a part of file paths like `C:\users\...`

Switching that parsing to ": " seems to address the problem.

## 💻 Examples

Just following [the basic Rust example from the docs](https://parceljs.org/rust.html)

## 🚨 Test instructions

Build the example from the docs on Windows under PowerShell (e.g. *not* within a WSL Ubuntu Bash shell) - no error should occur.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
  - Sorry, I'm rather new to Parcel and didn't find existing unit tests for RustAsset.js to modify. But, since this was a one-character fix, I thought it would be more handy to submit the PR as-is 😟 
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs