### PR TITLE
v1: CI: Fail if yarn.lock needs updates

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -36,7 +36,9 @@ jobs:
         cargo -V
       displayName: Install Rust
 
-  - script: yarn
+  # use `--frozen-lockfile` to fail immediately if the committed yarn.lock needs updates
+  # https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile
+  - script: yarn --frozen-lockfile
     displayName: 'Install dependencies'
   - script: yarn test-ci
     displayName: 'Run tests'


### PR DESCRIPTION
This backports #2943 to the master branch.

This adds `--frozen-lockfile` to the yarn install to make it fail if the yarn.lock committed differs from what would be written after invoking yarn. This should prevent issues like those in #2942 and the one currently present in the `v2` branch

Test Plan: Let CI run with the first commit and let it fail. Add a commit fixing `yarn.lock` and let it pass.