### PR TITLE
Use src references for utils

### DIFF
--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/Cache",
+  "main": "src/Cache",
   "scripts": {
     "build": "babel src --out-dir lib",
     "prepublish": "yarn build"

--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -3,7 +3,7 @@ import * as fs from '@parcel/fs';
 import pkg from '../package.json';
 import Path from 'path';
 import {md5FromString} from '@parcel/utils/src/md5';
-import objectHash from '@parcel/utils/lib/objectHash';
+import objectHash from '@parcel/utils/src/objectHash';
 import logger from '@parcel/logger';
 import type {
   FilePath,

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/core",
   "version": "2.0.0",
   "license": "MIT",
-  "main": "./lib/Parcel.js",
+  "main": "./src/Parcel.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -15,7 +15,7 @@ import type {
   PackageJSON
 } from '@parcel/types';
 import {md5FromString, md5FromFilePath} from '@parcel/utils/src/md5';
-import {loadConfig} from '@parcel/utils/lib/config';
+import {loadConfig} from '@parcel/utils/src/config';
 import Cache from '@parcel/cache';
 import Dependency from './Dependency';
 
@@ -151,14 +151,21 @@ export default class Asset implements IAsset {
     filePaths: Array<FilePath>,
     options: ?{packageKey?: string, parse?: boolean}
   ): Promise<Config | null> {
-    if (options && options.packageKey) {
+    let packageKey = options && options.packageKey;
+    let parse = options && options.parse;
+
+    if (packageKey) {
       let pkg = await this.getPackage();
-      if (pkg && options.packageKey && pkg[options.packageKey]) {
-        return pkg[options.packageKey];
+      if (pkg && pkg[packageKey]) {
+        return pkg[packageKey];
       }
     }
 
-    let conf = await loadConfig(this.filePath, filePaths, options);
+    let conf = await loadConfig(
+      this.filePath,
+      filePaths,
+      parse == null ? null : {parse}
+    );
     if (!conf) {
       return null;
     }

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -262,7 +262,7 @@ export default class AssetGraph extends Graph {
   }
 
   traverseAssets(
-    visit: GraphTraversalCallback<Asset>,
+    visit: GraphTraversalCallback<Asset, Node>,
     startNode: ?Node
   ): ?Node {
     return this.traverse((node, ...args) => {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -3,8 +3,7 @@ import type {
   Asset,
   Bundle,
   BundleGroup,
-  GraphTraversalCallback,
-  Node
+  GraphTraversalCallback
 } from '@parcel/types';
 import AssetGraph from './AssetGraph';
 
@@ -151,7 +150,9 @@ export default class BundleGraph extends AssetGraph {
       .map(node => node.value);
   }
 
-  traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node {
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<Bundle, TContext>
+  ): ?TContext {
     return this.traverse((node, ...args) => {
       if (node.type === 'bundle') {
         return visit(node.value, ...args);

--- a/packages/core/core/src/Config.js
+++ b/packages/core/core/src/Config.js
@@ -13,7 +13,7 @@ import type {
   Packager,
   Optimizer
 } from '@parcel/types';
-import localRequire from '@parcel/utils/lib/localRequire';
+import localRequire from '@parcel/utils/src/localRequire';
 import {isMatch} from 'micromatch';
 import {basename} from 'path';
 import {CONFIG} from '@parcel/plugin';

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -2,8 +2,8 @@
 
 import type {
   Node as _Node,
+  GraphTraversalCallback,
   TraversalActions,
-  TraversalContext,
   Graph as IGraph
 } from '@parcel/types';
 
@@ -25,13 +25,6 @@ type GraphOpts = {|
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
 |};
-
-type VisitCallback = (
-  node: Node,
-  context?: TraversalContext,
-  actions: TraversalActions
-) => ?Node;
-
 export default class Graph implements IGraph {
   nodes: Map<NodeId, Node>;
   edges: Set<Edge>;
@@ -219,7 +212,10 @@ export default class Graph implements IGraph {
     return {removed, added};
   }
 
-  traverse(visit: VisitCallback, startNode: ?Node): ?Node {
+  traverse<TContext>(
+    visit: GraphTraversalCallback<Node, TContext>,
+    startNode: ?Node
+  ): ?TContext {
     return this.dfs({
       visit,
       startNode,
@@ -227,7 +223,10 @@ export default class Graph implements IGraph {
     });
   }
 
-  traverseAncestors(startNode: Node, visit: VisitCallback) {
+  traverseAncestors<TContext>(
+    startNode: Node,
+    visit: GraphTraversalCallback<Node, TContext>
+  ) {
     return this.dfs({
       visit,
       startNode,
@@ -235,15 +234,15 @@ export default class Graph implements IGraph {
     });
   }
 
-  dfs({
+  dfs<TContext>({
     visit,
     startNode,
     getChildren
   }: {
-    visit: VisitCallback,
+    visit: GraphTraversalCallback<Node, TContext>,
     getChildren(node: Node): Array<Node>,
     startNode?: ?Node
-  }): ?Node {
+  }): ?TContext {
     let root = startNode || this.getRootNode();
     if (!root) {
       return null;

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -6,7 +6,7 @@ import type {
   EnvironmentContext,
   Engines
 } from '@parcel/types';
-import {loadConfig} from '@parcel/utils/lib/config';
+import {loadConfig} from '@parcel/utils/src/config';
 import Environment from './Environment';
 import path from 'path';
 import browserslist from 'browserslist';

--- a/packages/core/core/src/loadEnv.js
+++ b/packages/core/core/src/loadEnv.js
@@ -1,4 +1,4 @@
-import {resolveConfig} from '@parcel/utils/lib/config';
+import {resolveConfig} from '@parcel/utils/src/config';
 import dotenv from 'dotenv';
 import variableExpansion from 'dotenv-expand';
 

--- a/packages/core/register/src/hook.js
+++ b/packages/core/register/src/hook.js
@@ -3,7 +3,7 @@ import process from 'process';
 import path from 'path';
 import {addHook} from 'pirates';
 import Parcel, {Dependency, Environment} from '@parcel/core';
-import syncPromise from '@parcel/utils/lib/syncPromise';
+import syncPromise from '@parcel/utils/src/syncPromise';
 
 const originalRequire = Module.prototype.require;
 const DEFAULT_CLI_OPTS = {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1,16 +1,10 @@
 // @flow strict-local
 
-import type {
-  AST as _AST,
-  Config as _Config,
-  Node as _Node,
-  TraversalContext as _TraversalContext
-} from './unsafe';
+import type {AST as _AST, Config as _Config, Node as _Node} from './unsafe';
 
 export type AST = _AST;
 export type Config = _Config;
 export type Node = _Node;
-export type TraversalContext = _TraversalContext;
 
 export type JSONValue =
   | null
@@ -287,19 +281,23 @@ export interface TraversalActions {
   stop(): void;
 }
 
-export type GraphTraversalCallback<T> = (
-  asset: T,
-  context?: TraversalContext,
+export type GraphTraversalCallback<TNode, TContext> = (
+  node: TNode,
+  context: ?TContext,
   traversal: TraversalActions
-) => ?Node;
+) => ?TContext;
 
 export interface Graph {
   merge(graph: Graph): void;
+  traverse<TContext>(
+    visit: GraphTraversalCallback<Node, TContext>,
+    startNode: ?Node
+  ): ?TContext;
 }
 
 // TODO: what do we want to expose here?
 export interface AssetGraph extends Graph {
-  traverseAssets(visit: GraphTraversalCallback<Asset>): ?Node;
+  traverseAssets(visit: GraphTraversalCallback<Asset, Node>): ?Node;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
   getEntryAssets(): Array<Asset>;
@@ -331,7 +329,9 @@ export interface BundleGraph {
   findBundlesWithAsset(asset: Asset): Array<Bundle>;
   getBundles(bundleGroup: BundleGroup): Array<Bundle>;
   getBundleGroups(bundle: Bundle): Array<BundleGroup>;
-  traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node;
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<Bundle, TContext>
+  ): ?TContext;
 }
 
 export type Bundler = {|

--- a/packages/core/types/unsafe.js
+++ b/packages/core/types/unsafe.js
@@ -2,8 +2,6 @@
 
 export type Config = any;
 
-export type TraversalContext = any;
-
 export type AST = {|
   type: string,
   version: string,

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/DefaultResolver",
+  "main": "src/DefaultResolver",
   "engines": {
     "parcel": "2.x"
   },

--- a/packages/transformers/babel/src/babel6.js
+++ b/packages/transformers/babel/src/babel6.js
@@ -1,5 +1,5 @@
 // @flow
-import localRequire from '@parcel/utils/lib/localRequire';
+import localRequire from '@parcel/utils/src/localRequire';
 import type {Asset, AST} from '@parcel/types';
 import {babel6toBabel7} from './astConverter';
 

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -1,6 +1,6 @@
 // @flow
 import type {Asset, AST} from '@parcel/types';
-import localRequire from '@parcel/utils/lib/localRequire';
+import localRequire from '@parcel/utils/src/localRequire';
 
 export default async function babel7(
   asset: Asset,

--- a/packages/transformers/babel/src/babelrc.js
+++ b/packages/transformers/babel/src/babelrc.js
@@ -3,8 +3,8 @@ import type {Asset, PackageJSON} from '@parcel/types';
 import semver from 'semver';
 import logger from '@parcel/logger';
 import path from 'path';
-import localRequire from '@parcel/utils/lib/localRequire';
-import installPackage from '@parcel/utils/lib/installPackage';
+import localRequire from '@parcel/utils/src/localRequire';
+import installPackage from '@parcel/utils/src/installPackage';
 import micromatch from 'micromatch';
 
 export default async function getBabelConfig(

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -1,7 +1,7 @@
 import * as types from '@babel/types';
 import traverse from '@babel/traverse';
 import nodeBuiltins from 'node-libs-browser';
-import isURL from '@parcel/utils/lib/is-url';
+import isURL from '@parcel/utils/src/is-url';
 import {hasBinding} from './utils';
 
 const serviceWorkerPattern = ['navigator', 'serviceWorker', 'register'];


### PR DESCRIPTION
This updates references to `utils` to use their `src` versions. Since we're not yet building v2, we can leverage `@babel/register` to run from these locations while benefitting from flow checking. This will be changed to a parallel `lib` build when Parcel 2 is ready to ship.

Updates `Asset.js` to pass an exact object, not including `getConfig`'s other options. This satisfies flow and cleans up our use of our own api. In the case of `parse` being missing, `null` is passed.

Test Plan: `yarn && yarn flow && yarn lint && yarn test`