### PR TITLE
Exit with a code of 1 for failures outside watch

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -38,18 +38,17 @@ export default async function resolveOptions(
     await loadEnv(path.join(rootDir, 'index'));
   }
 
-  let cacheDir =
-    initialOptions.cacheDir != null
-      ? initialOptions.cacheDir
-      : DEFAULT_CACHE_DIR;
-
   // $FlowFixMe
   return {
     env: process.env,
     ...initialOptions,
-    cacheDir,
+    cacheDir:
+      initialOptions.cacheDir != null
+        ? initialOptions.cacheDir
+        : DEFAULT_CACHE_DIR,
     entries,
     rootDir,
-    targets
+    targets,
+    logLevel: initialOptions.logLevel != null ? initialOptions.logLevel : 'info'
   };
 }

--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -33,6 +33,7 @@ const DEFAULT_OPTIONS = {
   cache: false,
   cacheDir: '.parcel-cache',
   entries: [],
+  logLevel: 'none',
   rootDir: FIXTURES_DIR,
   targets: []
 };

--- a/packages/core/core/test/TransformerRunner.test.js
+++ b/packages/core/core/test/TransformerRunner.test.js
@@ -8,6 +8,7 @@ const config = require('@parcel/config-default');
 const EMPTY_OPTIONS = {
   cacheDir: '.parcel-cache',
   entries: [],
+  logLevel: 'none',
   rootDir: __dirname,
   targets: []
 };

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -4,11 +4,16 @@ import type {ParcelConfigFile, InitialParcelOptions} from '@parcel/types';
 
 require('v8-compile-cache');
 
+process.on('unhandledRejection', (reason: mixed) => {
+  console.error(reason);
+  process.exit(1);
+});
+
 const chalk = require('chalk');
 const program = require('commander');
-const version = require('../package.json').version;
 const path = require('path');
 const getPort = require('get-port');
+const version = require('../package.json').version;
 
 program.version(version);
 
@@ -135,7 +140,14 @@ async function run(entries: Array<string>, command: any) {
     ...(await normalizeOptions(command))
   });
 
-  parcel.run().catch(console.error);
+  try {
+    await parcel.run();
+  } catch (e) {
+    // Simply exit if the run fails. If an exception is thrown during the run,
+    // it is given to reporters in a buildFailure event. In watch mode,
+    // exceptions won't be thrown beyond Parcel.
+    process.exit(1);
+  }
 }
 
 async function normalizeOptions(command): Promise<InitialParcelOptions> {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -93,11 +93,11 @@ export function bundler(
   });
 }
 
