### PR TITLE
Parameterize Graph on `TNode`, a type of its Nodes

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -47,17 +47,17 @@ export const nodeFromAsset = (asset: Asset) => ({
   value: asset
 });
 
-const getFileNodesFromGraph = (graph: Graph): Array<Node> => {
+const getFileNodesFromGraph = (graph: Graph<Node>): Array<Node> => {
   return Array.from(graph.nodes.values()).filter(
     (node: any) => node.type === 'file'
   );
 };
 
-const getFilesFromGraph = (graph: Graph): Array<File> => {
+const getFilesFromGraph = (graph: Graph<Node>): Array<File> => {
   return getFileNodesFromGraph(graph).map(node => node.value);
 };
 
-const getDepNodesFromGraph = (graph: Graph): Array<Node> => {
+const getDepNodesFromGraph = (graph: Graph<Node>): Array<Node> => {
   return Array.from(graph.nodes.values()).filter(
     (node: any) => node.type === 'dependency'
   );
@@ -89,7 +89,7 @@ type AssetGraphOpts = {|
  *  * A dependency node should have an edge to exactly one file node
  *  * A file node can have one to many edges to asset nodes which can have zero to many edges dependency nodes
  */
-export default class AssetGraph extends Graph {
+export default class AssetGraph extends Graph<Node> {
   incompleteNodes: Map<NodeId, Node> = new Map();
   invalidNodes: Map<NodeId, Node> = new Map();
 

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -4,10 +4,10 @@ import type {
   CLIOptions,
   Dependency,
   FilePath,
+  Node,
   Target,
   TransformerRequest
 } from '@parcel/types';
-import type {Node} from './Graph';
 import type Config from './Config';
 import EventEmitter from 'events';
 import {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -3,7 +3,8 @@ import type {
   Asset,
   Bundle,
   BundleGroup,
-  GraphTraversalCallback
+  GraphTraversalCallback,
+  Node
 } from '@parcel/types';
 import type AssetGraph from './AssetGraph';
 
@@ -12,7 +13,7 @@ import Graph from './Graph';
 const getBundleGroupId = (bundleGroup: BundleGroup) =>
   'bundle_group:' + bundleGroup.entryAssetId;
 
-export default class BundleGraph extends Graph {
+export default class BundleGraph extends Graph<Node> {
   constructor() {
     super();
     this.setRootNode({

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -2,14 +2,12 @@
 
 import type {
   Edge,
-  Node as _Node,
+  Node,
   NodeId,
   GraphTraversalCallback,
   TraversalActions,
   Graph as IGraph
 } from '@parcel/types';
-
-export type Node = _Node;
 
 type GraphUpdates<TNode> = {|
   added: Graph<TNode>,

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -11,28 +11,30 @@ import type {
 
 export type Node = _Node;
 
-type GraphUpdates = {|
-  added: Graph,
-  removed: Graph
+type GraphUpdates<TNode> = {|
+  added: Graph<TNode>,
+  removed: Graph<TNode>
 |};
 
-type GraphOpts = {|
-  nodes?: Array<[NodeId, Node]>,
+type GraphOpts<TNode> = {|
+  nodes?: Array<[NodeId, TNode]>,
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
 |};
-export default class Graph implements IGraph {
-  nodes: Map<NodeId, Node>;
+export default class Graph<TNode: Node> implements IGraph<TNode> {
+  nodes: Map<NodeId, TNode>;
   edges: Set<Edge>;
   rootNodeId: ?NodeId;
 
-  constructor(opts: GraphOpts = {nodes: [], edges: [], rootNodeId: null}) {
+  constructor(
+    opts: GraphOpts<TNode> = {nodes: [], edges: [], rootNodeId: null}
+  ) {
     this.nodes = new Map(opts.nodes);
     this.edges = new Set(opts.edges);
     this.rootNodeId = opts.rootNodeId;
   }
 
-  serialize(): GraphOpts {
+  serialize(): GraphOpts<TNode> {
     return {
       nodes: [...this.nodes],
       edges: [...this.edges],
@@ -40,34 +42,34 @@ export default class Graph implements IGraph {
     };
   }
 
-  addNode(node: Node) {
+  addNode(node: TNode): TNode {
     this.nodes.set(node.id, node);
     return node;
   }
 
-  hasNode(id: string) {
+  hasNode(id: string): boolean {
     return this.nodes.has(id);
   }
 
-  getNode(id: string) {
+  getNode(id: string): ?TNode {
     return this.nodes.get(id);
   }
 
-  setRootNode(node: Node) {
+  setRootNode(node: TNode): void {
     this.addNode(node);
     this.rootNodeId = node.id;
   }
 
-  getRootNode(): ?Node {
+  getRootNode(): ?TNode {
     return this.rootNodeId ? this.getNode(this.rootNodeId) : null;
   }
 
-  addEdge(edge: Edge) {
+  addEdge(edge: Edge): Edge {
     this.edges.add(edge);
     return edge;
   }
 
-  hasEdge(edge: Edge) {
+  hasEdge(edge: Edge): boolean {
     for (let e of this.edges) {
       if (edge.from == e.from && edge.to === e.to) {
         return true;
@@ -77,7 +79,7 @@ export default class Graph implements IGraph {
     return false;
   }
 
-  getNodesConnectedTo(node: Node): Array<Node> {
+  getNodesConnectedTo(node: TNode): Array<TNode> {
     let edges = Array.from(this.edges).filter(edge => edge.to === node.id);
     return edges.map(edge => {
       // $FlowFixMe
@@ -85,7 +87,7 @@ export default class Graph implements IGraph {
     });
   }
 
-  getNodesConnectedFrom(node: Node): Array<Node> {
+  getNodesConnectedFrom(node: TNode): Array<TNode> {
     let edges = Array.from(this.edges).filter(edge => edge.from === node.id);
     return edges.map(edge => {
       // $FlowFixMe
@@ -93,8 +95,7 @@ export default class Graph implements IGraph {
     });
   }
 
-  // $FlowFixMe - fix interface
-  merge(graph: Graph) {
+  merge(graph: IGraph<TNode>): void {
     for (let [, node] of graph.nodes) {
       this.addNode(node);
     }
@@ -105,7 +106,7 @@ export default class Graph implements IGraph {
   }
 
   // Removes node and any edges coming from that node
-  removeNode(node: Node): this {
+  removeNode(node: TNode): this {
     let removed = new this.constructor();
 
     this.nodes.delete(node.id);
@@ -120,7 +121,7 @@ export default class Graph implements IGraph {
     return removed;
   }
 
-  removeEdges(node: Node): this {
+  removeEdges(node: TNode): this {
     let removed = new this.constructor();
 
     for (let edge of this.edges) {
@@ -150,7 +151,7 @@ export default class Graph implements IGraph {
     return removed;
   }
 
-  isOrphanedNode(node: Node) {
+  isOrphanedNode(node: TNode): boolean {
     for (let edge of this.edges) {
       if (edge.to === node.id) {
         return false;
@@ -159,7 +160,7 @@ export default class Graph implements IGraph {
     return true;
   }
 
-  replaceNode(fromNode: Node, toNode: Node) {
+  replaceNode(fromNode: TNode, toNode: TNode): void {
     this.addNode(toNode);
 
     for (let edge of this.edges) {
@@ -174,7 +175,10 @@ export default class Graph implements IGraph {
 
   // Update a node's downstream nodes making sure to prune any orphaned branches
   // Also keeps track of all added and removed edges and nodes
-  replaceNodesConnectedTo(fromNode: Node, toNodes: Array<Node>): GraphUpdates {
+  replaceNodesConnectedTo(
+    fromNode: TNode,
+    toNodes: Array<TNode>
+  ): GraphUpdates<TNode> {
     let removed = new this.constructor();
     let added = new this.constructor();
 
@@ -209,8 +213,8 @@ export default class Graph implements IGraph {
   }
 
   traverse<TContext>(
-    visit: GraphTraversalCallback<Node, TContext>,
-    startNode: ?Node
+    visit: GraphTraversalCallback<TNode, TContext>,
+    startNode: ?TNode
   ): ?TContext {
     return this.dfs({
       visit,
@@ -220,8 +224,8 @@ export default class Graph implements IGraph {
   }
 
   traverseAncestors<TContext>(
-    startNode: Node,
-    visit: GraphTraversalCallback<Node, TContext>
+    startNode: TNode,
+    visit: GraphTraversalCallback<TNode, TContext>
   ) {
     return this.dfs({
       visit,
@@ -235,16 +239,16 @@ export default class Graph implements IGraph {
     startNode,
     getChildren
   }: {
-    visit: GraphTraversalCallback<Node, TContext>,
-    getChildren(node: Node): Array<Node>,
-    startNode?: ?Node
+    visit: GraphTraversalCallback<TNode, TContext>,
+    getChildren(node: TNode): Array<TNode>,
+    startNode?: ?TNode
   }): ?TContext {
     let root = startNode || this.getRootNode();
     if (!root) {
       return null;
     }
 
-    let visited = new Set<Node>();
+    let visited = new Set<TNode>();
     let stopped = false;
     let skipped = false;
     let actions: TraversalActions = {
@@ -289,14 +293,14 @@ export default class Graph implements IGraph {
     return walk(root);
   }
 
-  bfs(visit: (node: Node) => ?boolean): ?Node {
+  bfs(visit: (node: TNode) => ?boolean): ?TNode {
     let root = this.getRootNode();
     if (!root) {
       return null;
     }
 
-    let queue: Array<Node> = [root];
-    let visited = new Set<Node>([root]);
+    let queue: Array<TNode> = [root];
+    let visited = new Set<TNode>([root]);
 
     while (queue.length > 0) {
       let node = queue.shift();
@@ -316,7 +320,7 @@ export default class Graph implements IGraph {
     return null;
   }
 
-  getSubGraph(node: Node): this {
+  getSubGraph(node: TNode): this {
     let graph = new this.constructor();
     graph.setRootNode(node);
 

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -297,18 +297,18 @@ export type Edge = {|
   to: NodeId
 |};
 
-export interface Graph {
-  nodes: Map<string, Node>;
+export interface Graph<TNode: Node> {
+  nodes: Map<string, TNode>;
   edges: Set<Edge>;
-  merge(graph: Graph): void;
+  merge(graph: Graph<TNode>): void;
   traverse<TContext>(
-    visit: GraphTraversalCallback<Node, TContext>,
-    startNode: ?Node
+    visit: GraphTraversalCallback<TNode, TContext>,
+    startNode: ?TNode
   ): ?TContext;
 }
 
 // TODO: what do we want to expose here?
-export interface AssetGraph extends Graph {
+export interface AssetGraph extends Graph<Node> {
   traverseAssets(visit: GraphTraversalCallback<Asset, Node>): ?Node;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
@@ -334,7 +334,7 @@ export type Bundle = {|
   filePath?: FilePath
 |};
 
-export interface BundleGraph extends Graph {
+export interface BundleGraph extends Graph<Node> {
   addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
   addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
   isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;

--- a/packages/core/utils/src/dumpGraphToGraphViz.js
+++ b/packages/core/utils/src/dumpGraphToGraphViz.js
@@ -1,13 +1,13 @@
 // @flow
 
-import type {Environment, Graph} from '@parcel/types';
+import type {Environment, Graph, Node} from '@parcel/types';
 
 import graphviz from 'graphviz';
 import tempy from 'tempy';
 import path from 'path';
 
 export default async function dumpGraphToGraphViz(
-  graph: Graph,
+  graph: Graph<Node>,
   name: string
 ): Promise<void> {
   let g = graphviz.digraph('G');
@@ -21,7 +21,7 @@ export default async function dumpGraphToGraphViz(
     default: 'white'
   };
 
-  let nodes = Array.from(graph.nodes.values());
+  let nodes: Array<Node> = Array.from(graph.nodes.values());
   for (let node of nodes) {
     let n = g.addNode(node.id);
 


### PR DESCRIPTION
All nodes must implement the `Node` interface. References to `Graph` have been updated to include the `Node` parameter, which is basically the behavior we have now. In a following pull request, each type of graph will have its Node type updated to the union of all the possible node types in the graph.

Also removes the `Node` export from Graph and updates importers to use the one from `@parcel/types`.

Also adds annotations for return values from the `Graph`'s (so far) public api.