### PR TITLE
Prevent relative cross-package imports with eslint-plugin-monorepo

### DIFF
--- a/packages/core/is-v2-ready-yet/.eslintrc
+++ b/packages/core/is-v2-ready-yet/.eslintrc
@@ -4,6 +4,8 @@
     "browser": true
   },
   "rules": {
+    "monorepo/no-internal-import": "off",
+    "monorepo/no-relative-import": "off",
     "react/prop-types": "off" // TODO: Enable this when this package is flow-typed
   }
 }

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -1,21 +1,15 @@
-const RESTRICTED_CONFIG = [
-  'error',
-  {
-    patterns: ['@parcel/*/*', '!@parcel/integration-tests/*']
-  }
-];
-
 module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:flowtype/recommended',
+    'plugin:monorepo/recommended',
     'plugin:react/recommended',
     'prettier',
     'prettier/flowtype',
     'prettier/react'
   ],
   parser: 'babel-eslint',
-  plugins: ['@parcel', 'flowtype', 'import', 'react'],
+  plugins: ['@parcel', 'flowtype', 'import', 'monorepo', 'react'],
   parserOptions: {
     ecmaVersion: 2018,
     ecmaFeatures: {
@@ -39,7 +33,9 @@ module.exports = {
         mocha: true
       },
       rules: {
-        'import/no-extraneous-dependencies': 'off'
+        'import/no-extraneous-dependencies': 'off',
+        'monorepo/no-internal-import': 'off',
+        'monorepo/no-relative-import': 'off'
       }
     }
   ],
@@ -49,9 +45,7 @@ module.exports = {
     'import/newline-after-import': 'error',
     'import/no-extraneous-dependencies': 'error',
     'import/no-self-import': 'error',
-    'no-return-await': 'error',
-    'no-restricted-imports': RESTRICTED_CONFIG,
-    'no-restricted-modules': RESTRICTED_CONFIG
+    'no-return-await': 'error'
   },
   settings: {
     flowtype: {

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -6,6 +6,7 @@
     "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-flowtype": "^3.1.1",
+    "eslint-plugin-monorepo": "^0.2.1",
     "eslint-plugin-import": "^2.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4728,6 +4728,13 @@ dir-glob@2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
+dir-glob@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
+    path-type "^3.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -5065,6 +5072,14 @@ eslint-import-resolver-node@^0.3.2:
     debug "^2.6.9"
     resolve "^1.5.0"
 
+eslint-module-utils@^2.1.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^2.0.0"
+
 eslint-module-utils@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
@@ -5095,6 +5110,19 @@ eslint-plugin-import@^2.16.0:
     minimatch "^3.0.4"
     read-pkg-up "^2.0.0"
     resolve "^1.9.0"
+
+eslint-plugin-monorepo@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-monorepo/-/eslint-plugin-monorepo-0.2.1.tgz#96cfc4af241077675f40d7017377897fb8ea537b"
+  integrity sha512-82JaAjuajVAsDT+pMvdt275H6F55H3MEofaMZbJurGqfXpPDT4eayTgYyyjfd1XR8VD1S+ORbuHCULnSqNyD9g==
+  dependencies:
+    eslint-module-utils "^2.1.1"
+    get-monorepo-packages "^1.1.0"
+    globby "^7.1.1"
+    load-json-file "^4.0.0"
+    minimatch "^3.0.4"
+    parse-package-name "^0.1.0"
+    path-is-inside "^1.0.2"
 
 eslint-plugin-react@^7.12.0:
   version "7.12.0"
@@ -5743,6 +5771,14 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-monorepo-packages@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/get-monorepo-packages/-/get-monorepo-packages-1.2.0.tgz#3eee88d30b11a5f65955dec6ae331958b2a168e4"
+  integrity sha512-aDP6tH+eM3EuVSp3YyCutOcFS4Y9AhRRH9FAd+cjtR/g63Hx+DCXdKoP1ViRPUJz5wm+BOEXB4FhoffGHxJ7jQ==
+  dependencies:
+    globby "^7.1.1"
+    load-json-file "^4.0.0"
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.0.tgz#b877b49a5c16aefac3655f2ed2ea5b684df8d203"
@@ -5937,6 +5973,18 @@ globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 globby@^8.0.1:
   version "8.0.2"
@@ -9159,6 +9207,11 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-package-name@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/parse-package-name/-/parse-package-name-0.1.0.tgz#3f44dd838feb4c2be4bf318bae4477d7706bade4"
+  integrity sha1-P0Tdg4/rTCvkvzGLrkR313BrreQ=
 
 parse-path@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This adds `eslint-plugin-monorepo` to our eslint config. It includes two rules:

* `monorepo/no-internal-import`, which prevents requiring deep into monorepo packages. This replaces our prior rule which used `no-restricted-imports` and `no-restricted-modules`, which was basically the same, except this has a clearer error message.
* `monorepo/no-relative-import`, which prevents requiring out of a package and into another using relative paths, i.e. `../../utils` rather than `@parcel/utils`.

Test Plan: Violate each rule in a file and verify `yarn lint` fails.