### PR TITLE
Restore rich CLI

### DIFF
--- a/flow-libs/ink.js.flow
+++ b/flow-libs/ink.js.flow
@@ -41,8 +41,14 @@ declare module 'ink' {
   |};
   declare export var Box: React$ComponentType<BoxProps>;
 
+  declare export type RerenderFunc = (node: React$Node) => void;
+
   declare export function render(
     node: React$Node,
     options?: RenderOptions
-  ): mixed;
+  ): {|
+    rerender: RerenderFunc,
+    unmount: () => void,
+    waitUntilExit: Promise<void>
+  |};
 }

--- a/flow-libs/ink.js.flow
+++ b/flow-libs/ink.js.flow
@@ -1,7 +1,8 @@
 // @flow
 
-// Derived from the ink source:
+// Derived from the ink source available at:
 // https://github.com/vadimdemedes/ink
+// Which is licensed MIT
 
 declare module 'ink' {
   declare export interface StdoutLike {
@@ -27,6 +28,8 @@ declare module 'ink' {
     yellow?: boolean
   |};
   declare export var Color: React$ComponentType<ColorProps>;
+  // https://github.com/vadimdemedes/ink#static
+  declare export var Static: React$ComponentType<{children: React$Node}>;
 
   declare type TextProps = {|
     children: React$Node

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -19,8 +19,8 @@
     "cli-spinners": "^2.0.0",
     "filesize": "^3.6.0",
     "grapheme-breaker": "^0.3.2",
-    "ink": "^2.0.0",
-    "ink-spinner": "^2.0.0",
+    "ink": "^2.1.1",
+    "ink-spinner": "^3.0.1",
     "nullthrows": "^1.1.1",
     "react": "^16.7.0"
   },

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -1,19 +1,149 @@
 // @flow strict-local
 
-import nullthrows from 'nullthrows';
+import type {
+  BundleGraph,
+  LogEvent,
+  ParcelOptions,
+  ProgressLogEvent,
+  ReporterEvent
+} from '@parcel/types';
+import type {RerenderFunc} from 'ink';
+
+import {prettifyTime} from '@parcel/utils';
+import {render} from 'ink';
 import {Reporter} from '@parcel/plugin';
 import React from 'react';
-import {render} from 'ink';
+
+import {getProgressMessage} from './utils';
+import logLevels from './logLevels';
 import UI from './UI';
 
-let ui: ?UI;
+type State = {|
+  progress: ?ProgressLogEvent,
+  logs: Array<LogEvent>,
+  bundleGraph: ?BundleGraph
+|};
+
+let state: State = {
+  progress: null,
+  logs: [],
+  bundleGraph: null
+};
+let rerender: RerenderFunc;
 
 export default new Reporter({
   report(event, options) {
-    if (!ui) {
-      render(<UI options={options} ref={u => (ui = u)} />);
+    let newState = reducer(state, event, options);
+    let uiElement = <UI {...newState} options={options} />;
+    if (rerender) {
+      rerender(uiElement);
+    } else {
+      render(uiElement);
     }
-
-    nullthrows(ui).report(event, options);
   }
 });
+
+function reducer(
+  state: State,
+  event: ReporterEvent,
+  options: ParcelOptions
+): State {
+  let logLevel = logLevels[options.logLevel];
+
+  switch (event.type) {
+    case 'buildStart':
+      if (logLevel < logLevels.info) {
+        break;
+      }
+
+      return {
+        ...state,
+        logs: [],
+        bundleGraph: null
+      };
+
+    case 'buildProgress': {
+      if (logLevel < logLevels.progress) {
+        break;
+      }
+
+      let message = getProgressMessage(event);
+      let progress = state.progress;
+      if (message != null) {
+        progress = {
+          type: 'log',
+          level: 'progress',
+          message
+        };
+      }
+
+      return {
+        ...state,
+        progress
+      };
+    }
+
+    case 'buildSuccess':
+      if (logLevel < logLevels.info) {
+        break;
+      }
+
+      return {
+        ...state,
+        progress: null,
+        bundleGraph: event.bundleGraph,
+        logs: [
+          ...state.logs,
+          {
+            type: 'log',
+            level: 'success',
+            message: `Built in ${prettifyTime(event.buildTime)}.`
+          }
+        ]
+      };
+
+    case 'buildFailure':
+      if (logLevel < logLevels.error) {
+        break;
+      }
+
+      return {
+        ...state,
+        progress: null,
+        logs: [
+          ...state.logs,
+          {
+            type: 'log',
+            level: 'error',
+            message: event.error
+          }
+        ]
+      };
+
+    case 'log': {
+      if (logLevel < logLevels[event.level]) {
+        break;
+      }
+
+      if (event.level === 'progress') {
+        return {
+          ...state,
+          progress: event
+        };
+      }
+
+      // Skip duplicate logs
+      let messages = new Set(state.logs.map(l => l.message));
+      if (messages.has(event.message)) {
+        break;
+      }
+
+      return {
+        ...state,
+        logs: [...state.logs, event]
+      };
+    }
+  }
+
+  return state;
+}

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -7,10 +7,13 @@ import {render} from 'ink';
 import UI from './UI';
 
 let ui: ?UI;
-render(<UI ref={u => (ui = u)} />);
 
 export default new Reporter({
   report(event, options) {
+    if (!ui) {
+      render(<UI options={options} ref={u => (ui = u)} />);
+    }
+
     nullthrows(ui).report(event, options);
   }
 });

--- a/packages/reporters/cli/src/Table.js
+++ b/packages/reporters/cli/src/Table.js
@@ -80,9 +80,9 @@ export function Cell(props: CellProps) {
   );
 }
 
-function getText(node: string | {props: CellProps}): string {
-  if (typeof node === 'string') {
-    return node;
+function getText(node: string | number | {props: CellProps}): string {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return node.toString();
   }
 
   if (!node.props) {

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -15,13 +15,17 @@ import logLevels from './logLevels';
 import {getProgressMessage} from './utils';
 import BundleReport from './BundleReport';
 
-type UIState = {|
+type Props = {|
+  options: ParcelOptions
+|};
+
+type State = {|
   progress: ?ProgressLogEvent,
   logs: Array<LogEvent>,
   bundleGraph: ?BundleGraph
 |};
 
-export default class UI extends React.PureComponent<{}, UIState> {
+export default class UI extends React.PureComponent<Props, State> {
   state = {
     progress: null,
     logs: [],
@@ -38,7 +42,8 @@ export default class UI extends React.PureComponent<{}, UIState> {
           {this.state.progress ? (
             <Progress event={this.state.progress} />
           ) : null}
-          {this.state.bundleGraph ? (
+          {this.props.options.mode === 'production' &&
+          this.state.bundleGraph ? (
             <BundleReport bundleGraph={this.state.bundleGraph} />
           ) : null}
         </div>
@@ -52,11 +57,11 @@ export default class UI extends React.PureComponent<{}, UIState> {
 }
 
 function reducer(
-  state: UIState,
+  state: State,
   event: ReporterEvent,
   options: ParcelOptions
-): UIState {
-  let logLevel = logLevels[options.logLevel || 'info'];
+): State {
+  let logLevel = logLevels[options.logLevel];
 
   switch (event.type) {
     case 'buildStart':
@@ -99,7 +104,6 @@ function reducer(
       return {
         ...state,
         progress: null,
-        // bundleGraph: options.mode === 'production' ? event.bundleGraph : null,
         bundleGraph: event.bundleGraph,
         logs: [
           ...state.logs,

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -4,159 +4,33 @@ import type {
   BundleGraph,
   LogEvent,
   ParcelOptions,
-  ProgressLogEvent,
-  ReporterEvent
+  ProgressLogEvent
 } from '@parcel/types';
+
 import {Color} from 'ink';
 import React from 'react';
 import {Log, Progress} from './Log';
-import {prettifyTime} from '@parcel/utils';
-import logLevels from './logLevels';
-import {getProgressMessage} from './utils';
 import BundleReport from './BundleReport';
 
 type Props = {|
-  options: ParcelOptions
-|};
-
-type State = {|
-  progress: ?ProgressLogEvent,
+  bundleGraph: ?BundleGraph,
   logs: Array<LogEvent>,
-  bundleGraph: ?BundleGraph
+  options: ParcelOptions,
+  progress: ?ProgressLogEvent
 |};
 
-export default class UI extends React.PureComponent<Props, State> {
-  state = {
-    progress: null,
-    logs: [],
-    bundleGraph: null
-  };
-
-  render() {
-    return (
-      <Color reset>
-        <div>
-          {this.state.logs.map((log, i) => (
-            <Log key={i} event={log} />
-          ))}
-          {this.state.progress ? (
-            <Progress event={this.state.progress} />
-          ) : null}
-          {this.props.options.mode === 'production' &&
-          this.state.bundleGraph ? (
-            <BundleReport bundleGraph={this.state.bundleGraph} />
-          ) : null}
-        </div>
-      </Color>
-    );
-  }
-
-  report(event: ReporterEvent, options: ParcelOptions) {
-    this.setState(state => reducer(state, event, options));
-  }
-}
-
-function reducer(
-  state: State,
-  event: ReporterEvent,
-  options: ParcelOptions
-): State {
-  let logLevel = logLevels[options.logLevel];
-
-  switch (event.type) {
-    case 'buildStart':
-      if (logLevel < logLevels.info) {
-        break;
-      }
-
-      return {
-        ...state,
-        logs: [],
-        bundleGraph: null
-      };
-
-    case 'buildProgress': {
-      if (logLevel < logLevels.progress) {
-        break;
-      }
-
-      let message = getProgressMessage(event);
-      let progress = state.progress;
-      if (message != null) {
-        progress = {
-          type: 'log',
-          level: 'progress',
-          message
-        };
-      }
-
-      return {
-        ...state,
-        progress
-      };
-    }
-
-    case 'buildSuccess':
-      if (logLevel < logLevels.info) {
-        break;
-      }
-
-      return {
-        ...state,
-        progress: null,
-        bundleGraph: event.bundleGraph,
-        logs: [
-          ...state.logs,
-          {
-            type: 'log',
-            level: 'success',
-            message: `Built in ${prettifyTime(event.buildTime)}.`
-          }
-        ]
-      };
-
-    case 'buildFailure':
-      if (logLevel < logLevels.error) {
-        break;
-      }
-
-      return {
-        ...state,
-        progress: null,
-        logs: [
-          ...state.logs,
-          {
-            type: 'log',
-            level: 'error',
-            message: event.error
-          }
-        ]
-      };
-
-    case 'log': {
-      if (logLevel < logLevels[event.level]) {
-        break;
-      }
-
-      if (event.level === 'progress') {
-        return {
-          ...state,
-          progress: event
-        };
-      }
-
-      // Skip duplicate logs
-      let messages = new Set(state.logs.map(l => l.message));
-      if (messages.has(event.message)) {
-        break;
-      }
-
-      return {
-        ...state,
-        logs: [...state.logs, event]
-      };
-    }
-  }
-
-  return state;
+export default function UI({logs, progress, bundleGraph, options}: Props) {
+  return (
+    <Color reset>
+      <div>
+        {logs.map((log, i) => (
+          <Log key={i} event={log} />
+        ))}
+        {progress ? <Progress event={progress} /> : null}
+        {options.mode === 'production' && bundleGraph ? (
+          <BundleReport bundleGraph={bundleGraph} />
+        ) : null}
+      </div>
+    </Color>
+  );
 }

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -75,13 +75,13 @@ function reducer(
         bundleGraph: null
       };
 
-    case 'buildProgress':
+    case 'buildProgress': {
       if (logLevel < logLevels.progress) {
         break;
       }
 
-      var message = getProgressMessage(event);
-      var progress = state.progress;
+      let message = getProgressMessage(event);
+      let progress = state.progress;
       if (message != null) {
         progress = {
           type: 'log',
@@ -94,13 +94,13 @@ function reducer(
         ...state,
         progress
       };
+    }
 
     case 'buildSuccess':
       if (logLevel < logLevels.info) {
         break;
       }
 
-      var time = prettifyTime(event.buildTime);
       return {
         ...state,
         progress: null,
@@ -110,7 +110,7 @@ function reducer(
           {
             type: 'log',
             level: 'success',
-            message: `Built in ${time}.`
+            message: `Built in ${prettifyTime(event.buildTime)}.`
           }
         ]
       };
@@ -133,7 +133,7 @@ function reducer(
         ]
       };
 
-    case 'log':
+    case 'log': {
       if (logLevel < logLevels[event.level]) {
         break;
       }
@@ -146,7 +146,7 @@ function reducer(
       }
 
       // Skip duplicate logs
-      var messages = new Set(state.logs.map(l => l.message));
+      let messages = new Set(state.logs.map(l => l.message));
       if (messages.has(event.message)) {
         break;
       }
@@ -155,6 +155,7 @@ function reducer(
         ...state,
         logs: [...state.logs, event]
       };
+    }
   }
 
   return state;

--- a/packages/reporters/cli/src/index.js
+++ b/packages/reporters/cli/src/index.js
@@ -1,10 +1,8 @@
 // @flow strict-local
 
 // $FlowFixMe This is fine.
-// const isTTY = process.stdout.isTTY;
+const isTTY = process.stdout.isTTY;
 
-module.exports = require('./SimpleCLIReporter');
-
-/*export default (isTTY
+export default (isTTY
   ? require('./CLIReporter').default
-  : require('./SimpleCLIReporter'));*/
+  : require('./SimpleCLIReporter').default);

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -61,6 +61,7 @@ export default class Server extends EventEmitter {
 
   buildSuccess(bundleGraph: BundleGraph) {
     this.bundleGraph = bundleGraph;
+    this.error = null;
     this.pending = false;
 
     this.emit('bundled');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,6 +3730,11 @@ ci-info@^1.5.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -3779,6 +3784,14 @@ cli-truncate@^0.2.1:
   dependencies:
     slice-ansi "0.0.4"
     string-width "^1.0.1"
+
+cli-truncate@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-1.1.0.tgz#2b2dfd83c53cfd3572b87fc4d430a808afb04086"
+  integrity sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==
+  dependencies:
+    slice-ansi "^1.0.0"
+    string-width "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -6613,33 +6626,36 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-ink-spinner@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ink-spinner/-/ink-spinner-2.0.0.tgz#621c751ab8cd1fb2a77bcb1896cfc49c23950f3b"
-  integrity sha512-ptUejHyUpR0CFeq1n2T711yu1KhqadfZO1bg2ROawU1JVvFQjCWmXK/rX/T0ZzjsctEkqFaJ+Dm01QoWLkR9Lg==
+ink-spinner@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ink-spinner/-/ink-spinner-3.0.1.tgz#7b4b206d2b18538701fd92593f9acabbfe308dce"
+  integrity sha512-AVR4Z/NXDQ7dT5ltWcCzFS9Dd4T8eaO//E2UO8VYNiJcZpPCSJ11o5A0UVPcMlZxGbGD6ikUFDR3ZgPUQk5haQ==
   dependencies:
     cli-spinners "^1.0.0"
-    object.omit "^2.0.1"
     prop-types "^15.5.10"
 
-ink@^2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/ink/-/ink-2.0.6.tgz#1ac54812ecd89e68ec53513a5d2f458f602f51dc"
-  integrity sha512-FGsR0tlVkeQJQDzOff/rIENgVWmQ7jZN1F4pXrE1WLjAaMl1th6lsj5+QhnlL28TMA+RAKo6Y7vKc7WZrbpj5Q==
+ink@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ink/-/ink-2.1.1.tgz#efb2adbd30be79b4f640d7c67b524bfb030205ba"
+  integrity sha512-vP1yE/uJoiY6uB9yHalczUA02I9fg7xDUbTEZitPK5y6dvnPo9a/6UWqIB2uCYkHOhEZMN+D/TsVr4v2sz8qYA==
   dependencies:
     "@types/react" "^16.8.6"
     arrify "^1.0.1"
     auto-bind "^2.0.0"
     chalk "^2.4.1"
     cli-cursor "^2.1.0"
+    cli-truncate "^1.1.0"
+    is-ci "^2.0.0"
     lodash.throttle "^4.1.1"
     log-update "^3.0.0"
     prop-types "^15.6.2"
     react-reconciler "^0.20.0"
     scheduler "^0.13.2"
+    signal-exit "^3.0.2"
     slice-ansi "^1.0.0"
     string-length "^2.0.0"
     widest-line "^2.0.0"
+    wrap-ansi "^5.0.0"
     yoga-layout-prebuilt "^1.9.3"
 
 inquirer@^6.2.0:
@@ -6759,6 +6775,13 @@ is-ci@^1.0.10:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-color-stop@^1.0.0:
   version "1.1.0"
@@ -8951,7 +8974,7 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.5.1"
 
-object.omit@^2.0.0, object.omit@^2.0.1:
+object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   integrity sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=


### PR DESCRIPTION
This restores the rich ink-based CLI to parcel 2. It was disabled following issues with the devserver, but those don't seem to be present anymore.

There is one behavioral change: we now only print the bundle report in production mode.

Additionally, an unrelated error where the server would continue to serve 500 pages after build errors were resolved has been fixed.

Test Plan: 
* Run the kitchen sink, simple, and react-hmr examples and verify output and relevant exit code.
* Start the hmr server in the react-hmr example and introduce a syntax error. Verify that hmr reflects the error without reload. Verify reloading shows a 500 page. Fix the error and reload without a 500 page.