### PR TITLE
Remove utils dependency from fs

### DIFF
--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -18,7 +18,6 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "mkdirp": "^0.5.1",
-    "@parcel/utils": "^1.10.3"
+    "mkdirp": "^0.5.1"
   }
 }


### PR DESCRIPTION
This removes a dependency on `@parcel/utils` from `@parcel/fs`. It was unused and caused cyclic dependencies amongst the packages.

Test Plan: run `yarn` before and after and verify the following cycles are gone:

```
lerna WARN ECYCLE @parcel/fs -> @parcel/utils -> @parcel/fs
lerna WARN ECYCLE @parcel/watcher -> @parcel/utils -> @parcel/fs -> @parcel/utils -> @parcel/utils@^1.10.3
lerna WARN ECYCLE @parcel/workers -> @parcel/utils -> @parcel/fs -> @parcel/utils -> @parcel/utils@^1.10.3
lerna WARN ECYCLE @parcel/resolver-default -> @parcel/utils -> @parcel/fs -> @parcel/utils -> @parcel/utils@^1.10.3
lerna WARN ECYCLE parcel-bundler -> @parcel/fs -> @parcel/utils -> @parcel/fs -> @parcel/fs@^1.10.3
lerna WARN ECYCLE @parcel/utils -> @parcel/fs -> @parcel/utils
lerna WARN ECYCLE @parcel/watcher -> @parcel/fs -> @parcel/utils -> @parcel/fs -> @parcel/fs@^1.10.3
lerna WARN ECYCLE @parcel/resolver-default -> @parcel/fs -> @parcel/utils -> @parcel/fs -> @parcel/fs@^1.10.3
lerna WARN ECYCLE @parcel/transformer-babel -> @parcel/fs -> @parcel/utils -> @parcel/fs -> @parcel/fs@^1.10.3
lerna WARN ECYCLE @parcel/fs -> @parcel/utils -> @parcel/logger -> @parcel/workers -> @parcel/utils -> @parcel/utils@^1.10.3
```