### PR TITLE
Public API: Convert bundles to internal equivalents across workers

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -54,7 +54,7 @@ export default class PackagerRunner {
       bundle
     });
 
-    let packager = await this.config.getPackager(nullthrows(bundle.filePath));
+    let packager = await this.config.getPackager(bundle.filePath);
     return packager.package(bundle, this.options);
   }
 
@@ -63,9 +63,7 @@ export default class PackagerRunner {
     contents: Blob
   ): Promise<Blob> {
     let bundle = new NamedBundle(internalBundle);
-    let optimizers = await this.config.getOptimizers(
-      nullthrows(bundle.filePath)
-    );
+    let optimizers = await this.config.getOptimizers(bundle.filePath);
     if (!optimizers.length) {
       return contents;
     }

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -1,8 +1,12 @@
-// @flow
-import Config from './Config';
+// @flow strict-local
+
 import type {ParcelOptions, ReporterEvent} from '@parcel/types';
-import logger from '@parcel/logger';
+
+import {bundleToInternal, NamedBundle} from './public/Bundle';
 import bus from '@parcel/workers/src/bus';
+import Config from './Config';
+import logger from '@parcel/logger';
+import nullthrows from 'nullthrows';
 
 type Opts = {|
   config: Config,
@@ -18,7 +22,19 @@ export default class ReporterRunner {
     this.options = opts.options;
 
     logger.onLog(event => this.report(event));
-    bus.on('reporterEvent', event => this.report(event));
+
+    // Convert any internal bundles back to their public equivalents as reporting
+    // is public api
+    bus.on('reporterEvent', event => {
+      if (event.bundle == null) {
+        this.report(event);
+      } else {
+        this.report({
+          ...event,
+          bundle: new NamedBundle(event.bundle)
+        });
+      }
+    });
   }
 
   async report(event: ReporterEvent) {
@@ -31,5 +47,14 @@ export default class ReporterRunner {
 }
 
 export function report(event: ReporterEvent) {
-  bus.emit('reporterEvent', event);
+  if (event.bundle == null) {
+    bus.emit('reporterEvent', event);
+  } else {
+    // Convert any public api bundles to their internal equivalents for
+    // easy serialization
+    bus.emit('reporterEvent', {
+      ...event,
+      bundle: nullthrows(bundleToInternal.get(event.bundle))
+    });
+  }
 }


### PR DESCRIPTION
In packaging and optimizing, we must report public bundles from within the workers, but they are not serializable. Use the worker's local weakmap to internal bundles and send those across IPC. In the main process, map those back to public bundles before giving them to plugins.

Test Plan: `yarn demo` in the simple example. This was broken before this change.