### PR TITLE
Add flow typings for abortcontroller-polyfill

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,7 @@
 [include]
 
 [libs]
+flow-libs/
 
 [lints]
 

--- a/flow-libs/abortcontroller-polyfill.js.flow
+++ b/flow-libs/abortcontroller-polyfill.js.flow
@@ -1,0 +1,13 @@
+declare module 'abortcontroller-polyfill/dist/cjs-ponyfill' {
+  // Identical to https://github.com/facebook/flow/blob/v0.92.1/lib/bom.js#L1048
+  declare export class AbortController {
+    constructor(): void;
+    +signal: AbortSignal;
+    abort(): void;
+  }
+
+  declare export class AbortSignal extends EventTarget {
+    +aborted: boolean;
+    onabort: (event: 'abort') => mixed;
+  }
+}

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -9,7 +9,10 @@ import type {
 import type {Node} from './Graph';
 import type Config from './Config';
 import EventEmitter from 'events';
-import {AbortController} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
+import {
+  AbortController,
+  type AbortSignal
+} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import Watcher from '@parcel/watcher';
 import PromiseQueue from './PromiseQueue';
 import AssetGraph from './AssetGraph';
@@ -18,13 +21,8 @@ import WorkerFarm from '@parcel/workers';
 
 const abortError = new Error('Build aborted');
 
-type Signal = {
-  aborted: boolean,
-  addEventListener?: Function
-};
-
 type BuildOpts = {
-  signal: Signal,
+  signal: AbortSignal,
   shallow?: boolean
 };
 


### PR DESCRIPTION
Once we're happy with them, we can contribute them upstream to flow-typed.

Also removes our custom `Signal` type in `AssetGraphBuilder.js` to use the DOM `AbortSignal` already defined in Flow.