### PR TITLE
Add deserializer function to Config

### DIFF
--- a/packages/core/core/src/Config.js
+++ b/packages/core/core/src/Config.js
@@ -204,4 +204,11 @@ export default class Config {
     let res = flatten();
     return res;
   }
+
+  static deserialize({
+    configPath,
+    ...config
+  }: ParcelConfig & {|configPath: string|}) {
+    return new Config(config, configPath);
+  }
 }


### PR DESCRIPTION
# ↪️ Pull Request
Config is being serialized/deserialized during worker initialization and was losing config path with default serialization.

## 🚨 Test instructions

Running simple example no longer crashes with an error. It still silently exits early for some reason, but that is a separate issue. 
