### PR TITLE
eslint: enable no-return-await

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,5 +13,8 @@
   "globals": {
     "parcelRequire": true,
     "define": true
+  },
+  "rules": {
+    "no-return-await": "error"
   }
 }

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -159,7 +159,7 @@ class Resolver {
     // First try as a file, then as a directory.
     return (
       (await this.loadAsFile(filename, extensions, pkg)) ||
-      (await this.loadDirectory(filename, extensions, pkg))
+      (await this.loadDirectory(filename, extensions, pkg)) // eslint-disable-line no-return-await
     );
   }
 

--- a/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
@@ -53,7 +53,7 @@ async function getBabelRc(asset, isSource) {
     }
 
     // Otherwise, return the .babelrc if babelify was found
-    return babelify ? await findBabelRc(asset) : null;
+    return babelify ? findBabelRc(asset) : null;
   }
 
   // If this asset is not in node_modules, always use the .babelrc

--- a/packages/core/parcel-bundler/src/utils/loadPlugins.js
+++ b/packages/core/parcel-bundler/src/utils/loadPlugins.js
@@ -3,13 +3,11 @@ const localRequire = require('./localRequire');
 module.exports = async function loadPlugins(plugins, relative) {
   if (Array.isArray(plugins)) {
     return Promise.all(
-      plugins.map(async p => loadPlugin(p, relative)).filter(Boolean)
+      plugins.map(p => loadPlugin(p, relative)).filter(Boolean)
     );
   } else if (typeof plugins === 'object') {
     let mapPlugins = await Promise.all(
-      Object.keys(plugins).map(
-        async p => await loadPlugin(p, relative, plugins[p])
-      )
+      Object.keys(plugins).map(p => loadPlugin(p, relative, plugins[p]))
     );
     return mapPlugins.filter(Boolean);
   } else {


### PR DESCRIPTION
This sets violations of the `no-return-await` to `error`. `return await` is redundant as values returned from an async function are effectively wrapped in a `Promise.resolve`, and awaiting another promise in addition to this will defer resolution another microtick.

[eslint is good enough to detect the valid use case of `return await` in a `try`/`catch`](https://eslint.org/docs/rules/no-return-await). We also get clever with a short circuiting `||` in `Resolver` so I disabled it there, but we should probably rewrite it to be clearer in the future.

Test Plan: `yarn && yarn lint && yarn test`