### PR TITLE
Scope Hoisting: Throw meaningful error on undefined exports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-undefined/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-undefined/a.js
@@ -1,0 +1,1 @@
+export {Test};

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -276,6 +276,23 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, ['test']);
     });
 
+    it('throws a meaningful error on undefined exports', async function() {
+      let threw = false;
+      try {
+        await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/export-undefined/a.js'
+          )
+        );
+      } catch (err) {
+        threw = true;
+        assert.equal(err.message, "export 'Test' is not defined");
+      }
+
+      assert(threw);
+    });
+
     it('supports import default CommonJS interop', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/parcel-bundler/src/scope-hoisting/hoist.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/hoist.js
@@ -533,7 +533,11 @@ function addExport(asset, path, local, exported) {
     asset.cacheData.exports[exported.name] = identifier.name;
   }
 
-  rename(scope, local.name, identifier.name);
+  try {
+    rename(scope, local.name, identifier.name);
+  } catch (e) {
+    throw new Error('export ' + e.message);
+  }
 
   constantViolations.forEach(path => path.insertAfter(t.cloneDeep(assignNode)));
 }

--- a/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/renamer.js
@@ -7,6 +7,10 @@ function rename(scope, oldName, newName) {
 
   let binding = scope.getBinding(oldName);
 
+  if (!binding) {
+    throw new Error("'" + oldName + "' is not defined");
+  }
+
   // Rename all constant violations
   for (let violation of binding.constantViolations) {
     let bindingIds = violation.getBindingIdentifierPaths(true, false);


### PR DESCRIPTION
# ↪️ Pull Request

Previously:
`lib2.js: Cannot read property 'constantViolations' of undefined`
Now:
`lib2.js: export 'Multiply' is not defined`

## 💻 Examples

```js
export {Multiply};
```


## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->