### PR TITLE
Normalize input path if possible

### DIFF
--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -30,6 +30,11 @@ class Resolver {
   }
 
   async resolve(input, parent) {
+    if (this.rootPackage) {
+      let rootNodeModules = this.rootPackage.pkgdir + "/node_modules/"
+      input = input.replace(rootNodeModules, '');
+    }
+    
     let filename = input;
 
     // Check the cache first

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -31,9 +31,11 @@ class Resolver {
 
   async resolve(input, parent) {
     if (this.rootPackage) {
-      let rootNodeModules = this.rootPackage.pkgdir + "/node_modules/"
-      input = input.replace(rootNodeModules, '');
+      let baseModulesPath = this.rootPackage.pkgdir + '/node_modules/';
+      let normalizer = baseModulesPath.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
+      input = input.replace(new RegExp("^" + normalizer), '');
     }
+
     
     let filename = input;
 

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -35,7 +35,6 @@ class Resolver {
       let normalizer = baseModulesPath.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
       input = input.replace(new RegExp("^" + normalizer), '');
     }
-
     
     let filename = input;
 


### PR DESCRIPTION
# ↪️ Pull Request

This pull request adds a simple normalization which tries to transform an absolute path (eg. /project/todo/node_modules/library/file) to a module path (library/file), this fixed a problem I was having when using the preset "react-app"

For some reason, previously it was throwing an error with this message
```
🚨 Cannot resolve dependency 
'/projects/my-project/node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/esm/extends' 
at '/projects/my-project/node_modules/babel-preset-react-app/node_modules/@babel/runtime/helpers/esm/extends'
```

I debugged and I saw the resolve function sometimes received the input **@babel/runtime/helpers...** which is fine, but other times it received the full path **/projects/my-project/node_modules/@babel/runtime/helpers...** 

I am not sure why, but I suspect it's related of how **@babel/plugin-transform-runtime** works

Despite parcel could run with **preset-env, preset-react** and **@babel/plugin-transform-runtime**, my bundle was increasing in 10KB compared to **create-react-app**
With this change, my bundle decreased 10KB :tada::tada::tada::tada: 

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

It is reproducible by creating a brand new project with **create-react-app** and **ejecting** it
Write a .baberc like
```
{
  "presets": [
    "react-app"
  ],
  "plugins": [
    "@babel/plugin-proposal-class-properties"
  ]
}

```
Run another npm install to assure all dependencies are ok (I needed to)... 
Add a tag script in `public/index.html` to reference `../src/index.js`
Adjust `public/index.html` to remove their dynamic % PUBLIC_URL %f
Run `npm install parcel`... then
```
npx parcel build public/index.html
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
