### PR TITLE
TypeScriptAsset: Support baseUrl for module resolution

### DIFF
--- a/packages/core/parcel-bundler/src/Asset.js
+++ b/packages/core/parcel-bundler/src/Asset.js
@@ -85,6 +85,10 @@ class Asset {
     this.dependencies.set(name, Object.assign({name}, opts));
   }
 
+  async resolveModuleDependency(dep) {
+    return await this.resolver.resolve(dep.name, this.name);
+  }
+
   resolveDependency(url, from = this.name) {
     const parsed = URL.parse(url);
     let depName;

--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -105,8 +105,8 @@ class Bundler extends EventEmitter {
       target === 'node'
         ? false
         : typeof options.hmr === 'boolean'
-          ? options.hmr
-          : watch;
+        ? options.hmr
+        : watch;
     const scopeHoist =
       options.scopeHoist !== undefined ? options.scopeHoist : false;
     return {
@@ -145,8 +145,8 @@ class Bundler extends EventEmitter {
         typeof options.autoInstall === 'boolean'
           ? options.autoInstall
           : process.env.PARCEL_AUTOINSTALL === 'false'
-            ? false
-            : !isProduction,
+          ? false
+          : !isProduction,
       scopeHoist: scopeHoist,
       contentHash:
         typeof options.contentHash === 'boolean'
@@ -481,7 +481,8 @@ class Bundler extends EventEmitter {
         return this.getLoadedAsset(dep.resolved);
       }
 
-      return await this.resolveAsset(dep.name, asset.name);
+      const {path} = await asset.resolveModuleDependency(dep);
+      return this.getLoadedAsset(path);
     } catch (err) {
       // If the dep is optional, return before we throw
       if (dep.optional) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

TypeScript's compiler options allow for supplying a `baseUrl` where bare module imports will get resolved relative to. This adds support for `baseUrl` to Parcel.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

```json
{
    "compilerOptions": {
        "baseUrl": "./src"
    }
}
```

```ts
// src/A.ts
import { B } from 'B';
```

```ts
// src/B.ts
export class B {}
```