### PR TITLE
Convert plugin parameters to param objects

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -17,7 +17,7 @@ type BundleContext = {|
 |};
 
 export default new Bundler({
-  bundle(assetGraph, bundleGraph) {
+  bundle({assetGraph, bundleGraph}) {
     // RULES:
     // 1. If dep.isAsync or dep.isEntry, start a new bundle group.
     // 2. If an asset is a different type than the current bundle, make a parallel bundle in the same bundle group.

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -39,11 +39,11 @@ export default class BundlerRunner {
     let bundler = await this.config.getBundler();
 
     let bundleGraph = new InternalBundleGraph();
-    await bundler.bundle(
-      new MainAssetGraph(graph),
-      new MutableBundleGraph(bundleGraph),
-      this.options
-    );
+    await bundler.bundle({
+      assetGraph: new MainAssetGraph(graph),
+      bundleGraph: new MutableBundleGraph(bundleGraph),
+      options: this.options
+    });
     await this.nameBundles(bundleGraph);
     await this.applyRuntimes(bundleGraph);
 

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -111,11 +111,11 @@ export default class BundlerRunner {
     for (let bundle of bundles) {
       let runtimes = await this.config.getRuntimes(bundle.env.context);
       for (let runtime of runtimes) {
-        let applied = await runtime.apply(
+        let applied = await runtime.apply({
           bundle,
-          new BundleGraph(bundleGraph),
-          this.options
-        );
+          bundleGraph: new BundleGraph(bundleGraph),
+          options: this.options
+        });
         if (applied) {
           await this.addRuntimesToBundle(
             bundle.id,

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -78,7 +78,7 @@ export default class BundlerRunner {
     let bundleGraph = new BundleGraph(internalBundleGraph);
 
     for (let namer of namers) {
-      let name = await namer.name(bundle, bundleGraph, this.options);
+      let name = await namer.name({bundle, bundleGraph, options: this.options});
 
       if (name != null) {
         if (path.extname(name).slice(1) !== bundle.type) {

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -74,11 +74,11 @@ export default class PackagerRunner {
     });
 
     let packager = await this.config.getPackager(bundle.filePath);
-    let packageContent = await packager.package(
+    let packageContent = await packager.package({
       bundle,
-      new BundleGraph(bundleGraph),
-      this.options
-    );
+      bundleGraph: new BundleGraph(bundleGraph),
+      options: this.options
+    });
 
     return typeof packageContent === 'string'
       ? replaceReferences(

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -105,7 +105,11 @@ export default class PackagerRunner {
     });
 
     for (let optimizer of optimizers) {
-      contents = await optimizer.optimize(bundle, contents, this.options);
+      contents = await optimizer.optimize({
+        bundle,
+        contents,
+        options: this.options
+      });
     }
 
     return contents;
@@ -116,7 +120,7 @@ export default class PackagerRunner {
  * Build a mapping from async, url dependency ids to web-friendly relative paths
  * to their bundles. These will be relative to the current bundle if `publicUrl`
  * is not provided. If `publicUrl` is provided, the paths will be joined to it.
- * 
+ *
  * These are used to translate any placeholder dependency ids written during
  * transformation back to a path that can be loaded in a browser (such as
  * in a "raw" loader or any transformed dependencies referred to by url).

--- a/packages/core/core/src/ResolverRunner.js
+++ b/packages/core/core/src/ResolverRunner.js
@@ -46,7 +46,7 @@ export default class ResolverRunner {
     let resolvers = await this.config.getResolvers();
 
     for (let resolver of resolvers) {
-      let result = await resolver.resolve(dependency, this.options);
+      let result = await resolver.resolve({dependency, options: this.options});
 
       if (result) {
         this.cache.set(key, result);

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -447,11 +447,11 @@ export type Bundler = {|
 |};
 
 export type Namer = {|
-  name(
+  name({
     bundle: Bundle,
     bundleGraph: BundleGraph,
-    opts: ParcelOptions
-  ): Async<?FilePath>
+    options: ParcelOptions
+  }): Async<?FilePath>
 |};
 
 export type RuntimeAsset = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -461,11 +461,11 @@ export type RuntimeAsset = {|
 |};
 
 export type Runtime = {|
-  apply(
+  apply({
     bundle: NamedBundle,
     bundleGraph: BundleGraph,
-    opts: ParcelOptions
-  ): Async<void | RuntimeAsset | Array<RuntimeAsset>>
+    options: ParcelOptions
+  }): Async<void | RuntimeAsset | Array<RuntimeAsset>>
 |};
 
 export type Packager = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -469,11 +469,11 @@ export type Runtime = {|
 |};
 
 export type Packager = {|
-  package(
+  package({
     bundle: Bundle,
     bundleGraph: BundleGraph,
-    opts: ParcelOptions
-  ): Async<Blob>
+    options: ParcelOptions
+  }): Async<Blob>
 |};
 
 export type Optimizer = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -483,10 +483,10 @@ export type Optimizer = {|
 |};
 
 export type Resolver = {|
-  resolve(
+  resolve({
     dependency: Dependency,
-    opts: ParcelOptions
-  ): Async<?TransformerRequest>
+    options: ParcelOptions
+  }): Async<?TransformerRequest>
 |};
 
 export type ProgressLogEvent = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -301,31 +301,31 @@ export interface TransformerResult {
 type Async<T> = T | Promise<T>;
 
 export type Transformer = {
-  getConfig?: (
+  getConfig?: ({
     asset: MutableAsset,
-    opts: ParcelOptions
-  ) => Async<Config | void>,
-  canReuseAST?: (ast: AST, opts: ParcelOptions) => boolean,
-  parse?: (
-    asset: MutableAsset,
-    config: ?Config,
-    opts: ParcelOptions
-  ) => Async<?AST>,
-  transform(
+    options: ParcelOptions
+  }) => Async<Config | void>,
+  canReuseAST?: ({ast: AST, options: ParcelOptions}) => boolean,
+  parse?: ({
     asset: MutableAsset,
     config: ?Config,
-    opts: ParcelOptions
-  ): Async<Array<TransformerResult | MutableAsset>>,
-  generate?: (
+    options: ParcelOptions
+  }) => Async<?AST>,
+  transform({
     asset: MutableAsset,
     config: ?Config,
-    opts: ParcelOptions
-  ) => Async<GenerateOutput>,
-  postProcess?: (
+    options: ParcelOptions
+  }): Async<Array<TransformerResult | MutableAsset>>,
+  generate?: ({
+    asset: MutableAsset,
+    config: ?Config,
+    options: ParcelOptions
+  }) => Async<GenerateOutput>,
+  postProcess?: ({
     assets: Array<MutableAsset>,
     config: ?Config,
-    opts: ParcelOptions
-  ) => Async<Array<TransformerResult>>
+    options: ParcelOptions
+  }) => Async<Array<TransformerResult>>
 };
 
 export interface TraversalActions {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -439,11 +439,11 @@ export interface MutableBundleGraph {
 }
 
 export type Bundler = {|
-  bundle(
-    graph: MainAssetGraph,
+  bundle({
+    assetGraph: MainAssetGraph,
     bundleGraph: MutableBundleGraph,
-    opts: ParcelOptions
-  ): Async<void>
+    options: ParcelOptions
+  }): Async<void>
 |};
 
 export type Namer = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -477,7 +477,9 @@ export type Packager = {|
 |};
 
 export type Optimizer = {|
-  optimize(bundle: Bundle, contents: Blob, opts: ParcelOptions): Async<Blob>
+  optimize({bundle: Bundle, contents: Blob, options: ParcelOptions}): Async<
+    Blob
+  >
 |};
 
 export type Resolver = {|

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -10,7 +10,7 @@ import path from 'path';
 const COMMON_NAMES = new Set(['index', 'src', 'lib']);
 
 export default new Namer({
-  name(bundle, bundleGraph, opts) {
+  name({bundle, bundleGraph, options}) {
     // If the bundle has an explicit file path given (e.g. by a target), use that.
     if (bundle.filePath != null) {
       // TODO: what about multiple assets in the same dep?
@@ -47,7 +47,7 @@ export default new Namer({
     // Base split bundle names on the first bundle in their group.
     // e.g. if `index.js` imports `foo.css`, the css bundle should be called
     //      `index.css`.
-    let name = nameFromContent(firstBundleInGroup, opts.rootDir);
+    let name = nameFromContent(firstBundleInGroup, options.rootDir);
     if (!bundle.isEntry) {
       name += '.' + getHash(bundle).slice(-8);
     }

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -3,7 +3,7 @@
 import {Packager} from '@parcel/plugin';
 
 export default new Packager({
-  async package(bundle) {
+  async package({bundle}) {
     let promises = [];
     bundle.traverseAssets({
       exit: asset => {

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import {Packager} from '@parcel/plugin';
 
 export default new Packager({
-  package(bundle) {
+  package({bundle}) {
     let assets = [];
     bundle.traverseAssets(asset => {
       assets.push(asset);

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -10,7 +10,7 @@ const PRELUDE = fs
   .replace(/;$/, '');
 
 export default new Packager({
-  async package(bundle, bundleGraph, options) {
+  async package({bundle, bundleGraph, options}) {
     // If scope hoisting is enabled, we use a different code path.
     if (options.scopeHoist) {
       let ast = await concat(bundle, bundleGraph);

--- a/packages/packagers/raw/src/RawPackager.js
+++ b/packages/packagers/raw/src/RawPackager.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import {Packager} from '@parcel/plugin';
 
 export default new Packager({
-  async package(bundle) {
+  async package({bundle}) {
     let assets = [];
     bundle.traverseAssets(asset => {
       assets.push(asset);

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -16,11 +16,11 @@ import builtins from './builtins';
 // import nodeBuiltins from 'node-libs-browser';
 
 export default new Resolver({
-  async resolve(dep: Dependency, options: ParcelOptions) {
+  async resolve({dependency, options}) {
     const resolved = await new NodeResolver({
       extensions: ['js', 'json', 'css'],
       options
-    }).resolve(dep);
+    }).resolve(dependency);
 
     if (!resolved) {
       return null;
@@ -28,7 +28,7 @@ export default new Resolver({
 
     let result: TransformerRequest = {
       filePath: resolved.path,
-      env: dep.env
+      env: dependency.env
     };
 
     if (resolved.pkg && !hasSideEffects(resolved.path, resolved.pkg)) {

--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -8,7 +8,7 @@ import path from 'path';
 const HMR_RUNTIME = './loaders/hmr-runtime.js';
 
 export default new Runtime({
-  async apply(bundle, bundleGraph, options) {
+  async apply({bundle, options}) {
     if (bundle.type !== 'js' || !options.hot) {
       return;
     }

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -21,7 +21,7 @@ const LOADERS = {
 };
 
 export default new Runtime({
-  async apply(bundle, bundleGraph) {
+  async apply({bundle, bundleGraph}) {
     // Dependency ids in code replaced with referenced bundle names
     // Loader runtime added for bundle groups that don't have a native loader (e.g. HTML/CSS/Worker - isURL?),
     // and which are not loaded by a parent bundle.

--- a/packages/transformers/babel/src/BabelTransformer.js
+++ b/packages/transformers/babel/src/BabelTransformer.js
@@ -7,15 +7,15 @@ import babel7 from './babel7';
 import getBabelConfig from './config';
 
 export default new Transformer({
-  async getConfig(asset) {
+  async getConfig({asset}) {
     return getBabelConfig(asset);
   },
 
-  canReuseAST(ast) {
+  canReuseAST({ast}) {
     return ast.type === 'babel' && semver.satisfies(ast.version, '^7.0.0');
   },
 
-  async transform(asset, config) {
+  async transform({asset, config}) {
     if (config) {
       if (config[6]) {
         asset.ast = await babel6(asset, config[6]);
@@ -29,7 +29,7 @@ export default new Transformer({
     return [asset];
   },
 
-  generate(asset /*, config, options*/) {
+  generate({asset}) {
     // let opts = {
     //   sourceMaps: options.sourceMaps,
     //   sourceFileName: this.relativeName

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -16,11 +16,11 @@ function canHaveDependencies(filePath: FilePath, code: string) {
 }
 
 export default new Transformer({
-  canReuseAST(ast) {
+  canReuseAST({ast}) {
     return ast.type === 'postcss' && semver.satisfies(ast.version, '^7.0.0');
   },
 
-  async parse(asset) {
+  async parse({asset}) {
     let code = await asset.getCode();
     if (!canHaveDependencies(asset.filePath, code)) {
       return null;
@@ -37,7 +37,7 @@ export default new Transformer({
     };
   },
 
-  transform(asset) {
+  transform({asset}) {
     let ast = asset.ast;
     if (!ast) {
       return [asset];
@@ -117,7 +117,7 @@ export default new Transformer({
     return [asset];
   },
 
-  async generate(asset) {
+  async generate({asset}) {
     let code;
     if (!asset.ast || !asset.ast.isDirty) {
       code = await asset.getCode();

--- a/packages/transformers/html/src/HTMLTransformer.js
+++ b/packages/transformers/html/src/HTMLTransformer.js
@@ -10,11 +10,11 @@ import collectDependencies from './dependencies';
 import extractInlineAssets from './inline';
 
 export default new Transformer({
-  canReuseAST(ast) {
+  canReuseAST({ast}) {
     return ast.type === 'posthtml' && semver.satisfies(ast.version, '^0.4.0');
   },
 
-  async parse(asset) {
+  async parse({asset}) {
     return {
       type: 'posthtml',
       version: '0.4.1',
@@ -24,14 +24,14 @@ export default new Transformer({
     };
   },
 
-  async transform(asset) {
+  async transform({asset}) {
     // Handle .htm
     asset.type = 'html';
     collectDependencies(asset);
     return [asset, ...extractInlineAssets(asset)];
   },
 
-  generate(asset) {
+  generate({asset}) {
     return {
       code: render(nullthrows(asset.ast).program)
     };

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -34,11 +34,11 @@ function canHaveDependencies(code) {
 }
 
 export default new Transformer({
-  canReuseAST(ast) {
+  canReuseAST({ast}) {
     return ast.type === 'babel' && semver.satisfies(ast.version, '^7.0.0');
   },
 
-  async parse(asset, config, options) {
+  async parse({asset, options}) {
     let code = await asset.getCode();
     if (
       !options.scopeHoist &&
@@ -63,7 +63,7 @@ export default new Transformer({
     };
   },
 
-  async transform(asset, config, options) {
+  async transform({asset, options}) {
     asset.type = 'js';
     if (!asset.ast) {
       return [asset];
@@ -129,7 +129,7 @@ export default new Transformer({
     return [asset];
   },
 
-  async generate(asset /*, config, options*/) {
+  async generate({asset}) {
     let code = await asset.getCode();
     let res = {
       code

--- a/packages/transformers/raw/src/RawTransformer.js
+++ b/packages/transformers/raw/src/RawTransformer.js
@@ -3,7 +3,7 @@
 import {Transformer} from '@parcel/plugin';
 
 export default new Transformer({
-  transform(asset) {
+  transform({asset}) {
     asset.isIsolated = true;
     return [asset];
   }

--- a/packages/transformers/terser/src/TerserTransformer.js
+++ b/packages/transformers/terser/src/TerserTransformer.js
@@ -12,7 +12,7 @@ import {Transformer} from '@parcel/plugin';
 // }
 
 export default new Transformer({
-  async getConfig(asset) {
+  async getConfig({asset}) {
     return asset.getConfig([
       '.terserrc',
       '.uglifyrc',
@@ -21,7 +21,7 @@ export default new Transformer({
     ]);
   },
 
-  async transform(asset, config, options) {
+  async transform({asset, config, options}) {
     if (!options.minify) {
       return [asset];
     }


### PR DESCRIPTION
This converts all the plugin apis to accept a single object with named keys. Some APIs are growing, and the number of parameters is getting awkward.

That said, we should continue to be conscious of the api we expose to plugins. Thanks @jamiebuilds for the suggestion 😃

Test Plan: flow, lint, test