### PR TITLE
Update to flow 0.98.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -28,4 +28,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.97.0
+0.98.1

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.1.0",
-    "flow-bin": "0.97.0",
+    "flow-bin": "0.98.1",
     "lerna": "^3.3.2",
     "lint-staged": "^7.2.2",
     "mocha": "^6.1.3",

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -38,7 +38,8 @@ export const realpath: $PropertyType<FSPromise, 'realpath'> = function(
     // do nothing
   }
 
-  return originalPath;
+  // $FlowFixMe
+  return Promise.resolve(originalPath);
 };
 
 export const lstat: (path: string) => Promise<Stats> = promisify(fs.lstat);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5426,10 +5426,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@0.97.0:
-  version "0.97.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
-  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
+flow-bin@0.98.1:
+  version "0.98.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.1.tgz#a8d781621c91703df69928acc83c9777e2fcbb49"
+  integrity sha512-y1YzQgbFUX4EG6h2EO8PhyJeS0VxNgER8XsTwU8IXw4KozfneSmGVgw8y3TwAOza7rVhTlHEoli1xNuNW1rhPw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
* Upgrades flow to version 0.98.1 in `flow-bin` and `.flowconfig`
* Normalizes return from promisified `realpath` to always return a promise

Test Plan: `yarn flow`