### PR TITLE
Parcel 2 Robust Caching

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -38,9 +38,10 @@ class Worker extends EventEmitter {
 
     this.child = childProcess.fork(childModule, process.argv, options);
 
-    // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
-    this.child.unref();
-    this.child.channel.unref();
+    // TODO: This was causing odd behavior, need to fix
+    // // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
+    // this.child.unref();
+    // this.child.channel.unref();
 
     this.child.on('message', data => this.receive(data));
 


### PR DESCRIPTION
# ↪️ Parcel 2 Robust Caching

We've done a bunch of brainstorming on Parcel 2 caching and it's time to start experimenting. Opening up a draft PR so I can gather feedback as I try things out. Closes #2137 

## Background: The AssetGraph

The first stage of Parcel v2 involves building an asset graph. Currently, on start up, Parcel starts with an empty graph and adds some initial nodes that represent dependency requests for all of the entries. Dependency request nodes are added before they have been resolved, so as they are added, the graph marks them as incomplete. To start building out the graph, all of the incomplete nodes are collected and added to a queue to be processed. Dependency requests will resolve to a file that should be transformed to produce assets that will end up in bundles as well as more dependency requests. Once a dependency request is resolved, we connect a transformation request to the dependency node, mark the dependency request node as complete and the transformation node as incomplete, and add the transformation request to the queue to be processed. One thing to note is that dependency requests may resolve to files that have already been transformed or have been queued to be transformed, in which case there should already be a transformation request node in the graph. In this case, we connect to the existing node and skip adding that node to the queue to be processed. Processing transformation requests works very similarly. Once the transformation request is completed, we (maybe) create and connect nodes for the resulting assets and dependency requests, mark the transformation request node as complete and the dependency request nodes as incomplete, and add all of the dependency request nodes to the the queue to be processed. The reason for keeping track of incomplete nodes in the graph is that we may need to pause work if we are watching the file system and notice a change that may alter the graph. Right now we have file nodes connected to transformation reqeust nodes that allow us to quickly invalidate those transformations when any of those files change. Since the new transformations may result in pruning dependencies, we don't want to continue filling out the edges of the graph that may no longer exist, so we pause processing incomplete nodes to process the invalidated nodes. Processing invalidated nodes is the same as processing incomplete nodes except that we do not add resulting nodes to the queue, as they will be marked as incomplete and picked up and added to the queue once we are ready to start processing incomplete nodes again.

## Caching Plans

As of now in the v2 branch, dependency resolutions and file transformations are both cached, but very naively. We don't check that resolver and transformer plugins are the same or that those plugins will return the same result based on things like config changing or the underlying tools or plugins changing versions. It would be interesting to add this information into the graph as in the end it is also just resolving and finding deps. We probably wouldn't need to add a plugin dependency's entire graph, resolving to the package.json, which should change when the version changes should be enough. Plugin dependencies for the babel transformer plugin would be things like `@babel/core/package.json`, `/project-root/.babelrc`, and `@babel/preset-env/package.json`. Resolver plugins might also want to specify files that don't exist yet, but would invalidate things if they are added to the filesystem. We still need to figure out how and when we get this information from plugins.

The current direction we are exploring is to cache the graph itself. If we have a way to determine what has changed in the file system since the last build, then a rebuild on start up should be exactly like a rebuild in watch mode. Watchman would help a lot with this approach, as it can query for file changes since it last checked, but since Watchman requires being set up separately from Parcel, we don't want to force people to use it. We can use it if we detect it is already set up, like Jest does, but we need something to fall back on for people not using Watchman. One option is to also persist a representation of the filesystem that we could compare against. The tricky part is figuring out which areas of the filesystem to pay attention to. Right now it's only file nodes that invalidate, which would give us a minimal list of files to stat, but we haven't covered all cases that should be invalidated yet. We may not be able to only use file nodes for invalidation. For instance, one idea for invalidating dependency resolutions would be to add a file node for each file that was checked for before resolving. That way if any of those files appeared, the resolver would run again to resolve to that file instead. But resolvers can end up checking a *lot* of files that don't exist. Perhaps using glob nodes would be better, but that means we no longer know exactly which files we need to pay attention to. It's possible we would have to end up checking against the entire project root, which would definitely require optimizations. Maybe the most performant thing would be to invalidate all globs on an initial rebuild if Watchman isn't being used. We'll have to explore this. (It's also possible that changes outside of the project root could invalidate things, but we've decided not to support that behavior) Ultimately we need to work through how to represent dependency resolution or file transformation invalidations in the graph, keeping in mind that restricting ourselves to file nodes without blowing up the graph would be ideal.

## Things to keep in mind

### Symlinks

Since we are talking about files so much, it's important to keep symlinks in mind, as it can bite you if you leave them as an after thought. We need to be mindful of when we use symlink path and when we use the real path. See this [comment](https://github.com/parcel-bundler/parcel/issues/1125#issuecomment-401451734) for context.

### Distributed Cache

We also have the goal of supporting [distributed caching](https://github.com/parcel-bundler/parcel/issues/28), so we need to make sure whatever we implement plays nicely with that.

## Todos

- [ ] Add used plugins meta to graph so transformation and resolutions can be invalidated if relevant parcel plugins have changed
- [ ] Add parcel plugin dependencies to graph so transformations and resolutions can be invalidated when config or underlying tools and their plugins change
- [ ] Initialize graph with a cached graph if it exists, and add logic to invalidate graph based on changes to the filesystem since the last build
