### PR TITLE
Keep babel env option while transforming

### DIFF
--- a/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/babelrc.js
@@ -15,7 +15,8 @@ async function getBabelConfig(asset, isSource) {
   // Ignore if the config is empty.
   if (
     (!config.plugins || config.plugins.length === 0) &&
-    (!config.presets || config.presets.length === 0)
+    (!config.presets || config.presets.length === 0) &&
+    !config.env
   ) {
     return null;
   }

--- a/packages/core/parcel-bundler/src/transforms/babel/config.js
+++ b/packages/core/parcel-bundler/src/transforms/babel/config.js
@@ -93,7 +93,8 @@ function mergeConfigs(result, config) {
   if (
     !config ||
     ((!config.config.presets || config.config.presets.length === 0) &&
-      (!config.config.plugins || config.config.plugins.length === 0))
+      (!config.config.plugins || config.config.plugins.length === 0) &&
+      !config.config.env)
   ) {
     return;
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

According to https://new.babeljs.io/docs/en/next/babelrc.html#env-environment-option, we can specify a plugin to run in a certain environment. But right now the `env` option will be ignored while parcel is doing the babel transformation.

This's probably related to https://github.com/parcel-bundler/parcel/issues/1605 and https://github.com/parcel-bundler/parcel/issues/2678.

I haven't write any test for this yet. But I think it would be better to check beforehand whether this behavior is desired or not. So I open this PR to confirm it first.

I tested this change manually in my project by directly modifying `parcel-bundler` in `node_modules` and this fix solves the issue 😅 

## 💻 Examples

Example:
```js
// .babelrc
{
  "env": {
    "development": {
      "plugins": ["babel-plugin-styled-components"]
    }
  }
}
```

Parcel will ignore the `env` option in the following `.babelrc` so it's gonna treat that `.babelrc` as an empty one and do nothing.

## 🚨 Test instructions

I'm still figuring out how to write a test for this. Here's the manual test instruction for the time being.

My project use TypeScript, Parcel, and Styled Components

```js
// .babelrc.js
module.exports = {
  "env": {
    "development": {
      "plugins": ["babel-plugin-styled-components"]
    }
  }
}
```
```json
// tsconfig.json
{
  "compilerOptions": {
    "target": "es5",
    "module": "esnext",
    "lib": [
      "es2017",
      "dom"
    ],
    "jsx": "react",
    "sourceMap": true,
    "removeComments": true,
    "noEmit": true,
    "strict": true,
    "noUnusedLocals": true,
    "noUnusedParameters": true,
    "noImplicitReturns": true,
    "noFallthroughCasesInSwitch": true,
    "moduleResolution": "node",
    "esModuleInterop": true,
    "experimentalDecorators": true,
    "forceConsistentCasingInFileNames": true
  }
}
```
The `babel-plugin-styled-components` won't be applied. But when I change `.babelrc.js to the one below, the plugin works.
```js
// .babelrc.js
module.exports = {
  "plugins": ["babel-plugin-styled-components"]
}
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
