### PR TITLE
For scope hoisting, Asset IDs cannot contain + or / (base64)

### DIFF
--- a/packages/core/parcel-bundler/src/Asset.js
+++ b/packages/core/parcel-bundler/src/Asset.js
@@ -196,9 +196,7 @@ class Asset {
     if (!this.id) {
       this.id =
         this.options.production || this.options.scopeHoist
-          ? md5(this.relativeName, 'base64')
-              .slice(0, 4)
-              .replace(/\+\//g, '_')
+          ? md5(this.relativeName, 'base64').slice(0, 4)
           : this.relativeName;
     }
 

--- a/packages/core/parcel-bundler/src/Asset.js
+++ b/packages/core/parcel-bundler/src/Asset.js
@@ -196,7 +196,9 @@ class Asset {
     if (!this.id) {
       this.id =
         this.options.production || this.options.scopeHoist
-          ? md5(this.relativeName, 'base64').slice(0, 4)
+          ? md5(this.relativeName, 'base64')
+              .slice(0, 4)
+              .replace(/\+\//g, '_')
           : this.relativeName;
     }
 

--- a/packages/core/parcel-bundler/src/assets/VueAsset.js
+++ b/packages/core/parcel-bundler/src/assets/VueAsset.js
@@ -2,6 +2,7 @@ const Asset = require('../Asset');
 const localRequire = require('../utils/localRequire');
 const md5 = require('../utils/md5');
 const {minify} = require('terser');
+const t = require('@babel/types');
 
 class VueAsset extends Asset {
   constructor(name, options) {
@@ -72,10 +73,10 @@ class VueAsset extends Asset {
 
     // TODO: make it possible to process this code with the normal scope hoister
     if (this.options.scopeHoist) {
-      optsVar = `$${this.id}$export$default`;
+      optsVar = `$${t.toIdentifier(this.id)}$export$default`;
 
       if (!js.includes(optsVar)) {
-        optsVar = `$${this.id}$exports`;
+        optsVar = `$${t.toIdentifier(this.id)}$exports`;
         if (!js.includes(optsVar)) {
           supplemental += `
             var ${optsVar} = {};


### PR DESCRIPTION
# ↪️ Pull Request

Asset IDs are base64 encoded, so `+` and `/` are also possible. The IDs are used for hoisting imports and exports, but with an ID `kA+M` then `$kA+M$exports` is not a valid JS identifier, causing an error (see issue): `Unexpected token, expected ; (2:19)`

Collisions might have become more likely now, but shouldn't be that significant?

Fixes #1971

## 💻 Examples

https://github.com/njscholfield/new-tracks/tree/8eba7b08f286cac510d55e5d85800d64633dd3fe


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
