### PR TITLE
Allow nullish coalescing and optional chaining in Parcel 2 codebase

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,6 +17,8 @@ untyped-type-import=error
 
 [options]
 esproposal.export_star_as=enable
+esproposal.nullish_coalescing=enable
+esproposal.optional_chaining=enable
 
 [strict]
 nonstrict-import

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.1.0",
     "flow-bin": "0.98.1",
     "lerna": "^3.3.2",
     "lint-staged": "^7.2.2",

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -318,7 +318,7 @@ export default class Asset {
     filePaths: Array<FilePath>,
     options: ?{packageKey?: string, parse?: boolean}
   ): Promise<Config | null> {
-    let packageKey = options && options.packageKey;
+    let packageKey = options?.packageKey;
     let parse = options && options.parse;
 
     if (packageKey != null) {

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -35,7 +35,7 @@ export default class TargetResolver {
   ): Promise<Array<Target>> {
     let packageTargets = await this.resolvePackageTargets(rootDir);
 
-    let serveOptions = initialOptions.serve || initialOptions.hot;
+    let serveOptions = initialOptions.serve ?? initialOptions.hot;
     let targets;
     if (initialOptions.targets) {
       if (initialOptions.targets.length === 0) {
@@ -75,10 +75,7 @@ export default class TargetResolver {
           {
             name: 'default',
             distDir: 'dist',
-            publicUrl:
-              serveOptions && serveOptions.publicUrl != null
-                ? serveOptions.publicUrl
-                : '/',
+            publicUrl: serveOptions?.publicUrl ?? '/',
             env: new Environment({
               context: 'browser',
               engines: {
@@ -132,8 +129,7 @@ export default class TargetResolver {
         name: 'main',
         distDir,
         distEntry,
-        publicUrl:
-          pkgTargets.main.publicUrl != null ? pkgTargets.main.publicUrl : '/',
+        publicUrl: pkgTargets.main?.publicUrl ?? '/',
         env: this.getEnvironment(pkgEngines, mainContext).merge(pkgTargets.main)
       });
     }
@@ -154,10 +150,7 @@ export default class TargetResolver {
         name: 'module',
         distDir,
         distEntry,
-        publicUrl:
-          pkgTargets.module.publicUrl != null
-            ? pkgTargets.module.publicUrl
-            : '/',
+        publicUrl: pkgTargets.module?.publicUrl ?? '/',
         env: this.getEnvironment(pkgEngines, mainContext).merge(
           pkgTargets.module
         )
@@ -184,10 +177,7 @@ export default class TargetResolver {
         name: 'browser',
         distEntry,
         distDir,
-        publicUrl:
-          pkgTargets.browser.publicUrl != null
-            ? pkgTargets.browser.publicUrl
-            : '/',
+        publicUrl: pkgTargets.browser?.publicUrl ?? '/',
         env: this.getEnvironment(pkgEngines, 'browser').merge(
           pkgTargets.browser
         )
@@ -218,7 +208,7 @@ export default class TargetResolver {
           name,
           distDir,
           distEntry,
-          publicUrl: env.publicUrl != null ? env.publicUrl : '/',
+          publicUrl: env.publicUrl ?? '/',
           env: this.getEnvironment(pkgEngines, context).merge(env)
         });
       }

--- a/packages/dev/babel-preset/index.js
+++ b/packages/dev/babel-preset/index.js
@@ -13,6 +13,8 @@ module.exports = () => ({
   ],
   plugins: [
     require('./serializer'),
-    require('@babel/plugin-proposal-class-properties')
+    require('@babel/plugin-proposal-class-properties'),
+    require('@babel/plugin-proposal-nullish-coalescing-operator'),
+    require('@babel/plugin-proposal-optional-chaining')
   ]
 });

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -4,6 +4,8 @@
   "license": "MIT",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",
+    "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@parcel/eslint-plugin": "^2.0.0",
     "babel-eslint": "^10.0.1",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-flowtype": "^3.1.1",
     "eslint-plugin-import": "^2.16.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,6 +442,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.4.4.tgz#41c360d59481d88e0ce3a3f837df10121a769b39"
+  integrity sha512-Amph7Epui1Dh/xxUxS2+K22/MUi6+6JVTvy3P58tja3B6yKTSjwwx0/d83rF7551D6PVSSoplQb8GCwqec7HRw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.2.0"
+
 "@babel/plugin-proposal-object-rest-spread@^7.0.0":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz#be27cd416eceeba84141305b93c282f5de23bbb4"
@@ -473,6 +481,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.2.0.tgz#ae454f4c21c6c2ce8cb2397dc332ae8b420c5441"
+  integrity sha512-ea3Q6edZC/55wEBVZAEz42v528VulyO0eir+7uky/sT4XRcdkWJcFi1aPtitTlwUzGnECWJNExWww1SStt+yWw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-optional-chaining" "^7.2.0"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.0.0", "@babel/plugin-proposal-unicode-property-regex@^7.2.0":
   version "7.4.0"
@@ -532,6 +548,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.2.0.tgz#f75083dfd5ade73e783db729bbd87e7b9efb7624"
+  integrity sha512-lRCEaKE+LTxDQtgbYajI04ddt6WW0WJq57xqkAZ+s11h4YgfRHhVA/Y2VhfPzzFD4qeLHWg32DMp9HooY4Kqlg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz#3b7a3e733510c57e820b9142a6579ac8b0dfad2e"
@@ -543,6 +566,13 @@
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz#a94013d6eda8908dfe6a477e7f9eda85656ecf5c"
   integrity sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-optional-chaining@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz#a59d6ae8c167e7608eaa443fda9fa8fa6bf21dff"
+  integrity sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
**NOTE: This does not add support to what Parcel can *build*, only how Parcel itself is built**

This adds support for the nullish coalescing operator[0] and optional chaining[1] proposals to JavaScript. These proposals are currently at Stage 1, which is quite early. However, given pain points in the codebase, the simplicity of these proposals, and their support across Babel, Flow, and ESLint, we can adopt them.

Should either of these proposals change or be withdrawn, codemodding back is pretty straightforward given their simplicity.

This PR also moves `eslint-config-prettier` to the eslint config package.

Test Plan: Updated a few usages with both proposals. Verify flow, lint, and test.

[0] https://github.com/tc39/proposal-nullish-coalescing
[1] https://github.com/tc39/proposal-optional-chaining