### PR TITLE
Build the bundle manually with 'rs' in CLI

### DIFF
--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -1,6 +1,7 @@
 require('v8-compile-cache');
 const chalk = require('chalk');
 const program = require('commander');
+const os = require('os');
 const version = require('../package.json').version;
 
 program.version(version);
@@ -228,6 +229,14 @@ async function bundle(main, command) {
         command.open
       );
     }
+
+    process.stdin.on('data', data => {
+      const inputString = data.toString();
+
+      if (inputString === 'rs' + os.EOL) {
+        bundler.bundle();
+      }
+    });
   } else {
     bundler.bundle();
   }


### PR DESCRIPTION
# ↪️ Pull Request

Closes #2342.

Hey,

Adding the same feature Nodemon has — https://github.com/remy/nodemon#manual-restarting — manually starting the build from the CLI.

I suppose this is also what's asked for in #2342.

## 💻 Examples

``` bash
>  parcel index.html
Server running at http://localhost:1234
✨ Built in 76ms.
[type rs and press enter]
✨ Built in 2ms.
```

## 🚨 Test instructions

(AFAIK we don't currently have tests involving CLI)

How to test it:
1. Create a dummy HTML file with any HTML contents
2. Run your dev version of `parcel` on it
3. Wait for it to get built
4. Type "rs" and press enter
5. Make sure it gets built again: check the update time of the compiled file in `dist/`

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->