### PR TITLE
Add var declaration to parcelRequire definition in prelude.js

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/prelude.js
+++ b/packages/core/parcel-bundler/src/builtins/prelude.js
@@ -5,7 +5,7 @@
 //
 // anything defined in a previous bundle is accessed via the
 // orig method which is the require for previous bundles
-parcelRequire = (function (modules, cache, entry, globalName) {
+var parcelRequire = (function (modules, cache, entry, globalName) {
   // Save the require from previous bundle to this closure if any
   var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
   var nodeRequire = typeof require === 'function' && require;

--- a/packages/core/parcel-bundler/src/builtins/prelude.js
+++ b/packages/core/parcel-bundler/src/builtins/prelude.js
@@ -5,7 +5,7 @@
 //
 // anything defined in a previous bundle is accessed via the
 // orig method which is the require for previous bundles
-var parcelRequire = (function (modules, cache, entry, globalName) {
+(typeof window !== 'undefined' ? window : global).parcelRequire = (function (modules, cache, entry, globalName) {
   // Save the require from previous bundle to this closure if any
   var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
   var nodeRequire = typeof require === 'function' && require;

--- a/packages/core/parcel-bundler/src/builtins/prelude.js
+++ b/packages/core/parcel-bundler/src/builtins/prelude.js
@@ -5,9 +5,12 @@
 //
 // anything defined in a previous bundle is accessed via the
 // orig method which is the require for previous bundles
-(typeof window !== 'undefined' ? window : global).parcelRequire = (function (modules, cache, entry, globalName) {
+function getGlobalObject(){
+  return typeof window !== 'undefined' ? window : global;
+}
+getGlobalObject().parcelRequire = (function (modules, cache, entry, globalName) {
   // Save the require from previous bundle to this closure if any
-  var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
+  var previousRequire = typeof getGlobalObject().parcelRequire === 'function' && getGlobalObject().parcelRequire;
   var nodeRequire = typeof require === 'function' && require;
 
   function newRequire(name, jumped) {
@@ -16,7 +19,7 @@
         // if we cannot find the module within our internal map or
         // cache jump to the current global require ie. the last bundle
         // that was added to the page.
-        var currentRequire = typeof parcelRequire === 'function' && parcelRequire;
+        var currentRequire = typeof getGlobalObject().parcelRequire === 'function' && getGlobalObject().parcelRequire;
         if (!jumped && currentRequire) {
           return currentRequire(name, true);
         }
@@ -109,7 +112,7 @@
   }
 
   // Override the current require with this new one
-  parcelRequire = newRequire;
+  getGlobalObject().parcelRequire = newRequire;
 
   if (error) {
     // throw error from earlier, _after updating parcelRequire_

--- a/packages/core/parcel-bundler/src/builtins/prelude2.js
+++ b/packages/core/parcel-bundler/src/builtins/prelude2.js
@@ -1,4 +1,4 @@
-var parcelRequire = (function (init) {
+(typeof window !== 'undefined' ? window : global).parcelRequire = (function (init) {
   // Save the require from previous bundle to this closure if any
   var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
   var nodeRequire = typeof require === 'function' && require;

--- a/packages/core/parcel-bundler/src/builtins/prelude2.js
+++ b/packages/core/parcel-bundler/src/builtins/prelude2.js
@@ -1,6 +1,9 @@
-(typeof window !== 'undefined' ? window : global).parcelRequire = (function (init) {
+function getGlobalObject(){
+  return typeof window !== 'undefined' ? window : global;
+}
+getGlobalObject().parcelRequire = (function (init) {
   // Save the require from previous bundle to this closure if any
-  var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
+  var previousRequire = typeof getGlobalObject().parcelRequire === 'function' && getGlobalObject().parcelRequire;
   var nodeRequire = typeof require === 'function' && require;
   var modules = {};
 
@@ -12,7 +15,7 @@
     // if we cannot find the module within our internal map or
     // cache jump to the current global require ie. the last bundle
     // that was added to the page.
-    var currentRequire = typeof parcelRequire === 'function' && parcelRequire;
+    var currentRequire = typeof getGlobalObject().parcelRequire === 'function' && getGlobalObject().parcelRequire;
     if (!jumped && currentRequire) {
       return currentRequire(name, true);
     }

--- a/packages/core/parcel-bundler/src/builtins/prelude2.js
+++ b/packages/core/parcel-bundler/src/builtins/prelude2.js
@@ -1,4 +1,4 @@
-parcelRequire = (function (init) {
+var parcelRequire = (function (init) {
   // Save the require from previous bundle to this closure if any
   var previousRequire = typeof parcelRequire === 'function' && parcelRequire;
   var nodeRequire = typeof require === 'function' && require;


### PR DESCRIPTION
# ↪️ Pull Request

This addresses the ReferenceError when running the final output bundles from issue #1401. The browser/node environment doesn't have `parcelRequire` defined before referencing it, and there was no `var/let/const` declaration.

## 💻 Examples

All JS modules that have the contents of **prelude.js** or **prelude2.js** prepended to them, once referenced as a finished bundle, give the error `Uncaught ReferenceError: parcelDefine is not defined` when run in a browser.

## 🚨 Test instructions

This PR passes all unit tests from running `yarn test` within /packages/core/parcel-bundler/ on macOS 10.14.2. I'm not familiar enough with unit testing browser output to write one.

1. Include a plain JavaScript dependency, in whatever module format (ESM, CommonJS etc), which itself includes dependencies on other JavaScript files, in your entry bundle.
2. Run this bundle in a browser via a <script> reference.
3. Ensure on page load that the browser dev tools show no ReferenceErrors relating to `parcelRequire`.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs