### PR TITLE
Implement a simple CLI reporter for non-TTYs

### DIFF
--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -14,7 +14,6 @@
     "@parcel/core": "^2.0.0",
     "chalk": "^2.1.0",
     "commander": "^2.19.0",
-    "ink": "^2.0.0-11",
     "react": "^16.7.0",
     "v8-compile-cache": "^2.0.0"
   }

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parcel/reporter-cli",
   "version": "2.0.0",
-  "main": "src/CLIReporter.js",
+  "main": "src/index.js",
   "engines": {
     "parcel": "^2.0.0"
   },

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -21,7 +21,7 @@
     "cli-spinners": "^2.0.0",
     "filesize": "^3.6.0",
     "grapheme-breaker": "^0.3.2",
-    "ink": "^2.0.0-11",
+    "ink": "^2.0.0",
     "ink-spinner": "^2.0.0",
     "nullthrows": "^1.1.1",
     "react": "^16.7.0"

--- a/packages/reporters/cli/src/BundleReport.js
+++ b/packages/reporters/cli/src/BundleReport.js
@@ -58,7 +58,7 @@ export default function BundleReport(
     for (let asset of largestAssets) {
       // Add a row for the asset.
       rows.push(
-        <Row key={`asset:${asset.id}`}>
+        <Row key={`bundle:${bundle.id}:asset:${asset.id}`}>
           <Cell>
             {asset == assets[assets.length - 1] ? '└── ' : '├── '}
             {formatFilename(asset.filePath, {})}

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -1,11 +1,10 @@
 // @flow strict-local
 
 import nullthrows from 'nullthrows';
-import {PassThrough} from 'stream';
 import {Reporter} from '@parcel/plugin';
 import {patchConsole} from '@parcel/logger';
 import React from 'react';
-import {render, type StdoutLike} from 'ink';
+import {render} from 'ink';
 import UI from './UI';
 
 // Misbehaved plugins or their dependencies can write to stdout, disrupting
@@ -13,20 +12,8 @@ import UI from './UI';
 // the main Parcel logger.
 patchConsole();
 
-// Ink expects stdout (or whatever is passed as stdout) to have a columns properly.
-// In environments like Lerna child processes, this property does not exist.
-// Create our own proxy object with `columns` on it that falls back to something sensible.
-
-// $FlowFixMe columns is added below
-const stdoutProxy: StdoutLike = new PassThrough();
-stdoutProxy.pipe(process.stdout);
-stdoutProxy.columns =
-  typeof process.stdout.columns === 'number' ? process.stdout.columns : 80;
-
 let ui: ?UI;
-render(<UI ref={u => (ui = u)} />, {
-  stdout: stdoutProxy
-});
+render(<UI ref={u => (ui = u)} />);
 
 export default new Reporter({
   report(event, options) {

--- a/packages/reporters/cli/src/SimpleCLIReporter.js
+++ b/packages/reporters/cli/src/SimpleCLIReporter.js
@@ -1,0 +1,103 @@
+// @flow strict-local
+
+import type {ReporterEvent, ParcelOptions} from '@parcel/types';
+
+import type {Writable} from 'stream';
+
+import {render} from 'ink';
+import {Reporter} from '@parcel/plugin';
+import * as React from 'react';
+import prettifyTime from '@parcel/utils/src/prettifyTime';
+
+import BundleReport from './BundleReport';
+import prettyError from './prettyError';
+import {getProgressMessage} from './utils';
+import logLevels from './logLevels';
+
+export default new Reporter({
+  report(event: ReporterEvent, options: ParcelOptions) {
+    _report(event, options);
+  }
+});
+
+let stdout = process.stdout;
+let stderr = process.stderr;
+
+// Exported only for test
+export function _setStdio(stdoutLike: Writable, stderrLike: Writable) {
+  stdout = stdoutLike;
+  stderr = stderrLike;
+}
+
+// Exported only for test
+export function _report(event: ReporterEvent, options: ParcelOptions): void {
+  let logLevelFilter = logLevels[options.logLevel || 'info'];
+
+  switch (event.type) {
+    case 'buildProgress': {
+      if (logLevelFilter < logLevels.info) {
+        break;
+      }
+
+      let message = getProgressMessage(event);
+      if (message != null) {
+        writeOut(message);
+      }
+      break;
+    }
+    case 'buildSuccess':
+      if (logLevelFilter < logLevels.info) {
+        break;
+      }
+
+      writeOut(`Built in ${prettifyTime(event.buildTime)}`);
+      if (options.mode === 'production') {
+        render(<BundleReport bundleGraph={event.bundleGraph} />);
+      }
+      break;
+    case 'buildFailure':
+      if (logLevelFilter < logLevels.error) {
+        break;
+      }
+
+      writeErr(event.error);
+      break;
+    case 'log': {
+      switch (event.level) {
+        case 'warn':
+        case 'error':
+          if (logLevelFilter >= logLevels[event.level]) {
+            writeErr(event.message);
+          }
+          break;
+        case 'info':
+        case 'verbose':
+        case 'progress':
+        case 'success':
+          if (logLevelFilter >= logLevels[event.level]) {
+            writeOut(event.message);
+          }
+          break;
+        default:
+          throw new Error('Unknown log level ' + event.level);
+      }
+    }
+  }
+}
+
+function writeOut(message: string): void {
+  stdout.write(message + '\n');
+}
+
+function writeErr(message: string | Error): void {
+  let error = prettyError(message, {color: false});
+  // prefix with parcel: to clarify the source of errors
+  writeErrLine('parcel: ' + error.message);
+  if (error.stack != null) {
+    writeErrLine(error.stack);
+  }
+}
+
+function writeErrLine(message: string): void {
+  stderr.write(message + '\n');
+}

--- a/packages/reporters/cli/src/index.js
+++ b/packages/reporters/cli/src/index.js
@@ -1,0 +1,8 @@
+// @flow strict-local
+
+// $FlowFixMe This is fine.
+const isTTY = process.stdout.isTTY;
+
+export default (isTTY
+  ? require('./CLIReporter').default
+  : require('./SimpleCLIReporter').default);

--- a/packages/reporters/cli/src/logLevels.js
+++ b/packages/reporters/cli/src/logLevels.js
@@ -1,0 +1,13 @@
+// @flow strict-local
+
+const logLevels = {
+  none: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  progress: 3,
+  success: 3,
+  verbose: 4
+};
+
+export default logLevels;

--- a/packages/reporters/cli/src/utils.js
+++ b/packages/reporters/cli/src/utils.js
@@ -1,0 +1,23 @@
+// @flow strict-local
+
+import type {BuildProgressEvent} from '@parcel/types';
+
+import path from 'path';
+
+export function getProgressMessage(event: BuildProgressEvent): ?string {
+  switch (event.phase) {
+    case 'transforming':
+      return `Building ${path.basename(event.request.filePath)}...`;
+
+    case 'bundling':
+      return 'Bundling...';
+
+    case 'packaging':
+      return `Packaging ${path.basename(event.bundle.filePath || '')}...`;
+
+    case 'optimizing':
+      return `Optimizing ${path.basename(event.bundle.filePath || '')}...`;
+  }
+
+  return null;
+}

--- a/packages/reporters/cli/test/SimpleCLIReporter.test.js
+++ b/packages/reporters/cli/test/SimpleCLIReporter.test.js
@@ -1,0 +1,79 @@
+// @flow strict-local
+
+import assert from 'assert';
+import {PassThrough} from 'stream';
+import {_report, _setStdio} from '../src/SimpleCLIReporter';
+
+describe('SimpleCLIReporter', () => {
+  let originalStdout;
+  let originalStderr;
+  let stdoutOutput;
+  let stderrOutput;
+
+  beforeEach(() => {
+    // Stub these out to avoid writing noise to real stdio and to read from these
+    // otherwise only writable streams
+    originalStdout = process.stdout;
+    originalStderr = process.stderr;
+
+    stdoutOutput = '';
+    stderrOutput = '';
+
+    let mockStdout = new PassThrough();
+    mockStdout.on('data', d => (stdoutOutput += d.toString()));
+    let mockStderr = new PassThrough();
+    mockStderr.on('data', d => (stderrOutput += d.toString()));
+    _setStdio(mockStdout, mockStderr);
+  });
+
+  afterEach(() => {
+    _setStdio(originalStdout, originalStderr);
+  });
+
+  it('defaults to an info logLevel filter', () => {
+    _report({type: 'log', level: 'info', message: 'info'}, {});
+    _report({type: 'log', level: 'success', message: 'success'}, {});
+    _report({type: 'log', level: 'verbose', message: 'verbose'}, {});
+
+    assert(!stdoutOutput.includes('verbose'));
+  });
+
+  it('writes log, info, success, and verbose log messages to stdout', () => {
+    let options = {
+      logLevel: 'verbose'
+    };
+
+    _report({type: 'log', level: 'info', message: 'info'}, options);
+    _report({type: 'log', level: 'success', message: 'success'}, options);
+    _report({type: 'log', level: 'verbose', message: 'verbose'}, options);
+
+    assert.equal(stdoutOutput, 'info\nsuccess\nverbose\n');
+  });
+
+  it('writes errors and warnings to stderr', () => {
+    _report({type: 'log', level: 'error', message: 'error'}, {});
+    _report({type: 'log', level: 'warn', message: 'warn'}, {});
+
+    assert.equal(stdoutOutput, '');
+    assert.equal(stderrOutput, 'parcel: error\nparcel: warn\n');
+  });
+
+  it('prints errors nicely', () => {
+    _report({type: 'log', level: 'error', message: new Error('error')}, {});
+    _report({type: 'log', level: 'warn', message: new Error('warn')}, {});
+
+    assert.equal(stdoutOutput, '');
+    assert(stderrOutput.includes('parcel: error\n'));
+    assert(stderrOutput.includes('parcel: warn\n'));
+  });
+
+  it('writes buildProgress messages to stdout on the default loglevel', () => {
+    _report({type: 'buildProgress', phase: 'bundling'}, {});
+    assert.equal(stdoutOutput, 'Bundling...\n');
+  });
+
+  it('writes buildSuccess messages to stdout on the default loglevel', () => {
+    _report({type: 'buildProgress', phase: 'bundling'}, {});
+    assert.equal(stdoutOutput, 'Bundling...\n');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,6 +1918,19 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
   integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
 
+"@types/prop-types@*":
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
+  integrity sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==
+
+"@types/react@^16.8.6":
+  version "16.8.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.8.tgz#4b60a469fd2469f7aa6eaa0f8cfbc51f6d76e662"
+  integrity sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/semver@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
@@ -2043,7 +2056,7 @@ ansi-escapes@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
   integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
 
-ansi-escapes@^3.1.0:
+ansi-escapes@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
@@ -2057,6 +2070,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
+  integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2278,6 +2296,11 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+auto-bind@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/auto-bind/-/auto-bind-2.0.0.tgz#9a55a461b521f58daf955169203bed1a07a970a9"
+  integrity sha512-rvRBv0/O7iriUMqSzTDhAfyAD1vVnElAEruo5rMSFeYLA0iKDEzLPSJiwMnL86+IPpTlhfOIAzjoKZ9TaySYdA==
 
 autoprefixer@^6.3.1:
   version "6.7.7"
@@ -3301,10 +3324,19 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.1:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -3544,21 +3576,14 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.3.0, color-convert@^1.9.1:
+color-convert@^1.3.0, color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
-color-convert@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
-  integrity sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==
-  dependencies:
-    color-name "^1.1.1"
-
-color-name@1.1.3, color-name@^1.1.1:
+color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
@@ -4182,6 +4207,11 @@ csso@~2.3.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
+csstype@^2.2.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.3.tgz#b701e5968245bf9b08d54ac83d00b624e622a9fa"
+  integrity sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -4717,6 +4747,11 @@ elm@^0.19.0:
   integrity sha512-CYgewByRByMOilPk5/yrW1mtflaS/vp+026gwb0EEX6aqUl+TGYoTSTW+uf44XB/FOKgUauV3TDH3Bl0IHZ8Ag==
   dependencies:
     binwrap "0.1.4"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -6248,18 +6283,21 @@ ink-spinner@^2.0.0:
     object.omit "^2.0.1"
     prop-types "^15.5.10"
 
-ink@^2.0.0-11:
-  version "2.0.0-11"
-  resolved "https://registry.yarnpkg.com/ink/-/ink-2.0.0-11.tgz#1af71f717e5ed549ba577531c7df8a9ac90e649a"
-  integrity sha512-f9ewmS37cbROEBUZ+KAp+BwOPgfLDoHdRT7IDw+y5N46NpofJqLxrMjJkp0N9ykUBxOvmBU43xNa0Tma9ojgKw==
+ink@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/ink/-/ink-2.0.6.tgz#1ac54812ecd89e68ec53513a5d2f458f602f51dc"
+  integrity sha512-FGsR0tlVkeQJQDzOff/rIENgVWmQ7jZN1F4pXrE1WLjAaMl1th6lsj5+QhnlL28TMA+RAKo6Y7vKc7WZrbpj5Q==
   dependencies:
-    ansi-escapes "^3.1.0"
+    "@types/react" "^16.8.6"
     arrify "^1.0.1"
+    auto-bind "^2.0.0"
     chalk "^2.4.1"
     cli-cursor "^2.1.0"
     lodash.throttle "^4.1.1"
+    log-update "^3.0.0"
     prop-types "^15.6.2"
-    react-reconciler "^0.17.0"
+    react-reconciler "^0.20.0"
+    scheduler "^0.13.2"
     slice-ansi "^1.0.0"
     string-length "^2.0.0"
     widest-line "^2.0.0"
@@ -7496,6 +7534,15 @@ log-update@^1.0.2:
     ansi-escapes "^1.0.0"
     cli-cursor "^1.0.2"
 
+log-update@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-3.1.0.tgz#fa22abbbcb30f505906758bbbd0f292b71bc2ad9"
+  integrity sha512-7ttbZj4w165ZemmS9YngKbBh4/UEiW1gS+SPpfQQHIMYcPMybTDM6UDlmQLrjJ8+j23On173OFB+pXKfPRJP3A==
+  dependencies:
+    ansi-escapes "^3.2.0"
+    cli-cursor "^2.1.0"
+    wrap-ansi "^5.0.0"
+
 lolex@^2.3.2, lolex@^2.4.2:
   version "2.7.5"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.5.tgz#113001d56bfc7e02d56e36291cc5c413d1aa0733"
@@ -7506,7 +7553,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9620,13 +9667,22 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -9923,15 +9979,20 @@ react-fast-compare@^2.0.0:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-reconciler@^0.17.0:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.17.2.tgz#cabe8cb403793f6462842e07b525c3b61c4f5cde"
-  integrity sha512-V3WjUlYgMjWWRQH5lzMMsy1jMDL28pInmwfCsKoOGqNQ0TN2DQHKBzycgFnZsiL3NoIb52GQtQgkYGeDDDoN+g==
+react-is@^16.8.1:
+  version "16.8.5"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
+  integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==
+
+react-reconciler@^0.20.0:
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.20.3.tgz#ff5f75eb73e004a2a8757b41cd645baf442ea4b9"
+  integrity sha512-kKowgno8ZRNhFSQcuQ2ja/Lrvav58qnwy4w7bVbA4x+WKlDrP1vU42AQwwi2fMltVRTprD6OVMuCumPFPrB9fQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.13.5"
 
 react@^16.6.3:
   version "16.6.3"
@@ -10550,6 +10611,14 @@ scheduler@^0.12.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.13.2, scheduler@^0.13.5:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.5.tgz#b7226625167041298af3b98088a9dbbf6d7733a8"
+  integrity sha512-K98vjkQX9OIt/riLhp6F+XtDPtMQhqNcf045vsh+pcuvHq+PHy1xCrH3pq1P40m6yR46lpVvVhKdEOtnimuUJw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -11077,6 +11146,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string_decoder@^1.0.0, string_decoder@^1.1.1, string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -11111,6 +11189,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -11184,7 +11269,7 @@ sugarss@^2.0.0:
   dependencies:
     postcss "^7.0.2"
 
-supports-color@5.4.0, supports-color@^5.3.0:
+supports-color@5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
@@ -11203,7 +11288,7 @@ supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.4.0, supports-color@^5.5.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -12177,6 +12262,15 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.0.0.tgz#c3838a85fbac6a647558ca97024d41d7631721dc"
+  integrity sha512-3ThemJUfTTju0SKG2gjGExzGRHxT5l/KEM5sff3TQReaVWe/bFTiF1GEr8DKr/j0LxGt8qPzx0yhd2RLyqgy2Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This implements `SimpleCLIReporter`, an alternate reporter to export in non-TTY environments. Instead of using ink, which freely rewrites the screen to make updates, simply log messages to stdout/stderr.

This does, however, use ink to write out the bundle report, in favor of reusing that component code. Since only write once and never update the `<BundleReport>`, the screen is never rewritten, so it outputs nicely. We should continue to do this selectively if the main CLI expands.

Test Plan: 
* Disable unrefing of worker processes. This causes the main process to exit too early. This is a bug outside the scope of this PR that needs to be fixed.
* Invoke the simple example and pipe its output to a file. 

Verify:
```
...
Packaging async.1760b8d1.js...
Packaging react.e190d87e.js...
Packaging async2.694a57a4.js...
Built in 1.48s

dist/legacy/react.e190d87e
    603.24      23ms
├── ../../../node_modules/lodash/lodas
   527.24 K     23ms
├── ../../../node_modules/react/cjs/react.developmen
    65.93 K     18ms
├── ../../../node_modules/react/node_modules/prop-types/checkPropType
     3.51 K     10ms
├── ../../../node_modules/object-assign/inde
     2.06 K      7ms
├── ../../../node_modules/react/node_modules/prop-types/lib/ReactPropTypesSecr
      314 B      8ms
└── ../../../node_modules/react/inde
       178       6ms
...
```