### PR TITLE
Prevent circular deps from causing a stack overflow in HMR runtime

### DIFF
--- a/packages/core/integration-tests/test/integration/hmr-circular/index.js
+++ b/packages/core/integration-tests/test/integration/hmr-circular/index.js
@@ -1,0 +1,9 @@
+var local = require('./local');
+
+function run() {
+  output(local.a + local.b);
+}
+
+run();
+
+module.exports = 'value';

--- a/packages/core/integration-tests/test/integration/hmr-circular/local.js
+++ b/packages/core/integration-tests/test/integration/hmr-circular/local.js
@@ -1,0 +1,4 @@
+var other = require('./index.js');
+
+exports.a = 1;
+exports.b = 2;

--- a/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
+++ b/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
@@ -28,7 +28,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
   var protocol = location.protocol === 'https:' ? 'wss' : 'ws';
   var ws = new WebSocket(protocol + '://' + hostname + ':' + process.env.HMR_PORT + '/');
   ws.onmessage = function(event) {
-    updatedAssets = new Set();
+    updatedAssets = {};
     
     var data = JSON.parse(event.data);
 
@@ -150,10 +150,10 @@ function hmrAccept(bundle, id) {
     return hmrAccept(bundle.parent, id);
   }
 
-  if (updatedAssets.has(id)) {
+  if (updatedAssets[id]) {
     return;
   }
-  updatedAssets.add(id);
+  updatedAssets[id] = true;
 
   var cached = bundle.cache[id];
   bundle.hotData = {};

--- a/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
+++ b/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
@@ -20,6 +20,7 @@ function Module(moduleName) {
 }
 
 module.bundle.Module = Module;
+var updatedAssets;
 
 var parent = module.bundle.parent;
 if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
@@ -27,6 +28,8 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
   var protocol = location.protocol === 'https:' ? 'wss' : 'ws';
   var ws = new WebSocket(protocol + '://' + hostname + ':' + process.env.HMR_PORT + '/');
   ws.onmessage = function(event) {
+    updatedAssets = new Set();
+    
     var data = JSON.parse(event.data);
 
     if (data.type === 'update') {
@@ -146,6 +149,11 @@ function hmrAccept(bundle, id) {
   if (!modules[id] && bundle.parent) {
     return hmrAccept(bundle.parent, id);
   }
+
+  if (updatedAssets.has(id)) {
+    return;
+  }
+  updatedAssets.add(id);
 
   var cached = bundle.cache[id];
   bundle.hotData = {};


### PR DESCRIPTION
# ↪️ Pull Request

This PR prevents a stack overflow when updating files that have circular dependencies. This issue occurs when HMR tries to reload dependencies and gets stuck flowing the loop. The fix is achieved by adding a set that contains each of the asset ID updated in the same HMR update event. This set is used to keep track of what has been updated and skips loading the same asset more than once.

Fixes #1192 
