### PR TITLE
[v2] Remove 'use strict' pragmas from es modules in source

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -1,5 +1,5 @@
 // @flow
-'use strict';
+
 import Graph, {Node, type NodeId} from './Graph';
 import type {
   CacheEntry,

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -1,5 +1,5 @@
 // @flow
-'use strict';
+
 import type {TraversalContext, Graph as IGraph} from '@parcel/types';
 
 export type NodeId = string;

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -1,5 +1,5 @@
 // @flow
-'use strict';
+
 import AssetGraph from './AssetGraph';
 import type {
   Bundle,

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -1,5 +1,5 @@
 // @flow
-'use strict';
+
 import assert from 'assert';
 import AssetGraph, {nodeFromTransformerRequest} from '../src/AssetGraph';
 import Dependency from '../src/Dependency';

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -1,5 +1,5 @@
 // @flow
-'use strict';
+
 import assert from 'assert';
 
 import Graph from '../src/Graph';

--- a/packages/core/plugin/src/PluginAPI.js
+++ b/packages/core/plugin/src/PluginAPI.js
@@ -1,5 +1,5 @@
 // @flow
-'use strict';
+
 import type {
   Transformer as TransformerOpts,
   Resolver as ResolverOpts,

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -1,5 +1,4 @@
 // @flow
-'use strict';
 
 import {Packager} from '@parcel/plugin';
 import fs from 'fs';


### PR DESCRIPTION
[ES Modules are automatically in strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Strict_mode_for_modules), so there isn't a need for this pragma. Environments that support modules natively run them in strict mode, but in our case Babel also inserts `'use strict'` pragma in its commonjs output.

   Test Plan: Run `yarn build` and verify the corresponding `lib` files
   continue to have a `'use strict'` pragma inserted at the top by babel.

   cc @padmaia @devongovett