### PR TITLE
Replace bundles with bundle references when merging bundle graph into bundles

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -68,7 +68,9 @@ export default new Bundler({
             // If there is a current bundle, but this asset is of a different type,
             // separate it out into a parallel bundle in the same bundle group.
             if (context.bundle) {
-              let bundles = bundleGraph.getBundles(context.bundleGroup);
+              let bundles = bundleGraph.getBundlesInBundleGroup(
+                context.bundleGroup
+              );
               let existingBundle = bundles.find(
                 b => b.type === node.value.type
               );
@@ -137,7 +139,8 @@ export default new Bundler({
     for (let {bundle, bundles} of sortedCandidates) {
       // Find all bundle groups connected to the original bundles
       let bundleGroups = bundles.reduce(
-        (arr, bundle) => arr.concat(bundleGraph.getBundleGroups(bundle)),
+        (arr, bundle) =>
+          arr.concat(bundleGraph.getBundleGroupsContainingBundle(bundle)),
         []
       );
 
@@ -145,7 +148,8 @@ export default new Bundler({
       if (
         !bundleGroups.every(
           group =>
-            bundleGraph.getBundles(group).length < OPTIONS.maxParallelRequests
+            bundleGraph.getBundlesInBundleGroup(group).length <
+            OPTIONS.maxParallelRequests
         )
       ) {
         continue;

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -6,7 +6,7 @@ import type {Bundle as InternalBundle} from './types';
 import type Config from './Config';
 
 import nullthrows from 'nullthrows';
-import {MutableBundleGraph} from './public/BundleGraph';
+import {BundleGraph, MutableBundleGraph} from './public/BundleGraph';
 import InternalBundleGraph from './BundleGraph';
 import MainAssetGraph from './public/MainAssetGraph';
 import {Bundle, NamedBundle} from './public/Bundle';
@@ -89,7 +89,11 @@ export default class BundlerRunner {
     for (let bundle of bundles) {
       let runtimes = await this.config.getRuntimes(bundle.env.context);
       for (let runtime of runtimes) {
-        let applied = await runtime.apply(bundle, this.options);
+        let applied = await runtime.apply(
+          bundle,
+          new BundleGraph(bundleGraph),
+          this.options
+        );
         if (applied) {
           await this.addRuntimesToBundle(
             bundle.id,

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -5,7 +5,6 @@ import type {Bundle as InternalBundle} from '../types';
 import type {
   Asset,
   Bundle as IBundle,
-  BundleGroup,
   Dependency,
   Environment,
   FilePath,
@@ -16,9 +15,7 @@ import type {
   Target
 } from '@parcel/types';
 
-import invariant from 'assert';
 import nullthrows from 'nullthrows';
-import {getBundleGroupId} from './utils';
 
 // Friendly access for other modules within this package that need access
 // to the internal bundle.
@@ -58,36 +55,6 @@ export class Bundle implements IBundle {
 
   get stats(): Stats {
     return this.#bundle.stats;
-  }
-
-  getBundleGroups(): Array<BundleGroup> {
-    return this.#bundle.assetGraph
-      .findNodes(node => node.type === 'bundle_group')
-      .map(node => {
-        invariant(node.type === 'bundle_group');
-        return node.value;
-      });
-  }
-
-  getBundlesInGroup(bundleGroup: BundleGroup): Array<IBundle> {
-    let bundleGroupNode = this.#bundle.assetGraph.getNode(
-      getBundleGroupId(bundleGroup)
-    );
-
-    if (bundleGroupNode == null) {
-      throw new Error(`Bundle group not found in bundle ${this.id}`);
-    }
-
-    return this.#bundle.assetGraph
-      .getNodesConnectedFrom(bundleGroupNode)
-      .map(node => {
-        invariant(node.type === 'bundle');
-        return node.value;
-      })
-      .sort(
-        bundle => (bundle.assetGraph.hasNode(bundleGroup.entryAssetId) ? 1 : -1)
-      )
-      .map(bundle => new Bundle(bundle));
   }
 
   getDependencies(asset: Asset): Array<Dependency> {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -57,13 +57,23 @@ export type AssetGraphNode =
   | FileNode
   | RootNode
   | TransformerRequestNode
-  // Bundle graphs are merged into asset graphs during the bundling phase
-  | BundleGraphNode;
+  | BundleGroupNode
+  | BundleReferenceNode;
+
+export interface BundleReference {
+  +id: string;
+  +type: string;
+  +env: Environment;
+  +isEntry: ?boolean;
+  +target: ?Target;
+  +filePath: ?FilePath;
+  +stats: Stats;
+}
 
 export type Bundle = {|
+  assetGraph: AssetGraph,
   id: string,
   type: string,
-  assetGraph: AssetGraph,
   env: Environment,
   isEntry: ?boolean,
   target: ?Target,
@@ -75,6 +85,12 @@ export type BundleNode = {|
   id: string,
   +type: 'bundle',
   value: Bundle
+|};
+
+export type BundleReferenceNode = {|
+  id: string,
+  +type: 'bundle_reference',
+  value: BundleReference
 |};
 
 export type BundleGroupNode = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -323,8 +323,6 @@ export interface Bundle extends AssetGraphLike {
   +target: ?Target;
   +filePath: ?FilePath;
   +stats: Stats;
-  getBundleGroups(): Array<BundleGroup>;
-  getBundlesInGroup(BundleGroup): Array<Bundle>;
   getDependencies(asset: Asset): Array<Dependency>;
   getEntryAssets(): Array<Asset>;
   getTotalSize(asset?: Asset): number;
@@ -350,8 +348,9 @@ export type BundleGroup = {
 
 export interface BundleGraph {
   findBundlesWithAsset(asset: Asset): Array<Bundle>;
-  getBundleGroups(bundle: Bundle): Array<BundleGroup>;
-  getBundles(bundleGroup: BundleGroup): Array<Bundle>;
+  getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
+  getBundleGroupsReferencedByBundle(bundle: Bundle): Array<BundleGroup>;
+  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<Bundle>;
   isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;
   traverseBundles<TContext>(
     visit: GraphTraversalCallback<Bundle, TContext>
@@ -362,8 +361,9 @@ export interface MutableBundleGraph {
   addBundle(bundleGroup: BundleGroup, bundle: Bundle): void;
   addBundleGroup(parentBundle: ?Bundle, bundleGroup: BundleGroup): void;
   findBundlesWithAsset(asset: Asset): Array<MutableBundle>;
-  getBundleGroups(bundle: Bundle): Array<BundleGroup>;
-  getBundles(bundleGroup: BundleGroup): Array<MutableBundle>;
+  getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
+  getBundleGroupsReferencedByBundle(bundle: Bundle): Array<BundleGroup>;
+  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<MutableBundle>;
   isAssetInAncestorBundle(bundle: Bundle, asset: Asset): boolean;
   traverseBundles<TContext>(
     visit: GraphTraversalCallback<MutableBundle, TContext>
@@ -391,6 +391,7 @@ export type RuntimeAsset = {|
 export type Runtime = {|
   apply(
     bundle: NamedBundle,
+    bundleGraph: BundleGraph,
     opts: ParcelOptions
   ): Async<void | RuntimeAsset | Array<RuntimeAsset>>
 |};

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -19,7 +19,7 @@ const LOADERS = {
 };
 
 export default new Runtime({
-  async apply(bundle) {
+  async apply(bundle, bundleGraph) {
     // Dependency ids in code replaced with referenced bundle names
     // Loader runtime added for bundle groups that don't have a native loader (e.g. HTML/CSS/Worker - isURL?),
     // and which are not loaded by a parent bundle.
@@ -38,13 +38,15 @@ export default new Runtime({
     }
 
     let assets = [];
-    for (let bundleGroup of bundle.getBundleGroups()) {
+    for (let bundleGroup of bundleGraph.getBundleGroupsReferencedByBundle(
+      bundle
+    )) {
       // Ignore deps with native loaders, e.g. workers.
       if (bundleGroup.dependency.isURL) {
         continue;
       }
 
-      let bundles = bundle.getBundlesInGroup(bundleGroup);
+      let bundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
       let loaderModules = bundles.map(b => {
         let loader = loaders[b.type];
         if (!loader) {


### PR DESCRIPTION
When adding new bundles to the bundle graph, we merge in a subgraph of the bundle graph into the bundle's own asset graph. This allows it to trace dependencies to other bundles and bundle groups.

However, merging this subgraph has a recursive effect: ancestor bundles will actually contain all the bundles of their children and every node, which makes serialization and IPC expensive, and sometimes impossible in the case a child bundle refers to its parent (see the `html-root` integration test).

Instead, convert bundle nodes to bundle reference nodes, which point to objects that don't expose the inner assetgraphs of bundles. Since they don't expose assetgraphs, they can't be recursive.

Test Plan: Run with graphviz visualization and verify `bundle_reference` nodes in bundle assetgraphs.