### PR TITLE
Reintroduce graphviz dumping as a development-only option

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -42,6 +42,8 @@
   "devDependencies": {
     "@parcel/babel-register": "2.0.0",
     "@parcel/config-default": "^2.0.0",
-    "sinon": "^5.0.1"
+    "graphviz": "^0.0.9",
+    "sinon": "^5.0.1",
+    "tempy": "^0.2.1"
   }
 }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -17,6 +17,7 @@ import AssetGraphBuilder, {BuildAbortError} from './AssetGraphBuilder';
 import ConfigResolver from './ConfigResolver';
 import ReporterRunner from './ReporterRunner';
 import MainAssetGraph from './public/MainAssetGraph';
+import dumpGraphToGraphViz from './dumpGraphToGraphViz';
 
 export default class Parcel {
   options: ParcelOptions;
@@ -119,8 +120,11 @@ export default class Parcel {
 
       let startTime = Date.now();
       let assetGraph = await this.assetGraphBuilder.build();
+      dumpGraphToGraphViz(assetGraph, 'MainAssetGraph');
 
       let bundleGraph = await this.bundle(assetGraph);
+      dumpGraphToGraphViz(bundleGraph, 'BundleGraph');
+
       await this.package(bundleGraph);
 
       this.reporterRunner.report({

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -1,0 +1,116 @@
+// @flow
+
+import type {Environment} from '@parcel/types';
+
+import type Graph from './Graph';
+import type {AssetGraphNode, BundleGraphNode} from './types';
+
+import invariant from 'assert';
+import nullthrows from 'nullthrows';
+import path from 'path';
+import BundleGraph from './BundleGraph';
+
+const COLORS = {
+  root: 'gray',
+  asset: 'green',
+  dependency: 'orange',
+  transformer_request: 'cyan',
+  file: 'gray',
+  default: 'white'
+};
+
+export default async function dumpGraphToGraphViz(
+  // $FlowFixMe
+  graph: Graph<AssetGraphNode> | Graph<BundleGraphNode>,
+  name: string
+): Promise<void> {
+  if (
+    process.env.PARCEL_BUILD_ENV === 'production' ||
+    process.env.PARCEL_DUMP_GRAPHVIZ == null
+  ) {
+    return;
+  }
+
+  const graphviz = require('graphviz');
+  const tempy = require('tempy');
+
+  let g = graphviz.digraph('G');
+
+  let nodes = Array.from(graph.nodes.values());
+  for (let node of nodes) {
+    let n = g.addNode(node.id);
+
+    // $FlowFixMe default is fine. Not every type needs to be in the map.
+    n.set('color', COLORS[node.type || 'default']);
+    n.set('shape', 'box');
+    n.set('style', 'filled');
+
+    let label = `${node.type || 'No Type'}: `;
+
+    if (node.type === 'dependency') {
+      label += node.value.moduleSpecifier;
+      let parts = [];
+      if (node.value.isEntry) parts.push('entry');
+      if (node.value.isAsync) parts.push('async');
+      if (node.value.isOptional) parts.push('optional');
+      if (parts.length) label += ' (' + parts.join(', ') + ')';
+      if (node.value.env) label += ` (${getEnvDescription(node.value.env)})`;
+    } else if (node.type === 'asset' || node.type === 'asset_reference') {
+      label += path.basename(node.value.filePath) + '#' + node.value.type;
+    } else if (node.type === 'file') {
+      label += path.basename(node.value.filePath);
+    } else if (node.type === 'transformer_request') {
+      label +=
+        path.basename(node.value.filePath) +
+        ` (${getEnvDescription(node.value.env)})`;
+    } else if (node.type === 'bundle') {
+      let rootAssets = node.value.assetGraph.getNodesConnectedFrom(
+        nullthrows(node.value.assetGraph.getRootNode())
+      );
+      label += rootAssets
+        .map(asset => {
+          invariant(asset.type === 'asset');
+          let parts = asset.value.filePath.split(path.sep);
+          let index = parts.lastIndexOf('node_modules');
+          if (index >= 0) {
+            return parts[index + 1];
+          }
+
+          return path.basename(asset.value.filePath);
+        })
+        .join(', ');
+    } else {
+      // label += node.id;
+      label = node.type;
+    }
+
+    n.set('label', label);
+  }
+
+  for (let edge of graph.edges) {
+    g.addEdge(edge.from, edge.to);
+  }
+
+  let tmp = tempy.file({name: `${name}.png`});
+
+  await g.output('png', tmp);
+  // eslint-disable-next-line no-console
+  console.log('Dumped', tmp);
+
+  if (graph instanceof BundleGraph) {
+    graph.traverseBundles(bundle => {
+      dumpGraphToGraphViz(bundle.assetGraph, bundle.id);
+    });
+  }
+}
+
+function getEnvDescription(env: Environment) {
+  let description = '';
+  if (env.engines.browsers) {
+    description = `${env.context}: ${env.engines.browsers.join(', ')}`;
+  } else if (env.engines.node) {
+    description = `node: ${env.engines.node}`;
+  }
+
+  return description;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,6 +4016,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -5922,6 +5927,13 @@ graphql@^0.11.7:
   integrity sha512-x7uDjyz8Jx+QPbpCFCMQ8lltnQa4p4vSYHx6ADe8rVYRTdsyhCJbvSty5DAsLVmU6cGakl+r8HQYolKHxk/tiw==
   dependencies:
     iterall "1.1.3"
+
+graphviz@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/graphviz/-/graphviz-0.0.9.tgz#0bbf1df588c6a92259282da35323622528c4bbc4"
+  integrity sha512-SmoY2pOtcikmMCqCSy2NO1YsRfu9OO0wpTlOYW++giGjfX1a6gax/m1Fo8IdUd0/3H15cTOfR1SMKwohj4LKsg==
+  dependencies:
+    temp "~0.4.0"
 
 growl@1.10.5:
   version "1.10.5"
@@ -11556,6 +11568,19 @@ temp@^0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
+temp@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.4.0.tgz#671ad63d57be0fe9d7294664b3fc400636678a60"
+  integrity sha1-ZxrWPVe+D+nXKUZks/xABjZnimA=
+
+tempy@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.2.1.tgz#9038e4dbd1c201b74472214179bc2c6f7776e54c"
+  integrity sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==
+  dependencies:
+    temp-dir "^1.0.0"
+    unique-string "^1.0.0"
+
 terser@^3.7.3, terser@^3.8.1:
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/terser/-/terser-3.10.3.tgz#4085f9e62171ca746c5759fe955d921291703ee6"
@@ -11862,6 +11887,13 @@ unique-slug@^2.0.0:
   integrity sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==
   dependencies:
     imurmurhash "^0.1.4"
+
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
~~This implements graphviz dumping as a reporter. Right now, it's included in the default config, which feels wrong. It only reports when the `PARCEL_DUMP_GRAPH` environment variable is present.~~

~~It also needs access to the internals of each graph to provide useful debugging information, so undocumented `_dumpToGraphViz` methods are exposed on each graph, and are invoked in the reporter. This does not leak any information or control to plugins as it only has a side effect of writing the image to disk and returning a path to it.~~

This is now a development-only option. `graphviz` is now a `devDependency`. We now also early return in a way that should be able to be optimized out in production builds of parcel.