### PR TITLE
Fix invalid type redeclaration

### DIFF
--- a/packages/core/parcel-bundler/test/integration/babel-ast-conversion/index.js
+++ b/packages/core/parcel-bundler/test/integration/babel-ast-conversion/index.js
@@ -26,4 +26,4 @@ var a: { [a: number]: string; };
 
 class C<+T,-U> {}
 function f<+T,-U>() {}
-type T<+T,-U> = {}
+type V<+T,-U> = {}


### PR DESCRIPTION
This fixes a redeclaration of a type whose name was already bound. Babel probably corrected this behavior in a recent release.

Test Plan: `yarn test`