-export function bundle(
+export async function bundle(
   entries: FilePath | Array<FilePath>,
   opts: InitialParcelOptions
 ): Promise<BundleGraph> {
-  return bundler(entries, opts).run();
+  return nullthrows(await bundler(entries, opts).run());
 }
 
 export async function run(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -117,6 +117,8 @@ export type PackageJSON = {
   peerDependencies?: PackageDependencies
 };
 
+export type LogLevel = 'none' | 'error' | 'warn' | 'info' | 'verbose';
+
 export type InitialParcelOptions = {|
   entries?: FilePath | Array<FilePath>,
   rootDir?: FilePath,
@@ -135,7 +137,7 @@ export type InitialParcelOptions = {|
   hot?: ServerOptions | false,
   serve?: ServerOptions | false,
   autoinstall?: boolean,
-  logLevel?: 'none' | 'error' | 'warn' | 'info' | 'verbose'
+  logLevel?: LogLevel
 
   // contentHash
   // scopeHoist
@@ -148,6 +150,7 @@ export type ParcelOptions = {|
   ...InitialParcelOptions,
   cacheDir: FilePath,
   entries: Array<FilePath>,
+  logLevel: LogLevel,
   rootDir: FilePath,
   targets: Array<Target>
 |};

--- a/packages/reporters/cli/src/SimpleCLIReporter.js
+++ b/packages/reporters/cli/src/SimpleCLIReporter.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {ReporterEvent, ParcelOptions} from '@parcel/types';
+import type {LogLevel, ReporterEvent, ParcelOptions} from '@parcel/types';
 
 import type {Writable} from 'stream';
 
@@ -59,14 +59,14 @@ export function _report(event: ReporterEvent, options: ParcelOptions): void {
         break;
       }
 
-      writeErr(event.error);
+      writeErr(event.error, options.logLevel);
       break;
     case 'log': {
       switch (event.level) {
         case 'warn':
         case 'error':
           if (logLevelFilter >= logLevels[event.level]) {
-            writeErr(event.message);
+            writeErr(event.message, options.logLevel);
           }
           break;
         case 'info':
@@ -88,11 +88,11 @@ function writeOut(message: string): void {
   stdout.write(message + '\n');
 }
 
-function writeErr(message: string | Error): void {
+function writeErr(message: string | Error, level: LogLevel): void {
   let error = prettyError(message, {color: false});
   // prefix with parcel: to clarify the source of errors
   writeErrLine('parcel: ' + error.message);
-  if (error.stack != null) {
+  if (error.stack != null && logLevels[level] >= logLevels.verbose) {
     writeErrLine(error.stack);
   }
 }

--- a/packages/reporters/cli/test/SimpleCLIReporter.test.js
+++ b/packages/reporters/cli/test/SimpleCLIReporter.test.js
@@ -7,6 +7,7 @@ import {_report, _setStdio} from '../src/SimpleCLIReporter';
 const EMPTY_OPTIONS = {
   cacheDir: '.parcel-cache',
   entries: [],
+  logLevel: 'info',
   rootDir: __dirname,
   targets: []
 };
@@ -35,14 +36,6 @@ describe('SimpleCLIReporter', () => {
 
   afterEach(() => {
     _setStdio(originalStdout, originalStderr);
-  });
-
-  it('defaults to an info logLevel filter', () => {
-    _report({type: 'log', level: 'info', message: 'info'}, EMPTY_OPTIONS);
-    _report({type: 'log', level: 'success', message: 'success'}, EMPTY_OPTIONS);
-    _report({type: 'log', level: 'verbose', message: 'verbose'}, EMPTY_OPTIONS);
-
-    assert(!stdoutOutput.includes('verbose'));
   });
 
   it('writes log, info, success, and verbose log messages to stdout', () => {


### PR DESCRIPTION
In the CLI, currently all exceptions are logged but are caught and allow the process to exit gracefully, even outside watch mode.

Instead:
* Catch all errors in watch mode **within Parcel**. With reporter infrastructure, it should be clear what caused an error, without disrupting 
	* Should certain classes of error allow Parcel to be terminated in watch mode? We should let things like e.g. transformer parse errors to keep the watcher going, but should more critical errors take down the watcher?
* In non-watch modes (not watch or server -- basically just the `build` command right now), throw exceptions from within `Parcel#run` (reject the promise it returns) and expect callers to handle them. This will ultimately be tools wrapping Parcel, but right now amounts to just the CLI.
* If the CLI catches an exception from Parcel, assume it was reported via a reporter and exit the process with code 1 immediately without logging or rethrowing.
	* Before this patch, errors were shown twice: once in a reporter, and once in the cli `console.error`.
* Catch all unhandled promise rejections in the CLI. We shouldn't do this within core as Parcel can be required as a library and we don't want to change the environment.
* Resolve a default `logLevel` of `info` at the start of Parcel.
* Don't show error stack traces unless `logLevel` is verbose.

Test Plan:
* Throw an error in the BundlerRunner (main process), and Transformer Runner (worker) and verify both cause Parcel to exit outside watch mode. 
	* Verify they let Parcel continue to run within watch mode, but that their messages are logged.
* Introduce a syntax error in the simple example and 
	* Verify that the long babel backtrace is not shown unless `logLevel` is verbose
	* Verify that the babel code frames continue to be shown. 
	* Verify that running with `logLevel` of verbose shows the babel stacktraces 
* flow, lint, test