### PR TITLE
Shake exports with pure property assignments

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/pure-assignment/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/pure-assignment/a.js
@@ -1,0 +1,3 @@
+import {foo} from './b';
+	
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/pure-assignment/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/pure-assignment/b.js
@@ -1,0 +1,4 @@
+export const foo = 2;
+
+export function bar() {}
+bar.displayName = 'hello';

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -549,6 +549,25 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 'bar');
     });
+
+    it('should shake pure property assignments', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/pure-assignment/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 2);
+
+      let contents = await fs.readFile(
+        path.join(__dirname, 'dist/a.js'),
+        'utf8'
+      );
+      assert(!/bar/.test(contents));
+      assert(!/displayName/.test(contents));
+    });
   });
 
   describe('commonjs', function() {

--- a/packages/core/parcel-bundler/src/scope-hoisting/shake.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/shake.js
@@ -1,7 +1,5 @@
 const t = require('@babel/types');
 
-const EXPORTS_RE = /^\$([^$]+)\$exports$/;
-
 /**
  * This is a small small implementation of dead code removal specialized to handle
  * removing unused exports. All other dead code removal happens in workers on each
@@ -44,12 +42,9 @@ function getUnusedBinding(path, name) {
     return null;
   }
 
-  if (isPure(binding)) {
+  let pure = isPure(binding);
+  if (!binding.referenced && pure) {
     return binding;
-  }
-
-  if (!EXPORTS_RE.test(name)) {
-    return null;
   }
 
   // Is there any references which aren't simple assignments?
@@ -57,18 +52,14 @@ function getUnusedBinding(path, name) {
     path => !isExportAssignment(path) && !isUnusedWildcard(path)
   );
 
-  if (bailout) {
-    return null;
-  } else {
+  if (!bailout && pure) {
     return binding;
   }
+
+  return null;
 }
 
 function isPure(binding) {
-  if (binding.referenced) {
-    return false;
-  }
-
   if (
     binding.path.isVariableDeclarator() &&
     binding.path.get('id').isIdentifier()
@@ -85,7 +76,8 @@ function isExportAssignment(path) {
     // match "path.any = any;"
     path.parentPath.isMemberExpression() &&
     path.parentPath.parentPath.isAssignmentExpression() &&
-    path.parentPath.parentPath.node.left === path.parentPath.node
+    path.parentPath.parentPath.node.left === path.parentPath.node &&
+    path.parentPath.parentPath.get('right').isPure()
   );
 }
 
@@ -122,6 +114,15 @@ function remove(path) {
   } else if (isUnusedWildcard(path)) {
     remove(path.parentPath);
   } else if (!path.removed) {
-    path.remove();
+    if (
+      path.parentPath.isSequenceExpression() &&
+      path.parent.expressions.length === 1
+    ) {
+      // replace sequence expression with it's sole child
+      path.parentPath.replaceWith(path);
+      remove(path.parentPath);
+    } else {
+      path.remove();
+    }
   }
 }

--- a/packages/core/parcel-bundler/src/scope-hoisting/shake.js
+++ b/packages/core/parcel-bundler/src/scope-hoisting/shake.js
@@ -76,8 +76,7 @@ function isExportAssignment(path) {
     // match "path.any = any;"
     path.parentPath.isMemberExpression() &&
     path.parentPath.parentPath.isAssignmentExpression() &&
-    path.parentPath.parentPath.node.left === path.parentPath.node &&
-    path.parentPath.parentPath.get('right').isPure()
+    path.parentPath.parentPath.node.left === path.parentPath.node
   );
 }
 


### PR DESCRIPTION
Fixes #2909.

For example, assigning a `displayName` to a function is pretty common in react code, and does not cause side effects.