### PR TITLE
README.md: Make autoinstall more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - ✂️ Zero configuration **code splitting** using dynamic `import()` statements.
 - 🔥 Built in support for **hot module replacement**
 - 🚨 Friendly error logging experience - syntax highlighted code frames help pinpoint the problem.
+- Automatically installs missing packages **from npm** by default (use `--no-autoinstall` to disable)
 
 ## Getting started
 


### PR DESCRIPTION
The npm autoinstall feature is a surprising default and it should be very visible anywhere Parcel's features are mentioned.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The autoinstall feature should be very visible in all documentation. So I'm taking the first step with the README.

I find the feature to be a potential security risk since I'm only a typo away from accidentally installing some malicious package.

Now the only mention of the autoinstall feature seems to be hidden away here:
https://parceljs.org/cli.html#disable-autoinstall

An aside: Ideally the default should be disabled, and there should also be a warning whenever autoinstall is in use.

