### PR TITLE
Unescaped "." in regex for JSAsset

### DIFF
--- a/packages/core/parcel-bundler/src/assets/JSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/JSAsset.js
@@ -45,7 +45,7 @@ class JSAsset extends Asset {
   mightHaveDependencies() {
     return (
       this.isAstDirty ||
-      !/.js$/.test(this.name) ||
+      !/\.js$/.test(this.name) ||
       IMPORT_RE.test(this.contents) ||
       GLOBAL_RE.test(this.contents) ||
       SW_RE.test(this.contents) ||


### PR DESCRIPTION
.js = ajs | 0js | sjs

was scrolling through the code trying to find Windows path issues and found this one

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
