### PR TITLE
Make Some Core Parcel API Private

### DIFF
--- a/flow-libs/ncp.js.flow
+++ b/flow-libs/ncp.js.flow
@@ -1,0 +1,35 @@
+// @flow
+
+// Derived from the README and source of ncp located at
+// https://github.com/AvianFlu/ncp and
+// https://github.com/AvianFlu/ncp/blob/6820b0fbe3f7400fdb283c741ef88b6d8e2d4994/lib/ncp.js
+// Which is licensed MIT
+
+declare module 'ncp' {
+  import type {Readable, Writable} from 'stream';
+
+  declare type NcpOptions = {
+    filter?: RegExp,
+    transform?: (
+      readable: Readable,
+      writable: Writable,
+      filePath: string
+    ) => mixed,
+    clobber?: boolean,
+    dereference?: boolean,
+    stopOnErr?: boolean,
+    errs?: Writable
+  };
+
+  declare module.exports: (
+    source: string,
+    destination: string,
+    callback: (errors: Array<Error>) => void
+  ) => void &
+    ((
+      source: string,
+      destination: string,
+      options: NcpOptions,
+      callback: (errors: Array<Error>) => void
+    ) => void);
+}

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -4,7 +4,6 @@ import type {InitialParcelOptions, ParcelOptions, Stats} from '@parcel/types';
 import type {Bundle} from './types';
 import type InternalBundleGraph from './BundleGraph';
 
-import AssetGraph from './AssetGraph';
 import {BundleGraph} from './public/BundleGraph';
 import BundlerRunner from './BundlerRunner';
 import WorkerFarm from '@parcel/workers';
