### PR TITLE
Flow strictify `Asset.js`

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -34,7 +34,8 @@
     "@parcel/babel-register": "2.0.0",
     "@parcel/eslint-config": "1.10.3",
     "delay": "^4.1.0",
-    "random-int": "^1.0.0"
+    "random-int": "^1.0.0",
+    "shallowequal": "^1.1.0"
   },
   "bin": {
     "parcel": "bin.js"

--- a/packages/core/core/test/Asset.test.js
+++ b/packages/core/core/test/Asset.test.js
@@ -1,0 +1,100 @@
+// @flow
+
+import assert from 'assert';
+import shallowEqual from 'shallowequal';
+
+import Asset from '../src/Asset';
+import Environment from '../src/Environment';
+
+const ast = {
+  type: 'program',
+  version: '1.0',
+  program: {},
+  isDirty: true
+};
+
+const DEFAULT_ENV = new Environment({
+  context: 'browser',
+  engines: {
+    browsers: ['> 1%']
+  }
+});
+
+function getDefaultOptions() {
+  return {
+    id: 'id',
+    hash: 'hash',
+    filePath: 'path/to/file',
+    type: 'file',
+    code: 'code',
+    ast,
+    dependencies: [],
+    connectedFiles: [],
+    output: {code: 'output'},
+    outputSize: 25,
+    outputHash: 'outputHash',
+    env: DEFAULT_ENV,
+    meta: {}
+  };
+}
+
+describe('Asset', () => {
+  it('assigns options to properties when provided', () => {
+    let defaultOptions = getDefaultOptions();
+    let asset = new Asset(defaultOptions);
+    assert.equal(asset.id, defaultOptions.id);
+    assert.equal(asset.hash, defaultOptions.hash);
+    assert.equal(asset.filePath, defaultOptions.filePath);
+    assert.equal(asset.type, defaultOptions.type);
+    assert.equal(asset.code, defaultOptions.code);
+    assert.equal(asset.ast, defaultOptions.ast);
+    assert(shallowEqual(asset.dependencies, defaultOptions.dependencies));
+    assert(shallowEqual(asset.connectedFiles, defaultOptions.connectedFiles));
+    assert.equal(asset.output, defaultOptions.output);
+    assert.equal(asset.outputSize, defaultOptions.outputSize);
+    assert.equal(asset.outputHash, defaultOptions.outputHash);
+    assert.equal(asset.env, defaultOptions.env);
+    assert.equal(asset.meta, defaultOptions.meta);
+  });
+
+  it('derives an id by hashing filePath, type, and env', () => {
+    let defaultOptionsWithoutId = getDefaultOptions();
+    delete defaultOptionsWithoutId.id;
+
+    let asset = new Asset(defaultOptionsWithoutId);
+    assert.equal(asset.id, 'a17a7cc344d5d92002c0100fb3eb3fef');
+  });
+
+  it('derives code from options.output.code if options.code is not provided', () => {
+    let defaultOptionsWithoutCode = getDefaultOptions();
+    delete defaultOptionsWithoutCode.code;
+
+    let asset = new Asset(defaultOptionsWithoutCode);
+    assert.equal(asset.code, 'output');
+  });
+
+  it('has empty code if neither options.output.code nor options.code is provided', () => {
+    let defaultOptionsWithoutCodeOrOutput = getDefaultOptions();
+    delete defaultOptionsWithoutCodeOrOutput.code;
+    delete defaultOptionsWithoutCodeOrOutput.output;
+
+    let asset = new Asset(defaultOptionsWithoutCodeOrOutput);
+    assert.equal(asset.code, '');
+  });
+
+  it('derives output from code if no output is provided', () => {
+    let defaultOptionsWithoutOutput = getDefaultOptions();
+    delete defaultOptionsWithoutOutput.output;
+
+    let asset = new Asset(defaultOptionsWithoutOutput);
+    assert.equal(asset.code, 'code');
+  });
+
+  it('derives output size from output code length if outputSize is not provided', () => {
+    let defaultOptionsWithoutOutputSize = getDefaultOptions();
+    delete defaultOptionsWithoutOutputSize.outputSize;
+
+    let asset = new Asset(defaultOptionsWithoutOutputSize);
+    assert.equal(asset.outputSize, 6);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10443,6 +10443,11 @@ shallow-copy@0.0.1, shallow-copy@~0.0.1:
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
   integrity sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
This moves `Asset.js` to use `flow strict`. It addresses what Flow calls sketchy null checks -- cases where we're using boolean logic to test whether something is null where falsy values could go unnoticed.

This also adds some basic test coverage to constructing `Asset`s to provide some confidence.

Note that this **does** change the logic in these places, but I believe this better implements intended behavior. For example, previously empty strings of `code` would not be considered, and now they are, as are `outputSize`s of 0, which also would have been ignored.