### PR TITLE
CSSPackager: Apply CSS Styles in the correct order

### DIFF
--- a/packages/core/integration-tests/test/integration/css-order/a.css
+++ b/packages/core/integration-tests/test/integration/css-order/a.css
@@ -1,0 +1,6 @@
+@import "./b.css";
+@import "./e.css";
+
+.a {
+  background: blue;
+}

--- a/packages/core/integration-tests/test/integration/css-order/b.css
+++ b/packages/core/integration-tests/test/integration/css-order/b.css
@@ -1,0 +1,6 @@
+@import "./c.css";
+@import "./d.css";
+
+.b {
+  background: green;
+}

--- a/packages/core/integration-tests/test/integration/css-order/c.css
+++ b/packages/core/integration-tests/test/integration/css-order/c.css
@@ -1,0 +1,3 @@
+.c {
+  background: red;
+}

--- a/packages/core/integration-tests/test/integration/css-order/d.css
+++ b/packages/core/integration-tests/test/integration/css-order/d.css
@@ -1,0 +1,3 @@
+.d {
+  background: purple;
+}

--- a/packages/core/integration-tests/test/integration/css-order/e.css
+++ b/packages/core/integration-tests/test/integration/css-order/e.css
@@ -1,0 +1,3 @@
+.e {
+  background: magenta;
+}

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -5,8 +5,10 @@ import {Packager} from '@parcel/plugin';
 export default new Packager({
   async package(bundle) {
     let promises = [];
-    bundle.traverseAssets(asset => {
-      promises.push(asset.getCode());
+    bundle.traverseAssets({
+      exit: asset => {
+        promises.push(asset.getCode());
+      }
     });
     let outputs = await Promise.all(promises);
 


### PR DESCRIPTION
Given the tree:

```
      A
    /   \
   B     E
  / \
 C   D
```

(A imports B (which imports C and D) and E)

... styles should be applied in the order C, D, B, E, A

Order is critical here since we're just concatenating styles, and CSS is sensitive to selector order.

This is possible now with the `exit` option added to traversals introduced in the scope hoisting PR

Test Plan: Integration test added. `yarn test`