### PR TITLE
[v2] Begin to adopt flow strict, starting with @parcel/types

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,3 +15,9 @@
 [options]
 
 [strict]
+nonstrict-import
+sketchy-null
+unclear-type
+unsafe-getters-setters
+untyped-import
+untyped-type-import

--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -24,7 +24,6 @@ export default new Bundler({
     // 6. If two assets are always seen together, put them in the same extracted bundle.
 
     // Step 1: create bundles for each of the explicit code split points.
-    // $FlowFixMe
     assetGraph.traverse((node, context: ?Context) => {
       if (node.type === 'dependency') {
         let dep: Dependency = node.value;

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -1,6 +1,6 @@
 // @flow
 
-import Graph, {Node, type NodeId} from './Graph';
+import Graph, {type Node, type NodeId} from './Graph';
 import type {
   CacheEntry,
   Dependency as IDependency,
@@ -262,7 +262,10 @@ export default class AssetGraph extends Graph {
     return res;
   }
 
-  traverseAssets(visit: GraphTraversalCallback<Asset>, startNode: ?Node) {
+  traverseAssets(
+    visit: GraphTraversalCallback<Asset>,
+    startNode: ?Node
+  ): ?Node {
     return this.traverse((node, ...args) => {
       if (node.type === 'asset') {
         return visit(node.value, ...args);

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -3,7 +3,8 @@ import type {
   Asset,
   Bundle,
   BundleGroup,
-  GraphTraversalCallback
+  GraphTraversalCallback,
+  Node
 } from '@parcel/types';
 import AssetGraph from './AssetGraph';
 
@@ -150,7 +151,7 @@ export default class BundleGraph extends AssetGraph {
       .map(node => node.value);
   }
 
-  traverseBundles(visit: GraphTraversalCallback<Bundle>): any {
+  traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node {
     return this.traverse((node, ...args) => {
       if (node.type === 'bundle') {
         return visit(node.value, ...args);

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1,4 +1,16 @@
-// @flow
+// @flow strict-local
+
+import type {
+  AST as _AST,
+  Config as _Config,
+  Node as _Node,
+  TraversalContext as _TraversalContext
+} from './unsafe';
+
+export type AST = _AST;
+export type Config = _Config;
+export type Node = _Node;
+export type TraversalContext = _TraversalContext;
 
 export type JSONValue =
   | null
@@ -154,7 +166,7 @@ export type SourceLocation = {
   end: {line: number, column: number}
 };
 
-export type Meta = {[string]: any};
+export type Meta = {[string]: JSONValue};
 export type DependencyOptions = {|
   moduleSpecifier: ModuleSpecifier,
   isAsync?: boolean,
@@ -225,14 +237,6 @@ export type AssetOutput = {
   [string]: Blob | JSONValue
 };
 
-export type AST = {
-  type: string,
-  version: string,
-  program: any,
-  isDirty?: boolean
-};
-
-export type Config = any;
 export type SourceMap = JSONObject;
 export type Blob = string | Buffer;
 
@@ -278,16 +282,16 @@ export type CacheEntry = {
   initialAssets: ?Array<Asset> // Initial assets, pre-post processing
 };
 
-export interface TraversalContext {
+export interface TraversalActions {
   skipChildren(): void;
   stop(): void;
 }
 
 export type GraphTraversalCallback<T> = (
   asset: T,
-  context?: any,
-  traversal: TraversalContext
-) => any;
+  context?: TraversalContext,
+  traversal: TraversalActions
+) => ?Node;
 
 export interface Graph {
   merge(graph: Graph): void;
@@ -295,7 +299,7 @@ export interface Graph {
 
 // TODO: what do we want to expose here?
 export interface AssetGraph extends Graph {
-  traverseAssets(visit: GraphTraversalCallback<Asset>): any;
+  traverseAssets(visit: GraphTraversalCallback<Asset>): ?Node;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
   getEntryAssets(): Array<Asset>;
@@ -327,7 +331,7 @@ export interface BundleGraph {
   findBundlesWithAsset(asset: Asset): Array<Bundle>;
   getBundles(bundleGroup: BundleGroup): Array<Bundle>;
   getBundleGroups(bundle: Bundle): Array<BundleGroup>;
-  traverseBundles(visit: GraphTraversalCallback<Bundle>): any;
+  traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node;
 }
 
 export type Bundler = {

--- a/packages/core/types/unsafe.js
+++ b/packages/core/types/unsafe.js
@@ -1,0 +1,18 @@
+// @flow
+
+export type Config = any;
+
+export type TraversalContext = any;
+
+export type AST = {
+  type: string,
+  version: string,
+  program: any,
+  isDirty?: boolean
+};
+
+export interface Node {
+  id: string;
+  type?: string;
+  value: any;
+}


### PR DESCRIPTION
This allows us to incrementally adopt [flow strict](https://flow.org/en/docs/strict/), a stricter set of rules, including built-in type-aware lints that detect questionable, unclear, or unsound behavior. Notably, this bans `any`, `Object`, `Function` and other unsound types. I started with `@parcel/types` by extracting unsafe types (those that are or include `any`) into `unsafe.js`, which will remain out of strict mode while we further refine our types.

I also took the opportunity to repurpose `TraversalContext` as `TraversalActions`, which was confusingly yielded along with something else called "context".

Test Plan: `flow` with no additional errors.