### PR TITLE
Make treeshaking handle "multiassignments"

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-multiassignment/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-multiassignment/a.js
@@ -1,0 +1,2 @@
+import x, {y} from "./b";
+export default [x, y];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-multiassignment/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-multiassignment/b.js
@@ -1,0 +1,9 @@
+exports.default = exports.y = exports.z = undefined;
+var y = 'y';
+exports.y = y;
+var z = 'z';
+exports.z = z;
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -485,6 +485,25 @@ describe('scope hoisting', function() {
       assert(!/.-./.test(contents));
     });
 
+    it('handle export multi-assignment', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/tree-shaking-multiassignment/a.js'
+        ),
+        {minify: true}
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output.default, [undefined, 'y']);
+
+      // let contents = await fs.readFile(
+      //   path.join(__dirname, '/dist/a.js'),
+      //   'utf8'
+      // );
+      // assert(!/["']z["']/.test(contents));
+    });
+
     it('support exporting a ES6 module exported as CommonJS', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/parcel-bundler/src/scope-hoisting/shake.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/shake.js
@@ -106,7 +106,9 @@ function remove(path) {
   if (path.isAssignmentExpression()) {
     if (path.parentPath.isSequenceExpression()) {
       if (path.parent.expressions.length == 1) {
-        path.parentPath.remove();
+        // replace sequence expression with it's sole child
+        path.parentPath.replaceWith(path);
+        remove(path.parentPath);
       } else {
         path.remove();
       }


### PR DESCRIPTION
# ↪️ Pull Request

The treeshake function tried to remove the right side of assignment if expression was of this form (when nested in a sequence expression):
```js
var $TJPF$export$default = ($TJPF$export$THING = ($TJPF$export$SOME = undefined, $TJPF$exports.SOME = $TJPF$export$SOME), $TJPF$exports.THING = $TJPF$export$THING);
```

(Don't think "multiassignments" are the official name)

Bug was introduced by myself in #2418 🙈 
Part of #1984


## 💻 Examples

from `react-transition-group`:
```js
exports.default = exports.EXITING = exports.ENTERED = exports.ENTERING = exports.EXITED = exports.UNMOUNTED = void 0;

var UNMOUNTED = 'unmounted';
exports.UNMOUNTED = UNMOUNTED;
var EXITED = 'exited';
exports.EXITED = EXITED;
var ENTERING = 'entering';
exports.ENTERING = ENTERING;
var ENTERED = 'entered';
exports.ENTERED = ENTERED;
var EXITING = 'exiting';
exports.EXITING = EXITING;
```

```
🚨  Property right of AssignmentExpression expected node to be of a type ["Expression"] but instead got null
    at Object.validate (.../parcel/node_modules/@babel/types/lib/definitions/utils.js:128:13)
    at Object.validate (.../parcel/node_modules/@babel/types/lib/validators/validate.js:17:9)
    at NodePath._replaceWith (.../parcel/node_modules/@babel/traverse/lib/path/replacement.js:194:9)
    at NodePath._remove (.../parcel/node_modules/@babel/traverse/lib/path/removal.js:51:10)
    at NodePath.remove (.../parcel/node_modules/@babel/traverse/lib/path/removal.js:30:8)
    at remove (.../parcel/packages/core/parcel-bundler/src/scope-hoisting/shake.js:109:25)
    at Array.forEach (<anonymous>)
    at Object.keys.forEach.name (.../parcel/packages/core/parcel-bundler/src/scope-hoisting/shake.js:30:65)
    at Array.forEach (<anonymous>)
    at treeShake (.../parcel/packages/core/parcel-bundler/src/scope-hoisting/shake.js:20:33)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

after hoisting:
```js
var $TJPF$export$default = ($TJPF$export$THING = ($TJPF$export$SOME = undefined, $TJPF$exports.SOME = $TJPF$export$SOME), $TJPF$exports.THING = $TJPF$export$THING);
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

