### PR TITLE
Flowify Watcher

### DIFF
--- a/flow-libs/chokidar.js.flow
+++ b/flow-libs/chokidar.js.flow
@@ -1,0 +1,51 @@
+// @flow
+
+declare module 'chokidar' {
+  declare class FSWatcher extends events$EventEmitter {
+    constructor(options: FSWatcherOptions): void;
+    add(paths: string | Array<string>): void;
+    on(eventName: 'addDir', callback: (path: string) => mixed): this;
+    on(
+      eventName: 'all',
+      callback: (eventName: string, path: string) => mixed
+    ): this;
+    on(eventName: 'unlinkDir', callback: (path: string) => mixed): this;
+    on(eventName: 'error', callback: (error: Error) => mixed): this;
+    on(eventName: 'ready', callback: () => mixed): this;
+    on(
+      eventName: 'raw',
+      callback: (eventName: string, path: string, details: any) => mixed
+    ): this;
+    on(eventName: string, callback: () => mixed): this;
+    unwatch(paths: string | Array<string>): this;
+    close(): this;
+    getWatched(
+      paths: string | Array<string>
+    ): {[directory: string]: Array<string>};
+  }
+
+  declare type FSWatcherOptions = {|
+    persistent?: boolean,
+    ignored?: RegExp | string | Array<RegExp | string>,
+    ignoreInitial?: boolean,
+    followSymlinks?: boolean,
+    cwd?: string,
+    disableGlobbing?: boolean,
+    usePolling?: boolean,
+    interval?: number,
+    binaryInterval?: number,
+    useFsEvents?: boolean,
+    alwaysStat?: boolean,
+    depth?: ?number,
+    awaitWriteFinish?:
+      | boolean
+      | {|stabilityThreshold?: number, pollInterval?: number|},
+    ignorePermissionErrors?: boolean,
+    atomic?: boolean
+  |};
+
+  declare module.exports: {
+    FSWatcher: typeof FSWatcher,
+    watch(paths: string | Array<string>, options: FSWatcherOptions): FSWatcher
+  };
+}

--- a/packages/core/watcher/.babelrc
+++ b/packages/core/watcher/.babelrc
@@ -1,13 +1,3 @@
 {
-  "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "node": "6"
-        }
-      }
-    ]
-  ],
-  "plugins": ["@babel/plugin-transform-runtime"]
+  "presets": ["@parcel/babel-preset"]
 }

--- a/packages/core/watcher/index.js
+++ b/packages/core/watcher/index.js
@@ -1,5 +1,0 @@
-// Node 8 supports native async functions - no need to use compiled code!
-module.exports =
-  parseInt(process.versions.node, 10) < 8
-    ? require('./lib/Watcher')
-    : require('./src/Watcher');

--- a/packages/core/watcher/package.json
+++ b/packages/core/watcher/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/watcher",
   "version": "1.10.3",
   "description": "Blazing fast, zero configuration web application bundler",
-  "main": "index.js",
+  "main": "src/Watcher.js",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -17,7 +17,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "chokidar": "^2.0.4"
+    "chokidar": "^2.0.4",
+    "nullthrows": "^1.1.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/packages/core/watcher/src/options.js
+++ b/packages/core/watcher/src/options.js
@@ -1,32 +1,44 @@
-function type(options) {
-  return Object.prototype.toString.call(options).slice(8, -1);
-}
+// @flow strict-local
 
