### PR TITLE
Remove parcel's eslint config as a devDependency

### DIFF
--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -13,8 +13,5 @@
   "dependencies": {
     "@parcel/plugin": "^2.0.0",
     "@parcel/utils": "^1.10.3"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "^1.10.3"
   }
 }

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -15,8 +15,5 @@
     "@parcel/fs": "^1.10.3",
     "@parcel/logger": "^2.0.0",
     "@parcel/utils": "^1.10.3"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "@parcel/babel-register": "2.0.0",
     "@parcel/config-default": "^2.0.0",
-    "@parcel/eslint-config": "1.10.3",
     "sinon": "^5.0.1"
   }
 }

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -24,7 +24,6 @@
     "strip-ansi": "^4.0.0"
   },
   "devDependencies": {
-    "@parcel/eslint-config": "1.10.3",
     "mocha": "^5.2.0",
     "sinon": "^5.0.1"
   }

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -13,8 +13,5 @@
   "main": "./src/PluginAPI.js",
   "dependencies": {
     "@parcel/types": "^2.0.0"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -6,8 +6,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -19,7 +19,6 @@
     "prepublish": "yarn build"
   },
   "devDependencies": {
-    "@parcel/eslint-config": "1.10.3",
     "mocha": "^5.2.0"
   },
   "dependencies": {

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -12,8 +12,5 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "^1.10.3"
   }
 }

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -12,8 +12,5 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -22,7 +22,6 @@
     "node-libs-browser": "^2.1.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2",
-    "@parcel/eslint-config": "1.10.3"
+    "@babel/core": "^7.2.2"
   }
 }

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -12,8 +12,5 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -28,8 +28,5 @@
     "browserslist": "^4.1.0",
     "micromatch": "^3.0.4",
     "semver": "^5.4.1"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -15,8 +15,5 @@
     "postcss": "^7.0.5",
     "postcss-value-parser": "^3.3.1",
     "semver": "^5.4.1"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -28,8 +28,5 @@
     "babylon-walk": "^1.0.2",
     "node-libs-browser": "^2.0.0",
     "semver": "^5.4.1"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }

--- a/packages/transformers/terser/package.json
+++ b/packages/transformers/terser/package.json
@@ -18,8 +18,5 @@
     "@parcel/plugin": "^2.0.0",
     "nullthrows": "^1.1.1",
     "terser": "^3.7.3"
-  },
-  "devDependencies": {
-    "@parcel/eslint-config": "1.10.3"
   }
 }


### PR DESCRIPTION
Since we run linting from the root of the monorepo, this isn't needed. Even packages with their own configs which extend `@parcel/eslint-config` can find it through the root-level symlinks from yarn workspaces.

Test Plan: `yarn lint`