### PR TITLE
Cherry-pick fixes from master for flaky tests and others

### DIFF
--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -90,7 +90,7 @@ export class Cache {
   }
 
   async _writeBlobs(assets: Array<Asset>): Promise<Array<Asset>> {
-    return await Promise.all(
+    return Promise.all(
       assets.map(async asset => {
         let assetCacheId = this.getCacheId(asset.id, asset.env);
         for (let blobKey in asset.output) {

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -178,6 +178,6 @@ export default class Asset implements IAsset {
   }
 
   async getPackage(): Promise<PackageJSON | null> {
-    return await this.getConfig(['package.json']);
+    return this.getConfig(['package.json']);
   }
 }

--- a/packages/core/core/src/Config.js
+++ b/packages/core/core/src/Config.js
@@ -1,4 +1,5 @@
 // @flow
+
 import type {
   ParcelConfig,
   FilePath,
@@ -132,7 +133,7 @@ export default class Config {
       return [];
     }
 
-    return await this.loadPlugins(runtimes);
+    return this.loadPlugins(runtimes);
   }
 
   async getPackager(filePath: FilePath): Promise<Packager> {
@@ -144,7 +145,7 @@ export default class Config {
       throw new Error(`No packager found for "${filePath}".`);
     }
 
-    return await this.loadPlugin(packagerName);
+    return this.loadPlugin(packagerName);
   }
 
   async getOptimizers(filePath: FilePath): Promise<Array<Optimizer>> {
@@ -156,7 +157,7 @@ export default class Config {
       return [];
     }
 
-    return await this.loadPlugins(optimizers);
+    return this.loadPlugins(optimizers);
   }
 
   isGlobMatch(filePath: FilePath, pattern: Glob) {

--- a/packages/core/core/src/ConfigResolver.js
+++ b/packages/core/core/src/ConfigResolver.js
@@ -33,7 +33,7 @@ export default class ConfigResolver {
 
   async loadConfig(configPath: FilePath, rootDir: FilePath) {
     let config: ParcelConfig = parse(await fs.readFile(configPath));
-    return await this.processConfig(config, configPath, rootDir);
+    return this.processConfig(config, configPath, rootDir);
   }
 
   async processConfig(
@@ -63,7 +63,7 @@ export default class ConfigResolver {
       return path.resolve(path.dirname(configPath), ext);
     } else {
       let [resolved] = await localRequire.resolve(ext, configPath);
-      return await fs.realpath(resolved);
+      return fs.realpath(resolved);
     }
   }
 

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -39,7 +39,7 @@ export default class PackagerRunner {
 
   async package(bundle: Bundle): Promise<Blob> {
     let packager = await this.config.getPackager(nullthrows(bundle.filePath));
-    return await packager.package(bundle, this.cliOpts);
+    return packager.package(bundle, this.cliOpts);
   }
 
   async optimize(bundle: Bundle, contents: Blob): Promise<Blob> {

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -113,7 +113,7 @@ export default class Parcel {
       this.build();
     });
 
-    return await this.build();
+    return this.build();
   }
 
   async build(): Promise<BundleGraph> {

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -1,4 +1,5 @@
 // @flow
+
 import type {
   Asset as IAsset,
   AssetOutput,
@@ -196,7 +197,7 @@ class TransformerRunner {
     // Create a generate function that can be called later to lazily generate
     let generate = async (input: Asset): Promise<AssetOutput> => {
       if (transformer.generate) {
-        return await transformer.generate(input, config, this.cliOpts);
+        return transformer.generate(input, config, this.cliOpts);
       }
 
       throw new Error(

--- a/packages/core/parcel-bundler/src/Asset.js
+++ b/packages/core/parcel-bundler/src/Asset.js
@@ -152,7 +152,7 @@ class Asset {
         return conf;
       }
 
-      return await config.load(opts.path || this.name, filenames);
+      return config.load(opts.path || this.name, filenames);
     }
 
     return null;
@@ -163,7 +163,7 @@ class Asset {
   }
 
   async load() {
-    return await fs.readFile(this.name, this.encoding);
+    return fs.readFile(this.name, this.encoding);
   }
 
   parse() {

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -479,7 +479,7 @@ class Bundler extends EventEmitter {
           this.options.autoinstall &&
           install
         ) {
-          return await this.installDep(asset, dep);
+          return this.installDep(asset, dep);
         }
 
         err.message = `Cannot resolve dependency '${dep.name}'`;
@@ -510,7 +510,7 @@ class Bundler extends EventEmitter {
       }
     }
 
-    return await this.resolveDep(asset, dep, false);
+    return this.resolveDep(asset, dep, false);
   }
 
   async throwDepError(asset, dep, err) {

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -159,7 +159,7 @@ class Resolver {
     // First try as a file, then as a directory.
     return (
       (await this.loadAsFile(filename, extensions, pkg)) ||
-      (await this.loadDirectory(filename, extensions, pkg))
+      (await this.loadDirectory(filename, extensions, pkg)) // eslint-disable-line no-return-await
     );
   }
 

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -251,7 +251,7 @@ class Resolver {
     }
 
     // Fall back to an index file inside the directory.
-    return await this.loadAsFile(path.join(dir, 'index'), extensions, pkg);
+    return this.loadAsFile(path.join(dir, 'index'), extensions, pkg);
   }
 
   async readPackage(dir) {

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -4,6 +4,7 @@ const path = require('path');
 const {isGlob} = require('./utils/glob');
 const fs = require('@parcel/fs');
 const micromatch = require('micromatch');
+const getModuleParts = require('./utils/getModuleParts');
 
 const EMPTY_SHIM = require.resolve('./builtins/_empty');
 
@@ -104,7 +105,7 @@ class Resolver {
 
     // If we couldn't resolve the node_modules path, just return the module name info
     if (!resolved) {
-      let parts = this.getModuleParts(filename);
+      let parts = getModuleParts(filename);
       resolved = {
         moduleName: parts[0],
         subPath: parts[1]
@@ -171,7 +172,7 @@ class Resolver {
       return {filePath: builtins[filename]};
     }
 
-    let parts = this.getModuleParts(filename);
+    let parts = getModuleParts(filename);
     let root = path.parse(dir).root;
 
     while (dir !== root) {
@@ -374,7 +375,7 @@ class Resolver {
       alias = this.lookupAlias(aliases, filename, dir);
       if (alias == null) {
         // If it didn't match, try only the module name.
-        let parts = this.getModuleParts(filename);
+        let parts = getModuleParts(filename);
         alias = this.lookupAlias(aliases, parts[0], dir);
         if (typeof alias === 'string') {
           // Append the filename back onto the aliased module.
@@ -437,16 +438,6 @@ class Resolver {
     // Load the local package, and resolve aliases
     let pkg = await this.findPackage(dir);
     return this.resolveAliases(filename, pkg);
-  }
-
-  getModuleParts(name) {
-    let parts = path.normalize(name).split(path.sep);
-    if (parts[0].charAt(0) === '@') {
-      // Scoped module (e.g. @scope/module). Merge the first two parts back together.
-      parts.splice(0, 2, `${parts[0]}/${parts[1]}`);
-    }
-
-    return parts;
   }
 }
 

--- a/packages/core/parcel-bundler/src/SourceMap.js
+++ b/packages/core/parcel-bundler/src/SourceMap.js
@@ -35,7 +35,7 @@ class SourceMap {
     }
     map = typeof map === 'string' ? JSON.parse(map) : map;
     if (map.sourceRoot) delete map.sourceRoot;
-    return await new SourceMapConsumer(map);
+    return new SourceMapConsumer(map);
   }
 
   async addMap(map, lineOffset = 0, columnOffset = 0) {

--- a/packages/core/parcel-bundler/src/SourceMap.js
+++ b/packages/core/parcel-bundler/src/SourceMap.js
@@ -10,20 +10,20 @@ class SourceMap {
 
   purifyMappings(mappings) {
     if (Array.isArray(mappings)) {
-      return mappings.filter(mapping => {
-        return (
+      return mappings.filter(
+        mapping =>
           mapping &&
-          mapping.source &&
-          mapping.original &&
-          typeof mapping.original.line === 'number' &&
-          mapping.original.line > 0 &&
-          typeof mapping.original.column === 'number' &&
+          (typeof mapping.original === 'object' &&
+            (mapping.original === null ||
+              (typeof mapping.original.line === 'number' &&
+                mapping.original.line > 0 &&
+                typeof mapping.original.column === 'number' &&
+                mapping.source))) &&
           mapping.generated &&
           typeof mapping.generated.line === 'number' &&
           mapping.generated.line > 0 &&
           typeof mapping.generated.column === 'number'
-        );
-      });
+      );
     }
 
     return [];
@@ -34,12 +34,14 @@ class SourceMap {
       return map;
     }
     map = typeof map === 'string' ? JSON.parse(map) : map;
+    if (map.sourceRoot) delete map.sourceRoot;
     return await new SourceMapConsumer(map);
   }
 
   async addMap(map, lineOffset = 0, columnOffset = 0) {
-    if (!(map instanceof SourceMap) && map.version) {
+    if (typeof map === 'string' || (typeof map === 'object' && map.version)) {
       let consumer = await this.getConsumer(map);
+      if (!consumer) return this;
 
       consumer.eachMapping(mapping => {
         this.addConsumerMapping(mapping, lineOffset, columnOffset);
@@ -55,7 +57,7 @@ class SourceMap {
         // Only needs to happen in source-map 0.7
         consumer.destroy();
       }
-    } else {
+    } else if (map.mappings && map.sources) {
       if (!map.eachMapping) {
         map = new SourceMap(map.mappings, map.sources);
       }
@@ -91,21 +93,22 @@ class SourceMap {
   }
 
   addConsumerMapping(mapping, lineOffset = 0, columnOffset = 0) {
+    let original = null;
     if (
-      !mapping.source ||
-      !mapping.originalLine ||
-      (!mapping.originalColumn && mapping.originalColumn !== 0)
+      typeof mapping.originalLine === 'number' &&
+      mapping.originalLine > 0 &&
+      typeof mapping.originalColumn === 'number'
     ) {
-      return;
+      original = {
+        line: mapping.originalLine,
+        column: mapping.originalColumn
+      };
     }
 
     this.mappings.push({
-      source: mapping.source,
+      source: original ? mapping.source : null,
       name: mapping.name,
-      original: {
-        line: mapping.originalLine,
-        column: mapping.originalColumn
-      },
+      original,
       generated: {
         line: mapping.generatedLine + lineOffset,
         column: mapping.generatedColumn + columnOffset

--- a/packages/core/parcel-bundler/src/assets/GLSLAsset.js
+++ b/packages/core/parcel-bundler/src/assets/GLSLAsset.js
@@ -37,7 +37,7 @@ class GLSLAsset extends Asset {
       }
     });
 
-    return await promisify(depper.inline.bind(depper))(this.contents, cwd);
+    return promisify(depper.inline.bind(depper))(this.contents, cwd);
   }
 
   collectDependencies() {

--- a/packages/core/parcel-bundler/src/assets/LESSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/LESSAsset.js
@@ -23,7 +23,7 @@ class LESSAsset extends Asset {
     opts.filename = this.name;
     opts.plugins = (opts.plugins || []).concat(urlPlugin(this));
 
-    return await render(code, opts);
+    return render(code, opts);
   }
 
   collectDependencies() {

--- a/packages/core/parcel-bundler/src/assets/RawAsset.js
+++ b/packages/core/parcel-bundler/src/assets/RawAsset.js
@@ -27,7 +27,7 @@ class RawAsset extends Asset {
   }
 
   async generateHash() {
-    return await md5.file(this.name);
+    return md5.file(this.name);
   }
 }
 

--- a/packages/core/parcel-bundler/src/assets/SASSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/SASSAsset.js
@@ -89,7 +89,7 @@ async function getSassRuntime(searchPath) {
     return await localRequire('node-sass', searchPath, true);
   } catch (e) {
     // If node-sass is not used locally, install dart-sass, as this causes no freezing issues
-    return await localRequire('sass', searchPath);
+    return localRequire('sass', searchPath);
   }
 }
 

--- a/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
@@ -53,7 +53,7 @@ async function getBabelRc(asset, isSource) {
     }
 
     // Otherwise, return the .babelrc if babelify was found
-    return babelify ? await findBabelRc(asset) : null;
+    return babelify ? findBabelRc(asset) : null;
   }
 
   // If this asset is not in node_modules, always use the .babelrc

--- a/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
@@ -58,7 +58,7 @@ async function getBabelRc(asset, isSource) {
 
   // If this asset is not in node_modules, always use the .babelrc
   if (isSource) {
-    return await findBabelRc(asset);
+    return findBabelRc(asset);
   }
 
   // Otherwise, don't load .babelrc for node_modules.
@@ -266,7 +266,7 @@ async function installPlugins(asset, babelrc) {
   let plugins = (babelrc.plugins || []).map(p =>
     resolveModule('plugin', getPluginName(p), asset.name)
   );
-  return await Promise.all([...presets, ...plugins]);
+  return Promise.all([...presets, ...plugins]);
 }
 
 async function resolveModule(type, name, path) {

--- a/packages/core/parcel-bundler/src/utils/getModuleParts.js
+++ b/packages/core/parcel-bundler/src/utils/getModuleParts.js
@@ -1,0 +1,11 @@
+const path = require('path');
+
+module.exports = function(name) {
+  let parts = path.normalize(name).split(path.sep);
+  if (parts[0].charAt(0) === '@') {
+    // Scoped module (e.g. @scope/module). Merge the first two parts back together.
+    parts.splice(0, 2, `${parts[0]}/${parts[1]}`);
+  }
+
+  return parts;
+};

--- a/packages/core/parcel-bundler/src/utils/loadPlugins.js
+++ b/packages/core/parcel-bundler/src/utils/loadPlugins.js
@@ -3,13 +3,11 @@ const localRequire = require('./localRequire');
 module.exports = async function loadPlugins(plugins, relative) {
   if (Array.isArray(plugins)) {
     return Promise.all(
-      plugins.map(async p => loadPlugin(p, relative)).filter(Boolean)
+      plugins.map(p => loadPlugin(p, relative)).filter(Boolean)
     );
   } else if (typeof plugins === 'object') {
     let mapPlugins = await Promise.all(
-      Object.keys(plugins).map(
-        async p => await loadPlugin(p, relative, plugins[p])
-      )
+      Object.keys(plugins).map(p => loadPlugin(p, relative, plugins[p]))
     );
     return mapPlugins.filter(Boolean);
   } else {

--- a/packages/core/parcel-bundler/src/utils/loadPlugins.js
+++ b/packages/core/parcel-bundler/src/utils/loadPlugins.js
@@ -2,8 +2,8 @@ const localRequire = require('./localRequire');
 
 module.exports = async function loadPlugins(plugins, relative) {
   if (Array.isArray(plugins)) {
-    return await Promise.all(
-      plugins.map(async p => await loadPlugin(p, relative)).filter(Boolean)
+    return Promise.all(
+      plugins.map(async p => loadPlugin(p, relative)).filter(Boolean)
     );
   } else if (typeof plugins === 'object') {
     let mapPlugins = await Promise.all(

--- a/packages/core/parcel-bundler/src/utils/localRequire.js
+++ b/packages/core/parcel-bundler/src/utils/localRequire.js
@@ -22,7 +22,7 @@ async function localResolve(name, path, triedInstall = false) {
       if (e.code === 'MODULE_NOT_FOUND' && !triedInstall) {
         const packageName = getModuleParts(name)[0];
         await installPackage(packageName, path);
-        return await localResolve(name, path, true);
+        return localResolve(name, path, true);
       }
       throw e;
     }

--- a/packages/core/parcel-bundler/src/utils/localRequire.js
+++ b/packages/core/parcel-bundler/src/utils/localRequire.js
@@ -2,6 +2,7 @@ const {dirname} = require('path');
 const {promisify} = require('@parcel/utils');
 const resolve = promisify(require('resolve'));
 const installPackage = require('./installPackage');
+const getModuleParts = require('./getModuleParts');
 
 const cache = new Map();
 
@@ -19,7 +20,8 @@ async function localResolve(name, path, triedInstall = false) {
       resolved = await resolve(name, {basedir});
     } catch (e) {
       if (e.code === 'MODULE_NOT_FOUND' && !triedInstall) {
-        await installPackage(name, path);
+        const packageName = getModuleParts(name)[0];
+        await installPackage(packageName, path);
         return await localResolve(name, path, true);
       }
       throw e;

--- a/packages/core/parcel-bundler/test/sourcemaps.js
+++ b/packages/core/parcel-bundler/test/sourcemaps.js
@@ -1,0 +1,199 @@
+const assert = require('assert');
+const fs = require('@parcel/fs');
+const SourceMap = require('../src/SourceMap');
+
+describe('sourcemaps', function() {
+  it('should purify mappings properly', async function() {
+    let mappings = [
+      {
+        source: 'index.js',
+        name: 'A',
+        original: {
+          line: 0,
+          column: 0
+        },
+        generated: {
+          line: 0,
+          column: 0
+        }
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: null,
+        source: null,
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: null,
+        source: null,
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: {
+          line: 0,
+          column: 0
+        },
+        source: null,
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: {
+          line: 1,
+          column: 0
+        },
+        source: null,
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: {
+          line: 1,
+          column: 0
+        },
+        source: 'index.js',
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: {
+          line: 0,
+          column: 0
+        },
+        source: 'index.js',
+        name: null
+      },
+      {
+        source: 'index.js',
+        name: 'A',
+        original: {
+          line: 1,
+          column: 18
+        },
+        generated: {
+          line: 4,
+          column: 187
+        }
+      }
+    ];
+
+    let expectedResult = [
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: null,
+        source: null,
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: null,
+        source: null,
+        name: null
+      },
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: {
+          line: 1,
+          column: 0
+        },
+        source: 'index.js',
+        name: null
+      },
+      {
+        source: 'index.js',
+        name: 'A',
+        original: {
+          line: 1,
+          column: 18
+        },
+        generated: {
+          line: 4,
+          column: 187
+        }
+      }
+    ];
+
+    let sourcemap = new SourceMap(mappings, {});
+    assert.deepEqual(sourcemap.mappings, expectedResult);
+  });
+
+  it('should be able to handle null mappings properly', async function() {
+    let mappings = [
+      {
+        generated: {
+          line: 1,
+          column: 0
+        },
+        original: {
+          line: 1,
+          column: 0
+        },
+        source: 'input.js',
+        name: 'console'
+      },
+      {
+        generated: {
+          line: 1,
+          column: 7
+        },
+        original: null,
+        source: null,
+        name: null
+      }
+    ];
+
+    let sources = {
+      'input.js': 'console.log("hello world!");'
+    };
+
+    let sourcemap = new SourceMap(mappings, sources);
+    assert.equal(sourcemap.mappings.length, 2);
+    assert.deepEqual(sourcemap.mappings, mappings);
+
+    let mapString = sourcemap.stringify('index.map', '/');
+    let combinedSourcemap = new SourceMap(mappings, sources);
+    await combinedSourcemap.addMap(mapString);
+
+    let newMapString = combinedSourcemap.stringify('index.map', '/');
+    assert.equal(mapString, newMapString);
+
+    let newSourcemap = new SourceMap([], {});
+    await newSourcemap.addMap(sourcemap);
+
+    assert.deepEqual(newSourcemap.mappings, mappings);
+
+    newSourcemap = new SourceMap([], {});
+    await newSourcemap.addMap(mapString);
+
+    assert.deepEqual(newSourcemap.mappings, mappings);
+  });
+});

--- a/packages/core/parcel-bundler/test/sourcemaps.js
+++ b/packages/core/parcel-bundler/test/sourcemaps.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const fs = require('@parcel/fs');
 const SourceMap = require('../src/SourceMap');
 
 describe('sourcemaps', function() {

--- a/packages/core/utils/src/loadPlugins.js
+++ b/packages/core/utils/src/loadPlugins.js
@@ -2,14 +2,12 @@ const localRequire = require('./localRequire');
 
 module.exports = async function loadPlugins(plugins, relative) {
   if (Array.isArray(plugins)) {
-    return await Promise.all(
-      plugins.map(async p => await loadPlugin(p, relative)).filter(Boolean)
+    return Promise.all(
+      plugins.map(p => loadPlugin(p, relative)).filter(Boolean)
     );
   } else if (typeof plugins === 'object') {
     let mapPlugins = await Promise.all(
-      Object.keys(plugins).map(
-        async p => await loadPlugin(p, relative, plugins[p])
-      )
+      Object.keys(plugins).map(p => loadPlugin(p, relative, plugins[p]))
     );
     return mapPlugins.filter(Boolean);
   } else {

--- a/packages/core/utils/src/localRequire.js
+++ b/packages/core/utils/src/localRequire.js
@@ -23,7 +23,7 @@ async function localResolve(name, path, triedInstall = false) {
           location: require.resolve('./installPackage.js'),
           args: [[name], path]
         });
-        return await localResolve(name, path, true);
+        return localResolve(name, path, true);
       }
       throw e;
     }

--- a/packages/core/watcher/test/fswatcher.js
+++ b/packages/core/watcher/test/fswatcher.js
@@ -23,10 +23,7 @@ describe('Watcher', function() {
     assert(watcher.child);
     assert(watcher.ready);
 
-    let childDeadPromise = new Promise(resolve =>
-      watcher.once('childDead', resolve)
-    );
     await watcher.stop();
-    await childDeadPromise;
+    assert(watcher.child.killed);
   });
 });

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -20,6 +20,7 @@ module.exports = {
     'import/first': 'error',
     'import/newline-after-import': 'error',
     'import/no-extraneous-dependencies': 'error',
-    'import/no-self-import': 'error'
+    'import/no-self-import': 'error',
+    'no-return-await': 'error'
   }
 };

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -180,7 +180,7 @@ class NodeResolver {
     // First try as a file, then as a directory.
     return (
       (await this.loadAsFile(filename, extensions, pkg)) ||
-      (await this.loadDirectory(filename, extensions, pkg))
+      (await this.loadDirectory(filename, extensions, pkg)) // eslint-disable-line no-return-await
     );
   }
 
@@ -276,7 +276,7 @@ class NodeResolver {
     }
 
     // Fall back to an index file inside the directory.
-    return await this.loadAsFile(path.join(dir, 'index'), extensions, pkg);
+    return this.loadAsFile(path.join(dir, 'index'), extensions, pkg);
   }
 
   async readPackage(dir: string): Promise<InternalPackageJSON> {

--- a/packages/transformers/babel/src/BabelTransformer.js
+++ b/packages/transformers/babel/src/BabelTransformer.js
@@ -8,7 +8,7 @@ import getBabelConfig from './config';
 
 export default new Transformer({
   async getConfig(asset) {
-    return await getBabelConfig(asset);
+    return getBabelConfig(asset);
   },
 
   canReuseAST(ast) {

--- a/packages/transformers/babel/src/babelrc.js
+++ b/packages/transformers/babel/src/babelrc.js
@@ -56,12 +56,12 @@ async function getBabelRc(asset, pkg, isSource) {
     }
 
     // Otherwise, return the .babelrc if babelify was found
-    return babelify ? await findBabelRc(asset) : null;
+    return babelify ? findBabelRc(asset) : null;
   }
 
   // If this asset is not in node_modules, always use the .babelrc
   if (isSource) {
-    return await findBabelRc(asset);
+    return findBabelRc(asset);
   }
 
   // Otherwise, don't load .babelrc for node_modules.
@@ -271,7 +271,7 @@ async function installPlugins(asset, babelrc) {
   let plugins = (babelrc.plugins || []).map(p =>
     resolveModule('plugin', getPluginName(p), asset.filePath)
   );
-  return await Promise.all([...presets, ...plugins]);
+  return Promise.all([...presets, ...plugins]);
 }
 
 async function resolveModule(type, name, path) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1956,12 +1956,7 @@ acorn@^4.0.4, acorn@~4.0.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
   integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
 
-acorn@^5.0.0:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
-  integrity sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==
-
-acorn@^5.5.0:
+acorn@^5.0.0, acorn@^5.5.0:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
@@ -3222,9 +3217,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000899"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000899.tgz#f66d667d507c2aa19603a4a3763d71aa89cc360f"
-  integrity sha512-MSCUohyoLU4/PGapapw/PLQkmQ+sFgzX6e3tM6ue8HX9HW9rBD5gRiAYKhC8r0QkvUE0pWTA8Ze6f3jrzBizVg==
+  version "1.0.30000946"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000946.tgz#c8fd9a53ccd23e26d87b6e22a4bdf257b7aff36c"
+  integrity sha512-qjpdekHW9uyy1U/VxuoR9ppn8HjoBxsR5dRTpumUeoYgL8IWUeos+QpJh9DaDdjaKitkNzgAFMXCZLDYKWWyEQ==
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000898:
   version "1.0.30000899"
@@ -4634,7 +4629,12 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.81:
+electron-to-chromium@^1.2.7:
+  version "1.3.115"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.115.tgz#fdaa56c19b9f7386dbf29abc1cc632ff5468ff3b"
+  integrity sha512-mN2qeapQWdi2B9uddxTZ4nl80y46hbyKY5Wt9Yjih+QZFQLdaujEDK4qJky35WhyxMzHF3ZY41Lgjd2BPDuBhg==
+
+electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.81:
   version "1.3.82"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz#7d13ae4437d2a783de3f4efba96b186c540b67b1"
   integrity sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew==
@@ -6720,9 +6720,9 @@ jest-validate@^23.5.0:
     pretty-format "^23.6.0"
 
 js-base64@^2.1.9:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
-  integrity sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.1.tgz#1efa39ef2c5f7980bb1784ade4a8af2de3291121"
+  integrity sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
 
 js-beautify@^1.7.5:
   version "1.8.8"


### PR DESCRIPTION
This cherry-picks the following commits from master:

```
commit ee6d19f329a924955f5ea95c773449d3ae759d35 (wbinnssmith/cherry-pick-master)
Author: tje3d <tje3d@yahoo.com>
Date:   Fri Mar 1 14:04:29 2019 +0330

    Remove unnecessary return await

commit b5cad1375663ae30cdf6e6baf4d171f4722de4ed
Author: Niklas Mischkulnig <mischnic@users.noreply.github.com>
Date:   Wed Jan 16 22:35:00 2019 +0100

    Fix localRequire with package/path requests (#2425)

commit f97eb4ae1d401e45b4cb0fa3600625bae2b33f1e
Author: Jasper De Moor <jasperdemoor@gmail.com>
Date:   Mon Jan 7 05:13:53 2019 +0100

    fix(sourcemaps): Handle null mappings properly (#2149)

commit adf574248ae2087d9c304428a9b098dbeac25c93
Author: sainthkh <sainthkh@naver.com>
Date:   Sun Feb 3 08:28:05 2019 +0900

    Use the test to assert this.child.killed rather than checking time difference. (#2609) (#2612)
```

As well as an additional commit from me cleaning up an unused import as a result of the merges.

Test Plan: lint, flow, and test. Run the simple example and verify its output.