### PR TITLE
Add JSON Reporter

### DIFF
--- a/packages/core/integration-tests/test/json-reporter.js
+++ b/packages/core/integration-tests/test/json-reporter.js
@@ -1,0 +1,68 @@
+// @flow
+
+/* eslint-disable no-console */
+
+import assert from 'assert';
+import path from 'path';
+import {bundle} from './utils';
+import defaultConfigContents from '@parcel/config-default';
+
+const jsonConfig = {
+  ...defaultConfigContents,
+  reporters: ['@parcel/reporter-json'],
+  filePath: require.resolve('@parcel/config-default')
+};
+
+describe('json reporter', () => {
+  it('logs bundling a commonjs bundle to stdout as json', async () => {
+    let oldConsoleLog = console.log;
+    let i = 0;
+    // $FlowFixMe
+    console.log = function log(msg) {
+      let parsed = JSON.parse(msg);
+      if (i === 0) {
+        assert.deepEqual(parsed, {type: 'buildStart'});
+      } else if (i > 0 && i < 9) {
+        assert.equal(parsed.type, 'buildProgress');
+        assert.equal(parsed.phase, 'transforming');
+        assert(typeof parsed.filePath === 'string');
+      } else if (i === 9) {
+        assert.deepEqual(parsed, {
+          type: 'buildProgress',
+          phase: 'bundling'
+        });
+      } else if (i === 10) {
+        assert.deepEqual(parsed, {
+          type: 'buildProgress',
+          phase: 'packaging',
+          bundleFilePath: 'dist/index.js'
+        });
+      } else if (i === 11) {
+        assert.equal(parsed.type, 'buildSuccess');
+        assert(typeof parsed.buildTime === 'number');
+        assert(Array.isArray(parsed.bundles));
+        let bundle = parsed.bundles[0];
+        assert.equal(bundle.filePath, 'dist/index.js');
+        assert(typeof bundle.size === 'number');
+        assert(typeof bundle.time === 'number');
+        assert(Array.isArray(bundle.largestAssets));
+      } else {
+        // $FlowFixMe
+        assert.fail(`Unexpected message ${msg} in position ${i}`);
+      }
+
+      i++;
+    };
+
+    try {
+      await bundle(path.join(__dirname, '/integration/commonjs/index.js'), {
+        defaultConfig: jsonConfig
+      });
+    } catch (e) {
+      throw e;
+    } finally {
+      // $FlowFixMe
+      console.log = oldConsoleLog;
+    }
+  });
+});

