### PR TITLE
Separate graphviz debugging and have BundleGraph subclass Graph directly

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -162,10 +162,14 @@ export default new Bundler({
       }
     }
 
-    // bundleGraph.dumpGraphViz();
-
-    // bundleGraph.traverseBundles(bundle => {
-    //   bundle.assetGraph.dumpGraphViz();
-    // });
+    if (process.env.PARCEL_DUMP_GRAPH != null) {
+      const dumpGraphToGraphViz = require('@parcel/utils/src/dumpGraphToGraphViz')
+        .default;
+      dumpGraphToGraphViz(assetGraph, 'BundlerInputAssetGraph');
+      dumpGraphToGraphViz(bundleGraph, 'BundleGraph');
+      bundleGraph.traverseBundles(bundle => {
+        dumpGraphToGraphViz(bundle.assetGraph, `${bundle.id}`);
+      });
+    }
   }
 });

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -1,17 +1,18 @@
 // @flow
 
-import Graph, {type Node, type NodeId} from './Graph';
+import Graph from './Graph';
 import type {
+  Asset,
+  Bundle,
   CacheEntry,
   Dependency as IDependency,
-  Asset,
   File,
   FilePath,
-  TransformerRequest,
+  GraphTraversalCallback,
+  Node,
+  NodeId,
   Target,
-  Environment,
-  Bundle,
-  GraphTraversalCallback
+  TransformerRequest
 } from '@parcel/types';
 import {md5FromString} from '@parcel/utils/src/md5';
 import Dependency from './Dependency';
