### PR TITLE
Upgrade flow to 0.97

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -25,3 +25,6 @@ unclear-type
 unsafe-getters-setters
 untyped-import
 untyped-type-import
+
+[version]
+0.97.0

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "flow-bin": "^0.93.0",
+    "flow-bin": "0.97.0",
     "lerna": "^3.3.2",
     "lint-staged": "^7.2.2",
     "prettier": "^1.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5500,10 +5500,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.93.0:
-  version "0.93.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.93.0.tgz#9192a08d88db2a8da0ff55e42420f44539791430"
-  integrity sha512-p8yq4ocOlpyJgOEBEj0v0GzCP25c9WP0ilFQ8hXSbrTR7RPKuR+Whr+OitlVyp8ocdX0j1MrIwQ8x28dacy1pg==
+flow-bin@^0.97.0:
+  version "0.97.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
+  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
I'm a little concerned about facebook/flow#7545, so we'll keep an eye on things and revert if necessary, but so far based on the test plan things seem fine.

Test Plan: 
  * `yarn flow`. 
  * Change the `version` field in `.flowconfig` and verify `yarn flow` does not start without matching versions
  * Exercise `flow-for-vscode`'s autocomplete, go-to-definition, diagnostics, etc.