### PR TITLE
add banner option for bundler and use in core packagers

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -44,7 +44,7 @@ describe('css', function() {
       path.join(__dirname, '/dist/index.css'),
       'utf8'
     );
-    assert(file.startsWith(`// ${bannerString} \n`));
+    assert(file.startsWith(`/* ${bannerString} */\n`));
   });
 
   it('should support loading a CSS bundle along side dynamic imports', async function() {

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -33,6 +33,20 @@ describe('css', function() {
     assert.equal(output(), 3);
   });
 
+  it('should include a banner when supplied', async function() {
+    const bannerString = 'Welcome to my bundle, v0';
+    let b = await bundle(path.join(__dirname, '/integration/css/index.js'), {
+      banner: bannerString
+    });
+
+    await run(b);
+    let file = await fs.readFile(
+      path.join(__dirname, '/dist/index.css'),
+      'utf8'
+    );
+    assert(file.startsWith(`// ${bannerString} \n`));
+  });
+
   it('should support loading a CSS bundle along side dynamic imports', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/dynamic-css/index.js')

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -54,6 +54,20 @@ describe('html', function() {
     }
   });
 
+  it('should include a banner when supplied', async function() {
+    const bannerString = 'Welcome to my bundle, v0';
+    let b = await bundle(path.join(__dirname, '/integration/html/index.html'), {
+      banner: bannerString
+    });
+
+    await run(b);
+    let file = await fs.readFile(
+      path.join(__dirname, '/dist/index.html'),
+      'utf8'
+    );
+    assert(file.startsWith(`<!-- ${bannerString} -->\n`));
+  });
+
   it('should find href attr when not first', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-attr-order/index.html')

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -56,11 +56,10 @@ describe('html', function() {
 
   it('should include a banner when supplied', async function() {
     const bannerString = 'Welcome to my bundle, v0';
-    let b = await bundle(path.join(__dirname, '/integration/html/index.html'), {
+    await bundle(path.join(__dirname, '/integration/html/index.html'), {
       banner: bannerString
     });
 
-    await run(b);
     let file = await fs.readFile(
       path.join(__dirname, '/dist/index.html'),
       'utf8'

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1889,4 +1889,19 @@ describe('javascript', function() {
 
     await run(b);
   });
+
+  it('should start with a banner when supplied', async function() {
+    const bannerString = 'Welcome to my bundle, v0';
+    let b = await bundle(
+      path.join(__dirname, '/integration/commonjs/index.js'),
+      {banner: bannerString}
+    );
+
+    await run(b);
+    let file = await fs.readFile(
+      path.join(__dirname, '/dist/index.js'),
+      'utf8'
+    );
+    assert(file.startsWith(`// ${bannerString} \n`));
+  });
 });

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1902,6 +1902,6 @@ describe('javascript', function() {
       path.join(__dirname, '/dist/index.js'),
       'utf8'
     );
-    assert(file.startsWith(`// ${bannerString} \n`));
+    assert(file.startsWith(`/** ${bannerString} */\n`));
   });
 });

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -141,6 +141,7 @@ class Bundler extends EventEmitter {
         (options.target === 'electron' ? 'localhost' : ''),
       detailedReport: options.detailedReport || false,
       global: options.global,
+      banner: options.banner || '',
       autoinstall:
         typeof options.autoinstall === 'boolean'
           ? options.autoinstall

--- a/packages/core/parcel-bundler/src/packagers/CSSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/CSSPackager.js
@@ -2,7 +2,7 @@ const Packager = require('./Packager');
 
 class CSSPackager extends Packager {
   async start() {
-    await this.writeBundleBanner('//');
+    await this.writeBundleBanner('/*', '*/');
   }
 
   async addAsset(asset) {

--- a/packages/core/parcel-bundler/src/packagers/CSSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/CSSPackager.js
@@ -1,6 +1,10 @@
 const Packager = require('./Packager');
 
 class CSSPackager extends Packager {
+  async start() {
+    await this.writeBundleBanner('//');
+  }
+
   async addAsset(asset) {
     let css = asset.generated.css || '';
 

--- a/packages/core/parcel-bundler/src/packagers/HTMLPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/HTMLPackager.js
@@ -16,6 +16,10 @@ const metadataContent = new Set([
 ]);
 
 class HTMLPackager extends Packager {
+  async start() {
+    await this.writeBundleBanner('<!--', '-->');
+  }
+
   static shouldAddAsset() {
     // We cannot combine multiple HTML files together - they should be written as separate bundles.
     return false;

--- a/packages/core/parcel-bundler/src/packagers/JSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSPackager.js
@@ -26,6 +26,7 @@ class JSPackager extends Packager {
           this.options.hmrHostname
         )};` + preludeCode;
     }
+    await this.writeBundleBanner('//');
     await this.write(preludeCode + '({');
     this.lineOffset = lineCounter(preludeCode);
   }

--- a/packages/core/parcel-bundler/src/packagers/JSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSPackager.js
@@ -26,7 +26,7 @@ class JSPackager extends Packager {
           this.options.hmrHostname
         )};` + preludeCode;
     }
-    await this.writeBundleBanner('//');
+    await this.writeBundleBanner('/**', '*/');
     await this.write(preludeCode + '({');
     this.lineOffset = lineCounter(preludeCode);
   }

--- a/packages/core/parcel-bundler/src/packagers/Packager.js
+++ b/packages/core/parcel-bundler/src/packagers/Packager.js
@@ -36,6 +36,16 @@ class Packager {
     throw new Error('Must be implemented by subclasses');
   }
 
+  async writeBundleBanner(commentBegin, commentEnd) {
+    commentBegin = commentBegin || '';
+    commentEnd = commentEnd || '';
+    if (this.options.banner) {
+      await this.write(
+        `${commentBegin} ${this.options.banner} ${commentEnd}\n`
+      );
+    }
+  }
+
   getSize() {
     return this.dest.bytesWritten;
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

closes #2459

Adds a `banner` option to `Bundler` and adds utility method in `Packager` to write that banner with the proper markup to the first line of the package.

Implements this pattern (with tests) for the `JSPackager`, `CSSPackager`, and `HTMLPackager`.

(If this approach looks good, I'm happy to add documentation for this new option to this PR.)

## 💻 Examples

The primary use case here is for library maintainers to write the version of their library (or some other information) to the top of the package file. An example string would be "The Best HTTP library ever v0.1" which would be written to the top of each package file with the appropriate comment markup. For example, the JS package would have this at the top of the file:

```js
/** The Best HTTP library ever v0.1 */

```

## 🚨 Test instructions

See included integration tests.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->