### PR TITLE
Implement Graph with adjacency lists rather than edge lists

### DIFF
--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -173,12 +173,12 @@ export default class BundlerRunner {
       // the node to it.
       bundle.assetGraph.merge(subGraph);
 
-      bundle.assetGraph.addEdge({
-        from: dependency
+      bundle.assetGraph.addEdge(
+        dependency
           ? dependency.id
           : nullthrows(bundle.assetGraph.getRootNode()).id,
-        to: entryId
-      });
+        entryId
+      );
     }
   }
 }

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -177,10 +177,7 @@ export class MutableBundleGraph extends BaseBundleGraph
     });
 
     this.#graph.addNode(node);
-    this.#graph.addEdge({
-      from: parentBundle ? parentBundle.id : 'root',
-      to: node.id
-    });
+    this.#graph.addEdge(parentBundle ? parentBundle.id : 'root', node.id);
   }
 
   addBundle(bundleGroup: BundleGroup, bundle: IBundle) {
@@ -199,7 +196,7 @@ export class MutableBundleGraph extends BaseBundleGraph
     };
 
     this.#graph.addNode(bundleNode);
-    this.#graph.addEdge({from: bundleGroupId, to: bundleNode.id});
+    this.#graph.addEdge(bundleGroupId, bundleNode.id);
 
     this.#graph.traverse(node => {
       // Replace dependencies in this bundle with bundle group references for
@@ -215,10 +212,7 @@ export class MutableBundleGraph extends BaseBundleGraph
             this.#graph.getSubGraph(node)
           );
           assetGraph.replaceNodesConnectedTo(depNode, [node]);
-          this.#graph.addEdge({
-            from: internalBundle.id,
-            to: node.id
-          });
+          this.#graph.addEdge(internalBundle.id, node.id);
         }
       }
 
@@ -229,10 +223,7 @@ export class MutableBundleGraph extends BaseBundleGraph
         node.value.assetGraph.hasNode(bundleGroupId)
       ) {
         node.value.assetGraph.addNode(referenceNode);
-        node.value.assetGraph.addEdge({
-          from: bundleGroupId,
-          to: referenceNode.id
-        });
+        node.value.assetGraph.addEdge(bundleGroupId, referenceNode.id);
       }
     });
   }
@@ -291,7 +282,7 @@ function mergeBundleGraphIntoBundleAssetGraph(
   }
 
   for (let edge of bundleGraph.getAllEdges()) {
-    bundleAssetGraph.addEdge(edge);
+    bundleAssetGraph.addEdge(edge.from, edge.to);
   }
 }
 

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -290,7 +290,7 @@ function mergeBundleGraphIntoBundleAssetGraph(
     }
   }
 
-  for (let edge of bundleGraph.edges) {
+  for (let edge of bundleGraph.getAllEdges()) {
     bundleAssetGraph.addEdge(edge);
   }
 }

--- a/packages/core/core/src/public/MainAssetGraph.js
+++ b/packages/core/core/src/public/MainAssetGraph.js
@@ -33,10 +33,7 @@ export default class MainAssetGraph implements IMainAssetGraph {
       value: null
     });
 
