### PR TITLE
Resolve option file paths as absolute

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -279,14 +279,11 @@ export default class Parcel {
     invariant(this.#watcherSubscription == null);
 
     let resolvedOptions = nullthrows(this.#resolvedOptions);
-    let targetDirs = resolvedOptions.targets.map(target =>
-      path.resolve(target.distDir)
-    );
-    let cacheDir = path.resolve(resolvedOptions.cacheDir);
+    let targetDirs = resolvedOptions.targets.map(target => target.distDir);
     let vcsDirs = ['.git', '.hg'].map(dir =>
       path.join(resolvedOptions.projectRoot, dir)
     );
-    let ignore = [cacheDir, ...targetDirs, ...vcsDirs];
+    let ignore = [resolvedOptions.cacheDir, ...targetDirs, ...vcsDirs];
 
     return watcher.subscribe(
       resolvedOptions.projectRoot,

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -26,11 +26,13 @@ const DEVELOPMENT_BROWSERS = [
   'last 1 Edge version'
 ];
 
-const DEFAULT_DIST_DIR = 'dist';
+const DEFAULT_DIST_DIRNAME = 'dist';
+const COMMON_TARGETS = ['main', 'module', 'browser'];
 
 export default class TargetResolver {
   async resolve(
     rootDir: FilePath,
+    cacheDir: FilePath,
     initialOptions: InitialParcelOptions
   ): Promise<Array<Target>> {
     let packageTargets = await this.resolvePackageTargets(rootDir);
@@ -51,7 +53,12 @@ export default class TargetResolver {
           return matchingTarget;
         }
 
-        return target;
+        return {
+          ...target,
+          // In the case the supplied target was a relative path, resolve it from
+          // cwd just like Node does for other file paths.
+          distDir: path.resolve(target.distDir)
+        };
       });
 
       if (serveOptions) {
@@ -74,7 +81,10 @@ export default class TargetResolver {
         targets = [
           {
             name: 'default',
-            distDir: 'dist',
+            // For serve, write the `dist` to inside the parcel cache, which is
+            // temporary, likely in a .gitignore or similar, but still readily
+            // available for introspection by the user if necessary.
+            distDir: path.resolve(cacheDir, DEFAULT_DIST_DIRNAME),
             publicUrl: serveOptions?.publicUrl ?? '/',
             env: new Environment({
               context: 'browser',
@@ -95,9 +105,22 @@ export default class TargetResolver {
   async resolvePackageTargets(rootDir: FilePath): Promise<Map<string, Target>> {
     let conf = await loadConfig(path.join(rootDir, 'index'), ['package.json']);
 
-    let pkg: PackageJSON = conf ? conf.config : {};
+    let pkg: PackageJSON;
+    let pkgDir: FilePath;
+    if (conf) {
+      pkg = conf.config;
+      let pkgFile = conf.files[0];
+      if (pkgFile == null) {
+        throw new Error('Expected package.json file');
+      }
+      pkgDir = path.dirname(pkgFile.filePath);
+    } else {
+      pkg = {};
+      pkgDir = process.cwd();
+    }
+
     let pkgTargets = pkg.targets || {};
-    let pkgEngines = Object.assign({}, pkg.engines);
+    let pkgEngines = {...pkg.engines};
     if (!pkgEngines.browsers) {
       pkgEngines.browsers = browserslist.loadConfig({path: rootDir});
     }
@@ -113,80 +136,45 @@ export default class TargetResolver {
         ? 'node'
         : 'browser';
 
-    if (typeof pkg.main === 'string' || pkgTargets.main) {
-      let distDir;
-      let distEntry;
-
-      let main = pkg.main;
-      if (typeof main === 'string') {
-        distDir = path.dirname(main);
-        distEntry = path.basename(main);
+    for (let targetName of COMMON_TARGETS) {
+      let targetDist;
+      if (
+        targetName === 'browser' &&
+        pkg[targetName] != null &&
+        typeof pkg[targetName] === 'object'
+      ) {
+        // The `browser` field can be a file path or an alias map.
+        targetDist = pkg[targetName][pkg.name];
       } else {
-        distDir = path.join(DEFAULT_DIST_DIR, 'main');
+        targetDist = pkg[targetName];
       }
 
-      targets.set('main', {
-        name: 'main',
-        distDir,
-        distEntry,
-        publicUrl: pkgTargets.main?.publicUrl ?? '/',
-        env: this.getEnvironment(pkgEngines, mainContext).merge(pkgTargets.main)
-      });
-    }
+      if (typeof targetDist === 'string' || pkgTargets[targetName]) {
+        let distDir;
+        let distEntry;
 
-    if (typeof pkg.module === 'string' || pkgTargets.module) {
-      let distDir;
-      let distEntry;
+        if (typeof targetDist === 'string') {
+          distDir = path.resolve(pkgDir, path.dirname(targetDist));
+          distEntry = path.basename(targetDist);
+        } else {
+          distDir = path.resolve(pkgDir, DEFAULT_DIST_DIRNAME, targetName);
+        }
 
-      let mod = pkg.module;
-      if (typeof mod === 'string') {
-        distDir = path.dirname(mod);
-        distEntry = path.basename(mod);
-      } else {
-        distDir = path.join(DEFAULT_DIST_DIR, 'module');
+        targets.set(targetName, {
+          name: targetName,
+          distDir,
+          distEntry,
+          publicUrl: pkgTargets[targetName]?.publicUrl ?? '/',
+          env: this.getEnvironment(pkgEngines, mainContext).merge(
+            pkgTargets[targetName]
+          )
+        });
       }
-
-      targets.set('module', {
-        name: 'module',
-        distDir,
-        distEntry,
-        publicUrl: pkgTargets.module?.publicUrl ?? '/',
-        env: this.getEnvironment(pkgEngines, mainContext).merge(
-          pkgTargets.module
-        )
-      });
-    }
-
-    // The `browser` field can be a file path or an alias map.
-    let browser = pkg.browser;
-    if (browser && typeof browser === 'object') {
-      browser = browser[pkg.name];
-    }
-
-    if (typeof browser === 'string' || pkgTargets.browser) {
-      let distDir;
-      let distEntry;
-      if (typeof browser === 'string') {
-        distDir = path.dirname(browser);
-        distEntry = path.basename(browser);
-      } else {
-        distDir = path.join(DEFAULT_DIST_DIR, 'browser');
-      }
-
-      targets.set('browser', {
-        name: 'browser',
-        distEntry,
-        distDir,
-        publicUrl: pkgTargets.browser?.publicUrl ?? '/',
-        env: this.getEnvironment(pkgEngines, 'browser').merge(
-          pkgTargets.browser
-        )
-      });
     }
 
     // Custom targets
     for (let name in pkgTargets) {
-      if (name === 'main' || name === 'module' || name === 'browser') {
+      if (COMMON_TARGETS.includes(name)) {
         continue;
       }
 
@@ -194,9 +182,9 @@ export default class TargetResolver {
       let distDir;
       let distEntry;
       if (distPath == null) {
-        distDir = path.join(DEFAULT_DIST_DIR, name);
+        distDir = path.resolve(pkgDir, DEFAULT_DIST_DIRNAME, name);
       } else {
-        distDir = path.dirname(distPath);
+        distDir = path.resolve(pkgDir, path.dirname(distPath));
         distEntry = path.basename(distPath);
       }
 
@@ -219,7 +207,7 @@ export default class TargetResolver {
       let context = browsers || !node ? 'browser' : 'node';
       targets.set('default', {
         name: 'default',
-        distDir: 'dist',
+        distDir: path.resolve(pkgDir, DEFAULT_DIST_DIRNAME),
         publicUrl: '/',
         env: this.getEnvironment(pkgEngines, context)
       });

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -207,7 +207,7 @@ export default class TargetResolver {
       let context = browsers || !node ? 'browser' : 'node';
       targets.set('default', {
         name: 'default',
-        distDir: path.resolve(pkgDir, DEFAULT_DIST_DIRNAME),
+        distDir: path.resolve(DEFAULT_DIST_DIRNAME),
         publicUrl: '/',
         env: this.getEnvironment(pkgEngines, context)
       });

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -13,7 +13,7 @@ import TargetResolver from './TargetResolver';
 import {resolveConfig} from '@parcel/utils';
 
 // Default cache directory name
-const DEFAULT_CACHE_DIR = '.parcel-cache';
+const DEFAULT_CACHE_DIRNAME = '.parcel-cache';
 
 export default async function resolveOptions(
   initialOptions: InitialParcelOptions
@@ -56,14 +56,18 @@ export default async function resolveOptions(
     ])) || path.join(process.cwd(), 'index')
   );
 
+  let cacheDir =
+    // If a cacheDir is provided, resolve it relative to cwd. Otherwise,
+    // use a default directory resolved relative to the project root.
+    initialOptions.cacheDir != null
+      ? path.resolve(initialOptions.cacheDir)
+      : path.resolve(projectRoot, DEFAULT_CACHE_DIRNAME);
+
   // $FlowFixMe
   return {
     env: process.env,
     ...initialOptions,
-    cacheDir:
-      initialOptions.cacheDir != null
-        ? initialOptions.cacheDir
-        : DEFAULT_CACHE_DIR,
+    cacheDir,
     entries,
     rootDir,
     targets,

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -32,20 +32,6 @@ export default async function resolveOptions(
       ? initialOptions.rootDir
       : getRootDir(entries);
 
-  let cacheDir =
-    // If a cacheDir is provided, resolve it relative to cwd. Otherwise,
-    // use a default directory resolved relative to the project root.
-    initialOptions.cacheDir != null
-      ? path.resolve(initialOptions.cacheDir)
-      : path.resolve(projectRoot, DEFAULT_CACHE_DIRNAME);
-
-  let targetResolver = new TargetResolver();
-  let targets = await targetResolver.resolve(rootDir, cacheDir, initialOptions);
-
-  if (!initialOptions.env) {
-    await loadEnv(path.join(rootDir, 'index'));
-  }
-
   let projectRoot = path.dirname(
     (await resolveConfig(path.join(process.cwd(), 'index'), [
       'yarn.lock',
@@ -62,6 +48,13 @@ export default async function resolveOptions(
     initialOptions.cacheDir != null
       ? path.resolve(initialOptions.cacheDir)
       : path.resolve(projectRoot, DEFAULT_CACHE_DIRNAME);
+
+  let targetResolver = new TargetResolver();
+  let targets = await targetResolver.resolve(rootDir, cacheDir, initialOptions);
+
+  if (!initialOptions.env) {
+    await loadEnv(path.join(rootDir, 'index'));
+  }
 
   // $FlowFixMe
   return {

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -32,8 +32,15 @@ export default async function resolveOptions(
       ? initialOptions.rootDir
       : getRootDir(entries);
 
+  let cacheDir =
+    // If a cacheDir is provided, resolve it relative to cwd. Otherwise,
+    // use a default directory resolved relative to the project root.
+    initialOptions.cacheDir != null
+      ? path.resolve(initialOptions.cacheDir)
+      : path.resolve(projectRoot, DEFAULT_CACHE_DIRNAME);
+
   let targetResolver = new TargetResolver();
-  let targets = await targetResolver.resolve(rootDir, initialOptions);
+  let targets = await targetResolver.resolve(rootDir, cacheDir, initialOptions);
 
   if (!initialOptions.env) {
     await loadEnv(path.join(rootDir, 'index'));

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -8,6 +8,8 @@ const https = require('https');
 const getPort = require('get-port');
 const sinon = require('sinon');
 
+const distDir = path.resolve(__dirname, '../../../../.parcel-cache/dist');
+
 function get(file, port, client = http) {
   return new Promise((resolve, reject) => {
     client.get(
@@ -77,10 +79,7 @@ describe('server', function() {
     await getNextBuild(b);
 
     let data = await get('/index.js', port);
-    let distFile = await fs.readFile(
-      path.join(__dirname, '../dist/index.js'),
-      'utf8'
-    );
+    let distFile = await fs.readFile(path.join(distDir, 'index.js'), 'utf8');
 
     assert.equal(data, distFile);
   });
@@ -102,13 +101,13 @@ describe('server', function() {
     let data = await get('/', port);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '../dist/index.html'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.html'), 'utf8')
     );
 
     data = await get('/foo/bar', port);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '../dist/index.html'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.html'), 'utf8')
     );
   });
 
@@ -186,7 +185,7 @@ describe('server', function() {
     let data = await get('/index.js', port, https);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '../dist/index.js'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.js'), 'utf8')
     );
   });
 
@@ -209,7 +208,7 @@ describe('server', function() {
     let data = await get('/index.js', port, https);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '../dist/index.js'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.js'), 'utf8')
     );
   });
 
@@ -230,7 +229,7 @@ describe('server', function() {
     let data = await get('/dist/index.js', port);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '../dist/index.js'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.js'), 'utf8')
     );
   });
 
@@ -253,11 +252,11 @@ describe('server', function() {
     let data = await get('/', port);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '/dist/index.html'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.html'), 'utf8')
     );
 
     // When accessing /hello.txt we should get txt document.
-    await fs.writeFile(path.join(__dirname, '/dist/hello.txt'), 'hello');
+    await fs.writeFile(path.join(distDir, 'hello.txt'), 'hello');
     data = await get('/hello.txt', port);
     assert.equal(data, 'hello');
   });
@@ -278,7 +277,7 @@ describe('server', function() {
     let data = await get('/index.js?foo=bar.baz', port);
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '../dist/index.js'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.js'), 'utf8')
     );
   });
 
@@ -291,7 +290,7 @@ describe('server', function() {
     let data = await get('/bar.baz');
     assert.equal(
       data,
-      await fs.readFile(path.join(__dirname, '/dist/index.html'), 'utf8')
+      await fs.readFile(path.join(distDir, 'index.html'), 'utf8')
     );
   });
 


### PR DESCRIPTION
This resolves all the file paths present in parcel options as absolute paths. Following `path.resolve(filePath)`, behavior, if a path is not absolute:

* Target `distDir`s resolved from package.json entries are resolved from the directory of the package.json file
    * Currently (before and after this patch), if targets are specified in `package.json` and the default is used, its distDir is actually resolved from `cwd`, not from the package.json file. Should we change this to be resolved from the package.json's directory instead?
* Target `distDir`s passed in the programmatic api (`new Parcel({targets: [{...}, ...})`  are resolved from cwd.
* `cacheDir` is always resolved from cwd.

Test Plan:
* Add a log after options are resolved and run the simple example. Verify every path listed is absolute.
* Add a log after bundle file paths are added and verify bundle file paths are absolute.
* `yarn test`