### PR TITLE
use fs.realpath to resolve module locations

### DIFF
--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -171,6 +171,13 @@ class Resolver {
       return {filePath: builtins[filename]};
     }
 
+    // use the "real path" of the directory to match default node resolution algorithm
+    try {
+      dir = await fs.realpath(dir);
+    } catch (err) {
+      // ignore
+    }
+
     let parts = this.getModuleParts(filename);
     let root = path.parse(dir).root;
 


### PR DESCRIPTION
# ↪️ Pull Request

This updates the way *node modules* are resolved by the Parcel resolver such that the "real path" is used. This way it matches the node resolution algorithm and makes Parcel compatible with other tools in the node ecosystem that rely on this behavior (like pnpm).

See issue #1125 which this PR would address.

## 💻 Examples

A pnpm workspace has this issue with transitive dependencies. For example, if a module in the workspace uses React, then Parcel will not find React's transitive dependencies (usually failing to find `object-assign`).

pnpm sets up a folder structure like this:
```
monorepo
├── web-ui <-- parcel run in this module
│   ├── package.json
│   ├── node_modules
│           ├── react <-- symlinked to the .registry.npmjs.org/react
├── node_modules
│       ├── .registry.npmjs.org
│               ├── react
│               ├── object-assign
```

Because Parcel ignores the real path, it tries to find `object-assign` like this:

- `/monorepo/web-ui/node_modules/react/node_modules`
- `/monorepo/web-ui/node_modules/`
- `/monorepo/node_modules` <-- not found here because it's in subfolder .registry.npmjs.org
- etc...

## 🚨 Test instructions

TODO: I may be able to contribute some tests, looking for guidance here

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
