### PR TITLE
Fix bug with original null mappings

### DIFF
--- a/packages/core/parcel-bundler/src/SourceMap.js
+++ b/packages/core/parcel-bundler/src/SourceMap.js
@@ -298,8 +298,9 @@ class SourceMap {
       generatedPosition.line,
       generatedPosition.column
     );
+
     let mapping = this.mappings[index];
-    if (!mapping) {
+    if (!mapping || !mapping.original) {
       return null;
     }
 
@@ -317,11 +318,13 @@ class SourceMap {
       originalPosition.column,
       'original'
     );
+
+    let mapping = this.mappings[index];
     return {
-      source: this.mappings[index].source,
-      name: this.mappings[index].name,
-      line: this.mappings[index].generated.line,
-      column: this.mappings[index].generated.column
+      source: mapping.source,
+      name: mapping.name,
+      line: mapping.generated.line,
+      column: mapping.generated.column
     };
   }
 


### PR DESCRIPTION
# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

If an original mapping had null and that map needed to be extended (aka null mappings from node_modules & TS).
`originalPositionFor` tried to get the location of this mapping.

Fixes #2738 

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

https://github.com/ross-pfahler/parcel-sourcemap-bug (note: remove yarn.lock if using yarn as it uses the Adobe corp artifactory)

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Run the Repo it should work. Probably gonna add a test for this though.

Tried to write a test for this but it seems hard to write a minimal repro testcase for this. This was probably also the reason I never added tests for sourcemaps in node_modules.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs