### PR TITLE
Fix scopehositing with nested dynamic imports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/a.js
@@ -1,0 +1,1 @@
+export default import("./b.js").then(b => b.default);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/b.js
@@ -1,0 +1,1 @@
+export default import('./c.js').then(b => b.default + 1);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/c.js
@@ -1,0 +1,1 @@
+export default 122;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -264,6 +264,18 @@ describe('scope hoisting', function() {
       assert.equal(await output.default, 5);
     });
 
+    it('supports nested dynamic imports', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/dynamic-import-dynamic/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.equal(await output.default, 123);
+    });
+
     it('should not export function arguments', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js
@@ -384,6 +384,7 @@ class JSConcatPackager extends Packager {
     if (this.bundle.assets.has(asset)) {
       return;
     }
+    this.assets.set(asset.id, asset);
     this.bundle.addAsset(asset);
     if (!asset.parentBundle) {
       asset.parentBundle = this.bundle;


### PR DESCRIPTION
# ↪️ Pull Request

Closes #2300, @garthenweb

Probably introduced by #1682

When the assets are iterated on `JSConcatPackager.start`
https://github.com/parcel-bundler/parcel/blob/c670decf1e8a039a80a47395bf916643d1955613/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js#L32-L49
they are also added to the `assets` Map. For "normal" bundles `bundle-loader` is added here, but for dynamically imported bundles only actual static imports is added.
For dynamically imported bundles which need also need the `bundle-loader`, it gets added here (called by `addAsset`) https://github.com/parcel-bundler/parcel/blob/c670decf1e8a039a80a47395bf916643d1955613/packages/core/parcel-bundler/src/packagers/JSConcatPackager.js#L400-L415, but `addAssetToBundle` didn't add it to the `assets` map, resulting in this error:

```
Cannot read property 'depAssets' of undefined 
    at JSConcatPackager.resolveModule (<work_space>/node_modules/parcel-bundler/src/packagers/JSConcatPackager.js:551:19)
    at CallExpression (<work_space>/node_modules/parcel-bundler/src/scope-hoisting/concat.js:152:28)
    at NodePath._call (<work_space>/node_modules/@babel/traverse/lib/path/context.js:53:20)
    at NodePath.call (<work_space>/node_modules/@babel/traverse/lib/path/context.js:40:17)
    at NodePath.visit (<work_space>/node_modules/@babel/traverse/lib/path/context.js:88:12)
    at TraversalContext.visitQueue (<work_space>/node_modules/@babel/traverse/lib/context.js:118:16)
    at TraversalContext.visitSingle (<work_space>/node_modules/@babel/traverse/lib/context.js:90:19)
    at TraversalContext.visit (<work_space>/node_modules/@babel/traverse/lib/context.js:146:19)
    at Function.traverse.node (<work_space>/node_modules/@babel/traverse/lib/index.js:94:17)
    at NodePath.visit (<work_space>/node_modules/@babel/traverse/lib/path/context.js:95:18)
```

## 💻 Examples

Fix scopehoisting for situations like this:
```
bundle   ----dynamic-import--->   bundle   ----!!dynamic-import!!--->   bundle
```


## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