@@ -89,14 +90,8 @@ type AssetGraphOpts = {|
  *  * A file node can have one to many edges to asset nodes which can have zero to many edges dependency nodes
  */
 export default class AssetGraph extends Graph {
-  incompleteNodes: Map<NodeId, Node>;
-  invalidNodes: Map<NodeId, Node>;
-
-  constructor(opts: any) {
-    super(opts);
-    this.incompleteNodes = new Map();
-    this.invalidNodes = new Map();
-  }
+  incompleteNodes: Map<NodeId, Node> = new Map();
+  invalidNodes: Map<NodeId, Node> = new Map();
 
   initializeGraph({
     entries,
@@ -326,91 +321,4 @@ export default class AssetGraph extends Graph {
       value: asset
     });
   }
-
-  async dumpGraphViz() {
-    let graphviz = require('graphviz');
-    let tempy = require('tempy');
-    let path = require('path');
-
-    let g = graphviz.digraph('G');
-
-    let colors = {
-      root: 'gray',
-      asset: 'green',
-      dependency: 'orange',
-      transformer_request: 'cyan',
-      file: 'gray',
-      default: 'white'
-    };
-
-    let nodes = Array.from(this.nodes.values());
-
-    for (let node of nodes) {
-      let n = g.addNode(node.id);
-
-      n.set('color', colors[node.type || 'default']);
-      n.set('shape', 'box');
-      n.set('style', 'filled');
-
-      let label = `${node.type || 'No Type'}: `;
-
-      if (node.type === 'dependency') {
-        label += node.value.moduleSpecifier;
-        let parts = [];
-        if (node.value.isEntry) parts.push('entry');
-        if (node.value.isAsync) parts.push('async');
-        if (node.value.isOptional) parts.push('optional');
-        if (parts.length) label += ' (' + parts.join(', ') + ')';
-        if (node.value.env) label += ` (${getEnvDescription(node.value.env)})`;
-      } else if (node.type === 'asset' || node.type === 'asset_reference') {
-        label += path.basename(node.value.filePath) + '#' + node.value.type;
-      } else if (node.type === 'file') {
-        label += path.basename(node.value.filePath);
-      } else if (node.type === 'transformer_request') {
-        label +=
-          path.basename(node.value.filePath) +
-          ` (${getEnvDescription(node.value.env)})`;
-      } else if (node.type === 'bundle') {
-        let rootAssets = node.value.assetGraph.getNodesConnectedFrom(
-          node.value.assetGraph.getRootNode()
-        );
-        label += rootAssets
-          .map(asset => {
-            let parts = asset.value.filePath.split(path.sep);
-            let index = parts.lastIndexOf('node_modules');
-            if (index >= 0) {
-              return parts[index + 1];
-            }
-
-            return path.basename(asset.value.filePath);
-          })
-          .join(', ');
-      } else {
-        // label += node.id;
-        label = node.type;
-      }
-
-      n.set('label', label);
-    }
-
-    for (let edge of this.edges) {
-      g.addEdge(edge.from, edge.to);
-    }
-
-    let tmp = tempy.file({name: 'graph.png'});
-
-    await g.output('png', tmp);
-    console.log(`open ${tmp}`); // eslint-disable-line no-console
-  }
-}
-
-function getEnvDescription(env: Environment) {
-  let description = '';
-  if (env.engines.browsers) {
-    description = `${env.context}: ${env.engines.browsers.join(', ')}`;
-  } else if (env.engines.node) {
-    description = `node: ${env.engines.node}`;
-  }
-
-  return description;
 }

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -47,17 +47,17 @@ export const nodeFromAsset = (asset: Asset) => ({
   value: asset
 });
 
-const getFileNodesFromGraph = (graph: Graph): Array<Node> => {
+const getFileNodesFromGraph = (graph: Graph<Node>): Array<Node> => {
   return Array.from(graph.nodes.values()).filter(
     (node: any) => node.type === 'file'
   );
 };
 
-const getFilesFromGraph = (graph: Graph): Array<File> => {
+const getFilesFromGraph = (graph: Graph<Node>): Array<File> => {
   return getFileNodesFromGraph(graph).map(node => node.value);
 };
 
-const getDepNodesFromGraph = (graph: Graph): Array<Node> => {
+const getDepNodesFromGraph = (graph: Graph<Node>): Array<Node> => {
   return Array.from(graph.nodes.values()).filter(
     (node: any) => node.type === 'dependency'
   );
@@ -89,7 +89,7 @@ type AssetGraphOpts = {|
  *  * A dependency node should have an edge to exactly one file node
  *  * A file node can have one to many edges to asset nodes which can have zero to many edges dependency nodes
  */
-export default class AssetGraph extends Graph {
+export default class AssetGraph extends Graph<Node> {
   incompleteNodes: Map<NodeId, Node> = new Map();
   invalidNodes: Map<NodeId, Node> = new Map();
 

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -4,10 +4,10 @@ import type {
   CLIOptions,
   Dependency,
   FilePath,
+  Node,
   Target,
   TransformerRequest
 } from '@parcel/types';
-import type {Node} from './Graph';
 import type Config from './Config';
 import EventEmitter from 'events';
 import {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -5,12 +5,14 @@ import type {
   BundleGroup,
   GraphTraversalCallback
 } from '@parcel/types';
-import AssetGraph from './AssetGraph';
+import type AssetGraph from './AssetGraph';
+
+import Graph from './Graph';
 
 const getBundleGroupId = (bundleGroup: BundleGroup) =>
   'bundle_group:' + bundleGroup.entryAssetId;
 
-export default class BundleGraph extends AssetGraph {
+export default class BundleGraph extends Graph {
   constructor() {
     super();
     this.setRootNode({

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -3,7 +3,8 @@ import type {
   Asset,
   Bundle,
   BundleGroup,
-  GraphTraversalCallback
+  GraphTraversalCallback,
+  Node
 } from '@parcel/types';
 import type AssetGraph from './AssetGraph';
 
@@ -12,7 +13,7 @@ import Graph from './Graph';
 const getBundleGroupId = (bundleGroup: BundleGroup) =>
   'bundle_group:' + bundleGroup.entryAssetId;
 
-export default class BundleGraph extends Graph {
+export default class BundleGraph extends Graph<Node> {
   constructor() {
     super();
     this.setRootNode({

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -1,19 +1,15 @@
 // @flow
 
 import type {
+  Edge,
   Node as _Node,
+  NodeId,
   GraphTraversalCallback,
   TraversalActions,
   Graph as IGraph
 } from '@parcel/types';
 
 export type Node = _Node;
-export type NodeId = string;
-
-export type Edge = {|
-  from: NodeId,
-  to: NodeId
-|};
 
 type GraphUpdates = {|
   added: Graph,

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -2,37 +2,37 @@
 
 import type {
   Edge,
-  Node as _Node,
+  Node,
   NodeId,
   GraphTraversalCallback,
   TraversalActions,
   Graph as IGraph
 } from '@parcel/types';
 
-export type Node = _Node;
-
-type GraphUpdates = {|
-  added: Graph,
-  removed: Graph
+type GraphUpdates<TNode> = {|
+  added: Graph<TNode>,
+  removed: Graph<TNode>
 |};
 
-type GraphOpts = {|
-  nodes?: Array<[NodeId, Node]>,
+type GraphOpts<TNode> = {|
+  nodes?: Array<[NodeId, TNode]>,
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
 |};
-export default class Graph implements IGraph {
-  nodes: Map<NodeId, Node>;
+export default class Graph<TNode: Node> implements IGraph<TNode> {
+  nodes: Map<NodeId, TNode>;
   edges: Set<Edge>;
   rootNodeId: ?NodeId;
 
-  constructor(opts: GraphOpts = {nodes: [], edges: [], rootNodeId: null}) {
+  constructor(
+    opts: GraphOpts<TNode> = {nodes: [], edges: [], rootNodeId: null}
+  ) {
     this.nodes = new Map(opts.nodes);
     this.edges = new Set(opts.edges);
     this.rootNodeId = opts.rootNodeId;
   }
 
-  serialize(): GraphOpts {
+  serialize(): GraphOpts<TNode> {
     return {
       nodes: [...this.nodes],
       edges: [...this.edges],
@@ -40,34 +40,34 @@ export default class Graph implements IGraph {
     };
   }
 
-  addNode(node: Node) {
+  addNode(node: TNode): TNode {
     this.nodes.set(node.id, node);
     return node;
   }
 
-  hasNode(id: string) {
+  hasNode(id: string): boolean {
     return this.nodes.has(id);
   }
 
-  getNode(id: string) {
+  getNode(id: string): ?TNode {
     return this.nodes.get(id);
   }
 
-  setRootNode(node: Node) {
+  setRootNode(node: TNode): void {
     this.addNode(node);
     this.rootNodeId = node.id;
   }
 
-  getRootNode(): ?Node {
+  getRootNode(): ?TNode {
     return this.rootNodeId ? this.getNode(this.rootNodeId) : null;
   }
 
-  addEdge(edge: Edge) {
+  addEdge(edge: Edge): Edge {
     this.edges.add(edge);
     return edge;
   }
 
-  hasEdge(edge: Edge) {
+  hasEdge(edge: Edge): boolean {
     for (let e of this.edges) {
       if (edge.from == e.from && edge.to === e.to) {
         return true;
@@ -77,7 +77,7 @@ export default class Graph implements IGraph {
     return false;
   }
 
-  getNodesConnectedTo(node: Node): Array<Node> {
+  getNodesConnectedTo(node: TNode): Array<TNode> {
     let edges = Array.from(this.edges).filter(edge => edge.to === node.id);
     return edges.map(edge => {
       // $FlowFixMe
@@ -85,7 +85,7 @@ export default class Graph implements IGraph {
     });
   }
 
-  getNodesConnectedFrom(node: Node): Array<Node> {
+  getNodesConnectedFrom(node: TNode): Array<TNode> {
     let edges = Array.from(this.edges).filter(edge => edge.from === node.id);
     return edges.map(edge => {
       // $FlowFixMe
@@ -93,8 +93,7 @@ export default class Graph implements IGraph {
     });
   }
 
-  // $FlowFixMe - fix interface
-  merge(graph: Graph) {
+  merge(graph: IGraph<TNode>): void {
     for (let [, node] of graph.nodes) {
       this.addNode(node);
     }
@@ -105,7 +104,7 @@ export default class Graph implements IGraph {
   }
 
   // Removes node and any edges coming from that node
-  removeNode(node: Node): this {
+  removeNode(node: TNode): this {
     let removed = new this.constructor();
 
     this.nodes.delete(node.id);
@@ -120,7 +119,7 @@ export default class Graph implements IGraph {
     return removed;
   }
 
-  removeEdges(node: Node): this {
+  removeEdges(node: TNode): this {
     let removed = new this.constructor();
 
     for (let edge of this.edges) {
@@ -150,7 +149,7 @@ export default class Graph implements IGraph {
     return removed;
   }
 
-  isOrphanedNode(node: Node) {
+  isOrphanedNode(node: TNode): boolean {
     for (let edge of this.edges) {
       if (edge.to === node.id) {
         return false;
@@ -159,7 +158,7 @@ export default class Graph implements IGraph {
     return true;
   }
 
-  replaceNode(fromNode: Node, toNode: Node) {
+  replaceNode(fromNode: TNode, toNode: TNode): void {
     this.addNode(toNode);
 
     for (let edge of this.edges) {
@@ -174,7 +173,10 @@ export default class Graph implements IGraph {
 
   // Update a node's downstream nodes making sure to prune any orphaned branches
   // Also keeps track of all added and removed edges and nodes
-  replaceNodesConnectedTo(fromNode: Node, toNodes: Array<Node>): GraphUpdates {
+  replaceNodesConnectedTo(
+    fromNode: TNode,
+    toNodes: Array<TNode>
+  ): GraphUpdates<TNode> {
     let removed = new this.constructor();
     let added = new this.constructor();
 
@@ -209,8 +211,8 @@ export default class Graph implements IGraph {
   }
 
   traverse<TContext>(
-    visit: GraphTraversalCallback<Node, TContext>,
-    startNode: ?Node
+    visit: GraphTraversalCallback<TNode, TContext>,
+    startNode: ?TNode
   ): ?TContext {
     return this.dfs({
       visit,
@@ -220,8 +222,8 @@ export default class Graph implements IGraph {
   }
 
   traverseAncestors<TContext>(
-    startNode: Node,
-    visit: GraphTraversalCallback<Node, TContext>
+    startNode: TNode,
+    visit: GraphTraversalCallback<TNode, TContext>
   ) {
     return this.dfs({
       visit,
@@ -235,16 +237,16 @@ export default class Graph implements IGraph {
     startNode,
     getChildren
   }: {
-    visit: GraphTraversalCallback<Node, TContext>,
-    getChildren(node: Node): Array<Node>,
-    startNode?: ?Node
+    visit: GraphTraversalCallback<TNode, TContext>,
+    getChildren(node: TNode): Array<TNode>,
+    startNode?: ?TNode
   }): ?TContext {
     let root = startNode || this.getRootNode();
     if (!root) {
       return null;
     }
 
-    let visited = new Set<Node>();
+    let visited = new Set<TNode>();
     let stopped = false;
     let skipped = false;
     let actions: TraversalActions = {
@@ -289,14 +291,14 @@ export default class Graph implements IGraph {
     return walk(root);
   }
 
-  bfs(visit: (node: Node) => ?boolean): ?Node {
+  bfs(visit: (node: TNode) => ?boolean): ?TNode {
     let root = this.getRootNode();
     if (!root) {
       return null;
     }
 
-    let queue: Array<Node> = [root];
-    let visited = new Set<Node>([root]);
+    let queue: Array<TNode> = [root];
+    let visited = new Set<TNode>([root]);
 
     while (queue.length > 0) {
       let node = queue.shift();
@@ -316,7 +318,7 @@ export default class Graph implements IGraph {
     return null;
   }
 
-  getSubGraph(node: Node): this {
+  getSubGraph(node: TNode): this {
     let graph = new this.constructor();
     graph.setRootNode(node);
 

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -119,8 +119,15 @@ export default class Parcel {
   async build() {
     try {
       // console.log('Starting build'); // eslint-disable-line no-console
+      // $FlowFixMe This reliably fails on Windows. Not sure why.
       let assetGraph = await this.assetGraphBuilder.build();
-      // await graph.dumpGraphViz();
+
+      if (process.env.PARCEL_DUMP_GRAPH != null) {
+        const dumpGraphToGraphViz = require('@parcel/utils/src/dumpGraphToGraphViz')
+          .default;
+        await dumpGraphToGraphViz(assetGraph, 'MainAssetGraph');
+      }
+
       let bundleGraph = await this.bundle(assetGraph);
       await this.package(bundleGraph);
 

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -290,7 +290,16 @@ export type GraphTraversalCallback<TNode, TContext> = (
   traversal: TraversalActions
 ) => ?TContext;
 
+export type NodeId = string;
+
+export type Edge = {|
+  from: NodeId,
+  to: NodeId
+|};
+
 export interface Graph {
+  nodes: Map<string, Node>;
+  edges: Set<Edge>;
   merge(graph: Graph): void;
   traverse<TContext>(
     visit: GraphTraversalCallback<Node, TContext>,
@@ -325,7 +334,7 @@ export type Bundle = {|
   filePath?: FilePath
 |};
 
-export interface BundleGraph {
+export interface BundleGraph extends Graph {
   addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
   addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
   isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -297,18 +297,18 @@ export type Edge = {|
   to: NodeId
 |};
 
-export interface Graph {
-  nodes: Map<string, Node>;
+export interface Graph<TNode: Node> {
+  nodes: Map<string, TNode>;
   edges: Set<Edge>;
-  merge(graph: Graph): void;
+  merge(graph: Graph<TNode>): void;
   traverse<TContext>(
-    visit: GraphTraversalCallback<Node, TContext>,
-    startNode: ?Node
+    visit: GraphTraversalCallback<TNode, TContext>,
+    startNode: ?TNode
   ): ?TContext;
 }
 
 // TODO: what do we want to expose here?
-export interface AssetGraph extends Graph {
+export interface AssetGraph extends Graph<Node> {
   traverseAssets(visit: GraphTraversalCallback<Asset, Node>): ?Node;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
@@ -334,7 +334,7 @@ export type Bundle = {|
   filePath?: FilePath
 |};
 
-export interface BundleGraph extends Graph {
+export interface BundleGraph extends Graph<Node> {
   addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
   addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
   isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;

--- a/packages/core/utils/src/dumpGraphToGraphViz.js
+++ b/packages/core/utils/src/dumpGraphToGraphViz.js
@@ -1,13 +1,13 @@
 // @flow
 
-import type {Environment, Graph} from '@parcel/types';
+import type {Environment, Graph, Node} from '@parcel/types';
 
 import graphviz from 'graphviz';
 import tempy from 'tempy';
 import path from 'path';
 
 export default async function dumpGraphToGraphViz(
-  graph: Graph,
+  graph: Graph<Node>,
   name: string
 ): Promise<void> {
   let g = graphviz.digraph('G');
@@ -21,7 +21,7 @@ export default async function dumpGraphToGraphViz(
     default: 'white'
   };
 
-  let nodes = Array.from(graph.nodes.values());
+  let nodes: Array<Node> = Array.from(graph.nodes.values());
   for (let node of nodes) {
     let n = g.addNode(node.id);
 

--- a/packages/core/utils/src/dumpGraphToGraphViz.js
+++ b/packages/core/utils/src/dumpGraphToGraphViz.js
@@ -1,0 +1,92 @@
+// @flow
+
+import type {Environment, Graph} from '@parcel/types';
+
+import graphviz from 'graphviz';
+import tempy from 'tempy';
+import path from 'path';
+
+export default async function dumpGraphToGraphViz(
+  graph: Graph,
+  name: string
+): Promise<void> {
+  let g = graphviz.digraph('G');
+
+  let colors = {
+    root: 'gray',
+    asset: 'green',
+    dependency: 'orange',
+    transformer_request: 'cyan',
+    file: 'gray',
+    default: 'white'
+  };
+
+  let nodes = Array.from(graph.nodes.values());
+  for (let node of nodes) {
+    let n = g.addNode(node.id);
+
+    n.set('color', colors[node.type || 'default']);
+    n.set('shape', 'box');
+    n.set('style', 'filled');
+
+    let label = `${node.type || 'No Type'}: `;
+
+    if (node.type === 'dependency') {
+      label += node.value.moduleSpecifier;
+      let parts = [];
+      if (node.value.isEntry) parts.push('entry');
+      if (node.value.isAsync) parts.push('async');
+      if (node.value.isOptional) parts.push('optional');
+      if (parts.length) label += ' (' + parts.join(', ') + ')';
+      if (node.value.env) label += ` (${getEnvDescription(node.value.env)})`;
+    } else if (node.type === 'asset' || node.type === 'asset_reference') {
+      label += path.basename(node.value.filePath) + '#' + node.value.type;
+    } else if (node.type === 'file') {
+      label += path.basename(node.value.filePath);
+    } else if (node.type === 'transformer_request') {
+      label +=
+        path.basename(node.value.filePath) +
+        ` (${getEnvDescription(node.value.env)})`;
+    } else if (node.type === 'bundle') {
+      let rootAssets = node.value.assetGraph.getNodesConnectedFrom(
+        node.value.assetGraph.getRootNode()
+      );
+      label += rootAssets
+        .map(asset => {
+          let parts = asset.value.filePath.split(path.sep);
+          let index = parts.lastIndexOf('node_modules');
+          if (index >= 0) {
+            return parts[index + 1];
+          }
+
+          return path.basename(asset.value.filePath);
+        })
+        .join(', ');
+    } else {
+      // label += node.id;
+      label = node.type;
+    }
+
+    n.set('label', label);
+  }
+
+  for (let edge of graph.edges) {
+    g.addEdge(edge.from, edge.to);
+  }
+
+  let tmp = tempy.file({name: `${name}.png`});
+
+  await g.output('png', tmp);
+  console.log(`open ${tmp}`); // eslint-disable-line no-console
+}
+
+function getEnvDescription(env: Environment) {
+  let description = '';
+  if (env.engines.browsers) {
+    description = `${env.context}: ${env.engines.browsers.join(', ')}`;
+  } else if (env.engines.node) {
+    description = `node: ${env.engines.node}`;
+  }
+
+  return description;
+}

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -36,7 +36,6 @@ export default new Runtime({
       return;
     }
 
-    // $FlowFixMe - define a better asset graph interface
     let bundleGroups = Array.from(bundle.assetGraph.nodes.values()).filter(
       n => n.type === 'bundle_group'
     );


### PR DESCRIPTION
Separate graphviz debugging and have BundleGraph subclass Graph directly

Since `BundleGraph` was subclassing `AssetGraph` only to share the graphviz debugging, extract that into a utility and rebase it directly on `Graph`.

This also moves this debugging to use an environment variable rather than toggling code comments. I'm open to switching this back but I think it's quite nice.

This also simplifies the `AssetGraph` constructor, removing its unused argument and moving property initialization to the near-standardized property initialization proposal. Open to revert this as well.

Test Plan: Run flow, lint, and test. Run `PARCEL_DUMP_GRAPH=1 yarn test` and verify graphviz images are dumped.