### PR TITLE
Remove unnecessary return await

### DIFF
--- a/packages/core/parcel-bundler/src/Asset.js
+++ b/packages/core/parcel-bundler/src/Asset.js
@@ -159,7 +159,7 @@ class Asset {
         return conf;
       }
 
-      return await config.load(opts.path || this.name, filenames);
+      return config.load(opts.path || this.name, filenames);
     }
 
     return null;
@@ -170,7 +170,7 @@ class Asset {
   }
 
   async load() {
-    return await fs.readFile(this.name, this.encoding);
+    return fs.readFile(this.name, this.encoding);
   }
 
   parse() {

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -490,7 +490,7 @@ class Bundler extends EventEmitter {
           this.options.autoinstall &&
           install
         ) {
-          return await this.installDep(asset, dep);
+          return this.installDep(asset, dep);
         }
 
         err.message = `Cannot resolve dependency '${dep.name}'`;
@@ -521,7 +521,7 @@ class Bundler extends EventEmitter {
       }
     }
 
-    return await this.resolveDep(asset, dep, false);
+    return this.resolveDep(asset, dep, false);
   }
 
   async throwDepError(asset, dep, err) {

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -251,7 +251,7 @@ class Resolver {
     }
 
     // Fall back to an index file inside the directory.
-    return await this.loadAsFile(path.join(dir, 'index'), extensions, pkg);
+    return this.loadAsFile(path.join(dir, 'index'), extensions, pkg);
   }
 
   async readPackage(dir) {

--- a/packages/core/parcel-bundler/src/SourceMap.js
+++ b/packages/core/parcel-bundler/src/SourceMap.js
@@ -35,7 +35,7 @@ class SourceMap {
     }
     map = typeof map === 'string' ? JSON.parse(map) : map;
     if (map.sourceRoot) delete map.sourceRoot;
-    return await new SourceMapConsumer(map);
+    return new SourceMapConsumer(map);
   }
 
   async addMap(map, lineOffset = 0, columnOffset = 0) {

--- a/packages/core/parcel-bundler/src/assets/GLSLAsset.js
+++ b/packages/core/parcel-bundler/src/assets/GLSLAsset.js
@@ -37,7 +37,7 @@ class GLSLAsset extends Asset {
       }
     });
 
-    return await promisify(depper.inline.bind(depper))(this.contents, cwd);
+    return promisify(depper.inline.bind(depper))(this.contents, cwd);
   }
 
   collectDependencies() {

--- a/packages/core/parcel-bundler/src/assets/LESSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/LESSAsset.js
@@ -23,7 +23,7 @@ class LESSAsset extends Asset {
     opts.filename = this.name;
     opts.plugins = (opts.plugins || []).concat(urlPlugin(this));
 
-    return await render(code, opts);
+    return render(code, opts);
   }
 
   collectDependencies() {

--- a/packages/core/parcel-bundler/src/assets/RawAsset.js
+++ b/packages/core/parcel-bundler/src/assets/RawAsset.js
@@ -27,7 +27,7 @@ class RawAsset extends Asset {
   }
 
   async generateHash() {
-    return await md5.file(this.name);
+    return md5.file(this.name);
   }
 }
 

--- a/packages/core/parcel-bundler/src/assets/SASSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/SASSAsset.js
@@ -90,7 +90,7 @@ async function getSassRuntime(searchPath) {
     return await localRequire('node-sass', searchPath, true);
   } catch (e) {
     // If node-sass is not used locally, install dart-sass, as this causes no freezing issues
-    return await localRequire('sass', searchPath);
+    return localRequire('sass', searchPath);
   }
 }
 

--- a/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
@@ -58,7 +58,7 @@ async function getBabelRc(asset, isSource) {
 
   // If this asset is not in node_modules, always use the .babelrc
   if (isSource) {
-    return await findBabelRc(asset);
+    return findBabelRc(asset);
   }
 
   // Otherwise, don't load .babelrc for node_modules.
@@ -266,7 +266,7 @@ async function installPlugins(asset, babelrc) {
   let plugins = (babelrc.plugins || []).map(p =>
     resolveModule('plugin', getPluginName(p), asset.name)
   );
-  return await Promise.all([...presets, ...plugins]);
+  return Promise.all([...presets, ...plugins]);
 }
 
 async function resolveModule(type, name, path) {

--- a/packages/core/parcel-bundler/src/utils/loadPlugins.js
+++ b/packages/core/parcel-bundler/src/utils/loadPlugins.js
@@ -2,8 +2,8 @@ const localRequire = require('./localRequire');
 
 module.exports = async function loadPlugins(plugins, relative) {
   if (Array.isArray(plugins)) {
-    return await Promise.all(
-      plugins.map(async p => await loadPlugin(p, relative)).filter(Boolean)
+    return Promise.all(
+      plugins.map(async p => loadPlugin(p, relative)).filter(Boolean)
     );
   } else if (typeof plugins === 'object') {
     let mapPlugins = await Promise.all(

--- a/packages/core/parcel-bundler/src/utils/localRequire.js
+++ b/packages/core/parcel-bundler/src/utils/localRequire.js
@@ -22,7 +22,7 @@ async function localResolve(name, path, triedInstall = false) {
       if (e.code === 'MODULE_NOT_FOUND' && !triedInstall) {
         const packageName = getModuleParts(name)[0];
         await installPackage(packageName, path);
-        return await localResolve(name, path, true);
+        return localResolve(name, path, true);
       }
       throw e;
     }


### PR DESCRIPTION
# ↪️ Pull Request

According to eslint's [no-return-await ](https://eslint.org/docs/rules/no-return-await) rule:
> Inside an async function, return await is seldom useful. Since the return value of an async function is always wrapped in Promise.resolve, return await doesn’t actually do anything except add extra time before the overarching Promise resolves or rejects. The only valid exception is if return await is used in a try/catch statement to catch errors from another Promise-based function.