-    graph.addEdge({
-      from: 'root',
-      to: assetNode.id
-    });
+    graph.addEdge('root', assetNode.id);
 
     // Prune assets that don't match the bundle type when including the asset's
     // subgraph. These are replaced with asset references, but the concrete assets

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -85,40 +85,20 @@ describe('AssetGraph', () => {
 
     graph.resolveDependency(dep, req);
     assert(graph.nodes.has(nodeFromTransformerRequest(req).id));
-    assert(
-      graph.hasEdge({
-        from: dep.id,
-        to: nodeFromTransformerRequest(req).id
-      })
-    );
+    assert(graph.hasEdge(dep.id, nodeFromTransformerRequest(req).id));
     assert(graph.incompleteNodes.has(nodeFromTransformerRequest(req).id));
 
     let req2 = {filePath: '/index.jsx', env: DEFAULT_ENV};
     graph.resolveDependency(dep, req2);
     assert(!graph.nodes.has(nodeFromTransformerRequest(req).id));
     assert(graph.nodes.has(nodeFromTransformerRequest(req2).id));
-    assert(
-      graph.hasEdge({
-        from: dep.id,
-        to: nodeFromTransformerRequest(req2).id
-      })
-    );
-    assert(
-      !graph.hasEdge({
-        from: dep.id,
-        to: nodeFromTransformerRequest(req).id
-      })
-    );
+    assert(graph.hasEdge(dep.id, nodeFromTransformerRequest(req2).id));
+    assert(!graph.hasEdge(dep.id, nodeFromTransformerRequest(req).id));
     assert(graph.incompleteNodes.has(nodeFromTransformerRequest(req2).id));
 
     graph.resolveDependency(dep, req2);
     assert(graph.nodes.has(nodeFromTransformerRequest(req2).id));
-    assert(
-      graph.hasEdge({
-        from: dep.id,
-        to: nodeFromTransformerRequest(req2).id
-      })
-    );
+    assert(graph.hasEdge(dep.id, nodeFromTransformerRequest(req2).id));
     assert(graph.incompleteNodes.has(nodeFromTransformerRequest(req2).id));
   });
 
@@ -205,42 +185,12 @@ describe('AssetGraph', () => {
     assert(graph.nodes.has(assets[0].getDependencies()[0].id));
     assert(graph.nodes.has(assets[1].getDependencies()[0].id));
     assert(graph.nodes.has('/index.js'));
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: '1'
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: '2'
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: '3'
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: filePath
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: '1',
-        to: assets[0].getDependencies()[0].id
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: '2',
-        to: assets[1].getDependencies()[0].id
-      })
-    );
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '1'));
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '2'));
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '3'));
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, filePath));
+    assert(graph.hasEdge('1', assets[0].getDependencies()[0].id));
+    assert(graph.hasEdge('2', assets[1].getDependencies()[0].id));
     assert(!graph.incompleteNodes.has(nodeFromTransformerRequest(req).id));
     assert(
       graph.incompleteNodes.has(
@@ -307,42 +257,12 @@ describe('AssetGraph', () => {
     assert(!graph.nodes.has('3'));
     assert(graph.nodes.has(assets[0].getDependencies()[0].id));
     assert(!graph.nodes.has(assets[1].getDependencies()[0].id));
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: '1'
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: '2'
-      })
-    );
-    assert(
-      !graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: '3'
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: nodeFromTransformerRequest(req).id,
-        to: filePath
-      })
-    );
-    assert(
-      graph.hasEdge({
-        from: '1',
-        to: assets[0].getDependencies()[0].id
-      })
-    );
-    assert(
-      !graph.hasEdge({
-        from: '2',
-        to: assets[1].getDependencies()[0].id
-      })
-    );
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '1'));
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '2'));
+    assert(!graph.hasEdge(nodeFromTransformerRequest(req).id, '3'));
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, filePath));
+    assert(graph.hasEdge('1', assets[0].getDependencies()[0].id));
+    assert(!graph.hasEdge('2', assets[1].getDependencies()[0].id));
     assert(!graph.incompleteNodes.has(nodeFromTransformerRequest(req).id));
     assert(
       graph.incompleteNodes.has(
@@ -416,9 +336,7 @@ describe('AssetGraph', () => {
     graph.resolveTransformerRequest(req, cacheEntry);
     assert(graph.nodes.has('1'));
     assert(graph.nodes.has('/foo/bar'));
-    assert(graph.hasEdge({from: nodeFromTransformerRequest(req).id, to: '1'}));
-    assert(
-      graph.hasEdge({from: nodeFromTransformerRequest(req).id, to: '/foo/bar'})
-    );
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '1'));
+    assert(graph.hasEdge(nodeFromTransformerRequest(req).id, '/foo/bar'));
   });
 });

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -50,25 +50,22 @@ describe('AssetGraph', () => {
         }).id
       )
     );