--- a/packages/core/utils/src/generateBundleReport.js
+++ b/packages/core/utils/src/generateBundleReport.js
@@ -4,13 +4,13 @@ import type {Asset, BundleGraph} from '@parcel/types';
 import nullthrows from 'nullthrows';
 
 export type BundleReport = {|
-  bundles: Array<{
+  bundles: Array<{|
     filePath: string,
     size: number,
     time: number,
     largestAssets: Array<{filePath: string, size: number, time: number}>,
     totalAssets: number
-  }>
+  |}>
 |};
 
 export default function generateBundleReport(

--- a/packages/core/utils/src/generateBundleReport.js
+++ b/packages/core/utils/src/generateBundleReport.js
@@ -1,0 +1,47 @@
+// @flow strict-local
+
+import type {Asset, BundleGraph} from '@parcel/types';
+import nullthrows from 'nullthrows';
+
+export type BundleReport = {|
+  bundles: Array<{
+    filePath: string,
+    size: number,
+    time: number,
+    largestAssets: Array<{filePath: string, size: number, time: number}>,
+    totalAssets: number
+  }>
+|};
+
+export default function generateBundleReport(
+  bundleGraph: BundleGraph,
+  largestAssetCount: number = 10
+): BundleReport {
+  let bundles = [];
+  bundleGraph.traverseBundles(bundle => {
+    bundles.push(bundle);
+  });
+  bundles.sort((a, b) => b.stats.size - a.stats.size);
+
+  return {
+    bundles: bundles.map(bundle => {
+      let assets: Array<Asset> = [];
+      bundle.assetGraph.traverseAssets(asset => {
+        assets.push(asset);
+      });
+      assets.sort((a, b) => b.stats.size - a.stats.size);
+
+      return {
+        filePath: nullthrows(bundle.filePath),
+        size: bundle.stats.size,
+        time: bundle.stats.time,
+        largestAssets: assets.slice(0, largestAssetCount).map(asset => ({
+          filePath: asset.filePath,
+          size: asset.stats.size,
+          time: asset.stats.time
+        })),
+        totalAssets: assets.length
+      };
+    })
+  };
+}

--- a/packages/reporters/json/.babelrc
+++ b/packages/reporters/json/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@parcel/babel-preset"]
+}

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@parcel/reporter-json",
+  "version": "2.0.0",
+  "main": "src/JSONReporter.js",
+  "engines": {
+    "parcel": "^2.0.0"
+  },
+  "scripts": {
+    "test": "echo this package has no tests yet",
+    "test-ci": "yarn test"
+  },
+  "dependencies": {
+    "@parcel/logger": "^2.0.0",
+    "@parcel/plugin": "^2.0.0",
+    "@parcel/types": "^2.0.0",
+    "@parcel/utils": "^1.10.3",
+    "nullthrows": "^1.1.1"
+  }
+}

