### PR TITLE
V2: Render errors on dev and hmr using HTML instead of ansi

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -139,6 +139,7 @@ export default class Server extends EventEmitter {
 
     if (this.error) {
       let error = prettyError(this.error, {color: true});
+      error.message = ansiHtml(error.message);
       error.stack = ansiHtml(error.stack);
 
       let template500 = (await readFile(

--- a/packages/reporters/dev-server/src/templates/500.html
+++ b/packages/reporters/dev-server/src/templates/500.html
@@ -9,7 +9,7 @@
       body {
         margin: 0;
       }
-      
+
       .error-title-style {
         display: flex;
       }
@@ -43,10 +43,10 @@
   <body>
     <div class="error-title-style">
       <div class="error-title-emoji">🚨</div>
-      <h1 class="error-title-heading"><%= error.message %></h1>
+      <h1 class="error-title-heading"><%- error.message %></h1>
     </div>
     <div class="error-stack-trace">
-      <%= error.stack %>
+      <%- error.stack %>
     </div>
   </body>
 </html>

--- a/packages/reporters/hmr-server/package.json
+++ b/packages/reporters/hmr-server/package.json
@@ -23,6 +23,7 @@
     "@parcel/logger": "^2.0.0",
     "@parcel/reporter-cli": "^2.0.0",
     "@parcel/utils": "^2.0.0",
+    "ansi-html": "^0.0.7",
     "ws": "^6.2.0"
   },
   "devDependencies": {

--- a/packages/reporters/hmr-server/src/HMRServer.js
+++ b/packages/reporters/hmr-server/src/HMRServer.js
@@ -7,6 +7,7 @@ import type {Server, ServerError, HMRServerOptions} from './types.js.flow';
 import http from 'http';
 import https from 'https';
 import WebSocket from 'ws';
+import ansiHtml from 'ansi-html';
 import {getCertificate, generateCertificate} from '@parcel/utils';
 import logger from '@parcel/logger';
 import {prettyError} from '@parcel/utils';
@@ -95,8 +96,8 @@ export default class HMRServer {
     this.unresolvedError = {
       type: 'error',
       error: {
-        message,
-        stack
+        message: ansiHtml(message),
+        stack: ansiHtml(stack)
       }
     };
 

--- a/packages/reporters/hmr-server/src/HMRServer.js
+++ b/packages/reporters/hmr-server/src/HMRServer.js
@@ -28,7 +28,8 @@ type HMRError = {|
 
 type HMRMessage = {|
   type: string,
-  error?: HMRError,
+  ansiError?: HMRError,
+  htmlError?: HMRError,
   assets?: Array<HMRAsset>
 |};
 
@@ -95,7 +96,11 @@ export default class HMRServer {
     // and so we can broadcast when the error is resolved
     this.unresolvedError = {
       type: 'error',
-      error: {
+      ansiError: {
+        message,
+        stack
+      },
+      htmlError: {
         message: ansiHtml(message),
         stack: ansiHtml(stack)
       }

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -72,7 +72,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
 
     if (data.type === 'error') {
       console.error(
-        '[parcel] 🚨  ' + data.error.message + '\n' + data.error.stack
+        '[parcel] 🚨  ' + data.ansiError.message + '\n' + data.ansiError.stack
       );
 
       removeErrorOverlay();
@@ -98,8 +98,8 @@ function createErrorOverlay(data) {
   // html encode message and stack trace
   var message = document.createElement('div');
   var stackTrace = document.createElement('pre');
-  message.innerText = data.error.message;
-  stackTrace.innerText = data.error.stack;
+  message.innerHTML = data.htmlError.message;
+  stackTrace.innerHTML = data.htmlError.stack;
 
   overlay.innerHTML =
     '<div style="background: black; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; opacity: 0.85; font-family: Menlo, Consolas, monospace; z-index: 9999;">' +


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This formats hmr stack traces and error messages from ansi to html.

See comments for detailed explanation to all changes

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
