### PR TITLE
Support pnpm for autoinstall

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -632,4 +632,27 @@ describe('css', function() {
     );
     assert(css.includes('rgba'));
   });
+
+  it('should automatically install postcss plugins with pnpm if needed', async function() {
+    await rimraf(path.join(__dirname, '/input'));
+    await ncp(
+      path.join(__dirname, '/integration/autoinstall/pnpm'),
+      path.join(__dirname, '/input')
+    );
+    await bundle(path.join(__dirname, '/input/index.css'));
+
+    // cssnext was installed
+    let pkg = require('./input/package.json');
+    assert(pkg.devDependencies['postcss-cssnext']);
+
+    // peer dependency caniuse-lite was installed
+    assert(pkg.devDependencies['caniuse-lite']);
+
+    // cssnext is applied
+    let css = await fs.readFile(
+      path.join(__dirname, '/dist/index.css'),
+      'utf8'
+    );
+    assert(css.includes('rgba'));
+  });
 });

--- a/packages/core/integration-tests/test/integration/autoinstall/pnpm/.postcssrc
+++ b/packages/core/integration-tests/test/integration/autoinstall/pnpm/.postcssrc
@@ -1,0 +1,5 @@
+{
+  "plugins": {
+    "postcss-cssnext": true
+  }
+}

--- a/packages/core/integration-tests/test/integration/autoinstall/pnpm/index.css
+++ b/packages/core/integration-tests/test/integration/autoinstall/pnpm/index.css
@@ -1,0 +1,3 @@
+.test {
+  background: #9d9c;
+}

--- a/packages/core/integration-tests/test/integration/autoinstall/pnpm/package.json
+++ b/packages/core/integration-tests/test/integration/autoinstall/pnpm/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "parcel-test-autoinstall-npm",
+  "private": true
+}

--- a/packages/core/parcel-bundler/src/utils/installPackage.js
+++ b/packages/core/parcel-bundler/src/utils/installPackage.js
@@ -111,7 +111,9 @@ async function checkForCommand(command) {
   try {
     hasCommand = await commandExists(command);
     commandCache.set(command, hasCommand);
-  } catch (err) {}
+  } catch (err) {
+    return false;
+  }
 
   return hasCommand;
 }

--- a/packages/core/parcel-bundler/src/utils/installPackage.js
+++ b/packages/core/parcel-bundler/src/utils/installPackage.js
@@ -84,7 +84,7 @@ async function determinePackageManager(filepath) {
     return 'npm';
   }
 
-  const hasYarn = await checkForYarnCommand();
+  const hasYarn = await checkForCommand('yarn');
   if (hasYarn) {
     return 'yarn';
   }
@@ -92,19 +92,19 @@ async function determinePackageManager(filepath) {
   return 'npm';
 }
 
-let hasYarn = null;
-async function checkForYarnCommand() {
-  if (hasYarn != null) {
-    return hasYarn;
+const commandCache = new Map();
+async function checkForCommand(command) {
+  if (commandCache.has(command)) {
+    return commandCache.get(command);
   }
 
+  let hasCommand = false;
   try {
-    hasYarn = await commandExists('yarn');
-  } catch (err) {
-    hasYarn = false;
-  }
+    hasCommand = await commandExists(command);
+    commandCache.set(command, hasCommand);
+  } catch (err) {}
 
-  return hasYarn;
+  return hasCommand;
 }
 
 let queue = new PromiseQueue(install, {maxConcurrent: 1, retry: false});


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Parcel has used npm or yarn for autoinstall, and even if another package manager is used for current project, it has always fallbacked to npm.
 
[Pnpm](https://github.com/pnpm/pnpm) is a fast, disk efficient packages, and enables to save disk space. So I added [pnpm](https://github.com/pnpm/pnpm) support.

With this PR, Parcel resolves the package manager with the following process.

1. yarn.lock exists => use yarn
2. pnpm-lock.yaml exists => use pnpm,
3. fallback to npm

Perhaps related to https://spectrum.chat/parcel/general/option-to-specify-package-manager-for-parcel-auto-install~42fdd468-f4e2-4f98-a8d4-b97b6b20c822

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
Test for autoinstall using pnpm was added in `packages/core/integration-tests/test/css.js`. However, this test uses npm if pnpm command is not available.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
