### PR TITLE
Add typings for node and graph types

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -166,6 +166,7 @@ export default new Bundler({
       const dumpGraphToGraphViz = require('@parcel/utils/src/dumpGraphToGraphViz')
         .default;
       dumpGraphToGraphViz(assetGraph, 'BundlerInputAssetGraph');
+      // $FlowFixMe
       dumpGraphToGraphViz(bundleGraph, 'BundleGraph');
       bundleGraph.traverseBundles(bundle => {
         dumpGraphToGraphViz(bundle.assetGraph, `${bundle.id}`);

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -5,20 +5,19 @@ import type {
   Node,
   NodeId,
   GraphTraversalCallback,
+  GraphUpdates,
   TraversalActions,
   Graph as IGraph
 } from '@parcel/types';
 
-type GraphUpdates<TNode> = {|
-  added: Graph<TNode>,
-  removed: Graph<TNode>
-|};
+import nullthrows from 'nullthrows';
 
 type GraphOpts<TNode> = {|
   nodes?: Array<[NodeId, TNode]>,
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
 |};
+
 export default class Graph<TNode: Node> implements IGraph<TNode> {
   nodes: Map<NodeId, TNode>;
   edges: Set<Edge>;
@@ -87,10 +86,7 @@ export default class Graph<TNode: Node> implements IGraph<TNode> {
 
   getNodesConnectedFrom(node: TNode): Array<TNode> {
     let edges = Array.from(this.edges).filter(edge => edge.from === node.id);
-    return edges.map(edge => {
-      // $FlowFixMe
-      return this.nodes.get(edge.to);
-    });
+    return edges.map(edge => nullthrows(this.nodes.get(edge.to)));
   }
 
   merge(graph: IGraph<TNode>): void {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -292,6 +292,43 @@ export type GraphTraversalCallback<TNode, TContext> = (
 
 export type NodeId = string;
 
+export type AssetNode = {|id: string, type: 'asset', value: Asset|};
+export type AssetReferenceNode = {|
+  id: string,
+  type: 'asset_reference',
+  value: Asset
+|};
+
+export type BundleGroupNode = {|
+  id: string,
+  type: 'bundle_group',
+  value: BundleGroup
+|};
+
+export type DependencyNode = {|
+  id: string,
+  type: 'dependency',
+  value: Dependency
+|};
+
+export type FileNode = {|id: string, type: 'file', value: File|};
+export type RootNode = {|id: string, type: 'root', value: string | null|};
+
+export type TransformerRequestNode = {|
+  id: string,
+  type: 'transformer_request',
+  value: TransformerRequest
+|};
+
+export type AssetGraphNode =
+  | AssetNode
+  | AssetReferenceNode
+  | BundleGroupNode
+  | DependencyNode
+  | FileNode
+  | RootNode
+  | TransformerRequestNode;
+
 export type Edge = {|
   from: NodeId,
   to: NodeId
@@ -308,8 +345,10 @@ export interface Graph<TNode: Node> {
 }
 
 // TODO: what do we want to expose here?
-export interface AssetGraph extends Graph<Node> {
-  traverseAssets(visit: GraphTraversalCallback<Asset, Node>): ?Node;
+export interface AssetGraph extends Graph<AssetGraphNode> {
+  traverseAssets(
+    visit: GraphTraversalCallback<Asset, AssetGraphNode>
+  ): ?AssetGraphNode;
   createBundle(asset: Asset): Bundle;
   getTotalSize(asset?: Asset): number;
   getEntryAssets(): Array<Asset>;

--- a/packages/core/types/unsafe.js
+++ b/packages/core/types/unsafe.js
@@ -11,6 +11,6 @@ export type AST = {|
 
 export interface Node {
   id: string;
-  type?: string;
+  +type?: string;
   value: any;
 }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -24,6 +24,7 @@
     "@parcel/workers": "^1.10.3"
   },
   "devDependencies": {
-    "@babel/plugin-transform-flow-strip-types": "^7.2.0"
+    "@babel/plugin-transform-flow-strip-types": "^7.2.0",
+    "nullthrows": "^1.1.1"
   }
 }

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -1,4 +1,7 @@
 // @flow
+
+import type {BundleGroup} from '@parcel/types';
+
 import {Runtime} from '@parcel/plugin';
 import path from 'path';
 
@@ -36,9 +39,11 @@ export default new Runtime({
       return;
     }
 
-    let bundleGroups = Array.from(bundle.assetGraph.nodes.values()).filter(
-      n => n.type === 'bundle_group'
-    );
+    // $FlowFixMe Flow can't refine on filter https://github.com/facebook/flow/issues/1414
+    let bundleGroups: Array<BundleGroup> = Array.from(
+      bundle.assetGraph.nodes.values()
+    ).filter(n => n.type === 'bundle_group');
+
     for (let bundleGroup of bundleGroups) {
       // Ignore deps with native loaders, e.g. workers.
       if (bundleGroup.value.dependency.isURL) {

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -1,9 +1,10 @@
 // @flow
 
-import type {BundleGroup} from '@parcel/types';
+import type {BundleGroupNode} from '@parcel/types';
 
-import {Runtime} from '@parcel/plugin';
+import invariant from 'assert';
 import path from 'path';
+import {Runtime} from '@parcel/plugin';
 
 const LOADERS = {
   browser: {
@@ -40,7 +41,7 @@ export default new Runtime({
     }
 
     // $FlowFixMe Flow can't refine on filter https://github.com/facebook/flow/issues/1414
-    let bundleGroups: Array<BundleGroup> = Array.from(
+    let bundleGroups: Array<BundleGroupNode> = Array.from(
       bundle.assetGraph.nodes.values()
     ).filter(n => n.type === 'bundle_group');
 
@@ -51,9 +52,11 @@ export default new Runtime({
       }
 
       let bundles = bundle.assetGraph
-        // $FlowFixMe - define a better asset graph interface
         .getNodesConnectedFrom(bundleGroup)
-        .map(node => node.value)
+        .map(node => {
+          invariant(node.type === 'bundle');
+          return node.value;
+        })
         .sort(
           bundle =>
             bundle.assetGraph.hasNode(bundleGroup.value.entryAssetId) ? 1 : -1


### PR DESCRIPTION
This adds typings for each of the individual types of Nodes that can be contained in the Asset Graph and the Bundle Graph, separately. Asset Graph typing and Bundle Graph typing are separated in two different commits: `AssetGraph` extends `Graph<AssetGraphNode>`, where `AssetGraphNode` is the union of all possible node types in the Asset Graph. Bundle Graph does the same.

Since we're moving from generic `Node`s we'll need to refine each use to a particular Node type (or union of Node types). This is done predominantly by refining with `invariant`, which has a hardcoded meaning in flow which allows it to refine based on unique properties in a union type.

This also expands the interfaces declared in `@parcel/types` and enforces that the concrete classes implement them with `implements`.

Test Plan: lint, flow, and test.