### PR TITLE
Fix capitalization typo in source for --no-autoinstall

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -105,8 +105,8 @@ class Bundler extends EventEmitter {
       target === 'node'
         ? false
         : typeof options.hmr === 'boolean'
-          ? options.hmr
-          : watch;
+        ? options.hmr
+        : watch;
     const scopeHoist =
       options.scopeHoist !== undefined ? options.scopeHoist : false;
     return {
@@ -142,11 +142,11 @@ class Bundler extends EventEmitter {
       detailedReport: options.detailedReport || false,
       global: options.global,
       autoinstall:
-        typeof options.autoInstall === 'boolean'
-          ? options.autoInstall
+        typeof options.autoinstall === 'boolean'
+          ? options.autoinstall
           : process.env.PARCEL_AUTOINSTALL === 'false'
-            ? false
-            : !isProduction,
+          ? false
+          : !isProduction,
       scopeHoist: scopeHoist,
       contentHash:
         typeof options.contentHash === 'boolean'


### PR DESCRIPTION
# ↪️ Pull Request

Fixes bug #2887 

See description of the bug above.

When using the CLI to serve or watch with the `--no-autoinstall` it will now correctly check for the flag.

## 🚨 Test instructions

Without unit tests for the cli instructions this isn't covered. There is an option, however, for adding end to end tests. Full flow from cli instruction to desired build. I would be interested in looking into adding this if requested.

You can manually test this by adding the flag to a simple project and seeing that the dependencies will no longer bu automatically installed.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
