### PR TITLE
Flowify md5 and flow strictify Asset and BundlerRunner

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,6 +12,7 @@
 flow-libs/
 
 [lints]
+untyped-type-import=error
 
 [options]
 

--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -2,7 +2,7 @@
 import * as fs from '@parcel/fs';
 import pkg from '../package.json';
 import Path from 'path';
-import md5 from '@parcel/utils/lib/md5';
+import {md5FromString} from '@parcel/utils/src/md5';
 import objectHash from '@parcel/utils/lib/objectHash';
 import logger from '@parcel/logger';
 import type {
@@ -56,7 +56,7 @@ export class Cache {
   }
 
   getCacheId(appendedData: string, env: Environment) {
-    return md5(this.optionsHash + appendedData + JSON.stringify(env));
+    return md5FromString(this.optionsHash + appendedData + JSON.stringify(env));
   }
 
   getCachePath(cacheId: string, extension: string = '.json'): FilePath {

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -14,7 +14,7 @@ import type {
   Config,
   PackageJSON
 } from '@parcel/types';
-import md5 from '@parcel/utils/lib/md5';
+import {md5FromString, md5FromFilePath} from '@parcel/utils/src/md5';
 import {loadConfig} from '@parcel/utils/lib/config';
 import Cache from '@parcel/cache';
 import Dependency from './Dependency';
@@ -53,7 +53,9 @@ export default class Asset implements IAsset {
   constructor(options: AssetOptions) {
     this.id =
       options.id ||
-      md5(options.filePath + options.type + JSON.stringify(options.env));
+      md5FromString(
+        options.filePath + options.type + JSON.stringify(options.env)
+      );
     this.hash = options.hash || '';
     this.filePath = options.filePath;
     this.type = options.type;
@@ -102,7 +104,7 @@ export default class Asset implements IAsset {
 
   async addConnectedFile(file: File) {
     if (!file.hash) {
-      file.hash = await md5.file(file.filePath);
+      file.hash = await md5FromFilePath(file.filePath);
     }
 
     this.connectedFiles.push(file);
@@ -111,7 +113,7 @@ export default class Asset implements IAsset {
   createChildAsset(result: TransformerResult) {
     let code = (result.output && result.output.code) || result.code || '';
     let opts: AssetOptions = {
-      hash: this.hash || md5(code),
+      hash: this.hash || md5FromString(code),
       filePath: this.filePath,
       type: result.type,
       code,

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -1,4 +1,5 @@
 // @flow
+
 import type {
   Asset as IAsset,
   TransformerResult,

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -13,7 +13,7 @@ import type {
   Bundle,
   GraphTraversalCallback
 } from '@parcel/types';
-import md5 from '@parcel/utils/lib/md5';
+import {md5FromString} from '@parcel/utils/src/md5';
 import Dependency from './Dependency';
 
 export const nodeFromRootDir = (rootDir: string) => ({
@@ -35,7 +35,7 @@ export const nodeFromFile = (file: File) => ({
 });
 
 export const nodeFromTransformerRequest = (req: TransformerRequest) => ({
-  id: md5(`${req.filePath}:${JSON.stringify(req.env)}`),
+  id: md5FromString(`${req.filePath}:${JSON.stringify(req.env)}`),
   type: 'transformer_request',
   value: req
 });

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -1,4 +1,5 @@
-// @flow
+// @flow strict-local
+
 import type AssetGraph from './AssetGraph';
 import type {
   Namer,
@@ -55,7 +56,7 @@ export default class BundlerRunner {
         rootDir: this.rootDir
       });
 
-      if (filePath) {
+      if (filePath != null) {
         bundle.filePath = filePath;
         return;
       }

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -9,7 +9,7 @@ import type {
   ModuleSpecifier,
   FilePath
 } from '@parcel/types';
-import md5 from '@parcel/utils/lib/md5';
+import {md5FromString} from '@parcel/utils/src/md5';
 
 type DependencyOpts = {|
   ...DependencyOptions,
@@ -45,7 +45,7 @@ export default class Dependency implements IDependency {
     this.sourcePath = opts.sourcePath || ''; // TODO: get from graph?
     this.id =
       opts.id ||
-      md5(
+      md5FromString(
         `${this.sourcePath}:${this.moduleSpecifier}:${JSON.stringify(this.env)}`
       );
   }

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -11,7 +11,7 @@ import type {
 import Asset from './Asset';
 import path from 'path';
 import clone from 'clone';
-import md5 from '@parcel/utils/lib/md5';
+import {md5FromString, md5FromFilePath} from '@parcel/utils/src/md5';
 import Cache from '@parcel/cache';
 import * as fs from '@parcel/fs';
 import Config from './Config';
@@ -34,7 +34,7 @@ class TransformerRunner {
 
   async transform(req: TransformerRequest): Promise<CacheEntry> {
     let code = req.code || (await fs.readFile(req.filePath, 'utf8'));
-    let hash = md5(code);
+    let hash = md5FromString(code);
 
     // If a cache entry matches, no need to transform.
     let cacheEntry;
@@ -235,7 +235,7 @@ async function finalize(asset: Asset, generate: GenerateFunc): Promise<Asset> {
 
   asset.ast = null;
   asset.code = '';
-  asset.outputHash = md5(asset.output.code);
+  asset.outputHash = md5FromString(asset.output.code);
 
   return asset;
 }
@@ -249,7 +249,9 @@ async function checkCachedAssets(assets: Array<IAsset>): Promise<boolean> {
 }
 
 async function checkConnectedFiles(files: Array<File>): Promise<boolean> {
-  let hashes = await Promise.all(files.map(file => md5.file(file.filePath)));
+  let hashes = await Promise.all(
+    files.map(file => md5FromFilePath(file.filePath))
+  );
 
   return files.every((file, index) => file.hash === hashes[index]);
 }

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -1,4 +1,5 @@
 // @flow
+
 import type {Config, File, FilePath} from '@parcel/types';
 import * as fs from '@parcel/fs';
 import path from 'path';

--- a/packages/core/utils/src/md5.js
+++ b/packages/core/utils/src/md5.js
@@ -15,9 +15,9 @@ export function md5FromString(
     .digest(encoding);
 }
 
-export function md5FromFilePath(filename: string): Promise<string> {
+export function md5FromFilePath(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    fs.createReadStream(filename)
+    fs.createReadStream(filePath)
       // $FlowFixMe A Hash is a duplex stream
       .pipe(crypto.createHash('md5').setEncoding('hex'))
       .on('finish', function() {

--- a/packages/core/utils/src/md5.js
+++ b/packages/core/utils/src/md5.js
@@ -1,22 +1,28 @@
-const crypto = require('crypto');
-const fs = require('fs');
+// @flow strict-local
 
-function md5(string, encoding = 'hex') {
+import crypto from 'crypto';
+import fs from 'fs';
+
+type StringHashEncoding = 'hex' | 'latin1' | 'binary' | 'base64';
+
+export function md5FromString(
+  string: string,
+  encoding: StringHashEncoding = 'hex'
+): string {
   return crypto
     .createHash('md5')
     .update(string)
     .digest(encoding);
 }
 
-md5.file = function(filename) {
+export function md5FromFilePath(filename: string): Promise<string> {
   return new Promise((resolve, reject) => {
     fs.createReadStream(filename)
+      // $FlowFixMe A Hash is a duplex stream
       .pipe(crypto.createHash('md5').setEncoding('hex'))
       .on('finish', function() {
         resolve(this.read());
       })
       .on('error', reject);
   });
-};
-
-module.exports = md5;
+}


### PR DESCRIPTION
This:   
  * sets the `untyped-type-import` lint to `error`, which will cause flow to error when untyped modules are referenced from a file in strict mode   
  * Opts `Asset` and `BundlerRunner` into flow strict mode.
  * Makes `md5` an es module, flowifies it, separates its exports, and adjusts its references
  * Addresses a sketchy null check in `BundlerRunner` where a falsy empty string would not throw.