### PR TITLE
Miscellaneous flow cleanup

### DIFF
--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -9,6 +9,8 @@ import type {
   TransformerRequest
 } from '@parcel/types';
 import type Config from './Config';
+
+import nullthrows from 'nullthrows';
 import BundleGraph from './BundleGraph';
 import AssetGraphBuilder from './AssetGraphBuilder';
 
@@ -106,8 +108,7 @@ export default class BundlerRunner {
 
     let graph: AssetGraph = await builder.build();
     let entry = graph.getEntryAssets()[0];
-    // $FlowFixMe - node will always exist
-    let subGraph = graph.getSubGraph(graph.getNode(entry.id));
+    let subGraph = graph.getSubGraph(nullthrows(graph.getNode(entry.id)));
 
     // Exclude modules that are already included in an ancestor bundle
     subGraph.traverseAssets(asset => {
@@ -117,7 +118,6 @@ export default class BundlerRunner {
     });
 
     bundle.assetGraph.merge(subGraph);
-    // $FlowFixMe
     bundle.assetGraph.addEdge({from: node.id, to: entry.id});
     return entry;
   }

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -78,10 +78,7 @@ export default class Graph<TNode: Node> implements IGraph<TNode> {
 
   getNodesConnectedTo(node: TNode): Array<TNode> {
     let edges = Array.from(this.edges).filter(edge => edge.to === node.id);
-    return edges.map(edge => {
-      // $FlowFixMe
-      return this.nodes.get(edge.from);
-    });
+    return edges.map(edge => nullthrows(this.nodes.get(edge.from)));
   }
 
   getNodesConnectedFrom(node: TNode): Array<TNode> {

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -38,14 +38,14 @@ export default class PackagerRunner {
   }
 
   async package(bundle: Bundle): Promise<Blob> {
-    // $FlowFixMe - filePath should already be filled in at this point
-    let packager = await this.config.getPackager(bundle.filePath);
+    let packager = await this.config.getPackager(nullthrows(bundle.filePath));
     return await packager.package(bundle, this.cliOpts);
   }
 
   async optimize(bundle: Bundle, contents: Blob): Promise<Blob> {
-    // $FlowFixMe - filePath should already be filled in at this point
-    let optimizers = await this.config.getOptimizers(bundle.filePath);
+    let optimizers = await this.config.getOptimizers(
+      nullthrows(bundle.filePath)
+    );
 
     for (let optimizer of optimizers) {
       contents = await optimizer.optimize(bundle, contents, this.cliOpts);

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -119,7 +119,6 @@ export default class Parcel {
   async build() {
     try {
       // console.log('Starting build'); // eslint-disable-line no-console
-      // $FlowFixMe This reliably fails on Windows. Not sure why.
       let assetGraph = await this.assetGraphBuilder.build();
 
       if (process.env.PARCEL_DUMP_GRAPH != null) {

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -36,7 +36,7 @@ export default class Parcel {
   assetGraphBuilder: AssetGraphBuilder;
   bundlerRunner: BundlerRunner;
   farm: WorkerFarm;
-  runPackage: (bundle: Bundle) => Promise<any>;
+  runPackage: (bundle: Bundle) => Promise<mixed>;
 
   constructor(options: ParcelOpts) {
     let {entries} = options;
@@ -45,7 +45,7 @@ export default class Parcel {
     this.rootDir = getRootDir(this.entries);
   }
 
-  async init() {
+  async init(): Promise<void> {
     await Cache.createCacheDir(this.options.cliOpts.cacheDir);
 
     if (!this.options.env) {
@@ -106,7 +106,7 @@ export default class Parcel {
     this.runPackage = this.farm.mkhandle('runPackage');
   }
 
-  async run() {
+  async run(): Promise<BundleGraph> {
     await this.init();
 
     this.assetGraphBuilder.on('invalidate', () => {
@@ -116,7 +116,7 @@ export default class Parcel {
     return await this.build();
   }
 
-  async build() {
+  async build(): Promise<BundleGraph> {
     try {
       // console.log('Starting build'); // eslint-disable-line no-console
       let assetGraph = await this.assetGraphBuilder.build();
@@ -140,14 +140,15 @@ export default class Parcel {
       if (e !== abortError) {
         console.error(e); // eslint-disable-line no-console
       }
+      throw e;
     }
   }
 
-  bundle(assetGraph: AssetGraph) {
+  bundle(assetGraph: AssetGraph): Promise<BundleGraph> {
     return this.bundlerRunner.bundle(assetGraph);
   }
 
-  package(bundleGraph: BundleGraph) {
+  package(bundleGraph: BundleGraph): Promise<mixed> {
     let promises = [];
     bundleGraph.traverseBundles(bundle => {
       promises.push(this.runPackage(bundle));

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@parcel/fs": "^1.10.3",
-    "@parcel/workers": "^1.10.3"
+    "@parcel/workers": "^1.10.3",
+    "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "@babel/plugin-transform-flow-strip-types": "^7.2.0",
-    "nullthrows": "^1.1.1"
+    "@babel/plugin-transform-flow-strip-types": "^7.2.0"
   }
 }


### PR DESCRIPTION
* Updates several uses of $FlowFixMe to use `nullthrows` to enforce the expectation that values aren't null
* Moves nullthrows from devDependency to dependency in utils
* Adds flow annotations to return values in `Cache`, `Parcel`, and `BundlerRunner`, making the latter `strict`.

Test Plan: lint, flow, test. Verify output of simple example.