### PR TITLE
Create public Asset and MutableAsset

### DIFF
--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict-local
 
 import {Readable} from 'stream';
 
@@ -77,10 +77,11 @@ export default class Asset {
 
   constructor(options: AssetOptions) {
     this.id =
-      options.id ||
-      md5FromString(
-        options.filePath + options.type + JSON.stringify(options.env)
-      );
+      options.id != null
+        ? options.id
+        : md5FromString(
+            options.filePath + options.type + JSON.stringify(options.env)
+          );
     this.hash = options.hash;
     this.filePath = options.filePath;
     this.isIsolated = options.isIsolated == null ? false : options.isIsolated;
@@ -163,7 +164,7 @@ export default class Asset {
   }
 
   async getCode(): Promise<string> {
-    if (this.contentKey) {
+    if (this.contentKey != null) {
       this.content = Cache.getStream(this.contentKey);
     }
 
@@ -176,7 +177,7 @@ export default class Asset {
   }
 
   async getBuffer(): Promise<Buffer> {
-    if (this.contentKey) {
+    if (this.contentKey != null) {
       this.content = Cache.getStream(this.contentKey);
     }
 
@@ -189,7 +190,7 @@ export default class Asset {
   }
 
   getStream(): Readable {
-    if (this.contentKey) {
+    if (this.contentKey != null) {
       this.content = Cache.getStream(this.contentKey);
     }
 
@@ -213,7 +214,7 @@ export default class Asset {
   }
 
   async getMap(): Promise<?SourceMap> {
-    if (this.mapKey) {
+    if (this.mapKey != null) {
       this.map = await Cache.get(this.mapKey);
     }
 
@@ -241,7 +242,7 @@ export default class Asset {
   }
 
   async addConnectedFile(file: File) {
-    if (!file.hash) {
+    if (file.hash == null) {
       file.hash = await md5FromFilePath(file.filePath);
     }
 
@@ -257,7 +258,14 @@ export default class Asset {
   }
 
   createChildAsset(result: TransformerResult): Asset {
-    let content = result.content || result.code || '';
+    let content;
+    if (result.content != null) {
+      content = result.content;
+    } else if (result.code != null) {
+      content = result.code;
+    } else {
+      content = '';
+    }
 
     let hash;
     let size;
@@ -313,7 +321,7 @@ export default class Asset {
     let packageKey = options && options.packageKey;
     let parse = options && options.parse;
 
-    if (packageKey) {
+    if (packageKey != null) {
       let pkg = await this.getPackage();
       if (pkg && pkg[packageKey]) {
         return pkg[packageKey];

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -3,7 +3,6 @@
 import {Readable} from 'stream';
 
 import type {
-  Asset as IAsset,
   AST,
   Blob,
   Config,
@@ -58,7 +57,7 @@ type SerializedOptions = {|
   |}
 |};
 
-export default class Asset implements IAsset {
+export default class Asset {
   id: string;
   hash: ?string;
   filePath: FilePath;
@@ -292,14 +291,14 @@ export default class Asset implements IAsset {
 
     let dependencies = result.dependencies;
     if (dependencies) {
-      for (let dep of dependencies.values()) {
+      for (let dep of dependencies) {
         asset.addDependency(dep);
       }
     }
 
     let connectedFiles = result.connectedFiles;
     if (connectedFiles) {
-      for (let file of connectedFiles.values()) {
+      for (let file of connectedFiles) {
         asset.addConnectedFile(file);
       }
     }

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -2,6 +2,7 @@
 
 import type {
   AssetGraphNode,
+  CacheEntry,
   DependencyNode,
   FileNode,
   NodeId,
@@ -9,8 +10,6 @@ import type {
 } from './types';
 
 import type {
-  Asset,
-  CacheEntry,
   Dependency as IDependency,
   File,
   FilePath,
@@ -18,6 +17,8 @@ import type {
   Target,
   TransformerRequest
 } from '@parcel/types';
+
+import type Asset from './Asset';
 
 import invariant from 'assert';
 import Graph from './Graph';

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
-import type {Asset, GraphTraversalCallback} from '@parcel/types';
+import type {GraphTraversalCallback} from '@parcel/types';
+import type Asset from './Asset';
 import type {Bundle, BundleGraphNode} from './types';
 
 import Graph from './Graph';

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -11,6 +11,7 @@ import nullthrows from 'nullthrows';
 import {BundleGraph, MutableBundleGraph} from './public/BundleGraph';
 import InternalBundleGraph from './BundleGraph';
 import MainAssetGraph from './public/MainAssetGraph';
+import {assetToInternalAsset} from './public/Asset';
 import {Bundle, NamedBundle} from './public/Bundle';
 import AssetGraphBuilder from './AssetGraphBuilder';
 import {report} from './ReporterRunner';

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -11,7 +11,6 @@ import nullthrows from 'nullthrows';
 import {BundleGraph, MutableBundleGraph} from './public/BundleGraph';
 import InternalBundleGraph from './BundleGraph';
 import MainAssetGraph from './public/MainAssetGraph';
-import {assetToInternalAsset} from './public/Asset';
 import {Bundle, NamedBundle} from './public/Bundle';
 import AssetGraphBuilder from './AssetGraphBuilder';
 import {report} from './ReporterRunner';

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -1,0 +1,145 @@
+// @flow strict-local
+// flowlint unsafe-getters-setters:off
+
+import type {Readable} from 'stream';
+
+import type {
+  Asset as IAsset,
+  AST,
+  Config,
+  Dependency,
+  DependencyOptions,
+  Environment,
+  File,
+  FilePath,
+  Meta,
+  PackageJSON,
+  SourceMap,
+  Stats
+} from '@parcel/types';
+
+import type InternalAsset from '../Asset';
+
+import nullthrows from 'nullthrows';
+
+const _assetToInternalAsset: WeakMap<IAsset, InternalAsset> = new WeakMap();
+
+export function assetToInternalAsset(asset: IAsset): InternalAsset {
+  return nullthrows(_assetToInternalAsset.get(asset));
+}
+
+export default class Asset implements IAsset {
+  #asset;
+
+  constructor(asset: InternalAsset) {
+    this.#asset = asset;
+    _assetToInternalAsset.set(this, asset);
+  }
+
+  get id(): string {
+    return this.#asset.id;
+  }
+
+  get ast(): ?AST {
+    return this.#asset.ast;
+  }
+
+  set ast(ast: ?AST): void {
+    this.#asset.ast = ast;
+  }
+
+  get type(): string {
+    return this.#asset.type;
+  }
+
+  set type(type: string): void {
+    this.#asset.type = type;
+  }
+
+  get env(): Environment {
+    return this.#asset.env;
+  }
+
+  get filePath(): FilePath {
+    return this.#asset.filePath;
+  }
+
+  get meta(): Meta {
+    return this.#asset.meta;
+  }
+
+  get outputHash(): string {
+    return this.#asset.outputHash;
+  }
+
+  get stats(): Stats {
+    return this.#asset.stats;
+  }
+
+  get isIsolated(): boolean {
+    return this.#asset.isIsolated;
+  }
+
+  set isIsolated(isIsolated: boolean): void {
+    this.#asset.isIsolated = isIsolated;
+  }
+
+  addDependency(dep: DependencyOptions): string {
+    return this.#asset.addDependency(dep);
+  }
+
+  addConnectedFile(file: File): Promise<void> {
+    return this.#asset.addConnectedFile(file);
+  }
+
+  getConfig(
+    filePaths: Array<FilePath>,
+    options: ?{packageKey?: string, parse?: boolean}
+  ): Promise<Config | null> {
+    return this.#asset.getConfig(filePaths, options);
+  }
+
+  getConnectedFiles(): $ReadOnlyArray<File> {
+    return this.#asset.getConnectedFiles();
+  }
+
+  getDependencies(): $ReadOnlyArray<Dependency> {
+    return this.#asset.getDependencies();
+  }
+
+  getPackage(): Promise<PackageJSON | null> {
+    return this.#asset.getPackage();
+  }
+
+  async getCode(): Promise<string> {
+    return this.#asset.getCode();
+  }
+
+  async getBuffer(): Promise<Buffer> {
+    return this.#asset.getBuffer();
+  }
+
+  getStream(): Readable {
+    return this.#asset.getStream();
+  }
+
+  getMap(): Promise<?SourceMap> {
+    return this.#asset.getMap();
+  }
+
+  setBuffer(buffer: Buffer): void {
+    this.#asset.setBuffer(buffer);
+  }
+
+  setCode(code: string): void {
+    this.#asset.setCode(code);
+  }
+
+  setStream(stream: Readable): void {
+    this.#asset.setStream(stream);
+  }
+
+  setMap(sourceMap: ?SourceMap): void {
+    this.#asset.setMap(sourceMap);
+  }
+}

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -18,7 +18,7 @@ import type {
 
 import nullthrows from 'nullthrows';
 
-import Asset from './Asset';
+import {Asset} from './Asset';
 import {getInternalAsset} from './utils';
 
 // Friendly access for other modules within this package that need access

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -25,6 +25,7 @@ import type InternalBundleGraph from '../BundleGraph';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
+import {assetToInternalAsset} from './Asset';
 import {Bundle, MutableBundle, bundleToInternal} from './Bundle';
 import {getBundleGroupId} from './utils';
 
@@ -66,7 +67,10 @@ class BaseBundleGraph {
   isAssetInAncestorBundle(bundle: IBundle, asset: Asset): boolean {
     let internalNode = this.#graph.getNode(bundle.id);
     invariant(internalNode != null && internalNode.type === 'bundle');
-    return this.#graph.isAssetInAncestorBundle(internalNode.value, asset);
+    return this.#graph.isAssetInAncestorBundle(
+      internalNode.value,
+      assetToInternalAsset(asset)
+    );
   }
 }
 

--- a/packages/core/core/src/public/MainAssetGraph.js
+++ b/packages/core/core/src/public/MainAssetGraph.js
@@ -9,7 +9,7 @@ import type {
   MainAssetGraphTraversable
 } from '@parcel/types';
 
-import Asset, {assetToInternalAsset} from './Asset';
+import {Asset, assetToInternalAsset} from './Asset';
 import {MutableBundle} from './Bundle';
 
 export default class MainAssetGraph implements IMainAssetGraph {

--- a/packages/core/core/src/public/utils.js
+++ b/packages/core/core/src/public/utils.js
@@ -1,6 +1,21 @@
 // @flow strict-local
 
-import type {BundleGroup} from '@parcel/types';
+import type {Asset, BundleGroup} from '@parcel/types';
+import type InternalAsset from '../Asset';
+import type AssetGraph from '../AssetGraph';
+
+import invariant from 'assert';
 
 export const getBundleGroupId = (bundleGroup: BundleGroup) =>
   'bundle_group:' + bundleGroup.entryAssetId;
+
+export function getInternalAsset(
+  assetGraph: AssetGraph,
+  publicAsset: Asset
+): InternalAsset {
+  let node = assetGraph.getNode(publicAsset.id);
+  invariant(
+    node != null && (node.type === 'asset' || node.type === 'asset_reference')
+  );
+  return node.value;
+}

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -1,17 +1,17 @@
 // @flow strict-local
 
 import type {
-  Asset,
   BundleGroup,
   Dependency,
   Environment,
   File,
   FilePath,
+  Stats,
   Target,
-  TransformerRequest,
-  Stats
+  TransformerRequest
 } from '@parcel/types';
 
+import type Asset from './Asset';
 import type AssetGraph from './AssetGraph';
 
 export type NodeId = string;
@@ -69,6 +69,14 @@ export interface BundleReference {
   +filePath: ?FilePath;
   +stats: Stats;
 }
+
+export type CacheEntry = {
+  filePath: FilePath,
+  env: Environment,
+  hash: string,
+  assets: Array<Asset>,
+  initialAssets: ?Array<Asset> // Initial assets, pre-post processing
+};
 
 export type Bundle = {|
   assetGraph: AssetGraph,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -214,34 +214,44 @@ export type TransformerRequest = {
   code?: string
 };
 
-export interface Asset {
-  ast: ?AST;
+interface BaseAsset {
+  +ast: ?AST;
   +env: Environment;
   +filePath: FilePath;
   +id: string;
   +meta: Meta;
-  +outputHash: string;
-  +stats: Stats;
-  isIsolated: boolean;
-  type: string;
+  +isIsolated: boolean;
+  +type: string;
 
-  addConnectedFile(file: File): Promise<void>;
-  addDependency(opts: DependencyOptions): string;
   getCode(): Promise<string>;
   getBuffer(): Promise<Buffer>;
   getStream(): Readable;
-  setCode(string): void;
-  setBuffer(Buffer): void;
-  setStream(Readable): void;
   getMap(): ?SourceMap;
-  setMap(?SourceMap): void;
   getDependencies(): $ReadOnlyArray<Dependency>;
   getConfig(
     filePaths: Array<FilePath>,
     options: ?{packageKey?: string, parse?: boolean}
   ): Promise<Config | null>;
   getPackage(): Promise<PackageJSON | null>;
+}
+
+export interface MutableAsset extends BaseAsset {
+  ast: ?AST;
+  isIsolated: boolean;
+  type: string;
+
   addDependency(dep: DependencyOptions): string;
+  setMap(?SourceMap): void;
+  setCode(string): void;
+  setBuffer(Buffer): void;
+  setStream(Readable): void;
+  addConnectedFile(file: File): Promise<void>;
+  addDependency(opts: DependencyOptions): string;
+}
+
+export interface Asset extends BaseAsset {
+  +outputHash: string;
+  +stats: Stats;
 }
 
 export type Stats = {|
@@ -276,17 +286,17 @@ export type Transformer = {
   canReuseAST?: (ast: AST, opts: ParcelOptions) => boolean,
   parse?: (asset: Asset, config: ?Config, opts: ParcelOptions) => Async<?AST>,
   transform(
-    asset: Asset,
+    asset: MutableAsset,
     config: ?Config,
     opts: ParcelOptions
-  ): Async<Array<TransformerResult | Asset>>,
+  ): Async<Array<TransformerResult | MutableAsset>>,
   generate?: (
-    asset: Asset,
+    asset: MutableAsset,
     config: ?Config,
     opts: ParcelOptions
   ) => Async<GenerateOutput>,
   postProcess?: (
-    assets: Array<Asset>,
+    assets: Array<MutableAsset>,
     config: ?Config,
     opts: ParcelOptions
   ) => Async<Array<TransformerResult>>

--- a/packages/transformers/babel/src/babel6.js
+++ b/packages/transformers/babel/src/babel6.js
@@ -1,12 +1,12 @@
 // @flow
 
-import type {Asset, AST} from '@parcel/types';
+import type {MutableAsset, AST} from '@parcel/types';
 
 import localRequire from '@parcel/local-require';
 import {babel6toBabel7} from './astConverter';
 
 export default async function babel6(
-  asset: Asset,
+  asset: MutableAsset,
   options: any
 ): Promise<?AST> {
   let babel = await localRequire('babel-core', asset.filePath);

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -1,9 +1,9 @@
 // @flow
-import type {Asset, AST} from '@parcel/types';
+import type {MutableAsset, AST} from '@parcel/types';
 import localRequire from '@parcel/local-require';
 
 export default async function babel7(
-  asset: Asset,
+  asset: MutableAsset,
   options: any
 ): Promise<?AST> {
   let config = options.config;

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -1,4 +1,5 @@
 // @flow
+
 import semver from 'semver';
 import generate from '@babel/generator';
 import {Transformer} from '@parcel/plugin';

--- a/packages/transformers/js/src/visitors/fs.js
+++ b/packages/transformers/js/src/visitors/fs.js
@@ -62,7 +62,7 @@ export default {
         replacementNode = t.stringLiteral(res);
       }
 
-      asset.connectedFiles.set(filename, {
+      asset.addConnectedFile({
         filePath: filename
       });
 

--- a/packages/transformers/raw/src/RawTransformer.js
+++ b/packages/transformers/raw/src/RawTransformer.js
@@ -3,8 +3,6 @@
 import {Transformer} from '@parcel/plugin';
 
 export default new Transformer({
-  parse() {},
-
   transform(asset) {
     asset.isIsolated = true;
     return [asset];


### PR DESCRIPTION
* Creates public `Asset` and `MutableAsset` interfaces and implementations, which prevent access to internal-only methods like `commit`, direct access to the `content` blob, the `Map`s used for dependency and connected files, etc.
	* Currently `MutableAsset` is only needed in `Transformer#transform`!
* Makes `CacheEntry` an internal-only type
* Removes unused `TransformFinishedEvent` (cc @DeMoorJasper ?) which exposed a `CacheEntry`
* Fixes types in `TransformerRunner` and normalizes all returned types to `TransformerResults`

Test Plan: flow, lint, test. Manual test with the simple example.