--- a/packages/reporters/json/src/JSONReporter.js
+++ b/packages/reporters/json/src/JSONReporter.js
@@ -1,0 +1,183 @@
+// @flow strict-local
+
+import type {
+  BuildProgressEvent,
+  LogEvent,
+  ParcelOptions,
+  ReporterEvent
+} from '@parcel/types';
+
+import {Reporter} from '@parcel/plugin';
+import generateBundleReport, {
+  type BundleReport
+} from '@parcel/utils/src/generateBundleReport';
+
+/* eslint-disable no-console */
+const writeToStdout = makeWriter(console.log);
+const writeToStderr = makeWriter(console.error);
+/* eslint-enable no-console */
+
+const LOG_LEVELS = {
+  none: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  progress: 3,
+  success: 3,
+  verbose: 4
+};
+
+export default new Reporter({
+  report(event: ReporterEvent, options: ParcelOptions) {
+    let logLevelFilter = options.logLevel || 'info';
+
+    switch (event.type) {
+      case 'buildStart':
+        if (LOG_LEVELS[logLevelFilter] >= LOG_LEVELS.info) {
+          writeToStdout({type: 'buildStart'}, logLevelFilter);
+        }
+        break;
+      case 'buildFailure':
+        if (LOG_LEVELS[logLevelFilter] >= LOG_LEVELS.error) {
+          writeToStderr(
+            {type: 'buildFailure', message: event.error.message},
+            logLevelFilter
+          );
+        }
+        break;
+      case 'buildProgress':
+        if (LOG_LEVELS[logLevelFilter] >= LOG_LEVELS.progress) {
+          let jsonEvent = progressEventToJSONEvent(event);
+          if (jsonEvent != null) {
+            writeToStdout(jsonEvent, logLevelFilter);
+          }
+        }
+        break;
+      case 'buildSuccess':
+        if (LOG_LEVELS[logLevelFilter] >= LOG_LEVELS.success) {
+          writeToStdout(
+            {
+              type: 'buildSuccess',
+              buildTime: event.buildTime,
+              bundles: event.bundleGraph
+                ? generateBundleReport(event.bundleGraph).bundles
+                : undefined
+            },
+            logLevelFilter
+          );
+        }
+        break;
+      case 'log':
+        writeLogEvent(event, logLevelFilter);
+    }
+  }
+});
+
+function makeWriter(
+  write: string => mixed
+): (JSONReportEvent, $Keys<typeof LOG_LEVELS>) => void {
+  return (
+    event: JSONReportEvent,
+    logLevelFilter: $Keys<typeof LOG_LEVELS>
+  ): void => {
+    let stringified;
+    try {
+      stringified = JSON.stringify(event);
+    } catch (err) {
+      // This should never happen so long as JSONReportEvent is easily serializable
+      if (LOG_LEVELS[logLevelFilter] >= LOG_LEVELS.error) {
+        writeToStderr(
+          {type: 'log', level: 'error', message: err},
+          logLevelFilter
+        );
+      }
+      return;
+    }
+
+    write(stringified);
+  };
+}
+
+function writeLogEvent(
+  event: LogEvent,
+  logLevelFilter: $Keys<typeof LOG_LEVELS>
+): void {
+  if (LOG_LEVELS[logLevelFilter] < LOG_LEVELS[event.level]) {
+    return;
+  }
+  switch (event.level) {
+    case 'info':
+    case 'progress':
+    case 'success':
+    case 'verbose':
+      writeToStdout(event, logLevelFilter);
+      break;
+    case 'warn':
+    case 'error':
+      writeToStderr(
+        {
+          type: 'log',
+          level: event.level,
+          message:
+            typeof event.message === 'string'
+              ? event.message
+              : event.message.message
+        },
+        logLevelFilter
+      );
+      break;
+  }
+}
+
+function progressEventToJSONEvent(
+  progressEvent: BuildProgressEvent
+): ?JSONProgressEvent {
+  switch (progressEvent.phase) {
+    case 'transforming':
+      return {
+        type: 'buildProgress',
+        phase: 'transforming',
+        filePath: progressEvent.request.filePath
+      };
+    case 'bundling':
+      return {
+        type: 'buildProgress',
+        phase: 'bundling'
+      };
+    case 'optimizing':
+    case 'packaging':
+      return {
+        type: 'buildProgress',
+        phase: progressEvent.phase,
+        bundleFilePath: progressEvent.bundle.filePath
+      };
+  }
+}
+
+type JSONReportEvent =
+  | {|
+      +type: 'log',
+      +level: 'info' | 'success' | 'verbose' | 'progress' | 'warn' | 'error',
+      +message: string
+    |}
+  | {|+type: 'buildStart'|}
+  | {|+type: 'buildFailure', message: string|}
+  | {|
+      +type: 'buildSuccess',
+      buildTime: number,
+      bundles?: $PropertyType<BundleReport, 'bundles'>
+    |}
+  | JSONProgressEvent;
+
+type JSONProgressEvent =
+  | {|
+      +type: 'buildProgress',
+      phase: 'transforming',
+      filePath: string
+    |}
+  | {|+type: 'buildProgress', phase: 'bundling'|}
+  | {|
+      +type: 'buildProgress',
+      +phase: 'packaging' | 'optimizing',
+      bundleFilePath?: string
+    |};

--- a/packages/reporters/json/test/mocha.opts
+++ b/packages/reporters/json/test/mocha.opts
@@ -1,0 +1,2 @@
+--require @parcel/babel-register
+--exit


### PR DESCRIPTION
This adds a JSON reporter to Parcel 2. While refactoring how we invoke yarn and log its output, I found its JSON reporter really useful in the absence of a programmatic api. Similarly,  outputting feedback in newline-delimited json allows Parcel to be used in novel ways outside of JavaScript programs that could otherwise use it as a library.

This:
* Removes the old cli interface that was replaced in #2362
* Removes the cli reporter from the base parcel config. This replaced with an option for "environmental reporters", reporters that are automatically added when specified as an option in `ParcelOptions`. 
	* This is to avoid coupling reporters specific to how Parcel was invoked (via the cli with or without `--json`, as a programmatic api, etc.) to the core config object.
* Patches `console` in workers. This allows them to send messages to the main process via the logger and also be written (as newline-delimited json in this case)
* Extracts generation of the summary of the bundle graph to be re-used across the JSON reporter, as well as the simple and rich cli reporters.

