### PR TITLE
Added await for middleware 'bundle' call

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -831,8 +831,8 @@ class Bundler extends EventEmitter {
     this.bundle();
   }
 
-  middleware() {
-    this.bundle();
+  async middleware() {
+    await this.bundle();
     return Server.middleware(this);
   }
 


### PR DESCRIPTION
Return middleware only after bundled server for using parcel projects as package.
It doesn't make sense start server before we've bundled all files.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
