### PR TITLE
Fix sourcemap loading if name contains spaces

### DIFF
--- a/packages/core/parcel-bundler/src/utils/loadSourceMap.js
+++ b/packages/core/parcel-bundler/src/utils/loadSourceMap.js
@@ -2,7 +2,7 @@ const logger = require('@parcel/logger');
 const path = require('path');
 const fs = require('@parcel/fs');
 
-const SOURCEMAP_RE = /(?:\/\*|\/\/)\s*[@#]\s*sourceMappingURL\s*=\s*([^\s*]+)(?:\s*\*\/)?/;
+const SOURCEMAP_RE = /(?:\/\*|\/\/)\s*[@#]\s*sourceMappingURL\s*=\s*([^\r\n*]+)(?:\s*\*\/)?/;
 const DATA_URL_RE = /^data:[^;]+(?:;charset=[^;]+)?;base64,(.*)/;
 
 async function loadSourceMap(asset) {
@@ -12,7 +12,7 @@ async function loadSourceMap(asset) {
   if (match) {
     asset.contents = asset.contents.replace(SOURCEMAP_RE, '');
 
-    let url = match[1];
+    let url = match[1].trim();
     let dataURLMatch = url.match(DATA_URL_RE);
 
     try {
@@ -63,6 +63,7 @@ async function loadSourceMap(asset) {
         sourceMap.sourcesContent = sourceMap.sourcesContent.concat(contents);
       }
     } catch (e) {
+      console.error(e);
       logger.warn(
         `Could not load existing sourcemap of "${asset.relativeName}".`
       );

--- a/packages/core/parcel-bundler/src/utils/loadSourceMap.js
+++ b/packages/core/parcel-bundler/src/utils/loadSourceMap.js
@@ -63,7 +63,6 @@ async function loadSourceMap(asset) {
         sourceMap.sourcesContent = sourceMap.sourcesContent.concat(contents);
       }
     } catch (e) {
-      console.error(e);
       logger.warn(
         `Could not load existing sourcemap of "${asset.relativeName}".`
       );


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

If a sourcemap had any spaces in it's filename sourcemapLoader would fail and create syntax errors by only removing a part of the sourcemap

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

This would fail:

```JS
//# sourceMappingURL=this is a sourcemap.js.map
```

Now it works :)

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
