### PR TITLE
Make connectedFiles and dependencies Maps

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -189,7 +189,7 @@ export default class AssetGraph extends Graph<AssetGraphNode>
     // Get connected files from each asset and connect them to the file node
     let fileNodes = [];
     for (let asset of cacheEntry.assets) {
-      let files = asset.connectedFiles.map(file => nodeFromFile(file));
+      let files = asset.getConnectedFiles().map(file => nodeFromFile(file));
       fileNodes = fileNodes.concat(files);
     }
 

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -206,9 +206,9 @@ export default class AssetGraph extends Graph<AssetGraphNode>
     let removedFiles = getFilesFromGraph(removed);
 
     for (let assetNode of assetNodes) {
-      let depNodes = assetNode.value.dependencies.map(dep => {
-        return nodeFromDep(dep);
-      });
+      let depNodes = assetNode.value
+        .getDependencies()
+        .map(dep => nodeFromDep(dep));
       let {removed, added} = this.replaceNodesConnectedTo(assetNode, depNodes);
       removedFiles = removedFiles.concat(getFilesFromGraph(removed));
       newDepNodes = newDepNodes.concat(getDepNodesFromGraph(added));

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -13,7 +13,6 @@ import {md5FromString} from '@parcel/utils/src/md5';
 
 type DependencyOpts = {|
   ...DependencyOptions,
-  moduleSpecifier: ModuleSpecifier,
   env: IEnvironment,
   id?: string,
   sourcePath?: FilePath

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -250,7 +250,7 @@ async function finalize(asset: Asset, generate: GenerateFunc): Promise<Asset> {
 
 async function checkCachedAssets(assets: Array<IAsset>): Promise<boolean> {
   let results = await Promise.all(
-    assets.map(asset => checkConnectedFiles(asset.connectedFiles))
+    assets.map(asset => checkConnectedFiles(asset.getConnectedFiles()))
   );
 
   return results.every(Boolean);

--- a/packages/core/core/test/Asset.test.js
+++ b/packages/core/core/test/Asset.test.js
@@ -20,4 +20,34 @@ describe('Asset', () => {
       }
     ]);
   });
+
+  it('only includes dependencies once per id', () => {
+    let asset = new Asset({
+      filePath: '/foo/asset.js',
+      env: new Environment(),
+      type: 'js'
+    });
+
+    asset.addDependency({moduleSpecifier: './foo'});
+    asset.addDependency({moduleSpecifier: './foo'});
+    let dependencies = asset.getDependencies();
+    assert(dependencies.length === 1);
+    assert(dependencies[0].moduleSpecifier === './foo');
+  });
+
+  it('includes different dependencies if their id differs', () => {
+    let asset = new Asset({
+      filePath: '/foo/asset.js',
+      env: new Environment(),
+      type: 'js'
+    });
+
+    asset.addDependency({moduleSpecifier: './foo'});
+    asset.addDependency({
+      moduleSpecifier: './foo',
+      env: {context: 'web-worker', engines: {}}
+    });
+    let dependencies = asset.getDependencies();
+    assert(dependencies.length === 2);
+  });
 });

--- a/packages/core/core/test/Asset.test.js
+++ b/packages/core/core/test/Asset.test.js
@@ -1,0 +1,23 @@
+// @flow strict-local
+
+import assert from 'assert';
+import Asset from '../src/Asset';
+import Environment from '../src/Environment';
+
+describe('Asset', () => {
+  it('only includes connected files once per filePath', () => {
+    let asset = new Asset({
+      filePath: '/foo/asset.js',
+      env: new Environment(),
+      type: 'js'
+    });
+    asset.addConnectedFile({filePath: '/foo/file', hash: 'abc'});
+    asset.addConnectedFile({filePath: '/foo/file', hash: 'bcd'});
+    assert.deepEqual(asset.getConnectedFiles(), [
+      {
+        filePath: '/foo/file',
+        hash: 'bcd'
+      }
+    ]);
+  });
+});

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -146,11 +146,14 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#1',
         dependencies: [
-          new Dependency({
-            moduleSpecifier: './utils',
-            env: DEFAULT_ENV,
-            sourcePath
-          })
+          [
+            'utils',
+            new Dependency({
+              moduleSpecifier: './utils',
+              env: DEFAULT_ENV,
+              sourcePath
+            })
+          ]
         ],
         env: DEFAULT_ENV,
         output: {code: ''},
