### PR TITLE
Only patch `console` in workers. Ignore their stdout.

### DIFF
--- a/packages/core/logger/src/Logger.js
+++ b/packages/core/logger/src/Logger.js
@@ -3,7 +3,6 @@
 import type {IDisposable, LogEvent} from '@parcel/types';
 
 import EventEmitter from 'events';
-import {inspect} from 'util';
 
 class Logger {
   // TODO: This can't be explicitly annotated as an EventEmitter since
@@ -68,29 +67,3 @@ class Logger {
 
 const logger = new Logger();
 export default logger;
-
-let consolePatched;
-export function patchConsole() {
-  if (consolePatched) {
-    return;
-  }
-
-  /* eslint-disable no-console */
-  // $FlowFixMe
-  console.log = (...messages: Array<mixed>) => {
-    logger.info(messages.map(m => inspect(m)).join(' '));
-  };
-
-  // $FlowFixMe
-  console.warn = message => {
-    logger.warn(message);
-  };
-
-  // $FlowFixMe
-  console.error = message => {
-    logger.error(message);
-  };
-  /* eslint-enable no-console */
-
-  consolePatched = true;
-}

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -371,6 +371,10 @@ if (!WorkerFarm.isWorker()) {
         invariant(typeof e.message === 'string');
         Logger.progress(e.message);
         break;
+      case 'verbose':
+        invariant(typeof e.message === 'string');
+        Logger.verbose(e.message);
+        break;
       case 'warn':
         Logger.warn(e.message);
         break;

--- a/packages/core/workers/test/integration/workerfarm/console.js
+++ b/packages/core/workers/test/integration/workerfarm/console.js
@@ -1,0 +1,18 @@
+const WorkerFarm = require('../../../').default;
+
+function run() {
+  if (WorkerFarm.isWorker()) {
+    // Only test this behavior in workers. Logging in the main process will
+    // always work.
+    console.log('one');
+    console.info('two');
+    console.warn('three');
+    console.error('four');
+    console.debug('five');
+  }
+}
+
+function init() {}
+
+exports.init = init;
+exports.run = run;

--- a/packages/core/workers/test/workerfarm.js
+++ b/packages/core/workers/test/workerfarm.js
@@ -177,6 +177,53 @@ describe('WorkerFarm', () => {
     await workerfarm.end();
   });
 
+  it('Forwards stdio from the child process and levels event source', async () => {
+    let events = [];
+    let logDisposable = Logger.onLog(event => events.push(event));
+
+    let workerfarm = new WorkerFarm(
+      {},
+      {
+        warmWorkers: true,
+        useLocalWorker: false,
+        workerPath: require.resolve('./integration/workerfarm/console.js')
+      }
+    );
+
+    await workerfarm.run();
+
+    assert.deepEqual(events, [
+      {
+        level: 'info',
+        message: 'one',
+        type: 'log'
+      },
+      {
+        level: 'info',
+        message: 'two',
+        type: 'log'
+      },
+      {
+        level: 'warn',
+        message: 'three',
+        type: 'log'
+      },
+      {
+        level: 'error',
+        message: 'four',
+        type: 'log'
+      },
+      {
+        level: 'verbose',
+        message: 'five',
+        type: 'log'
+      }
+    ]);
+
+    logDisposable.dispose();
+    await workerfarm.end();
+  });
+
   it('Forwards logger events to the main process', async () => {
     let events = [];
     let logDisposable = Logger.onLog(event => events.push(event));

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -2,15 +2,9 @@
 
 import nullthrows from 'nullthrows';
 import {Reporter} from '@parcel/plugin';
-import {patchConsole} from '@parcel/logger';
 import React from 'react';
 import {render} from 'ink';
 import UI from './UI';
-
-// Misbehaved plugins or their dependencies can write to stdout, disrupting
-// ink's output. Patch console.log and similar to route output through
-// the main Parcel logger.
-patchConsole();
 
 let ui: ?UI;
 render(<UI ref={u => (ui = u)} />);


### PR DESCRIPTION
This removes the Logger's ability to patch `console.log` and friends. This was used in reporters that have sensitive stdio (such as the ink and JSON reporters) to prevent things from disrupting terminal output. This happened when plugins wrote to their stdout/stderr, which we have no control over. This currently only happens when [Browserslist writes a warning to stderr when its database is out of date](https://github.com/browserslist/browserslist/issues/361).

Instead, don't inherit subprocess stdio from the main process -- create a local pipe that transforms the stdio from the subprocess into lines sent to the logger. This will allow us to tag these log messages in the future as originating from a particular worker.

Note: it's still possible that plugins which run in the main process (Bundlers, Reporters, etc) could write to stdio and disrupt things.

Test Plan: 
  * Wrote integration tests in the workerfarm module to cover this behavior (`yarn test`).
  * Temporarily added `console.log`, `process.stio.write`, and `Logger` calls in the babel transform and verified multiple sets of output came through the main process's stdout/stderr in the simple example.