### PR TITLE
Update remaining non-transformer src references

### DIFF
--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/Cache",
+  "main": "src/Cache",
   "scripts": {
     "build": "babel src --out-dir lib",
     "prepublish": "yarn build"

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/core",
   "version": "2.0.0",
   "license": "MIT",
-  "main": "./lib/Parcel.js",
+  "main": "./src/Parcel.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -262,7 +262,7 @@ export default class AssetGraph extends Graph {
   }
 
   traverseAssets(
-    visit: GraphTraversalCallback<Asset>,
+    visit: GraphTraversalCallback<Asset, Node>,
     startNode: ?Node
   ): ?Node {
     return this.traverse((node, ...args) => {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -3,8 +3,7 @@ import type {
   Asset,
   Bundle,
   BundleGroup,
-  GraphTraversalCallback,
-  Node
+  GraphTraversalCallback
 } from '@parcel/types';
 import AssetGraph from './AssetGraph';
 
@@ -151,7 +150,9 @@ export default class BundleGraph extends AssetGraph {
       .map(node => node.value);
   }
 
-  traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node {
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<Bundle, TContext>
+  ): ?TContext {
     return this.traverse((node, ...args) => {
       if (node.type === 'bundle') {
         return visit(node.value, ...args);

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -2,8 +2,8 @@
 
 import type {
   Node as _Node,
+  GraphTraversalCallback,
   TraversalActions,
-  TraversalContext,
   Graph as IGraph
 } from '@parcel/types';
 
@@ -25,13 +25,6 @@ type GraphOpts = {|
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
 |};
-
-type VisitCallback = (
-  node: Node,
-  context?: TraversalContext,
-  actions: TraversalActions
-) => ?Node;
-
 export default class Graph implements IGraph {
   nodes: Map<NodeId, Node>;
   edges: Set<Edge>;
@@ -219,7 +212,10 @@ export default class Graph implements IGraph {
     return {removed, added};
   }
 
-  traverse(visit: VisitCallback, startNode: ?Node): ?Node {
+  traverse<TContext>(
+    visit: GraphTraversalCallback<Node, TContext>,
+    startNode: ?Node
+  ): ?TContext {
     return this.dfs({
       visit,
       startNode,
@@ -227,7 +223,10 @@ export default class Graph implements IGraph {
     });
   }
 
-  traverseAncestors(startNode: Node, visit: VisitCallback) {
+  traverseAncestors<TContext>(
+    startNode: Node,
+    visit: GraphTraversalCallback<Node, TContext>
+  ) {
     return this.dfs({
       visit,
       startNode,
@@ -235,15 +234,15 @@ export default class Graph implements IGraph {
     });
   }
 
-  dfs({
+  dfs<TContext>({
     visit,
     startNode,
     getChildren
   }: {
-    visit: VisitCallback,
+    visit: GraphTraversalCallback<Node, TContext>,
     getChildren(node: Node): Array<Node>,
     startNode?: ?Node
-  }): ?Node {
+  }): ?TContext {
     let root = startNode || this.getRootNode();
     if (!root) {
       return null;

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1,16 +1,10 @@
 // @flow strict-local
 
-import type {
-  AST as _AST,
-  Config as _Config,
-  Node as _Node,
-  TraversalContext as _TraversalContext
-} from './unsafe';
+import type {AST as _AST, Config as _Config, Node as _Node} from './unsafe';
 
 export type AST = _AST;
 export type Config = _Config;
 export type Node = _Node;
-export type TraversalContext = _TraversalContext;
 
 export type JSONValue =
   | null
@@ -287,19 +281,23 @@ export interface TraversalActions {
   stop(): void;
 }
 
-export type GraphTraversalCallback<T> = (
-  asset: T,
-  context?: TraversalContext,
+export type GraphTraversalCallback<TNode, TContext> = (
+  node: TNode,
+  context: ?TContext,
   traversal: TraversalActions
-) => ?Node;
+) => ?TContext;
 
 export interface Graph {
   merge(graph: Graph): void;
+  traverse<TContext>(
+    visit: GraphTraversalCallback<Node, TContext>,
+    startNode: ?Node
+  ): ?TContext;
 }
 
 // TODO: what do we want to expose here?
 export interface AssetGraph extends Graph {
-  traverseAssets(visit: GraphTraversalCallback<Asset>): ?Node;
+  traverseAssets(visit: GraphTraversalCallback<Asset, Node>): ?Node;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
   getEntryAssets(): Array<Asset>;
@@ -331,7 +329,9 @@ export interface BundleGraph {
   findBundlesWithAsset(asset: Asset): Array<Bundle>;
   getBundles(bundleGroup: BundleGroup): Array<Bundle>;
   getBundleGroups(bundle: Bundle): Array<BundleGroup>;
-  traverseBundles(visit: GraphTraversalCallback<Bundle>): ?Node;
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<Bundle, TContext>
+  ): ?TContext;
 }
 
 export type Bundler = {|

--- a/packages/core/types/unsafe.js
+++ b/packages/core/types/unsafe.js
@@ -2,8 +2,6 @@
 
 export type Config = any;
 
-export type TraversalContext = any;
-
 export type AST = {|
   type: string,
   version: string,

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/DefaultResolver",
+  "main": "src/DefaultResolver",
   "engines": {
     "parcel": "2.x"
   },


### PR DESCRIPTION
This updates the remaining non-transformer src references. In the process, I made `GraphTraversalCallback` more generic, parameterized on `TContext`, which was necessary to correctly type `DefaultBundler.js`.

Test Plan: `yarn && yarn flow && yarn lint && yarn test`