### PR TITLE
Flowify cli reporter

### DIFF
--- a/flow-libs/cli-spinners.js.flow
+++ b/flow-libs/cli-spinners.js.flow
@@ -1,0 +1,10 @@
+// @flow
+
+declare module 'cli-spinners' {
+  declare export type CLISpinner = {interval: number, frames: Array<number>};
+  declare type CLISpinners = {
+    dots: CLISpinner,
+    [string]: ?CLISpinner
+  };
+  declare export default CLISpinners;
+}

--- a/flow-libs/ink.js.flow
+++ b/flow-libs/ink.js.flow
@@ -1,0 +1,45 @@
+// @flow
+
+// Derived from the ink source:
+// https://github.com/vadimdemedes/ink
+
+declare module 'ink' {
+  declare export interface StdoutLike {
+    columns: number;
+    write(chunk: string | Buffer | Uint8Array): mixed;
+  }
+
+  declare type RenderOptions =
+    | StdoutLike
+    | {|
+        stdout?: StdoutLike
+      |};
+
+  declare type ColorProps = {|
+    bold?: boolean,
+    children: React$Node,
+    dim?: boolean,
+    gray?: boolean,
+    green?: boolean,
+    keyword?: string,
+    magenta?: boolean,
+    reset?: boolean,
+    yellow?: boolean
+  |};
+  declare export var Color: React$ComponentType<ColorProps>;
+
+  declare type TextProps = {|
+    children: React$Node
+  |};
+  declare export var Text: React$ComponentType<TextProps>;
+
+  declare type BoxProps = {|
+    children: React$Node
+  |};
+  declare export var Box: React$ComponentType<BoxProps>;
+
+  declare export function render(
+    node: React$Node,
+    options?: RenderOptions
+  ): mixed;
+}

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -446,11 +446,24 @@ export type Resolver = {|
   ): Async<FilePath | null>
 |};
 
