### PR TITLE
Prevent scope hosting from inserting requires for non-js assets

### DIFF
--- a/packages/core/core/src/public/MainAssetGraph.js
+++ b/packages/core/core/src/public/MainAssetGraph.js
@@ -38,6 +38,19 @@ export default class MainAssetGraph implements IMainAssetGraph {
       to: assetNode.id
     });
 
+    // Prune assets that don't match the bundle type when including the asset's
+    // subgraph. These are replaced with asset references, but the concrete assets
+    // cannot exist in this bundle.
+    //
+    // The concrete assets are visited when traversing the MainAssetGraph, so they
+    // will have their own opportunity to be bundled in a bundle of the appropriate
+    // type.
+    graph.traverseAssets(currentAsset => {
+      if (currentAsset.type !== asset.type) {
+        graph.removeAsset(currentAsset);
+      }
+    });
+
     return new MutableBundle({
       id: 'bundle:' + asset.id,
       filePath: null,

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/missing-non-js/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/missing-non-js/a.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+export default 27;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -788,6 +788,18 @@ describe('scope hoisting', function() {
       assert.equal(output, 5);
     });
 
+    it("doesn't insert parcelRequire for missing non-js assets", async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/missing-non-js/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.equal(output.default, 27);
+    });
+
     it('define exports in the outermost scope', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -222,7 +222,7 @@ export function link(bundle: Bundle, ast: AST, options: ParcelOptions) {
               let call = t.callExpression(getIdentifier(mod, 'init'), []);
               node = node ? t.sequenceExpression([call, node]) : call;
             }
-          } else {
+          } else if (mod.type === 'js') {
             node = REQUIRE_TEMPLATE({ID: t.stringLiteral(mod.id)}).expression;
           }
 


### PR DESCRIPTION
This was causing failures in the simple example.

Also pulls in the following change from #3037:

We now prune assets that don't match the bundle type when cloning the asset's subtree in the main asset graph. Prior to this change, it was possible for bundles to contain assets of different types in some circumstances.


Test Plan: Added an integration test. Run the simple example.