### PR TITLE
Output shebang for node entry files

### DIFF
--- a/packages/core/parcel-bundler/src/packagers/JSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSPackager.js
@@ -26,6 +26,21 @@ class JSPackager extends Packager {
           this.options.hmrHostname
         )};` + preludeCode;
     }
+
+    // If target is node, check if the main asset is an entry asset and if it has a shebang.
+    // In that case, strip it from the asset and put it at the top of the output
+    if (this.bundler.options.target === 'node') {
+      const entryAsset = this.bundle.entryAsset;
+      if (
+        this.bundler.entryAssets.has(entryAsset) &&
+        entryAsset.generated.js.trimStart().startsWith('#!')
+      ) {
+        const firstNewline = entryAsset.generated.js.indexOf('\n') + 1;
+        preludeCode = trimmed.slice(0, firstNewline) + preludeCode;
+        entryContent.js = trimmed.slice(firstNewline);
+      }
+    }
+
     await this.write(preludeCode + '({');
     this.lineOffset = lineCounter(preludeCode);
   }


### PR DESCRIPTION
# ↪️ Pull Request

If target is node, check if the main asset is an entry asset and if it
has a shebang. In that case, strip it from the asset and put it at the
top of the output.

Fixes #2381 

## 💻 Examples

See the expected behaviour in #2381 

## 🚨 Test instructions

`index.js`:
```js
#!/usr/bin/env node
console.log("Hola")
```
When this PR is applied, it will not give a syntax error, and will run as expected when used as an executable script (`chmod +x dist/index.js` and `./dist/index.js`).

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs