### PR TITLE
Public API: Split BundleGraph into mutable and immutable variants

### DIFF
--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -6,7 +6,7 @@ import type {Bundle as InternalBundle} from './types';
 import type Config from './Config';
 
 import nullthrows from 'nullthrows';
-import BundleGraph from './public/BundleGraph';
+import {MutableBundleGraph} from './public/BundleGraph';
 import InternalBundleGraph from './BundleGraph';
 import MainAssetGraph from './public/MainAssetGraph';
 import {Bundle, NamedBundle} from './public/Bundle';
@@ -42,7 +42,7 @@ export default class BundlerRunner {
     let bundleGraph = new InternalBundleGraph();
     await bundler.bundle(
       new MainAssetGraph(graph),
-      new BundleGraph(bundleGraph),
+      new MutableBundleGraph(bundleGraph),
       this.options
     );
     await this.nameBundles(bundleGraph);

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -5,7 +5,7 @@ import type {Bundle} from './types';
 import type InternalBundleGraph from './BundleGraph';
 
 import AssetGraph from './AssetGraph';
-import BundleGraph from './public/BundleGraph';
+import {BundleGraph} from './public/BundleGraph';
 import BundlerRunner from './BundlerRunner';
 import WorkerFarm from '@parcel/workers';
 import TargetResolver from './TargetResolver';

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -1,31 +1,109 @@
 // @flow strict-local
 
-import type {BundleNode} from '../types';
+import type {Bundle as InternalBundle, BundleNode} from '../types';
 
 import type {
   Asset,
-  Bundle,
+  Bundle as IBundle,
   BundleGraph as IBundleGraph,
   BundleGroup,
   GraphTraversalCallback,
-  MutableBundle as IMutableBundle
+  MutableBundle as IMutableBundle,
+  MutableBundleGraph as IMutableBundleGraph
 } from '@parcel/types';
 
 import type InternalBundleGraph from '../BundleGraph';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
-import {MutableBundle, bundleToInternal} from './Bundle';
+import {Bundle, MutableBundle, bundleToInternal} from './Bundle';
 import {getBundleGroupId} from './utils';
 
-export default class BundleGraph implements IBundleGraph {
+class BaseBundleGraph {
   #graph; // InternalBundleGraph
 
   constructor(graph: InternalBundleGraph) {
     this.#graph = graph;
   }
 
-  addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup) {
+  getBundleGroups(bundle: IBundle): Array<BundleGroup> {
+    let node = this.#graph.getNode(bundle.id);
+    if (!node) {
+      return [];
+    }
+
+    return this.#graph.getNodesConnectedTo(node).map(node => {
+      invariant(node.type === 'bundle_group');
+      return node.value;
+    });
+  }
+
+  isAssetInAncestorBundle(bundle: IBundle, asset: Asset): boolean {
+    let internalNode = this.#graph.getNode(bundle.id);
+    invariant(internalNode != null && internalNode.type === 'bundle');
+    return this.#graph.isAssetInAncestorBundle(internalNode.value, asset);
+  }
+}
+
+export class BundleGraph extends BaseBundleGraph implements IBundleGraph {
+  #graph; // InternalBundleGraph
+
+  constructor(graph: InternalBundleGraph) {
+    super(graph);
+    this.#graph = graph; // Repeating for flow
+  }
+
+  getBundles(bundleGroup: BundleGroup): Array<IBundle> {
+    return getBundles(this.#graph, bundleGroup).map(
+      bundle => new Bundle(bundle)
+    );
+  }
+
+  findBundlesWithAsset(asset: Asset): Array<IBundle> {
+    return findBundlesWithAsset(this.#graph, asset).map(
+      bundle => new Bundle(bundle)
+    );
+  }
+
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<IBundle, TContext>
+  ): ?TContext {
+    this.#graph.traverseBundles((bundle, ...args) => {
+      visit(new Bundle(bundle), ...args);
+    });
+  }
+}
+
+export class MutableBundleGraph extends BaseBundleGraph
+  implements IMutableBundleGraph {
+  #graph; // InternalBundleGraph
+
+  constructor(graph: InternalBundleGraph) {
+    super(graph);
+    this.#graph = graph; // Repeating for flow
+  }
+
+  getBundles(bundleGroup: BundleGroup): Array<IMutableBundle> {
+    return getBundles(this.#graph, bundleGroup).map(
+      bundle => new MutableBundle(bundle)
+    );
+  }
+
+  findBundlesWithAsset(asset: Asset): Array<IMutableBundle> {
+    return findBundlesWithAsset(this.#graph, asset).map(
+      bundle => new MutableBundle(bundle)
+    );
+  }
+
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<IMutableBundle, TContext>
+  ): ?TContext {
+    this.#graph.traverseBundles((bundle, ...args) => {
+      visit(new MutableBundle(bundle), ...args);
+    });
+  }
+
+  addBundleGroup(parentBundle: ?IBundle, bundleGroup: BundleGroup) {
     let node = {
       id: getBundleGroupId(bundleGroup),
       type: 'bundle_group',
@@ -51,7 +129,7 @@ export default class BundleGraph implements IBundleGraph {
     });
   }
 