@@ -162,11 +165,14 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#2',
         dependencies: [
-          new Dependency({
-            moduleSpecifier: './styles',
-            env: DEFAULT_ENV,
-            sourcePath
-          })
+          [
+            'styles',
+            new Dependency({
+              moduleSpecifier: './styles',
+              env: DEFAULT_ENV,
+              sourcePath
+            })
+          ]
         ],
         env: DEFAULT_ENV,
         output: {code: ''},
@@ -196,8 +202,8 @@ describe('AssetGraph', () => {
     assert(graph.nodes.has('1'));
     assert(graph.nodes.has('2'));
     assert(graph.nodes.has('3'));
-    assert(graph.nodes.has(assets[0].dependencies[0].id));
-    assert(graph.nodes.has(assets[1].dependencies[0].id));
+    assert(graph.nodes.has(assets[0].getDependencies()[0].id));
+    assert(graph.nodes.has(assets[1].getDependencies()[0].id));
     assert(graph.nodes.has('/index.js'));
     assert(
       graph.hasEdge({
@@ -226,13 +232,13 @@ describe('AssetGraph', () => {
     assert(
       graph.hasEdge({
         from: '1',
-        to: assets[0].dependencies[0].id
+        to: assets[0].getDependencies()[0].id
       })
     );
     assert(
       graph.hasEdge({
         from: '2',
-        to: assets[1].dependencies[0].id
+        to: assets[1].getDependencies()[0].id
       })
     );
     assert(!graph.incompleteNodes.has(nodeFromTransformerRequest(req).id));
@@ -262,11 +268,14 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#1',
         dependencies: [
-          new Dependency({
-            moduleSpecifier: './utils',
-            env: DEFAULT_ENV,
-            sourcePath
-          })
+          [
+            'utils',
+            new Dependency({
+              moduleSpecifier: './utils',
+              env: DEFAULT_ENV,
+              sourcePath
+            })
+          ]
         ],
         env: DEFAULT_ENV,
         output: {code: ''},
@@ -296,8 +305,8 @@ describe('AssetGraph', () => {
     assert(graph.nodes.has('1'));
     assert(graph.nodes.has('2'));
     assert(!graph.nodes.has('3'));
-    assert(graph.nodes.has(assets[0].dependencies[0].id));
-    assert(!graph.nodes.has(assets[1].dependencies[0].id));
+    assert(graph.nodes.has(assets[0].getDependencies()[0].id));
+    assert(!graph.nodes.has(assets[1].getDependencies()[0].id));
     assert(
       graph.hasEdge({
         from: nodeFromTransformerRequest(req).id,
@@ -325,13 +334,13 @@ describe('AssetGraph', () => {
     assert(
       graph.hasEdge({
         from: '1',
-        to: assets[0].dependencies[0].id
+        to: assets[0].getDependencies()[0].id
       })
     );
     assert(
       !graph.hasEdge({
         from: '2',
-        to: assets[1].dependencies[0].id
+        to: assets[1].getDependencies()[0].id
       })
     );
     assert(!graph.incompleteNodes.has(nodeFromTransformerRequest(req).id));
@@ -375,11 +384,14 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#1',
         dependencies: [
-          new Dependency({
-            moduleSpecifier: './utils',
-            env: DEFAULT_ENV,
-            sourcePath
-          })
+          [
+            'utils',
+            new Dependency({
+              moduleSpecifier: './utils',
+              env: DEFAULT_ENV,
+              sourcePath
+            })
+          ]
         ],
         env: DEFAULT_ENV,
         output: {code: ''},

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -383,11 +383,14 @@ describe('AssetGraph', () => {
         ],
         env: DEFAULT_ENV,
         output: {code: ''},
-        connectedFiles: [
-          {
-            filePath: '/foo/bar'
-          }
-        ]
+        connectedFiles: new Map([
+          [
+            '/foo/bar',
+            {
+              filePath: '/foo/bar'
+            }
+          ]
+        ])
       })
     ];
     let cacheEntry = {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -209,7 +209,7 @@ export interface Asset {
   type: string;
   code: string;
   ast: ?AST;
-  dependencies: Array<Dependency>;
+  dependencies: Map<string, Dependency>;
   connectedFiles: Map<FilePath, File>;
   output: AssetOutput;
   outputHash: string;
@@ -222,6 +222,7 @@ export interface Asset {
     options: ?{packageKey?: string, parse?: boolean}
   ): Promise<Config | null>;
   getConnectedFiles(): Array<File>;
+  getDependencies(): Array<Dependency>;
   getPackage(): Promise<PackageJSON | null>;
   addDependency(dep: DependencyOptions): string;
   createChildAsset(result: TransformerResult): Asset;
@@ -246,7 +247,7 @@ export type TransformerResult = {
   type: string,
   code?: string,
   ast?: ?AST,
-  dependencies?: Array<DependencyOptions>,
+  dependencies?: Map<string, DependencyOptions>,
   connectedFiles?: Map<FilePath, File>,
   output?: AssetOutput,
   env?: EnvironmentOpts,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -210,7 +210,7 @@ export interface Asset {
   code: string;
   ast: ?AST;
   dependencies: Array<Dependency>;
-  connectedFiles: Array<File>;
+  connectedFiles: Map<FilePath, File>;
   output: AssetOutput;
   outputHash: string;
   env: Environment;
@@ -221,6 +221,7 @@ export interface Asset {
     filePaths: Array<FilePath>,
     options: ?{packageKey?: string, parse?: boolean}
   ): Promise<Config | null>;
+  getConnectedFiles(): Array<File>;
   getPackage(): Promise<PackageJSON | null>;
   addDependency(dep: DependencyOptions): string;
   createChildAsset(result: TransformerResult): Asset;
@@ -246,7 +247,7 @@ export type TransformerResult = {
   code?: string,
   ast?: ?AST,
   dependencies?: Array<DependencyOptions>,
-  connectedFiles?: Array<File>,
+  connectedFiles?: Map<FilePath, File>,
   output?: AssetOutput,
   env?: EnvironmentOpts,
   meta?: Meta

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -79,7 +79,9 @@ export default new Transformer({
 
     if (!asset.env.isNode()) {
       // Inline fs calls
-      let fsDep = asset.dependencies.find(dep => dep.moduleSpecifier === 'fs');
+      let fsDep = asset
+        .getDependencies()
+        .find(dep => dep.moduleSpecifier === 'fs');
       if (fsDep && FS_RE.test(asset.code)) {
         // Check if we should ignore fs calls
         // See https://github.com/defunctzombie/node-browser-resolve#skip

--- a/packages/transformers/js/src/visitors/fs.js
+++ b/packages/transformers/js/src/visitors/fs.js
@@ -62,7 +62,7 @@ export default {
         replacementNode = t.stringLiteral(res);
       }
 
-      asset.connectedFiles.push({
+      asset.connectedFiles.set(filename, {
         filePath: filename
       });
 


### PR DESCRIPTION
This prevents them from containing multiple references to the same file/dependency. Currently in v2 assets contain many duplicate `connectedFiles`

This also exposes a public api for retrieving them as Arrays. I'm thinking this, along with `addConnectedFile`/`addDependency`, should be the only public api to these structures when we wrap `Asset`.

In each case, the stored value is overwritten in when the new value is added.

Test Plan: wrote unit tests for `Asset` (`yarn test`)