### PR TITLE
Assorted cleanup

### DIFF
--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -68,16 +68,14 @@ export default class TargetResolver {
       }
     } else {
       // Explicit targets were not provided
-      if (initialOptions.mode === 'development' || serveOptions) {
-        // Since the user hasn't specified a target explicitly in development,
-        // use one targeting modern browsers for development rather than the
-        // targets in package json
+      if (serveOptions) {
+        // In serve mode, we only support a single browser target. Since the user
+        // hasn't specified a target, use one targeting modern browsers for development
         targets = [
           {
             name: 'default',
             distDir: 'dist',
             publicUrl:
-              // TODO: How to configure publicUrl for non-server development?
               serveOptions && serveOptions.publicUrl != null
                 ? serveOptions.publicUrl
                 : '/',

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -299,8 +299,8 @@ async function summarizeRequest(
     hash = await md5FromReadableStream(
       createReadStream(req.filePath).pipe(
         new TapStream(buf => {
+          size += buf.length;
           if (content instanceof Buffer) {
-            size += buf.length;
             if (size > BUFFER_LIMIT) {
               // if buffering this content would put this over BUFFER_LIMIT, replace
               // it with a stream

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -29,18 +29,16 @@ export const readdir: $PropertyType<FSPromise, 'readdir'> = promisify(
 export const unlink: $PropertyType<FSPromise, 'unlink'> = promisify(fs.unlink);
 
 const _realpath = promisify(fs.realpath);
-export const realpath: $PropertyType<FSPromise, 'realpath'> = function(
-  originalPath
-) {
+
+export async function realpath(originalPath: string): Promise<string> {
   try {
-    return _realpath(originalPath);
+    return _realpath(originalPath, 'utf8');
   } catch (e) {
     // do nothing
   }
 
-  // $FlowFixMe
-  return Promise.resolve(originalPath);
-};
+  return originalPath;
+}
 
 export const lstat: (path: string) => Promise<Stats> = promisify(fs.lstat);
 


### PR DESCRIPTION
Fixes a handful of issues:

* Asset size was not incremented past `BUFFER_LIMIT`
* Make promisified `realpath` an async function so errors are actually caught in the `try`/`catch`
* Revert making all development modes use a browser-only target. This should only be for the built-in server where we know we're targeting browsers only.