I'm open to not including the JSON reporter itself in core, but if we don't we should provide the facility for something like the environmental reporters implemented here.

Test Plan:
* Remove the process `unref` in Worker. This once again caused the main process to exit too early. This is a bug outside the scope of this PR that needs to be fixed.
* Invoke `yarn demo --json` in the simple example and verify json output (shortened with [...]):

```
~/s/p/p/e/simple $ yarn demo --json                                                                                                                                                                                                                                                             
yarn run v1.15.2
$ node -r @parcel/babel-register ./node_modules/.bin/parcel2 build src/index.js --json
{"type":"buildStart"}
{"type":"buildProgress","phase":"transforming","filePath":"/Users/wbinnssmith/src/parcel/packages/examples/simple/src/index.js"}
[...]
{"type":"buildProgress","phase":"transforming","filePath":"/Users/wbinnssmith/src/parcel/node_modules/prop-types/lib/ReactPropTypesSecret.js"}
{"type":"buildProgress","phase":"bundling"}
{"type":"buildProgress","phase":"transforming","filePath":"/Users/wbinnssmith/src/parcel/packages/runtimes/js/src/JSRuntime.js"}
{"type":"log","level":"warn","message":"'Browserslist: caniuse-lite is outdated. Please run next command `yarn upgrade caniuse-lite browserslist`'"}
[...]
{"type":"buildProgress","phase":"transforming","filePath":"/Users/wbinnssmith/src/parcel/packages/runtimes/js/src/bundle-url.js"}
{"type":"buildProgress","phase":"packaging","bundleFilePath":"dist/legacy/index.js"}
[...]
{"type":"buildProgress","phase":"packaging","bundleFilePath":"dist/modern/worker.5074a895.js"}
```

There's also a final `buildSuccess` event emitted that I'll shorten and indent below, but this is also newline-delimited JSON:

```
{
  "type": "buildSuccess",
  "buildTime": 1831,
  "bundles": [
    {
      "filePath": "dist/legacy/react.804b5e33.js",
      "size": 617494,
      "time": 57,
      "largestAssets": [
        {
          "filePath": "/Users/wbinnssmith/src/parcel/node_modules/lodash/lodash.js",
          "size": 539894,
          "time": 52
        },
        {
          "filePath": "/Users/wbinnssmith/src/parcel/node_modules/react/cjs/react.development.js",
          "size": 67515,
          "time": 63
        },
        {
          "filePath": "/Users/wbinnssmith/src/parcel/node_modules/prop-types/checkPropTypes.js",
          "size": 3368,
          "time": 26
        },
        {
          "filePath": "/Users/wbinnssmith/src/parcel/node_modules/object-assign/index.js",
          "size": 2108,
          "time": 8
        },
        {
          "filePath": "/Users/wbinnssmith/src/parcel/node_modules/prop-types/lib/ReactPropTypesSecret.js",
          "size": 314,
          "time": 30
        },
        {
          "filePath": "/Users/wbinnssmith/src/parcel/node_modules/react/index.js",
          "size": 182,
          "time": 11
        }
      ],
      "totalAssets": 6
    },
    [...]
    {
      "filePath": "dist/modern/worker.5074a895.js",
      "size": 3473,
      "time": 25,
      "largestAssets": [
        {
          "filePath": "/Users/wbinnssmith/src/parcel/packages/examples/simple/src/worker.js",
          "size": 24,
          "time": 17
        }
      ],
      "totalAssets": 1
    }
  ]
}
```

[Here are the bundle report types](https://github.com/parcel-bundler/parcel/blob/56522b78865646ab7730dc98892a508600419fcb/packages/core/utils/src/generateBundleReport.js#L6) and [here are the json message types](https://github.com/parcel-bundler/parcel/blob/56522b78865646ab7730dc98892a508600419fcb/packages/reporters/json/src/JSONReporter.js#L163)