-  addBundle(bundleGroup: BundleGroup, bundle: Bundle) {
+  addBundle(bundleGroup: BundleGroup, bundle: IBundle) {
     let internalBundle = nullthrows(bundleToInternal.get(bundle));
 
     // Propagate target from bundle group to bundle
@@ -67,10 +145,7 @@ export default class BundleGraph implements IBundleGraph {
     };
 
     this.#graph.addNode(bundleNode);
-    this.#graph.addEdge({
-      from: bundleGroupId,
-      to: bundleNode.id
-    });
+    this.#graph.addEdge({from: bundleGroupId, to: bundleNode.id});
 
     this.#graph.traverse(node => {
       // Replace dependencies in this bundle with bundle group references for
@@ -84,7 +159,10 @@ export default class BundleGraph implements IBundleGraph {
           // $FlowFixMe Merging a graph of a subtype into a graph of the supertype
           assetGraph.merge(this.#graph.getSubGraph(node));
           assetGraph.replaceNodesConnectedTo(depNode, [node]);
-          this.#graph.addEdge({from: internalBundle.id, to: node.id});
+          this.#graph.addEdge({
+            from: internalBundle.id,
+            to: node.id
+          });
         }
       }
 
@@ -101,60 +179,34 @@ export default class BundleGraph implements IBundleGraph {
       }
     });
   }
+}
 
-  getBundles(bundleGroup: BundleGroup): Array<IMutableBundle> {
-    let bundleGroupId = getBundleGroupId(bundleGroup);
-    let node = this.#graph.getNode(bundleGroupId);
-    if (!node) {
-      return [];
-    }
-
-    return this.#graph.getNodesConnectedFrom(node).map(node => {
-      invariant(node.type === 'bundle');
-      return new MutableBundle(node.value);
-    });
+function getBundles(
+  graph: InternalBundleGraph,
+  bundleGroup: BundleGroup
+): Array<InternalBundle> {
+  let bundleGroupId = getBundleGroupId(bundleGroup);
+  let node = graph.getNode(bundleGroupId);
+  if (!node) {
+    return [];
   }
 
-  getBundleGroups(bundle: Bundle): Array<BundleGroup> {
-    let node = this.#graph.getNode(bundle.id);
-    if (!node) {
-      return [];
-    }
+  return graph.getNodesConnectedFrom(node).map(node => {
+    invariant(node.type === 'bundle');
+    return node.value;
+  });
+}
 
-    return this.#graph.getNodesConnectedTo(node).map(node => {
-      invariant(node.type === 'bundle_group');
+function findBundlesWithAsset(
+  graph: InternalBundleGraph,
+  asset: Asset
+): Array<InternalBundle> {
+  return Array.from(graph.nodes.values())
+    .filter(
+      node => node.type === 'bundle' && node.value.assetGraph.hasNode(asset.id)
+    )
+    .map(node => {
+      invariant(node.type === 'bundle');
       return node.value;
     });
-  }
-
-  isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean {
-    let node = this.#graph.getNode(bundle.id);
-    if (node == null) {
-      throw new Error('Bundle not found');
-    }
-    if (node.type !== 'bundle') {
-      throw new Error('Not a bundle id');
-    }
-    return this.#graph.isAssetInAncestorBundle(node.value, asset);
-  }
-
-  findBundlesWithAsset(asset: Asset): Array<IMutableBundle> {
-    return Array.from(this.#graph.nodes.values())
-      .filter(
-        node =>
-          node.type === 'bundle' && node.value.assetGraph.hasNode(asset.id)
-      )
-      .map(node => {
-        invariant(node.type === 'bundle');
-        return new MutableBundle(node.value);
-      });
-  }
-
-  traverseBundles<TContext>(
-    visit: GraphTraversalCallback<IMutableBundle, TContext>
-  ): ?TContext {
-    this.#graph.traverseBundles((bundle, ...args) => {
-      visit(new MutableBundle(bundle), ...args);
-    });
-  }
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -349,6 +349,16 @@ export type BundleGroup = {
 };
 
 export interface BundleGraph {
+  findBundlesWithAsset(asset: Asset): Array<Bundle>;
+  getBundleGroups(bundle: Bundle): Array<BundleGroup>;
+  getBundles(bundleGroup: BundleGroup): Array<Bundle>;
+  isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;
+  traverseBundles<TContext>(
+    visit: GraphTraversalCallback<Bundle, TContext>
+  ): ?TContext;
+}
+
+export interface MutableBundleGraph {
   addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
   addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
   findBundlesWithAsset(asset: Asset): Array<MutableBundle>;
@@ -363,7 +373,7 @@ export interface BundleGraph {
 export type Bundler = {|
   bundle(
     graph: MainAssetGraph,
-    bundleGraph: BundleGraph,
+    bundleGraph: MutableBundleGraph,
     opts: ParcelOptions
   ): Async<void>
 |};
@@ -377,6 +387,7 @@ export type RuntimeAsset = {|
   code: string,
   bundleGroup?: BundleGroup
 |};
+
 export type Runtime = {|
   apply(
     bundle: NamedBundle,


### PR DESCRIPTION
This implements a read-only, public `BundleGraph`, which should be used in place of the mutable version in every case but the bundler.

Test Plan: `yarn demo` in the simple example