### PR TITLE
[v2] Make types exact

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -8,10 +8,10 @@ const OPTIONS = {
   maxParallelRequests: 5
 };
 
-type Context = {
+type Context = {|
   bundleGroup: BundleGroup,
   bundle: Bundle
-};
+|};
 
 export default new Bundler({
   bundle(assetGraph, bundleGraph) {

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -18,7 +18,7 @@ import {loadConfig} from '@parcel/utils/lib/config';
 import Cache from '@parcel/cache';
 import Dependency from './Dependency';
 
-type AssetOptions = {
+type AssetOptions = {|
   id?: string,
   hash?: string,
   filePath: FilePath,
@@ -32,7 +32,7 @@ type AssetOptions = {
   outputHash?: string,
   env: Environment,
   meta?: JSONObject
-};
+|};
 
 export default class Asset implements IAsset {
   id: string;

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -63,23 +63,23 @@ const getDepNodesFromGraph = (graph: Graph): Array<Node> => {
   );
 };
 
-type DepUpdates = {
+type DepUpdates = {|
   newRequest?: TransformerRequest,
   prunedFiles: Array<File>
-};
+|};
 
-type FileUpdates = {
+type FileUpdates = {|
   newDeps: Array<Dependency>,
   addedFiles: Array<File>,
   removedFiles: Array<File>
-};
+|};
 
-type AssetGraphOpts = {
+type AssetGraphOpts = {|
   entries?: Array<string>,
   targets?: Array<Target>,
   transformerRequest?: TransformerRequest,
   rootDir: string
-};
+|};
 
 /**
  * AssetGraph is a Graph with some extra rules.

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -1,4 +1,5 @@
 // @flow
+
 import type {
   CLIOptions,
   Dependency,
@@ -18,15 +19,10 @@ import WorkerFarm from '@parcel/workers';
 
 const abortError = new Error('Build aborted');
 
-type Signal = {
-  aborted: boolean,
-  addEventListener?: Function
-};
-
-type BuildOpts = {
-  signal: Signal,
+type BuildOpts = {|
+  signal: AbortSignal,
   shallow?: boolean
-};
+|};
 
 type Opts = {|
   cliOpts: CLIOptions,
@@ -48,16 +44,17 @@ export default class AssetGraphBuilder extends EventEmitter {
 
   constructor(opts: Opts) {
     super();
+    let {config, cliOpts, rootDir, entries, targets, transformerRequest} = opts;
 
     this.queue = new PromiseQueue();
     this.resolverRunner = new ResolverRunner({
-      config: opts.config,
-      cliOpts: opts.cliOpts,
-      rootDir: opts.rootDir
+      config,
+      cliOpts,
+      rootDir
     });
 
     this.graph = new AssetGraph();
-    this.graph.initializeGraph(opts);
+    this.graph.initializeGraph({entries, targets, transformerRequest, rootDir});
 
     this.controller = new AbortController();
     if (opts.cliOpts.watch) {

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -11,11 +11,11 @@ import type Config from './Config';
 import BundleGraph from './BundleGraph';
 import AssetGraphBuilder from './AssetGraphBuilder';
 
-type Opts = {
+type Opts = {|
   cliOpts: CLIOptions,
   config: Config,
   rootDir: FilePath
-};
+|};
 
 export default class BundlerRunner {
   cliOpts: CLIOptions;

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -11,13 +11,13 @@ import type {
 } from '@parcel/types';
 import md5 from '@parcel/utils/lib/md5';
 
-type DependencyOpts = {
+type DependencyOpts = {|
   ...DependencyOptions,
   moduleSpecifier: ModuleSpecifier,
   env: IEnvironment,
   id?: string,
   sourcePath?: FilePath
-};
+|};
 
 export default class Dependency implements IDependency {
   id: string;

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -10,21 +10,21 @@ import type {
 export type Node = _Node;
 export type NodeId = string;
 
-export type Edge = {
+export type Edge = {|
   from: NodeId,
   to: NodeId
-};
+|};
 
-type GraphUpdates = {
+type GraphUpdates = {|
   added: Graph,
   removed: Graph
-};
+|};
 
-type GraphOpts = {
+type GraphOpts = {|
   nodes?: Array<[NodeId, Node]>,
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
-};
+|};
 
 type VisitCallback = (
   node: Node,
@@ -37,10 +37,10 @@ export default class Graph implements IGraph {
   edges: Set<Edge>;
   rootNodeId: ?NodeId;
 
-  constructor(opts: GraphOpts = {}) {
+  constructor(opts: GraphOpts = {nodes: [], edges: [], rootNodeId: null}) {
     this.nodes = new Map(opts.nodes);
     this.edges = new Set(opts.edges);
-    this.rootNodeId = opts.rootNodeId || null;
+    this.rootNodeId = opts.rootNodeId;
   }
 
   serialize(): GraphOpts {

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -4,10 +4,10 @@ import {mkdirp, writeFile} from '@parcel/fs';
 import path from 'path';
 import type {Bundle, CLIOptions, Blob, FilePath} from '@parcel/types';
 
-type Opts = {
+type Opts = {|
   config: Config,
   cliOpts: CLIOptions
-};
+|};
 
 export default class PackagerRunner {
   config: Config;

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -19,7 +19,7 @@ import ConfigResolver from './ConfigResolver';
 
 const abortError = new Error('Build aborted');
 
-type ParcelOpts = {
+type ParcelOpts = {|
   entries: string | Array<string>,
   cwd?: string,
   cliOpts: CLIOptions,
@@ -27,7 +27,7 @@ type ParcelOpts = {
   env?: {[string]: ?string},
   config?: ParcelConfig,
   defaultConfig?: ParcelConfig
-};
+|};
 
 export default class Parcel {
   options: ParcelOpts;

--- a/packages/core/core/src/PromiseQueue.js
+++ b/packages/core/core/src/PromiseQueue.js
@@ -1,8 +1,8 @@
 // @flow
 
-type PromiseQueueOpts = {
-  maxConcurrent?: number
-};
+type PromiseQueueOpts = {|
+  maxConcurrent: number
+|};
 
 export default class PromiseQueue {
   _queue: Array<Function>;
@@ -12,10 +12,9 @@ export default class PromiseQueue {
   _resolve: Function;
   _reject: Function;
 
-  constructor(opts: PromiseQueueOpts = {}) {
+  constructor(opts: PromiseQueueOpts = {maxConcurrent: Infinity}) {
     this._resetState();
-
-    this._maxConcurrent = opts.maxConcurrent || Infinity;
+    this._maxConcurrent = opts.maxConcurrent;
   }
 
   _resetState() {

--- a/packages/core/core/src/ResolverRunner.js
+++ b/packages/core/core/src/ResolverRunner.js
@@ -4,11 +4,11 @@ import type {CLIOptions, Dependency, FilePath} from '@parcel/types';
 import path from 'path';
 import Config from './Config';
 
-type Opts = {
+type Opts = {|
   config: Config,
   cliOpts: CLIOptions,
   rootDir: string
-};
+|};
 
 const getCacheKey = (filename, parent) =>
   (parent ? path.dirname(parent) : '') + ':' + filename;

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -16,10 +16,10 @@ import Cache from '@parcel/cache';
 import fs from '@parcel/fs';
 import Config from './Config';
 
-type Opts = {
+type Opts = {|
   config: Config,
   cliOpts: CLIOptions
-};
+|};
 
 type GenerateFunc = ?(input: Asset) => Promise<AssetOutput>;
 

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -11,11 +11,11 @@ import PackagerRunner from './PackagerRunner';
 import Config from './Config';
 import Cache from '@parcel/cache';
 
-type Options = {
+type Options = {|
   config: Config,
   cliOpts: CLIOptions,
   env: JSONObject
-};
+|};
 
 let transformerRunner: TransformerRunner | null = null;
 let packagerRunner: PackagerRunner | null = null;

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -32,7 +32,7 @@ type SemverRange = string;
 export type ModuleSpecifier = string;
 
 export type GlobMap<T> = {[Glob]: T};
-export type ParcelConfig = {
+export type ParcelConfig = {|
   extends?: PackageName | FilePath | Array<PackageName | FilePath>,
   resolvers?: Array<PackageName>,
   transforms?: {
@@ -50,7 +50,7 @@ export type ParcelConfig = {
     [Glob]: Array<PackageName>
   },
   reporters?: Array<PackageName>
-};
+|};
 
 export type Engines = {
   node?: SemverRange,
@@ -58,11 +58,11 @@ export type Engines = {
   browsers?: Array<string>
 };
 
-export type Target = {
+export type Target = {|
   name: string,
   distPath?: FilePath,
   env: Environment
-};
+|};
 
 export type EnvironmentContext =
   | 'browser'
@@ -89,9 +89,9 @@ export interface Environment {
   isIsolated(): boolean;
 }
 
-type PackageDependencies = {
+type PackageDependencies = {|
   [PackageName]: Semver
-};
+|};
 
 export type PackageJSON = {
   name: PackageName,
@@ -113,7 +113,7 @@ export type PackageJSON = {
   peerDependencies?: PackageDependencies
 };
 
-export type ParcelOptions = {
+export type ParcelOptions = {|
   entries?: Array<FilePath>,
   rootDir?: FilePath,
   config?: ParcelConfig,
@@ -139,18 +139,18 @@ export type ParcelOptions = {
   // throwErrors
   // global?
   // detailedReport
-};
+|};
 
-export type ServerOptions = {
+export type ServerOptions = {|
   host?: string,
   port?: number,
   https?: HTTPSOptions | boolean
-};
+|};
 
-export type HTTPSOptions = {
+export type HTTPSOptions = {|
   cert?: FilePath,
   key?: FilePath
-};
+|};
 
 export type CLIOptions = {
   cacheDir?: FilePath,
@@ -160,11 +160,11 @@ export type CLIOptions = {
   cache?: boolean
 };
 
-export type SourceLocation = {
+export type SourceLocation = {|
   filePath: string,
   start: {line: number, column: number},
   end: {line: number, column: number}
-};
+|};
 
 export type Meta = {[string]: JSONValue};
 export type DependencyOptions = {|
@@ -231,11 +231,11 @@ export interface Asset {
   getOutput(): Promise<AssetOutput>;
 }
 
-export type AssetOutput = {
+export type AssetOutput = {|
   code: string,
   map?: SourceMap,
   [string]: Blob | JSONValue
-};
+|};
 
 export type SourceMap = JSONObject;
 export type Blob = string | Buffer;
@@ -314,7 +314,7 @@ export type BundleGroup = {
   entryAssetId: string
 };
 
-export type Bundle = {
+export type Bundle = {|
   id: string,
   type: string,
   assetGraph: AssetGraph,
@@ -322,7 +322,7 @@ export type Bundle = {
   isEntry?: boolean,
   target?: Target,
   filePath?: FilePath
-};
+|};
 
 export interface BundleGraph {
   addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
@@ -334,38 +334,38 @@ export interface BundleGraph {
   traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node;
 }
 
-export type Bundler = {
+export type Bundler = {|
   bundle(
     graph: AssetGraph,
     bundleGraph: BundleGraph,
     opts: CLIOptions
   ): Async<void>
-};
+|};
 
-export type Namer = {
+export type Namer = {|
   name(bundle: Bundle, opts: CLIOptions): Async<?FilePath>
-};
+|};
 
-export type Runtime = {
+export type Runtime = {|
   apply(bundle: Bundle, opts: CLIOptions): Async<void>
-};
+|};
 
-export type Packager = {
+export type Packager = {|
   package(bundle: Bundle, opts: CLIOptions): Async<Blob>
-};
+|};
 
-export type Optimizer = {
+export type Optimizer = {|
   optimize(bundle: Bundle, contents: Blob, opts: CLIOptions): Async<Blob>
-};
+|};
 
-export type Resolver = {
+export type Resolver = {|
   resolve(
     dependency: Dependency,
     opts: CLIOptions,
     rootDir: string
   ): Async<FilePath | null>
-};
+|};
 
-export type Reporter = {
+export type Reporter = {|
   report(bundles: Array<Bundle>, opts: CLIOptions): void
-};
+|};

--- a/packages/core/types/unsafe.js
+++ b/packages/core/types/unsafe.js
@@ -4,12 +4,12 @@ export type Config = any;
 
 export type TraversalContext = any;
 
-export type AST = {
+export type AST = {|
   type: string,
   version: string,
   program: any,
   isDirty?: boolean
-};
+|};
 
 export interface Node {
   id: string;

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -4,14 +4,14 @@ import fs from '@parcel/fs';
 import path from 'path';
 import clone from 'clone';
 
-type ConfigOutput = {
+type ConfigOutput = {|
   config: Config,
   files: Array<File>
-};
+|};
 
-type ConfigOptions = {
+type ConfigOptions = {|
   parse?: boolean
-};
+|};
 
 const PARSERS = {
   json: require('json5').parse,

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -27,11 +27,11 @@ type InternalPackageJSON = PackageJSON & {
 
 const EMPTY_SHIM = require.resolve('./_empty');
 
-type Options = {
+type Options = {|
   cli: CLIOptions,
   rootDir: string,
   extensions: Array<string>
-};
+|};
 
 /**
  * This resolver implements a modified version of the node_modules resolution algorithm:


### PR DESCRIPTION
This makes many of the defined types [exact object types](https://flow.org/en/docs/types/objects/#toc-exact-object-types). This [is going to be the default in Flow going forward](https://medium.com/flow-type/on-the-roadmap-exact-objects-by-default-16b72933c5cf) and anecdotally catches many issues like mistyped property names from silently introducing errors. Flow will provide codemods to get us back to the same type notation while maintaining these semantics and behavior.

These are the more trivial cases. There are more exact objects to come.

Also replaces our custom `Signal` type with the DOM `AbortSignal`, since Flow doesn't differentiate between environments. Seems okay for now.

Test Plan: `flow`