### PR TITLE
Clean existing lints and enable recommended flowtype lints

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -13,7 +13,6 @@ import type {
   Bundle,
   GraphTraversalCallback
 } from '@parcel/types';
-import path from 'path';
 import md5 from '@parcel/utils/lib/md5';
 import Dependency from './Dependency';
 

--- a/packages/core/register/example/index.js
+++ b/packages/core/register/example/index.js
@@ -7,5 +7,7 @@ const something = require('something');
 const numberOne = number();
 const numberTwo = number();
 
+/* eslint-disable no-console */
 console.log(`${numberOne} + ${numberTwo} =`, count(numberOne, numberTwo));
 console.log(something());
+/* eslint-enable */

--- a/packages/core/register/src/hook.js
+++ b/packages/core/register/src/hook.js
@@ -58,8 +58,10 @@ export default function register(opts = DEFAULT_CLI_OPTS) {
         return output;
       }
     } catch (e) {
+      /* eslint-disable no-console */
       console.error('@parcel/register failed to process: ', filename);
       console.error(e);
+      /* eslint-enable */
     } finally {
       isProcessing = false;
     }

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: 'eslint:recommended',
+  extends: ['eslint:recommended', 'plugin:flowtype/recommended'],
   parser: 'babel-eslint',
   plugins: ['flowtype'],
   parserOptions: {


### PR DESCRIPTION
Clean existing lints and enable recommended flowtype lints

This:
* Resolves an unused import lint
* Suppresses lint warnings for two reasonable cases of console.log, though one should probably use `@parcel/logger`
* Enables recommended flowtype lints. As far as I can tell, we had the flow eslint plugin installed and registered but never opted into any of its rules. This does that, though we could take a more minimal approach and just enable the `flowtype/define-flow-type` rule, which we need for eslint to ignore special global flow types and functions.

Test Plan: `yarn lint` from the root with no errors. `yarn flow` from the root with no errors.