### PR TITLE
Don't git add in a precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "lint-staged": {
     "*.{js,json,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "collective": {


### PR DESCRIPTION
This removes a line that told `lint-stage` to automatically stage modifications in the working tree right before `git commit` took place.

Often times I'll interactively stage changes to create multiple commits from a single work tree of modifications. 

Test Plan: `git add -p` some changes, make a commit, and verify the unstaged changes aren't part of the commit