### PR TITLE
Fix remaining v2 tests

### DIFF
--- a/packages/core/parcel-bundler/test/babel-register.js
+++ b/packages/core/parcel-bundler/test/babel-register.js
@@ -1,8 +1,0 @@
-if (parseInt(process.versions.node, 10) < 8) {
-  const config = require('./.babelrc');
-  require('@babel/register')({
-    ignore: [filepath => filepath.includes('/node_modules/'), ...config.ignore],
-    presets: config.presets,
-    plugins: config.plugins
-  });
-}

--- a/packages/core/parcel-bundler/test/mocha.opts
+++ b/packages/core/parcel-bundler/test/mocha.opts
@@ -1,3 +1,3 @@
 --timeout 50000
---require ./test/babel-register
+--require @parcel/babel-register
 --exit

--- a/packages/core/watcher/src/child.js
+++ b/packages/core/watcher/src/child.js
@@ -19,6 +19,14 @@ function init(options) {
   watcher = new FSWatcher(options);
   watcher.on('all', sendEvent);
   sendEvent('ready');
+
+  // only used for testing
+  watcher.once('ready', async () => {
+    // Wait an additional macrotask. This seems to be necessary before changes
+    // can be picked up.
+    await new Promise(resolve => setImmediate(resolve));
+    sendEvent('_chokidarReady');
+  });
 }
 
 function executeFunction(functionName, args) {

--- a/packages/core/watcher/test/changeEvent.js
+++ b/packages/core/watcher/test/changeEvent.js
@@ -7,64 +7,38 @@ const {sleep} = require('@parcel/test-utils');
 describe('change event', function() {
   let tmpFolder = path.join(__dirname, './tmp/');
 
-  before(() => {
-    fs.mkdirp(tmpFolder);
+  before(async () => {
+    await fs.mkdirp(tmpFolder);
   });
 
-  it('Should emit event on filechange', async () => {
-    let watcher = new Watcher({});
-
+  it('emits change events when an existing file is changed', async () => {
     let filepath = path.join(tmpFolder, 'file1.txt');
-
     await fs.writeFile(filepath, 'this is a text document');
 
+    let watcher = new Watcher({});
     watcher.add(filepath);
 
-    let changed = false;
-    watcher.once('change', () => {
-      changed = true;
-    });
+    await new Promise(resolve => watcher.once('_chokidarReady', resolve));
 
-    if (!watcher.ready) {
-      await new Promise(resolve => watcher.once('ready', resolve));
-    }
-
-    await sleep(250);
-
+    let changePromise = new Promise(resolve => watcher.once('change', resolve));
     await fs.writeFile(filepath, 'this is not a text document');
-
-    await sleep(500);
-
-    assert(changed, 'File should be flagged as changed.');
+    await changePromise;
 
     await watcher.stop();
   });
 
-  it('Should emit event on filechange using arrays', async () => {
-    let watcher = new Watcher({});
-
+  it('emits change events when any of a list of files is changed', async () => {
     let filepath = path.join(tmpFolder, 'file1.txt');
-
     await fs.writeFile(filepath, 'this is a text document');
 
+    let watcher = new Watcher({});
     watcher.add([filepath]);
 
-    let changed = false;
-    watcher.once('change', () => {
-      changed = true;
-    });
+    await new Promise(resolve => watcher.once('_chokidarReady', resolve));
 
-    if (!watcher.ready) {
-      await new Promise(resolve => watcher.once('ready', resolve));
-    }
-
-    await sleep(250);
-
+    let changePromise = new Promise(resolve => watcher.once('change', resolve));
     await fs.writeFile(filepath, 'this is not a text document');
-
-    await sleep(500);
-
-    assert(changed, 'File should be flagged as changed.');
+    await changePromise;
 
     await watcher.stop();
   });

--- a/packages/core/watcher/test/fswatcher.js
+++ b/packages/core/watcher/test/fswatcher.js
@@ -1,32 +1,32 @@
 const Watcher = require('../index');
-const {sleep} = require('@parcel/test-utils');
 const assert = require('assert');
 
 describe('Watcher', function() {
   it('Should be able to create a new watcher', async () => {
     let watcher = new Watcher();
 
-    assert(!!watcher.child);
+    assert(watcher.child);
     assert(!watcher.ready);
 
-    await sleep(1000);
+    await new Promise(resolve => watcher.once('ready', resolve));
 
-    assert(!!watcher.child);
+    assert(watcher.child);
     assert(watcher.ready);
 
     await watcher.stop();
   });
 
-  it('Should be able to properly destroy the watcher', async () => {
+  it('Cleans up the related child process', async () => {
     let watcher = new Watcher();
+    await new Promise(resolve => watcher.once('ready', resolve));
 
-    await sleep(1000);
-
-    assert(!!watcher.child);
+    assert(watcher.child);
     assert(watcher.ready);
 
-    let time = Date.now();
+    let childDeadPromise = new Promise(resolve =>
+      watcher.once('childDead', resolve)
+    );
     await watcher.stop();
-    assert.notEqual(time, Date.now());
+    await childDeadPromise;
   });
 });

--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -1,7 +1,8 @@
 const parcelBabelPreset = require('@parcel/babel-preset');
+const path = require('path');
 
 require('@babel/register')({
-  ignore: [filepath => filepath.includes('/node_modules/')],
+  ignore: [filepath => filepath.includes(path.sep + 'node_modules' + path.sep)],
   presets: [parcelBabelPreset]
 });
 


### PR DESCRIPTION
This addresses the remaining failing tests in v2.

* Moves `parcel-bundler` to use `@parcel/babel-register` in its mocha options as it relies on `fs`, which is now flowified
* Lessens reliance on async `sleep` in watcher tests by waiting for the watcher to be ready and specific events to be emitted. I assume these events are public API?

Test Plan: `yarn && yarn flow && yarn lint && yarn test`