-function encode(options) {
-  if (options && options.ignored) {
-    const ignoredType = type(options.ignored);
-    if (ignoredType !== 'Array') {
-      options.ignored = [options.ignored];
+import type {FSWatcherOptions} from 'chokidar';
+
+import invariant from 'assert';
+
+export type EncodedFSWatcherOptions = FSWatcherOptions & {
+  _regIndexs?: Array<number>
+};
+
+export function encodeOptions(
+  options?: FSWatcherOptions
+): EncodedFSWatcherOptions {
+  let outputOptions: EncodedFSWatcherOptions = {...options};
+  if (outputOptions && outputOptions.ignored != null) {
+    if (!Array.isArray(outputOptions.ignored)) {
+      outputOptions.ignored = [outputOptions.ignored];
     }
 
-    options.ignored.forEach((value, index) => {
-      const valueType = type(value);
-      if (valueType === 'RegExp') {
-        options.ignored[index] = value.source;
-        if (!options._regIndexs) {
-          options._regIndexs = [];
+    outputOptions.ignored.forEach((value, index) => {
+      invariant(outputOptions != null);
+      if (value instanceof RegExp) {
+        invariant(Array.isArray(outputOptions.ignored));
+        outputOptions.ignored[index] = value.source;
+        if (!outputOptions._regIndexs) {
+          outputOptions._regIndexs = [];
         }
-        options._regIndexs.push(index);
+        outputOptions._regIndexs.push(index);
       }
     });
   }
 
-  return options;
+  return outputOptions;
 }
 
-function decode(options) {
-  if (options && options.ignored && options._regIndexs) {
+export function decodeOptions(
+  options: EncodedFSWatcherOptions
+): FSWatcherOptions {
+  if (options && options.ignored != null && options._regIndexs) {
     for (let index of options._regIndexs) {
+      invariant(Array.isArray(options.ignored));
       options.ignored[index] = new RegExp(options.ignored[index]);
     }
     delete options._regIndexs;
@@ -34,6 +46,3 @@ function decode(options) {
 
   return options;
 }
-
-exports.encode = encode;
-exports.decode = decode;

--- a/packages/core/watcher/test/changeEvent.js
+++ b/packages/core/watcher/test/changeEvent.js
@@ -1,8 +1,10 @@
-const Watcher = require('../index');
-const fs = require('@parcel/fs');
-const path = require('path');
-const assert = require('assert');
-const {sleep} = require('@parcel/test-utils');
+// @flow
+
+import Watcher from '../';
+import * as fs from '@parcel/fs';
+import path from 'path';
+import assert from 'assert';
+import {sleep} from '@parcel/test-utils';
 
 describe('change event', function() {
   let tmpFolder = path.join(__dirname, './tmp/');

--- a/packages/core/watcher/test/errorHandling.js
+++ b/packages/core/watcher/test/errorHandling.js
@@ -1,7 +1,9 @@
-const Watcher = require('../index');
-const fs = require('@parcel/fs');
-const path = require('path');
-const assert = require('assert');
+// @flow
+
+import Watcher from '../';
+import * as fs from '@parcel/fs';
+import path from 'path';
+import assert from 'assert';
 
 describe('error handling', function() {
   let tmpFolder = path.join(__dirname, './tmp/');

--- a/packages/core/watcher/test/fswatcher.js
+++ b/packages/core/watcher/test/fswatcher.js
@@ -1,5 +1,10 @@
-const Watcher = require('../index');
-const assert = require('assert');
+// @flow
+
+import Watcher from '../';
+import assert from 'assert';
+
+// For flow
+const invariant = assert;
 
 describe('Watcher', function() {
   it('Should be able to create a new watcher', async () => {
@@ -20,10 +25,11 @@ describe('Watcher', function() {
     let watcher = new Watcher();
     await new Promise(resolve => watcher.once('ready', resolve));
 
-    assert(watcher.child);
+    assert(watcher.child != null);
     assert(watcher.ready);
 
     await watcher.stop();
+    invariant(watcher.child != null);
     assert(watcher.child.killed);
   });
 });

--- a/packages/core/watcher/test/options.js
+++ b/packages/core/watcher/test/options.js
@@ -1,14 +1,16 @@
-const Watcher = require('../index');
-const fs = require('@parcel/fs');
-const path = require('path');
-const assert = require('assert');
-const {sleep} = require('@parcel/test-utils');
+// @flow
+
+import Watcher from '../';
+import * as fs from '@parcel/fs';
+import path from 'path';
+import assert from 'assert';
+import {sleep} from '@parcel/test-utils';
 
 describe('options', function() {
   let tmpFolder = path.join(__dirname, './tmp/');
 
-  before(() => {
-    fs.mkdirp(tmpFolder);
+  before(async () => {
+    await fs.mkdirp(tmpFolder);
   });
 
   it('Should pass init options with correct ignored regex', async () => {

--- a/packages/core/watcher/test/watched.js
+++ b/packages/core/watcher/test/watched.js
@@ -1,13 +1,15 @@
-const Watcher = require('../index');
-const fs = require('@parcel/fs');
-const path = require('path');
-const assert = require('assert');
+// @flow
+
+import Watcher from '../';
+import * as fs from '@parcel/fs';
+import path from 'path';
+import assert from 'assert';
 
 describe('watched paths', function() {
   let tmpFolder = path.join(__dirname, './tmp/');
 
-  before(() => {
-    fs.mkdirp(tmpFolder);
+  before(async () => {
+    await fs.mkdirp(tmpFolder);
   });
 
   it('Should return watched paths', async () => {


### PR DESCRIPTION
This adds types for chokidar, the package the watcher uses under the hood, as well as for the watcher itself.

There are a few meaningful changes to the runtime code, and are noted inline.

Test Plan: lint, flow, and test. Run the simple example and verify its output.