### PR TITLE
Server: Added the OPTIONS method to CORS

### DIFF
--- a/packages/core/parcel-bundler/src/Server.js
+++ b/packages/core/parcel-bundler/src/Server.js
@@ -24,7 +24,7 @@ function enableCors(res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader(
     'Access-Control-Allow-Methods',
-    'GET, HEAD, PUT, PATCH, POST, DELETE'
+    'GET, HEAD, PUT, PATCH, POST, DELETE, OPTIONS'
   );
   res.setHeader(
     'Access-Control-Allow-Headers',


### PR DESCRIPTION
When doing cross-origin requests the browser first tries to send an [OPTIONS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS) request.


# ↪️ Pull Request

I just added the `OPTIONS` method to the Access-Control-Allow-Methods header to resolve issues with CORS.

## 💻 Examples

Without this change Chrome would spit out following error.
![image](https://user-images.githubusercontent.com/18233294/53806033-20b04c80-3f4c-11e9-9ecd-885d0c918d47.png)


## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
