### PR TITLE
Implement explicit `watch` function and remove option

### DIFF
--- a/flow-libs/parcel-watcher.js.flow
+++ b/flow-libs/parcel-watcher.js.flow
@@ -1,6 +1,6 @@
 // @flow
 
-// Derived from the README and source of ncp located at
+// Derived from the README and source of @parcel/watcher located at
 // https://github.com/parcel-bundler/watcher and
 // https://github.com/parcel-bundler/watcher/blob/411903f55462dd93350edb18088476f775381921/index.js
 // Which is licensed MIT
@@ -27,7 +27,7 @@ declare module '@parcel/watcher' {
       dir: FilePath,
       fn: (err: Error, events: Array<Event>) => mixed,
       opts: Options
-    ): AsyncSubscription,
+    ): Promise<AsyncSubscription>,
     unsubscribe(
       dir: FilePath,
       fn: (err: Error, events: Array<Event>) => mixed,

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@parcel/cache": "^2.0.0",
+    "@parcel/events": "^2.0.0",
     "@parcel/fs": "^2.0.0",
     "@parcel/local-require": "^2.0.0",
     "@parcel/logger": "^2.0.0",

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -167,7 +167,11 @@ export default class AssetGraphBuilder extends EventEmitter {
   respondToFSEvents(events: Array<Event>) {
     for (let {type, path} of events) {
       // TODO: eventually handle all types of events
-      if (type === 'update' && this.graph.hasNode(path)) {
+      if (
+        // macOS often sends a 'create' event when a file is actually updated
+        (type === 'update' || type === 'create') &&
+        this.graph.hasNode(path)
+      ) {
         this.graph.invalidateFile(path);
       }
     }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -510,6 +510,14 @@ export type BuildStartEvent = {|
   type: 'buildStart'
 |};
 
+type WatchStartEvent = {|
+  type: 'watchStart'
+|};
+
+type WatchEndEvent = {|
+  type: 'watchEnd'
+|};
+
 type ResolvingProgressEvent = {|
   type: 'buildProgress',
   phase: 'resolving',
@@ -564,7 +572,9 @@ export type ReporterEvent =
   | BuildStartEvent
   | BuildProgressEvent
   | BuildSuccessEvent
-  | BuildFailureEvent;
+  | BuildFailureEvent
+  | WatchStartEvent
+  | WatchEndEvent;
 
 export type Reporter = {|
   report(event: ReporterEvent, opts: ParcelOptions): Async<void>
@@ -575,7 +585,7 @@ export interface ErrorWithCode extends Error {
 }
 
 export interface IDisposable {
-  dispose(): void;
+  dispose(): mixed;
 }
 
 export interface AsyncSubscription {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -128,7 +128,6 @@ export type InitialParcelOptions = {|
   env?: {[string]: ?string},
   targets?: ?Array<string | Target>,
 
-  watch?: boolean,
   cache?: boolean,
   cacheDir?: FilePath,
   killWorkers?: boolean,
@@ -577,4 +576,8 @@ export interface ErrorWithCode extends Error {
 
 export interface IDisposable {
   dispose(): void;
+}
+
+export interface AsyncSubscription {
+  unsubscribe(): Promise<mixed>;
 }

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -2,6 +2,8 @@
 import type {Request, Response, DevServerOptions} from './types.js.flow';
 import type {BundleGraph} from '@parcel/types';
 import type {PrintableError} from '@parcel/utils';
+import type {Server as HTTPServer} from 'http';
+import type {Server as HTTPSServer} from 'https';
 
 import EventEmitter from 'events';
 import path from 'path';
@@ -39,6 +41,7 @@ export default class Server extends EventEmitter {
   ) => any;
   bundleGraph: BundleGraph | null;
   error: PrintableError | null;
+  server: HTTPServer | HTTPSServer;
 
   constructor(options: DevServerOptions) {
     super();
@@ -161,7 +164,6 @@ export default class Server extends EventEmitter {
   }
 
   async start() {
-    let server;
     const handler = (req: Request, res: Response) => {
       this.logAccessIfVerbose(req);
 
@@ -176,39 +178,53 @@ export default class Server extends EventEmitter {
     };
 
     if (!this.options.https) {
-      server = http.createServer(handler);
+      this.server = http.createServer(handler);
     } else if (typeof this.options.https === 'boolean') {
-      server = https.createServer(
+      this.server = https.createServer(
         await generateCertificate(this.options.cacheDir),
         handler
       );
     } else {
-      server = https.createServer(
+      this.server = https.createServer(
         await getCertificate(this.options.https),
         handler
       );
     }
 
-    server.listen(this.options.port, this.options.host);
+    this.server.listen(this.options.port, this.options.host);
 
     return new Promise((resolve, reject) => {
-      server.on('error', err => {
+      this.server.once('error', err => {
         logger.error(new Error(serverErrors(err, this.options.port)));
         reject(err);
       });
 
-      server.once('listening', () => {
+      this.server.once('listening', () => {
         let addon =
-          server.address().port !== this.options.port
+          this.server.address().port !== this.options.port
             ? `- configured port ${this.options.port.toString()} could not be used.`
             : '';
 
         logger.log(
           `Server running at ${this.options.https ? 'https' : 'http'}://${this
-            .options.host || 'localhost'}:${server.address().port} ${addon}`
+            .options.host || 'localhost'}:${
+            this.server.address().port
+          } ${addon}`
         );
 
-        resolve(server);
+        resolve(this.server);
+      });
+    });
+  }
+
+  stop(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.close(err => {
+        if (err != null) {
+          reject(err);
+          return;
+        }
+        resolve();
       });
     });
   }

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -1,5 +1,7 @@
 // @flow
+
 import {Reporter} from '@parcel/plugin';
+import invariant from 'assert';
 import Server from './Server';
 
 let servers: Map<number, Server> = new Map();
@@ -8,30 +10,42 @@ export default new Reporter({
     let serve = options.serve;
     if (!serve) return;
 
-    let target = options.targets[0];
+    let server = servers.get(serve.port);
+    switch (event.type) {
+      case 'watchStart': {
+        // If there's already a server when watching has just started, something
+        // is wrong.
+        invariant(server == null);
 
-    let serverOptions = {
-      ...serve,
-      cacheDir: options.cacheDir,
-      distDir: target.distDir,
-      // Override the target's publicUrl as that is likely meant for production.
-      // This could be configurable in the future.
-      publicUrl: serve.publicUrl != null ? serve.publicUrl : '/'
-    };
+        let target = options.targets[0];
+        let serverOptions = {
+          ...serve,
+          cacheDir: options.cacheDir,
+          distDir: target.distDir,
+          // Override the target's publicUrl as that is likely meant for production.
+          // This could be configurable in the future.
+          publicUrl: serve.publicUrl ?? '/'
+        };
 
-    let server = servers.get(serverOptions.port);
-    if (!server) {
-      server = new Server(serverOptions);
-      servers.set(serverOptions.port, server);
-      await server.start();
-    }
+        server = new Server(serverOptions);
+        servers.set(serverOptions.port, server);
+        await server.start();
 
-    if (event.type === 'buildSuccess') {
-      server.buildSuccess(event.bundleGraph);
-    }
-
-    if (event.type === 'buildFailure') {
-      server.buildError(event.error);
+        break;
+      }
+      case 'watchEnd':
+        invariant(server != null);
+        await server.stop();
+        servers.delete(serve.port);
+        break;
+      case 'buildSuccess':
+        invariant(server != null);
+        server.buildSuccess(event.bundleGraph);
+        break;
+      case 'buildFailure':
+        invariant(server != null);
+        server.buildError(event.error);
+        break;
     }
   }
 });


### PR DESCRIPTION
Rather than implement watch as an option to the `Parcel` constructor, allow for callers to subscribe to results from a `.watch()` function instead.

Here's the interface:

```
  async watch(
    cb?: (err: ?Error, buildEvent?: BuildEvent) => mixed
  ): Promise<AsyncSubscription>;
```

`watch` accepts a callback that receives either an error object or a `BuildEvent`. `BuildEvent` is either a success or failure event identical to what we give reporters. 

Setting up a watch subscription itself is an asynchronous process, so a promise to an `AsyncSubscription` is returned. An `AsyncSubscription` is an object with an asynchronous `unsubscribe` method.

`parcel.watch()` supports multiple subscribers by returning a subscription object that allows callers to unsubscribe when they are no longer interested in events. On the first watch subscription, Parcel begins subscribing to the underlying `@parcel/watcher`, and when the last subscriber unsubscribes, the inner watcher subscription is unsubscribed and removed.

This means that `parcel.run()` has predictable behavior (always returning a promise of a single result), and that callers interested in build successes and failures over time (such as the server tests) can receive them.

Since `watch` is no longer a parcel option, reporters like the server reporter need to know when parcel has been invoked with `watch` as opposed to a single `run`. This change adds `watchStart` and `watchEnd` events to be broadcast to reporters, allowing for reporters to respond like starting a server. The `watchEnd` event is also awaited, so things like servers can be shut down.

Test Plan: Reworked server tests to use the watch api and new `watchStart` and `watchEnd` events.