### PR TITLE
Support less import paths from .lessrc

### DIFF
--- a/packages/core/integration-tests/test/.lessrc
+++ b/packages/core/integration-tests/test/.lessrc
@@ -1,0 +1,5 @@
+{
+    "paths": [
+        "./import-path/"
+    ]
+}

--- a/packages/core/integration-tests/test/integration/less-import-paths/import-path/a.less
+++ b/packages/core/integration-tests/test/integration/less-import-paths/import-path/a.less
@@ -1,0 +1,3 @@
+.imported {
+  color: red;
+}

--- a/packages/core/integration-tests/test/integration/less-import-paths/index.js
+++ b/packages/core/integration-tests/test/integration/less-import-paths/index.js
@@ -1,0 +1,5 @@
+require('./index.less');
+
+module.exports = function () {
+  return 2;
+};

--- a/packages/core/integration-tests/test/integration/less-import-paths/index.less
+++ b/packages/core/integration-tests/test/integration/less-import-paths/index.less
@@ -1,0 +1,5 @@
+@import 'a.less';
+
+.index {
+  color: blue;
+}

--- a/packages/core/integration-tests/test/less.js
+++ b/packages/core/integration-tests/test/less.js
@@ -65,6 +65,38 @@ describe('less', function() {
     assert(css.includes('.base'));
   });
 
+  it('should support less import paths', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/less-import-paths/index.js')
+    );
+
+    await assertBundleTree(b, {
+      name: 'index.js',
+      assets: ['index.js', 'index.less'],
+      childBundles: [
+        {
+          type: 'map'
+        },
+        {
+          name: 'index.css',
+          assets: ['index.less'],
+          childBundles: []
+        }
+      ]
+    });
+
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 2);
+
+    let css = await fs.readFile(
+      path.join(__dirname, '/dist/index.css'),
+      'utf8'
+    );
+    assert(css.includes('.index'));
+    assert(css.includes('.imported'));
+  });
+
   it('should support advanced less imports', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/less-advanced-import/index.js')


### PR DESCRIPTION
# ↪️ Pull Request

Respect the "paths" setting from `.lessrc` to set additional import paths. This was not recognized by the resolver in LESSAsset.

## 💻 Examples

If `.lessrc` contains

```
{
    "paths": [
        "../node_modules/foo/bar/"
    ]
}
```
And file at `./src/index.less` contains:
```
@import "baz";
```
It will find the file at `./src/baz.less`, but if that doesn't exist it will also look for `./node_modules/foo/bar/baz.less`

## 🚨 Test instructions

Added one test to `test/less.js`.

## ✔️ PR Todo

- [X] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs

## Related issues/PRs

- Open issue #1818 
- Previous closed PR #1823 