-    assert.deepEqual(
-      graph.edges,
-      new Set([
-        {
-          from: '/',
-          to: new Dependency({
-            moduleSpecifier: './index1',
-            env: DEFAULT_ENV
-          }).id
-        },
-        {
-          from: '/',
-          to: new Dependency({
-            moduleSpecifier: './index2',
-            env: DEFAULT_ENV
-          }).id
-        }
-      ])
-    );
+    assert.deepEqual(graph.getAllEdges(), [
+      {
+        from: '/',
+        to: new Dependency({
+          moduleSpecifier: './index1',
+          env: DEFAULT_ENV
+        }).id
+      },
+      {
+        from: '/',
+        to: new Dependency({
+          moduleSpecifier: './index2',
+          env: DEFAULT_ENV
+        }).id
+      }
+    ]);
   });
 
   it('resolveDependency should update the file a dependency is connected to', () => {

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -11,15 +11,6 @@ describe('Graph', () => {
     assert.deepEqual(graph.getAllEdges(), []);
   });
 
-  it('throws when constructed with duplicate edges', () => {
-    assert.throws(() => {
-      new Graph({
-        nodes: [['a', {id: 'a', value: 'b'}], ['b', {id: 'b', value: 'b'}]],
-        edges: [{from: 'a', to: 'b'}, {from: 'a', to: 'b'}]
-      });
-    }, /Graph already has edge from a to b/);
-  });
-
   it('addNode should add a node to the graph', () => {
     let graph = new Graph();
     let node = {id: 'a', value: 'a'};

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -28,9 +28,8 @@ describe('Graph', () => {
 
   it('addEdge should add an edge to the graph', () => {
     let graph = new Graph();
-    let edge = {from: 'a', to: 'b'};
-    graph.addEdge(edge);
-    assert(graph.hasEdge(edge));
+    graph.addEdge('a', 'b');
+    assert(graph.hasEdge('a', 'b'));
   });
 
   it('isOrphanedNode should return true or false if the node is orphaned or not', () => {
@@ -39,7 +38,7 @@ describe('Graph', () => {
     let nodeB = {id: 'b', value: 'b'};
     graph.addNode(nodeA);
     graph.addNode(nodeB);
-    graph.addEdge({from: 'a', to: 'b'});
+    graph.addEdge('a', 'b');
     assert(graph.isOrphanedNode(nodeA));
     assert(!graph.isOrphanedNode(nodeB));
   });
@@ -50,20 +49,24 @@ describe('Graph', () => {
     graph.addNode({id: 'b', value: 'b'});
     graph.addNode({id: 'c', value: 'c'});
     graph.addNode({id: 'd', value: 'd'});
-    let edgeAB = graph.addEdge({from: 'a', to: 'b'});
-    let edgeAD = graph.addEdge({from: 'a', to: 'd'});
-    let edgeBC = graph.addEdge({from: 'b', to: 'c'});
-    let edgeBD = graph.addEdge({from: 'b', to: 'd'});
+    graph.addEdge('a', 'b');
+    graph.addEdge('a', 'd');
+    graph.addEdge('b', 'c');
+    graph.addEdge('b', 'd');
 
-    let removed = graph.removeEdge(edgeAB);
+    let removed = graph.removeEdge('a', 'b');
     assert(graph.nodes.has('a'));
     assert(graph.nodes.has('d'));
     assert(!graph.nodes.has('b'));
     assert(!graph.nodes.has('c'));
-    assert.deepEqual(graph.getAllEdges(), [edgeAD]);
+    assert.deepEqual(graph.getAllEdges(), [{from: 'a', to: 'd'}]);
     assert(removed.nodes.has('b'));
     assert(removed.nodes.has('c'));
-    assert.deepEqual(removed.getAllEdges(), [edgeAB, edgeBC, edgeBD]);
+    assert.deepEqual(removed.getAllEdges(), [
+      {from: 'a', to: 'b'},
+      {from: 'b', to: 'c'},
+      {from: 'b', to: 'd'}
+    ]);
   });
 
   it("updateNodeDownStream should update a node's downstream nodes", () => {
@@ -71,20 +74,21 @@ describe('Graph', () => {
     let nodeA = graph.addNode({id: 'a', value: 'a'});
     let nodeB = graph.addNode({id: 'b', value: 'b'});
     graph.addNode({id: 'c', value: 'c'});
-    let edgeAB = graph.addEdge({from: 'a', to: 'b'});
-    let edgeAC = graph.addEdge({from: 'a', to: 'c'});
+    graph.addEdge('a', 'b');
+    graph.addEdge('a', 'c');
 
     let nodeD = {id: 'd', value: 'd'};
-    let edgeAD = {from: 'a', to: 'd'};
-
     let {removed} = graph.replaceNodesConnectedTo(nodeA, [nodeB, nodeD]);
 
     assert(graph.nodes.has('a'));
     assert(graph.nodes.has('b'));
     assert(!graph.nodes.has('c'));
     assert(graph.nodes.has('d'));
-    assert.deepEqual(graph.getAllEdges(), [edgeAB, edgeAD]);
+    assert.deepEqual(graph.getAllEdges(), [
+      {from: 'a', to: 'b'},
+      {from: 'a', to: 'd'}
+    ]);
     assert(removed.nodes.has('c'));
-    assert.deepEqual(removed.getAllEdges(), [edgeAC]);
+    assert.deepEqual(removed.getAllEdges(), [{from: 'a', to: 'c'}]);
   });
 });

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -8,7 +8,16 @@ describe('Graph', () => {
   it('constructor should initialize an empty graph', () => {
     let graph = new Graph();
     assert.deepEqual(graph.nodes, new Map());
-    assert.deepEqual(graph.edges, new Set());
+    assert.deepEqual(graph.getAllEdges(), []);
+  });
+
+  it('throws when constructed with duplicate edges', () => {
+    assert.throws(() => {
+      new Graph({
+        nodes: [['a', {id: 'a', value: 'b'}], ['b', {id: 'b', value: 'b'}]],
+        edges: [{from: 'a', to: 'b'}, {from: 'a', to: 'b'}]
+      });
+    }, /Graph already has edge from a to b/);
   });
 
   it('addNode should add a node to the graph', () => {
@@ -30,7 +39,7 @@ describe('Graph', () => {
     let graph = new Graph();
     let edge = {from: 'a', to: 'b'};
     graph.addEdge(edge);
-    assert(graph.edges.has(edge));
+    assert(graph.hasEdge(edge));
   });
 
   it('isOrphanedNode should return true or false if the node is orphaned or not', () => {
@@ -60,10 +69,10 @@ describe('Graph', () => {
     assert(graph.nodes.has('d'));
     assert(!graph.nodes.has('b'));
     assert(!graph.nodes.has('c'));
-    assert.deepEqual(graph.edges, new Set([edgeAD]));
+    assert.deepEqual(graph.getAllEdges(), [edgeAD]);
     assert(removed.nodes.has('b'));
     assert(removed.nodes.has('c'));
-    assert.deepEqual(removed.edges, new Set([edgeAB, edgeBC, edgeBD]));
+    assert.deepEqual(removed.getAllEdges(), [edgeAB, edgeBC, edgeBD]);
   });
 
   it("updateNodeDownStream should update a node's downstream nodes", () => {
@@ -83,8 +92,8 @@ describe('Graph', () => {
     assert(graph.nodes.has('b'));
     assert(!graph.nodes.has('c'));
     assert(graph.nodes.has('d'));
-    assert.deepEqual(graph.edges, new Set([edgeAB, edgeAD]));
+    assert.deepEqual(graph.getAllEdges(), [edgeAB, edgeAD]);
     assert(removed.nodes.has('c'));
-    assert.deepEqual(removed.edges, new Set([edgeAC]));
+    assert.deepEqual(removed.getAllEdges(), [edgeAC]);
   });
 });

--- a/packages/core/utils/src/DefaultMap.js
+++ b/packages/core/utils/src/DefaultMap.js
@@ -1,0 +1,23 @@
+// @flow strict-local
+
+export default class DefaultMap<K, V> extends Map<K, V> {
+  _getDefault: K => V;
+
+  constructor(getDefault: K => V, entries?: Iterable<[K, V]>) {
+    super(entries);
+    this._getDefault = getDefault;
+  }
+
+  get(key: K): V {
+    let ret;
+    if (this.has(key)) {
+      ret = super.get(key);
+    } else {
+      ret = this._getDefault(key);
+      this.set(key, ret);
+    }
+
+    // $FlowFixMe
+    return ret;
+  }
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -4,6 +4,7 @@ export type * from './errorUtils';
 export type * from './generateBundleReport';
 export type * from './prettyError';
 
+export {default as DefaultMap} from './DefaultMap';
 export {default as generateBundleReport} from './generateBundleReport';
 export {default as generateCertificate} from './generateCertificate';
 export {default as getCertificate} from './getCertificate';

--- a/packages/core/utils/test/DefaultMap.test.js
+++ b/packages/core/utils/test/DefaultMap.test.js
@@ -1,0 +1,32 @@
+// @flow strict-local
+
+import assert from 'assert';
+import DefaultMap from '../src/DefaultMap';
+
+describe('DefaultMap', () => {
+  it('constructs with entries just like Map', () => {
+    let map = new DefaultMap(k => k, [[1, 3], [2, 27]]);
+    assert.equal(map.get(1), 3);
+    assert.deepEqual(Array.from(map.entries()), [[1, 3], [2, 27]]);
+  });
+
+  it("returns a default value based on a key if it doesn't exist", () => {
+    let map = new DefaultMap(k => k);
+    assert.equal(map.get(3), 3);
+  });
+
+  it("sets a default value based on a key if it doesn't exist", () => {
+    let map = new DefaultMap(k => k);
+    map.get(3);
+    assert.deepEqual(Array.from(map.entries()), [[3, 3]]);
+  });
+
+  it('respects undefined/null if it already existed in the map', () => {
+    let map = new DefaultMap<number, number | void | null>(k => k);
+    map.set(3, undefined);
+    assert.equal(map.get(3), undefined);
+
+    map.set(4, null);
+    assert.equal(map.get(4), null);
+  });
+});


### PR DESCRIPTION
* The existing edge list implementation of `Graph` very frequently iterates the entire list of edges in the graph to find outbound and inbound edges for specific uses.
* Instead, create two adjacency lists[0]: one for outbound edges from nodes and one for inbound edges. This means that getting a node's inbound or outbound edges no longer grows with the entire set of edges in the graph, and instead only grows with the node's own edges.
* `graph.hasEdge` and `graph.removeEdge` are now O(1) rather than O(E).
* `graph.getNodesConnectedTo` and `graph.getNodesConnectedFrom` are now bounded by the number of edges attached to the node rather than O(E).
* Retains an interfaces for retrieving all the edges in the graph. Like `graph.edges`, except it returns an array rather than a set (edge membership can still be tested with `graph.hasEdge`).
    * This is used to serialize the graph, as well as for graph copying.

This also implements `DefaultMap`, like python's `defaultdict`, for easy setting of default mappings if they don't exist for a node.

Test Plan: `yarn test`, and manual test the simple example.

[0] https://en.wikipedia.org/wiki/Adjacency_list