### PR TITLE
remove unnecessary package level lint and format scripts

### DIFF
--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -14,8 +14,6 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha",
     "test-ci": "yarn build && yarn test",
-    "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
-    "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },

--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -126,12 +126,10 @@
     "test-coverage": "rm -rf coverage/* && nyc yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json",
     "report-coverage": "nyc report --reporter=lcov --reporter=cobertura --reporter=html && codecov",
     "test-ci": "yarn test-coverage && yarn report-coverage",
-    "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
     "build": "yarn minify && babel src -d lib && ncp src/builtins lib/builtins",
     "prepublish": "yarn build",
     "minify": "terser -c -m -o src/builtins/prelude.min.js src/builtins/prelude.js && terser -c -m -o src/builtins/prelude2.min.js src/builtins/prelude2.js",
     "precommit": "lint-staged",
-    "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",
     "postinstall": "node -e \"console.log('\\u001b[35m\\u001b[1mLove Parcel? You can now donate to our open collective:\\u001b[22m\\u001b[39m\\n > \\u001b[34mhttps://opencollective.com/parcel/donate\\u001b[0m')\"",
     "clean": "rm -rf node_modules lib && yarn"
   },

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -14,8 +14,6 @@
   "scripts": {
     "test": "mocha",
     "test-ci": "yarn build && yarn test",
-    "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
-    "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },

--- a/packages/core/watcher/package.json
+++ b/packages/core/watcher/package.json
@@ -11,8 +11,6 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha",
     "test-ci": "yarn build && yarn test",
-    "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
-    "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -8,8 +8,6 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha",
     "test-ci": "yarn build && yarn test",
-    "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
-    "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },


### PR DESCRIPTION
Prettier and eslint are called from the root, so there's no need to have those scripts defined by at the package level.
