### PR TITLE
Unify build abort errors

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -20,8 +20,6 @@ import AssetGraph from './AssetGraph';
 import ResolverRunner from './ResolverRunner';
 import WorkerFarm from '@parcel/workers';
 
-const abortError = new Error('Build aborted');
-
 type BuildOpts = {|
   signal: AbortSignal,
   shallow?: boolean
@@ -134,7 +132,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     }
 
     if (signal.aborted) {
-      throw abortError;
+      throw new BuildAbortError();
     }
 
     let req = {filePath: resolvedPath, env: dep.env};
@@ -149,7 +147,7 @@ export default class AssetGraphBuilder extends EventEmitter {
   async transform(req: TransformerRequest, {signal, shallow}: BuildOpts) {
     let cacheEntry = await this.runTransform(req);
 
-    if (signal.aborted) throw abortError;
+    if (signal.aborted) throw new BuildAbortError();
     let {
       addedFiles,
       removedFiles,
@@ -173,4 +171,8 @@ export default class AssetGraphBuilder extends EventEmitter {
       }
     }
   }
+}
+
+export class BuildAbortError extends Error {
+  name = 'BuildAbortError';
 }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -14,10 +14,8 @@ import getRootDir from '@parcel/utils/getRootDir';
 import loadEnv from './loadEnv';
 import path from 'path';
 import Cache from '@parcel/cache';
-import AssetGraphBuilder from './AssetGraphBuilder';
+import AssetGraphBuilder, {BuildAbortError} from './AssetGraphBuilder';
 import ConfigResolver from './ConfigResolver';
-
-const abortError = new Error('Build aborted');
 
 type ParcelOpts = {|
   entries: string | Array<string>,
@@ -137,7 +135,7 @@ export default class Parcel {
       // console.log('Finished build'); // eslint-disable-line no-console
       return bundleGraph;
     } catch (e) {
-      if (e !== abortError) {
+      if (!(e instanceof BuildAbortError)) {
         console.error(e); // eslint-disable-line no-console
       }
       throw e;

--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -1,0 +1,79 @@
+// @flow strict-local
+
+import invariant from 'assert';
+import path from 'path';
+import nullthrows from 'nullthrows';
+import {AbortController} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
+
+import AssetGraphBuilder, {BuildAbortError} from '../src/AssetGraphBuilder';
+import ConfigResolver from '../src/ConfigResolver';
+import Dependency from '../src/Dependency';
+import Environment from '../src/Environment';
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+const CONFIG_DIR = path.join(FIXTURES_DIR, 'config');
+
+const DEFAULT_ENV = new Environment({
+  context: 'browser',
+  engines: {
+    browsers: ['> 1%']
+  }
+});
+
+const TARGETS = [
+  {
+    name: 'test',
+    distPath: 'dist/out.js',
+    env: DEFAULT_ENV
+  }
+];
+
+describe('AssetGraphBuilder', () => {
+  let config;
+  let builder;
+  beforeEach(async () => {
+    config = nullthrows(await new ConfigResolver().resolve(CONFIG_DIR));
+
+    builder = new AssetGraphBuilder({
+      cliOpts: {cache: false},
+      config,
+      rootDir: FIXTURES_DIR,
+      entries: ['./module-b'],
+      targets: TARGETS
+    });
+  });
+
+  it('creates an AssetGraphBuilder', async () => {
+    invariant(
+      builder.graph.nodes.has(
+        new Dependency({
+          moduleSpecifier: './module-b',
+          env: DEFAULT_ENV
+        }).id
+      )
+    );
+  });
+
+  it('throws a BuildAbortError when resolving if signal aborts', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      await builder.resolve(
+        new Dependency({
+          moduleSpecifier: './module-b',
+          env: DEFAULT_ENV,
+          sourcePath: FIXTURES_DIR + '/index'
+        }),
+        {
+          signal: controller.signal
+        }
+      );
+    } catch (e) {
+      invariant(e instanceof BuildAbortError);
+      return;
+    }
+
+    throw new Error('must throw BuildAbortError');
+  });
+});

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -52,18 +52,22 @@ class NodeResolver {
   rootPackage: InternalPackageJSON | null;
 
   constructor(options: Options) {
-    this.options = options;
+    // $FlowFixMe
+    this.options = Object.assign({}, options, {
+      // normalize extensions that don't lead with '.'
+      extensions: options.extensions.map(
+        ext => (ext.startsWith('.') ? ext : '.' + ext)
+      )
+    });
     this.packageCache = new Map();
     this.rootPackage = null;
   }
 
   async resolve({
-    moduleSpecifier: input,
+    moduleSpecifier: filename,
     sourcePath: parent,
     isURL
   }: Dependency) {
-    let filename = input;
-
     // Check if this is a glob
     if (glob.isGlob(filename)) {
       return {path: path.resolve(path.dirname(parent), filename)};


### PR DESCRIPTION
This unifies the concept of a `BuildAbortError`, which is often thrown in response to a build's abort controller being aborted. It also tests that it is properly thrown in `AssetGraphBuilder`'s `resolve` method if the signal has been aborted.

Previously, `Parcel.js` checked identity against an error that was never thrown, which would never have logged anything.