### PR TITLE
Update transformer entries to use `src`

### DIFF
--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -2,17 +2,17 @@
 
 import type {
   Asset as IAsset,
-  TransformerResult,
-  DependencyOptions,
-  Dependency as IDependency,
-  FilePath,
-  File,
-  Environment,
-  JSONObject,
-  AST,
   AssetOutput,
+  AST,
   Config,
-  PackageJSON
+  Dependency as IDependency,
+  DependencyOptions,
+  Environment,
+  File,
+  FilePath,
+  Meta,
+  PackageJSON,
+  TransformerResult
 } from '@parcel/types';
 import {md5FromString, md5FromFilePath} from '@parcel/utils/src/md5';
 import {loadConfig} from '@parcel/utils/src/config';
@@ -32,7 +32,7 @@ type AssetOptions = {|
   outputSize?: number,
   outputHash?: string,
   env: Environment,
-  meta?: JSONObject
+  meta?: Meta
 |};
 
 export default class Asset implements IAsset {
@@ -48,7 +48,7 @@ export default class Asset implements IAsset {
   outputSize: number;
   outputHash: string;
   env: Environment;
-  meta: JSONObject;
+  meta: Meta;
 
   constructor(options: AssetOptions) {
     this.id =

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -10,7 +10,7 @@
     "build": "babel src --out-dir lib",
     "prepublish": "yarn build"
   },
-  "main": "./lib/PluginAPI.js",
+  "main": "./src/PluginAPI.js",
   "dependencies": {
     "@parcel/types": "^2.0.0"
   },

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parcel/register",
   "version": "2.0.0",
-  "main": "./lib/register.js",
+  "main": "./src/register.js",
   "license": "MIT",
   "scripts": {
     "build": "babel src -d lib",

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -160,7 +160,10 @@ export type SourceLocation = {|
   end: {line: number, column: number}
 |};
 
-export type Meta = {[string]: JSONValue};
+export type Meta = {
+  globals?: Map<string, Asset>,
+  [string]: JSONValue
+};
 export type DependencyOptions = {|
   moduleSpecifier: ModuleSpecifier,
   isAsync?: boolean,

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/BabelTransformer.js",
+  "main": "src/BabelTransformer.js",
   "engines": {
     "parcel": "2.x"
   },

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/JSTransformer",
+  "main": "src/JSTransformer",
   "engines": {
     "parcel": "2.x"
   },

--- a/packages/transformers/terser/package.json
+++ b/packages/transformers/terser/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/TerserTransformer",
+  "main": "src/TerserTransformer",
   "engines": {
     "parcel": "2.x"
   },


### PR DESCRIPTION
Similar to #2728 and #2730, this updates the final references from `lib` to `src`. This allows us to leverage flow properly and run the app and tests through `@babel/register` before we prepare a build process.

This refines the `Meta` type to include a `globals` key which is used to map global names to Assets.