### PR TITLE
Implement Basic CSS Packager

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -1,5 +1,5 @@
 // @flow
-import type {BundleGroup, Bundle, MutableBundle} from '@parcel/types';
+import type {BundleGroup, MutableBundle} from '@parcel/types';
 import {Bundler} from '@parcel/plugin';
 
 const OPTIONS = {
@@ -10,7 +10,7 @@ const OPTIONS = {
 
 type BundleContext = {|
   bundleGroup: BundleGroup,
-  bundle?: Bundle
+  bundle?: MutableBundle
 |};
 
 export default new Bundler({
@@ -61,13 +61,22 @@ export default new Bundler({
 
             // Mark bundle as an entry, and set explicit file path from target if the dependency has one
             bundle.isEntry = !!dep.isEntry;
-            if (dep.target && dep.target.distPath) {
-              bundle.filePath = dep.target.distPath;
+            let target = dep.target;
+            if (
+              target &&
+              target.distPath &&
+              target.distPathType === bundle.type
+            ) {
+              bundle.filePath = target.distPath;
             }
 
             // If there is a current bundle, but this asset is of a different type,
             // separate it out into a parallel bundle in the same bundle group.
             if (context.bundle) {
+              // Remove this asset from the current bundle since it's of a different type.
+              // `removeAsset` leaves behind an asset reference in its place.
+              context.bundle.removeAsset(node.value);
+
               let bundles = bundleGraph.getBundlesInBundleGroup(
                 context.bundleGroup
               );

--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -14,6 +14,7 @@
     "node": ["@parcel/runtime-js"]
   },
   "packagers": {
+    "*.css": "@parcel/packager-css",
     "*.js": "@parcel/packager-js"
   },
   "resolvers": ["@parcel/resolver-default"],

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -13,6 +13,7 @@
     "@parcel/bundler-default": "^2.0.0",
     "@parcel/namer-default": "^2.0.0",
     "@parcel/packager-js": "^2.0.0",
+    "@parcel/packager-css": "^2.0.0",
     "@parcel/reporter-cli": "^2.0.0",
     "@parcel/resolver-default": "^2.0.0",
     "@parcel/runtime-js": "^2.0.0",

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -55,7 +55,7 @@ export default class BundlerRunner {
     let namers = await this.config.getNamers();
     let promises = [];
     bundleGraph.traverseBundles(bundle => {
-      promises.push(this.nameBundle(namers, bundle));
+      promises.push(this.nameBundle(namers, bundle, bundleGraph));
     });
 
     await Promise.all(promises);
@@ -63,11 +63,15 @@ export default class BundlerRunner {
 
   async nameBundle(
     namers: Array<Namer>,
-    internalBundle: InternalBundle
+    internalBundle: InternalBundle,
+    internalBundleGraph: InternalBundleGraph
   ): Promise<void> {
     let bundle = new Bundle(internalBundle);
+    let bundleGraph = new BundleGraph(internalBundleGraph);
+
     for (let namer of namers) {
-      let filePath = await namer.name(bundle, {
+      let filePath = await namer.name(bundle, bundleGraph, {
+        ...this.options,
         rootDir: this.rootDir
       });
 

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -43,6 +43,7 @@ export default class TargetResolver {
       targets.push({
         name: 'main',
         distPath: pkg.main,
+        distPathType: 'js',
         env: this.getEnvironment(pkgEngines, mainContext).merge(pkgTargets.main)
       });
     }
@@ -51,6 +52,7 @@ export default class TargetResolver {
       targets.push({
         name: 'module',
         distPath: pkg.module,
+        distPathType: 'js',
         env: this.getEnvironment(pkgEngines, mainContext).merge(
           pkgTargets.module
         )
@@ -67,6 +69,7 @@ export default class TargetResolver {
       targets.push({
         name: 'browser',
         distPath: typeof browser === 'string' ? browser : undefined,
+        distPathType: 'js',
         env: this.getEnvironment(pkgEngines, 'browser').merge(
           pkgTargets.browser
         )

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -5,6 +5,7 @@ import type {Bundle as InternalBundle} from '../types';
 import type {
   Asset,
   Bundle as IBundle,
+  BundleTraversable,
   Dependency,
   Environment,
   FilePath,
@@ -71,6 +72,18 @@ export class Bundle implements IBundle {
 
   getTotalSize(asset?: Asset): number {
     return this.#bundle.assetGraph.getTotalSize(asset);
+  }
+
+  traverse<TContext>(
+    visit: GraphTraversalCallback<BundleTraversable, TContext>
+  ): ?TContext {
+    return this.#bundle.assetGraph.traverse((node, ...args) => {
+      if (node.type === 'asset') {
+        return visit({type: 'asset', value: node.value}, ...args);
+      } else if (node.type === 'asset_reference') {
+        return visit({type: 'asset_reference', value: node.value}, ...args);
+      }
+    });
   }
 
   traverseAssets<TContext>(

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -219,15 +219,10 @@ function getBundles(
     return [];
   }
 
-  return graph
-    .getNodesConnectedFrom(node)
-    .map(node => {
-      invariant(node.type === 'bundle');
-      return node.value;
-    })
-    .sort(
-      bundle => (bundle.assetGraph.hasNode(bundleGroup.entryAssetId) ? 1 : -1)
-    );
+  return graph.getNodesConnectedFrom(node).map(node => {
+    invariant(node.type === 'bundle');
+    return node.value;
+  });
 }
 
 function findBundlesWithAsset(

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -30,8 +30,7 @@ describe('css in v2', () => {
     assert.equal(output(), 3);
   });
 
-  // Currently failing as Windows produces different hashes
-  it.skip('should support loading a CSS bundle along side dynamic imports', async () => {
+  it('should support loading a CSS bundle along side dynamic imports', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/dynamic-css/index.js')
     );
@@ -48,8 +47,8 @@ describe('css in v2', () => {
           'JSRuntime.js'
         ]
       },
-      {name: 'local.0feb842b.js', assets: ['local.js']},
-      {name: 'local.6f071801.css', assets: ['local.css']},
+      {name: /local\.[0-9a-f]{8}\.js/, assets: ['local.js']},
+      {name: /local\.[0-9a-f]{8}\.css/, assets: ['local.css']},
       {name: 'index.css', assets: ['index.css']}
     ]);
 

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -20,7 +20,7 @@ describe('css in v2', () => {
         assets: ['index.js', 'local.js']
       },
       {
-        name: 'local.css',
+        name: 'index.css',
         assets: ['index.css', 'local.css']
       }
     ]);

--- a/packages/core/integration-tests/test/utils.js
+++ b/packages/core/integration-tests/test/utils.js
@@ -256,7 +256,16 @@ async function assertBundles(bundleGraph, bundles) {
   for (let bundle of bundles) {
     let actualBundle = actualBundles[i++];
     if (bundle.name) {
-      assert.equal(actualBundle.name, bundle.name);
+      if (typeof bundle.name === 'string') {
+        assert.equal(actualBundle.name, bundle.name);
+      } else if (bundle.name instanceof RegExp) {
+        assert(
+          actualBundle.name.match(bundle.name),
+          `${actualBundle.name} does not match regexp ${bundle.name.toString()}`
+        );
+      } else {
+        assert.fail();
+      }
     }
 
     if (bundle.type) {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -386,8 +386,17 @@ export type Bundler = {|
   ): Async<void>
 |};
 
+export type NamerOptions = {|
+  ...ParcelOptions,
+  rootDir: FilePath
+|};
+
 export type Namer = {|
-  name(bundle: Bundle, opts: ParcelOptions): Async<?FilePath>
+  name(
+    bundle: Bundle,
+    bundleGraph: BundleGraph,
+    opts: NamerOptions
+  ): Async<?FilePath>
 |};
 
 export type RuntimeAsset = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -60,6 +60,7 @@ export type Engines = {
 export type Target = {|
   name: string,
   distPath?: FilePath,
+  distPathType?: string,
   env: Environment
 |};
 
@@ -303,6 +304,10 @@ interface AssetGraphLike {
   ): ?TContext;
 }
 
+export type BundleTraversable =
+  | {|+type: 'asset', value: Asset|}
+  | {|+type: 'asset_reference', value: Asset|};
+
 export type MainAssetGraphTraversable =
   | {|+type: 'asset', value: Asset|}
   | {|+type: 'dependency', value: Dependency|};
@@ -326,6 +331,9 @@ export interface Bundle extends AssetGraphLike {
   getDependencies(asset: Asset): Array<Dependency>;
   getEntryAssets(): Array<Asset>;
   getTotalSize(asset?: Asset): number;
+  traverse<TContext>(
+    visit: GraphTraversalCallback<BundleTraversable, TContext>
+  ): ?TContext;
 }
 
 export interface MutableBundle extends Bundle {

--- a/packages/examples/simple/legacy.html
+++ b/packages/examples/simple/legacy.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Legacy Simple Example</title>
+    <link rel="stylesheet" href="dist/legacy/styles.css" />
+    <script src="dist/legacy/index.js"></script>
+  </head>
+  <body>
+    <h1>I am an H1</h1>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Minima saepe eos
+      nihil recusandae, tempora id! Nostrum quia aliquid culpa nemo
+      consequuntur, eos dolore? Sit earum voluptatem ab aliquid iure
+      exercitationem?
+    </p>
+    <h2>I am an H2</h2>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis repudiandae
+      placeat ullam ab, explicabo non similique, voluptate culpa, illo facilis
+      ea? Quia perspiciatis esse earum eaque explicabo reiciendis ratione quasi.
+    </p>
+  </body>
+</html>

--- a/packages/examples/simple/modern.html
+++ b/packages/examples/simple/modern.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Modern Simple Example</title>
+    <link rel="stylesheet" href="dist/legacy/styles.css" />
+    <script src="dist/modern/index.js"></script>
+  </head>
+  <body>
+    <h1>I am an H1</h1>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Minima saepe eos
+      nihil recusandae, tempora id! Nostrum quia aliquid culpa nemo
+      consequuntur, eos dolore? Sit earum voluptatem ab aliquid iure
+      exercitationem?
+    </p>
+    <h2>I am an H2</h2>
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis repudiandae
+      placeat ullam ab, explicabo non similique, voluptate culpa, illo facilis
+      ea? Quia perspiciatis esse earum eaque explicabo reiciendis ratione quasi.
+    </p>
+  </body>
+</html>

--- a/packages/examples/simple/src/async.js
+++ b/packages/examples/simple/src/async.js
@@ -1,3 +1,5 @@
+require('./paragraphs.css');
+
 console.log(require('react'));
 require('lodash');
 

--- a/packages/examples/simple/src/paragraphs.css
+++ b/packages/examples/simple/src/paragraphs.css
@@ -1,0 +1,3 @@
+p {
+  color: red;
+}

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -1,4 +1,7 @@
-// @flow
+// @flow strict-local
+
+import type {Bundle, BundleGraph, FilePath, NamerOptions} from '@parcel/types';
+
 import {Namer} from '@parcel/plugin';
 import crypto from 'crypto';
 import path from 'path';
@@ -7,9 +10,9 @@ const COMMON_NAMES = new Set(['index', 'src', 'lib']);
 const DEFAULT_DIST_DIR = 'dist';
 
 export default new Namer({
-  name(bundle, opts) {
+  name(bundle, bundleGraph, opts) {
     // If the bundle has an explicit file path given (e.g. by a target), use that.
-    if (bundle.filePath) {
+    if (bundle.filePath != null) {
       // TODO: what about multiple assets in the same dep?
       // e.g. input is a Vue file, output is JS + CSS
       // which is defined as a target in package.json?
@@ -25,11 +28,7 @@ export default new Namer({
     if (bundle.isEntry) {
       name = path
         .join(
-          path.relative(
-            // $FlowFixMe
-            opts.rootDir,
-            path.dirname(entryFilePath)
-          ),
+          path.relative(opts.rootDir, path.dirname(entryFilePath)),
           `${name}.${bundle.type}`
         )
         .replace(/\.\.(\/|\\)/g, '__$1');
@@ -47,7 +46,7 @@ export default new Namer({
     }
 
     let distDir =
-      bundle.target && bundle.target.distPath
+      bundle.target && bundle.target.distPath != null
         ? path.dirname(bundle.target.distPath)
         : DEFAULT_DIST_DIR;
     return path.join(distDir, name);

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@parcel/packager-css",
+  "version": "2.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "src/CSSPackager",
+  "engines": {
+    "parcel": "2.x"
+  },
+  "dependencies": {
+    "@parcel/plugin": "^2.0.0"
+  }
+}

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -1,0 +1,15 @@
+// @flow strict-local
+
+import {Packager} from '@parcel/plugin';
+
+export default new Packager({
+  async package(bundle) {
+    let promises = [];
+    bundle.traverseAssets(asset => {
+      promises.push(asset.getOutput());
+    });
+    let outputs = await Promise.all(promises);
+
+    return outputs.map(output => output.code).join('\n');
+  }
+});

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -46,7 +46,16 @@ export default new Runtime({
         continue;
       }
 
-      let bundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
+      // Sort so the bundles containing the entry asset appear last
+      let bundles = bundleGraph.getBundlesInBundleGroup(bundleGroup).sort(
+        bundle =>
+          bundle
+            .getEntryAssets()
+            .map(asset => asset.id)
+            .includes(bundleGroup.entryAssetId)
+            ? 1
+            : -1
+      );
       let loaderModules = bundles.map(b => {
         let loader = loaders[b.type];
         if (!loader) {


### PR DESCRIPTION
This implements a basic css packager for Parcel 2:
* The css packager currently just concatenates the bundle's css together . No support for source maps yet.
* The default bundler now removes non-matching assets when assembling bundles (e.g. it does not include css text in a js bundle). It leaves behind asset references in their place.
* `AssetGraph` now exposes `traverseAssetsWithReferences` which iterates both "real" assets as well as references.
* In the case of asset references, the JS Packager no longer includes content, and instead leaves behind an empty no-op function.

A no-op will not always be the desired behavior for importing non-matching assets: for example CSS Modules export a mapping, and raw assets export a path. @padmaia and I believe that it might be best in those cases for transformers to return an additional JS Asset containing code with that behavior. Let me know if this is in line with what you might have had in mind, @devongovett.

Test Plan: Run the simple example with the new html docs. Verify headings and paragraphs are colored.