### PR TITLE
[v2] Fix import paths in ConfigResolver

### DIFF
--- a/packages/core/core/src/ConfigResolver.js
+++ b/packages/core/core/src/ConfigResolver.js
@@ -1,11 +1,11 @@
 // @flow
 import type {FilePath, ParcelConfig, PackageName} from '@parcel/types';
-import {resolveConfig} from '@parcel/utils/lib/config';
+import {resolveConfig} from '@parcel/utils/src/config';
 import Config from './Config';
 import fs from '@parcel/fs';
 import {parse} from 'json5';
 import path from 'path';
-import localRequire from '@parcel/utils/lib/localRequire';
+import localRequire from '@parcel/utils/src/localRequire';
 import assert from 'assert';
 
 type Pipeline = Array<PackageName>;

--- a/packages/core/core/src/ConfigResolver.js
+++ b/packages/core/core/src/ConfigResolver.js
@@ -1,11 +1,11 @@
 // @flow
 import type {FilePath, ParcelConfig, PackageName} from '@parcel/types';
-import {resolveConfig} from '@parcel/utils/config';
+import {resolveConfig} from '@parcel/utils/lib/config';
 import Config from './Config';
 import fs from '@parcel/fs';
 import {parse} from 'json5';
 import path from 'path';
-import localRequire from '@parcel/utils/localRequire';
+import localRequire from '@parcel/utils/lib/localRequire';
 import assert from 'assert';
 
 type Pipeline = Array<PackageName>;


### PR DESCRIPTION
Every other use of the modules `config` and `localRequire` in
`@parcel/utils` imports it from `@parcel/utils/lib/config`, which is a real
file on disk after build. Without this, both mocha and flow fail right
away.

Please let me know if this is intentional for some reason.

Test Plan: `mocha` in `packages/core` and `flow` in the repo root. Verify
error messages related to the missing module are no longer there.