### PR TITLE
Use @parcel/babel-register for mocha.opts across packages

### DIFF
--- a/packages/core/logger/test/mocha.opts
+++ b/packages/core/logger/test/mocha.opts
@@ -1,2 +1,2 @@
---require @babel/register
+--require @parcel/babel-register
 --exit

--- a/packages/core/watcher/test/mocha.opts
+++ b/packages/core/watcher/test/mocha.opts
@@ -1,3 +1,3 @@
---require @babel/register
+--require @parcel/babel-register
 --timeout 10000
 --exit

--- a/packages/core/workers/test/mocha.opts
+++ b/packages/core/workers/test/mocha.opts
@@ -1,3 +1,3 @@
---require @babel/register
+--require @parcel/babel-register
 --timeout 10000
 --exit


### PR DESCRIPTION
This makes sure that babel continues to process files across packages. Addresses test failures in the v2 branch.

Test Plan: `yarn test` and verify errors on v2 have been resolved.