@@ -19,27 +18,28 @@ import dumpGraphToGraphViz from './dumpGraphToGraphViz';
 import resolveOptions from './resolveOptions';
 
 export default class Parcel {
-  initialOptions: InitialParcelOptions;
-  resolvedOptions: ?ParcelOptions;
-  assetGraphBuilder: AssetGraphBuilder;
-  bundlerRunner: BundlerRunner;
-  reporterRunner: ReporterRunner;
-  farm: WorkerFarm;
-  runPackage: (bundle: Bundle) => Promise<Stats>;
-  _initialized: boolean = false;
+  #assetGraphBuilder; // AssetGraphBuilder
+  #bundlerRunner; // BundlerRunner
+  #farm; // WorkerFarm
+  #initialized = false; // boolean
+  #initialOptions; // InitialParcelOptions;
+  #reporterRunner; // ReporterRunner
+  #resolvedOptions; // ?ParcelOptions
+  #runPackage; // (bundle: Bundle) => Promise<Stats>;
 
   constructor(options: InitialParcelOptions) {
-    this.initialOptions = clone(options);
+    this.#initialOptions = clone(options);
   }
 
   async init(): Promise<void> {
-    if (this._initialized) {
+    if (this.#initialized) {
       return;
     }
 
-    let resolvedOptions = (this.resolvedOptions = await resolveOptions(
-      this.initialOptions
-    ));
+    let resolvedOptions: ParcelOptions = await resolveOptions(
+      this.#initialOptions
+    );
+    this.#resolvedOptions = resolvedOptions;
     await Cache.createCacheDir(resolvedOptions.cacheDir);
 
     let configResolver = new ConfigResolver();
@@ -61,24 +61,24 @@ export default class Parcel {
       throw new Error('Could not find a .parcelrc');
     }
 
-    this.bundlerRunner = new BundlerRunner({
+    this.#bundlerRunner = new BundlerRunner({
       options: resolvedOptions,
       config
     });
 
-    this.reporterRunner = new ReporterRunner({
+    this.#reporterRunner = new ReporterRunner({
       config,
       options: resolvedOptions
     });
 
-    this.assetGraphBuilder = new AssetGraphBuilder({
+    this.#assetGraphBuilder = new AssetGraphBuilder({
       options: resolvedOptions,
       config,
       entries: resolvedOptions.entries,
       targets: resolvedOptions.targets
     });
 
-    this.farm = await WorkerFarm.getShared(
+    this.#farm = await WorkerFarm.getShared(
       {
         config,
         options: resolvedOptions,
@@ -89,21 +89,21 @@ export default class Parcel {
       }
     );
 
-    this.runPackage = this.farm.mkhandle('runPackage');
+    this.#runPackage = this.#farm.mkhandle('runPackage');
 
-    this._initialized = true;
+    this.#initialized = true;
   }
 
   // `run()` returns `Promise<?BundleGraph>` because in watch mode it does not
   // return a bundle graph, but outside of watch mode it always will.
   async run(): Promise<?BundleGraph> {
-    if (!this._initialized) {
+    if (!this.#initialized) {
       await this.init();
     }
 
-    let resolvedOptions = nullthrows(this.resolvedOptions);
+    let resolvedOptions = nullthrows(this.#resolvedOptions);
     try {
-      this.assetGraphBuilder.on('invalidate', () => {
+      this.#assetGraphBuilder.on('invalidate', () => {
         this.build().catch(e => {
           if (!resolvedOptions.watch) {
             throw e;
@@ -124,36 +124,36 @@ export default class Parcel {
 
   async build(): Promise<BundleGraph> {
     try {
-      this.reporterRunner.report({
+      this.#reporterRunner.report({
         type: 'buildStart'
       });
 
       let startTime = Date.now();
-      let assetGraph = await this.assetGraphBuilder.build();
+      let assetGraph = await this.#assetGraphBuilder.build();
       dumpGraphToGraphViz(assetGraph, 'MainAssetGraph');
 
-      let bundleGraph = await this.bundle(assetGraph);
+      let bundleGraph = await this.#bundlerRunner.bundle(assetGraph);
       dumpGraphToGraphViz(bundleGraph, 'BundleGraph');
 
-      await this.package(bundleGraph);
+      await packageBundles(bundleGraph, this.#runPackage);
 
-      this.reporterRunner.report({
+      this.#reporterRunner.report({
         type: 'buildSuccess',
-        changedAssets: new Map(this.assetGraphBuilder.changedAssets),
+        changedAssets: new Map(this.#assetGraphBuilder.changedAssets),
         assetGraph: new MainAssetGraph(assetGraph),
         bundleGraph: new BundleGraph(bundleGraph),
         buildTime: Date.now() - startTime
       });
 
-      let resolvedOptions = nullthrows(this.resolvedOptions);
+      let resolvedOptions = nullthrows(this.#resolvedOptions);
       if (!resolvedOptions.watch && resolvedOptions.killWorkers !== false) {
-        await this.farm.end();
+        await this.#farm.end();
       }
 
       return new BundleGraph(bundleGraph);
     } catch (e) {
       if (!(e instanceof BuildAbortError)) {
-        await this.reporterRunner.report({
+        await this.#reporterRunner.report({
           type: 'buildFailure',
           error: e
         });
@@ -162,24 +162,24 @@ export default class Parcel {
       throw e;
     }
   }
-
-  bundle(assetGraph: AssetGraph): Promise<InternalBundleGraph> {
-    return this.bundlerRunner.bundle(assetGraph);
-  }
-
-  package(bundleGraph: InternalBundleGraph): Promise<mixed> {
-    let promises = [];
-    bundleGraph.traverseBundles(bundle => {
-      promises.push(
-        this.runPackage(bundle).then(stats => {
-          bundle.stats = stats;
-        })
-      );
-    });
-
-    return Promise.all(promises);
-  }
 }
+
+function packageBundles(
+  bundleGraph: InternalBundleGraph,
+  runPackage: (bundle: Bundle) => Promise<Stats>
+): Promise<mixed> {
+  let promises = [];
+  bundleGraph.traverseBundles(bundle => {
+    promises.push(
+      runPackage(bundle).then(stats => {
+        bundle.stats = stats;
+      })
+    );
+  });
+
+  return Promise.all(promises);
+}
+
 export {default as Asset} from './Asset';
 export {default as Dependency} from './Dependency';
 export {default as Environment} from './Environment';

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
+    "ncp": "^2.0.0",
     "rimraf": "^2.6.2"
   }
 }

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -3,9 +3,11 @@
 import type {FilePath} from '@parcel/types';
 import type {Readable} from 'stream';
 import type {FSPromise, Stats} from 'fs';
+import type {NcpOptions} from 'ncp';
 
 import {promisify} from 'util';
 import fs from 'fs';
+import _ncp from 'ncp';
 import _mkdirp from 'mkdirp';
 import _rimraf, {type Options as RimrafOptions} from 'rimraf';
 
@@ -54,6 +56,12 @@ export const rimraf: (
   path: FilePath,
   options?: RimrafOptions
 ) => Promise<void> = promisify(_rimraf);
+
+export const ncp: (
+  source: FilePath,
+  destination: FilePath,
+  options?: NcpOptions
+) => void = promisify(_ncp);
 
 export function writeFileStream(
   filePath: FilePath,


### PR DESCRIPTION
* Moves all the current properties on the core `Parcel` object to private properties. None are currently used externally, and most (if not all) look that they shouldn't be.
* Removes the `.bundle()` method, which wasn't used publicly, simply called the bundler runner, and returned an internal-only `BundleGraph`. We now call out to the bundler runner directly inside Parcel.
* Removes `.package()` method, instead using it as an unexposed  function.

Currently `@parcel/register` isn't tested or flow-typed, so the test plan passes. However, `@parcel/register` broke a while back, and we should expose more narrow APIs on `Parcel` or elsewhere to get it functioning again.

Test Plan: flow, lint, test