-export type LogEvent = {|
-  type: 'log',
-  level: 'error' | 'warn' | 'info' | 'progress' | 'success' | 'verbose',
-  message: string | Error
+export type ProgressLogEvent = {|
+  +type: 'log',
+  +level: 'progress',
+  +message: string
 |};
+
+export type LogEvent =
+  | ProgressLogEvent
+  | {|
+      +type: 'log',
+      +level: 'error' | 'warn',
+      +message: string | Error
+    |}
+  | {|
+      +type: 'log',
+      +level: 'info' | 'success' | 'verbose',
+      +message: string
+    |};
 
 export type BuildStartEvent = {|
   type: 'buildStart'

--- a/packages/core/utils/src/prettifyTime.js
+++ b/packages/core/utils/src/prettifyTime.js
@@ -1,5 +1,5 @@
 // @flow strict-local
 
-export default function prettifyTime(timeInMs: number) {
+export default function prettifyTime(timeInMs: number): string {
   return timeInMs < 1000 ? `${timeInMs}ms` : `${(timeInMs / 1000).toFixed(2)}s`;
 }

--- a/packages/reporters/cli/.babelrc
+++ b/packages/reporters/cli/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@parcel/babel-preset"]
+}

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -5,6 +5,14 @@
   "engines": {
     "parcel": "^2.0.0"
   },
+  "scripts": {
+    "test": "cross-env NODE_ENV=test mocha",
+    "test-ci": "yarn build && yarn test",
+    "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
+    "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",
+    "build": "babel src -d lib",
+    "prepublish": "yarn build"
+  },
   "dependencies": {
     "@parcel/logger": "^2.0.0",
     "@parcel/plugin": "^2.0.0",
@@ -15,6 +23,7 @@
     "grapheme-breaker": "^0.3.2",
     "ink": "^2.0.0-11",
     "ink-spinner": "^2.0.0",
+    "nullthrows": "^1.1.1",
     "react": "^16.7.0"
   }
 }

--- a/packages/reporters/cli/src/BundleReport.js
+++ b/packages/reporters/cli/src/BundleReport.js
@@ -1,6 +1,8 @@
-// @flow
+// @flow strict-local
 
-import React from 'react';
+import type {FilePath} from '@parcel/types';
+
+import * as React from 'react';
 import {BundleGraph} from '@parcel/types';
 import filesize from 'filesize';
 import {Box, Color} from 'ink';
@@ -11,16 +13,18 @@ import {Table, Row, Cell} from './Table';
 
 const LARGE_BUNDLE_SIZE = 1024 * 1024;
 
-type ReportProps = {
+type ReportProps = {|
   bundleGraph: BundleGraph
-};
+|};
 
-export default function BundleReport(props: ReportProps) {
+export default function BundleReport(
+  props: ReportProps
+): React.Element<typeof Table> {
   let bundles = [];
   props.bundleGraph.traverseBundles(bundle => bundles.push(bundle));
   bundles.sort((a, b) => b.stats.size - a.stats.size);
 
-  let rows = [<Row />];
+  let rows: Array<React.Element<typeof Row>> = [<Row />];
   for (let bundle of bundles) {
     rows.push(
       <Row>
@@ -94,7 +98,7 @@ export default function BundleReport(props: ReportProps) {
   return <Table>{rows.map((r, i) => React.cloneElement(r, {key: i}))}</Table>;
 }
 
-function formatFilename(filename, color = {}) {
+function formatFilename(filename: FilePath, color = {}) {
   let dir = path.relative(process.cwd(), path.dirname(filename));
 
   return (
@@ -105,7 +109,7 @@ function formatFilename(filename, color = {}) {
   );
 }
 
-function prettifySize(size, isLarge) {
+function prettifySize(size: number, isLarge?: boolean) {
   let res = filesize(size);
   if (isLarge) {
     return <Color yellow>{emoji.warning + '  ' + res}</Color>;

--- a/packages/reporters/cli/src/Log.js
+++ b/packages/reporters/cli/src/Log.js
@@ -1,4 +1,5 @@
-// @flow
+// @flow strict-local
+
 import type {LogEvent} from '@parcel/types';
 import {Box, Text, Color} from 'ink';
 import Spinner from './Spinner';
@@ -6,15 +7,15 @@ import React from 'react';
 import prettyError from './prettyError';
 import * as Emoji from './emoji';
 
-type StringOrErrorLogProps = {
+type StringOrErrorLogProps = {|
   event: LogEvent
-};
+|};
 
-type StringLogProps = {
+type StringLogProps = {|
   event: {
     +message: string
   }
-};
+|};
 
 export function Log({event}: StringOrErrorLogProps) {
   switch (event.level) {
@@ -56,11 +57,11 @@ function Stack({
           {emoji} {message}
         </Color>
       </div>
-      {stack && (
+      {stack != null && stack !== '' ? (
         <div>
           <Color gray>{stack}</Color>
         </div>
-      )}
+      ) : null}
     </React.Fragment>
   );
 }

--- a/packages/reporters/cli/src/Log.js
+++ b/packages/reporters/cli/src/Log.js
@@ -6,25 +6,35 @@ import React from 'react';
 import prettyError from './prettyError';
 import * as Emoji from './emoji';
 
-type LogProps = {
+type StringOrErrorLogProps = {
   event: LogEvent
 };
 
-let logTypes = {
-  info: InfoLog,
-  progress: Progress,
-  verbose: InfoLog,
-  warn: WarnLog,
-  error: ErrorLog,
-  success: SuccessLog
+type StringLogProps = {
+  event: {
+    +message: string
+  }
 };
 
-export function Log({event}: LogProps) {
-  let LogType = logTypes[event.level];
-  return <LogType event={event} />;
+export function Log({event}: StringOrErrorLogProps) {
+  switch (event.level) {
+    case 'verbose':
+    case 'info':
+      return <InfoLog event={event} />;
+    case 'progress':
+      return <Progress event={event} />;
+    case 'success':
+      return <SuccessLog event={event} />;
+    case 'error':
+      return <ErrorLog event={event} />;
+    case 'warn':
+      return <WarnLog event={event} />;
+  }
+
+  throw new Error('Unknown log event type');
 }
 
-function InfoLog({event}: LogProps) {
+function InfoLog({event}: StringLogProps) {
   return <Text>{event.message}</Text>;
 }
 
@@ -55,15 +65,15 @@ function Stack({
   );
 }
 
-function WarnLog({event}: LogProps) {
+function WarnLog({event}: StringOrErrorLogProps) {
   return <Stack err={event.message} emoji={Emoji.warning} color="yellow" />;
 }
 
-function ErrorLog({event}: LogProps) {
+function ErrorLog({event}: StringOrErrorLogProps) {
   return <Stack err={event.message} emoji={Emoji.error} color="red" bold />;
 }
 
-function SuccessLog({event}: LogProps) {
+function SuccessLog({event}: StringLogProps) {
   return (
     <Color green bold>
       {Emoji.success} {event.message}
@@ -71,7 +81,7 @@ function SuccessLog({event}: LogProps) {
   );
 }
 
-export function Progress({event}: LogProps) {
+export function Progress({event}: StringLogProps) {
   return (
     <Box>
       <Color gray bold>

--- a/packages/reporters/cli/src/Spinner.js
+++ b/packages/reporters/cli/src/Spinner.js
@@ -1,7 +1,7 @@
-// @flow
+// @flow strict-local
 
 import React from 'react';
-import spinners from 'cli-spinners';
+import spinners, {type CLISpinner} from 'cli-spinners';
 
 type Props = {|
   type: string
@@ -22,7 +22,7 @@ export default class Spinner extends React.Component<Props, State> {
     frame: 0
   };
 
-  getSpinner() {
+  getSpinner(): CLISpinner {
     return spinners[this.props.type] || spinners.dots;
   }
 

--- a/packages/reporters/cli/src/Table.js
+++ b/packages/reporters/cli/src/Table.js
@@ -1,8 +1,14 @@
-import React from 'react';
+// @flow strict-local
+
+import * as React from 'react';
+import nullthrows from 'nullthrows';
 import {Box} from 'ink';
 import {countBreaks} from 'grapheme-breaker';
 
-export function Table({children}) {
+type TableProps = {|
+  children: React.Element<typeof Row> | Iterable<React.Element<typeof Row>>
+|};
+export function Table({children}: TableProps) {
   // Measure column widths
   let colWidths = [];
   React.Children.forEach(children, row => {
@@ -18,7 +24,16 @@ export function Table({children}) {
   });
 }
 
-export function Row({colWidths, children}) {
+type RowProps = {|
+  colWidths?: Array<number>,
+  children?: React.Element<typeof Cell> | Iterable<React.Element<typeof Cell>>
+|};
+
+export function Row(props: RowProps) {
+  let children = props.children;
+  // This is injected above in cloneElement
+  let colWidths = nullthrows(props.colWidths);
+
   let childArray = React.Children.toArray(children);
   let items = childArray.map((cell, i) => {
     // Add padding between columns unless the alignment is the opposite to the
@@ -34,12 +49,20 @@ export function Row({colWidths, children}) {
   return <Box>{items.length > 0 ? items : ' '}</Box>;
 }
 
-function getAlign(node) {
+function getAlign(node: React.Element<typeof Cell>): 'left' | 'right' {
   return node.props.align || 'left';
 }
 
-export function Cell(props) {
-  let pad = ' '.repeat(props.length - countBreaks(getText({props})));
+type CellProps = {|
+  align?: 'left' | 'right',
+  children: React.Node,
+  length?: number
+|};
+export function Cell(props: CellProps) {
+  // This is injected above in cloneElement
+  let length = nullthrows(props.length);
+
+  let pad = ' '.repeat(length - countBreaks(getText({props})));
   if (props.align === 'right') {
     return (
       <React.Fragment>
@@ -57,7 +80,7 @@ export function Cell(props) {
   );
 }
 
-function getText(node) {
+function getText(node: string | {props: CellProps}): string {
   if (typeof node === 'string') {
     return node;
   }

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -14,11 +14,11 @@ import prettifyTime from '@parcel/utils/src/prettifyTime';
 import BundleReport from './BundleReport';
 import path from 'path';
 
-type UIState = {
+type UIState = {|
   progress: ?ProgressLogEvent,
   logs: Array<LogEvent>,
   bundleGraph: ?BundleGraph
-};
+|};
 
 const LOG_LEVELS = {
   none: 0,

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -1,4 +1,5 @@
-// @flow
+// @flow strict-local
+
 import type {
   BundleGraph,
   LogEvent,

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -1,9 +1,10 @@
 // @flow
 import type {
-  ReporterEvent,
-  LogEvent,
   BundleGraph,
-  ParcelOptions
+  LogEvent,
+  ParcelOptions,
+  ProgressLogEvent,
+  ReporterEvent
 } from '@parcel/types';
 import {Color} from 'ink';
 import React from 'react';
@@ -13,7 +14,7 @@ import BundleReport from './BundleReport';
 import path from 'path';
 
 type UIState = {
-  progress: ?LogEvent,
+  progress: ?ProgressLogEvent,
   logs: Array<LogEvent>,
   bundleGraph: ?BundleGraph
 };

--- a/packages/reporters/cli/src/emoji.js
+++ b/packages/reporters/cli/src/emoji.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict-local
 
 const supportsEmoji =
   process.platform !== 'win32' || process.env.TERM === 'xterm-256color';

--- a/packages/reporters/cli/test/mocha.opts
+++ b/packages/reporters/cli/test/mocha.opts
@@ -1,0 +1,2 @@
+--require @parcel/babel-register
+--exit


### PR DESCRIPTION
This:
* Adds minimal necessary typings for ink and cli-spinners
* Annotates function arguments in `BundleReport` and `CLIReporter` and makes these files flow strict
* Makes existing types, including props for React components exact object types.
* Adds test package.json scripts to actually test `prettyError.test.js`

Test Plan: flow, lint, and test. Manually test the cli reporter using the simple example.