### PR TITLE
New AssetGraph

### DIFF
--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -115,16 +115,16 @@ export default class Graph<TNode: Node> {
   removeNode(node: TNode): this {
     let removed = new this.constructor();
 
-    this.nodes.delete(node.id);
-    removed.addNode(node);
+    for (let from of this.inboundEdges.get(node.id)) {
+      removed.merge(this.removeEdge(from, node.id));
+    }
 
     for (let to of this.outboundEdges.get(node.id)) {
       removed.merge(this.removeEdge(node.id, to));
     }
 
-    for (let from of this.inboundEdges.get(node.id)) {
-      removed.merge(this.removeEdge(from, node.id));
-    }
+    this.nodes.delete(node.id);
+    removed.addNode(node);
 
     return removed;
   }

--- a/packages/core/core/src/OldAssetGraph.js
+++ b/packages/core/core/src/OldAssetGraph.js
@@ -1,0 +1,427 @@
+// @flow strict-local
+
+import type {
+  OldAssetGraphNode,
+  CacheEntry,
+  DependencyNode,
+  FileNode,
+  NodeId,
+  RootNode
+} from './types';
+
+import type {
+  Dependency as IDependency,
+  File,
+  FilePath,
+  Target,
+  GraphVisitor,
+  Symbol,
+  SymbolResolution,
+  TransformerRequest
+} from '@parcel/types';
+
+import type Asset from './Asset';
+
+import invariant from 'assert';
+import nullthrows from 'nullthrows';
+import Graph from './Graph';
+import {md5FromString} from '@parcel/utils';
+import Dependency from './Dependency';
+
+import clone from 'clone';
+
+export const nodeFromRootDir = (rootDir: string): RootNode => ({
+  id: rootDir,
+  type: 'root',
+  value: rootDir
+});
+
+export const nodeFromDep = (dep: IDependency): DependencyNode => ({
+  id: dep.id,
+  type: 'dependency',
+  value: dep
+});
+
+export const nodeFromFile = (file: File): FileNode => ({
+  id: file.filePath,
+  type: 'file',
+  value: file
+});
+
+export const nodeFromTransformerRequest = (req: TransformerRequest) => ({
+  id: md5FromString(`${req.filePath}:${JSON.stringify(req.env)}`),
+  type: 'transformer_request',
+  value: req
+});
+
+export const nodeFromAsset = (asset: Asset) => ({
+  id: asset.id,
+  type: 'asset',
+  value: asset
+});
+
+const getFileNodesFromGraph = (
+  graph: Graph<OldAssetGraphNode>
+): Array<FileNode> => {
+  // $FlowFixMe Flow can't refine on filter https://github.com/facebook/flow/issues/1414
+  return Array.from(graph.nodes.values()).filter(node => node.type === 'file');
+};
+
+const getFilesFromGraph = (graph: Graph<OldAssetGraphNode>): Array<File> => {
+  return getFileNodesFromGraph(graph).map(node => node.value);
+};
+
+const getDepNodesFromGraph = (
+  graph: Graph<OldAssetGraphNode>
+): Array<DependencyNode> => {
+  // $FlowFixMe Flow can't refine on filter https://github.com/facebook/flow/issues/1414
+  return Array.from(graph.nodes.values()).filter(
+    node => node.type === 'dependency'
+  );
+};
+
+const invertMap = <K, V>(map: Map<K, V>): Map<V, K> =>
+  new Map([...map].map(([key, val]) => [val, key]));
+
+type DepUpdates = {|
+  newRequest?: TransformerRequest,
+  prunedFiles: Array<File>
+|};
+
+type FileUpdates = {|
+  newDeps: Array<IDependency>,
+  addedFiles: Array<File>,
+  removedFiles: Array<File>
+|};
+
+type AssetGraphOpts = {|
+  entries?: Array<string>,
+  targets?: Array<Target>,
+  transformerRequest?: TransformerRequest,
+  rootDir: string
+|};
+
+/**
+ * AssetGraph is a Graph with some extra rules.
+ *  * Nodes can only have one of the following types "root", "dependency", "file", "asset"
+ *  * There is one root node that represents the root directory
+ *  * The root note has edges to dependency nodes for each entry file
+ *  * A dependency node should have an edge to exactly one file node
+ *  * A file node can have one to many edges to asset nodes which can have zero to many edges dependency nodes
+ */
+export default class OldAssetGraph extends Graph<OldAssetGraphNode> {
+  incompleteNodes: Map<NodeId, OldAssetGraphNode> = new Map();
+  invalidNodes: Map<NodeId, OldAssetGraphNode> = new Map();
+  deferredNodes: Set<NodeId> = new Set();
+
+  initializeGraph({
+    entries,
+    targets,
+    transformerRequest,
+    rootDir
+  }: AssetGraphOpts) {
+    let rootNode = nodeFromRootDir(rootDir);
+    this.setRootNode(rootNode);
+
+    let nodes = [];
+    if (entries) {
+      if (!targets) {
+        throw new Error('Targets are required when entries are specified');
+      }
+
+      for (let entry of entries) {
+        for (let target of targets) {
+          let node = nodeFromDep(
+            new Dependency({
+              moduleSpecifier: entry,
+              target: target,
+              env: target.env,
+              isEntry: true
+            })
+          );
+
+          nodes.push(node);
+        }
+      }
+    } else if (transformerRequest) {
+      let node = nodeFromTransformerRequest(transformerRequest);
+      nodes.push(node);
+    }
+
+    this.replaceNodesConnectedTo(rootNode, nodes);
+    for (let depNode of nodes) {
+      this.incompleteNodes.set(depNode.id, depNode);
+    }
+  }
+
+  removeNode(node: OldAssetGraphNode): this {
+    this.incompleteNodes.delete(node.id);
+    return super.removeNode(node);
+  }
+
+  /**
+   * Marks a dependency as resolved, and connects it to a transformer
+   * request node for the file it was resolved to.
+   */
+  resolveDependency(dep: IDependency, req: TransformerRequest): DepUpdates {
+    let newRequest;
+
+    let depNode = nodeFromDep(dep);
+    this.incompleteNodes.delete(depNode.id);
+    this.invalidNodes.delete(depNode.id);
+
+    let requestNode = nodeFromTransformerRequest(req);
+    let {added, removed} = this.replaceNodesConnectedTo(depNode, [requestNode]);
+
+    // Defer transforming this dependency if it is marked as weak, there are no side effects,
+    // and no re-exported symbols are used by ancestor dependencies.
+    // This helps with performance building large libraries like `lodash-es`, which re-exports
+    // a huge number of functions since we can avoid even transforming the files that aren't used.
+    let defer = false;
+    if (dep.isWeak && req.sideEffects === false) {
+      let assets = this.getNodesConnectedTo(depNode);
+      let symbols = invertMap(dep.symbols);
+      invariant(
+        assets[0].type === 'asset' || assets[0].type === 'asset_reference'
+      );
+      let resolvedAsset = assets[0].value;
+      let deps = this.getAncestorDependencies(resolvedAsset);
+      defer = deps.every(
+        d =>
+          !d.symbols.has('*') &&
+          ![...d.symbols.keys()].some(symbol => {
+            let assetSymbol = resolvedAsset.symbols.get(symbol);
+            return assetSymbol != null && symbols.has(assetSymbol);
+          })
+      );
+    }
+
+    if (added.nodes.size) {
+      this.deferredNodes.add(requestNode.id);
+    }
+
+    if (!defer && this.deferredNodes.has(requestNode.id)) {
+      newRequest = req;
+      this.incompleteNodes.set(requestNode.id, requestNode);
+      this.deferredNodes.delete(requestNode.id);
+    }
+
+    let prunedFiles = getFilesFromGraph(removed);
+    return {newRequest, prunedFiles};
+  }
+
+  /**
+   * Marks a transformer request as resolved, and connects it to asset and file
+   * nodes for the generated assets and connected files.
+   */
+  resolveTransformerRequest(
+    req: TransformerRequest,
+    cacheEntry: CacheEntry
+  ): FileUpdates {
+    let newDepNodes: Array<DependencyNode> = [];
+
+    let requestNode = nodeFromTransformerRequest(req);
+    this.incompleteNodes.delete(requestNode.id);
+    this.invalidNodes.delete(requestNode.id);
+
+    // Get connected files from each asset and connect them to the file node
+    let fileNodes = [];
+    for (let asset of cacheEntry.assets) {
+      let files = asset.getConnectedFiles().map(file => nodeFromFile(file));
+      fileNodes = fileNodes.concat(files);
+    }
+
+    // Add a file node for the file that the transformer request resolved to
+    fileNodes.push(
+      nodeFromFile({
+        filePath: req.filePath
+      })
+    );
+
+    let assetNodes = cacheEntry.assets.map(asset => nodeFromAsset(asset));
+    let {added, removed} = this.replaceNodesConnectedTo(requestNode, [
+      ...assetNodes,
+      ...fileNodes
+    ]);
+
+    let addedFiles = getFilesFromGraph(added);
+    let removedFiles = getFilesFromGraph(removed);
+
+    for (let assetNode of assetNodes) {
+      let depNodes = assetNode.value.getDependencies().map(dep => {
+        let node = this.getNode(dep.id);
+        if (node && node.type === 'dependency') {
+          node.value.merge(dep);
+          return node;
+        }
+
+        return nodeFromDep(dep);
+      });
+      let {removed, added} = this.replaceNodesConnectedTo(assetNode, depNodes);
+      removedFiles = removedFiles.concat(getFilesFromGraph(removed));
+      newDepNodes = newDepNodes.concat(getDepNodesFromGraph(added));
+    }
+
+    for (let depNode of newDepNodes) {
+      this.incompleteNodes.set(depNode.id, depNode);
+    }
+
+    let newDeps = newDepNodes.map(node => node.value);
+
+    return {newDeps, addedFiles, removedFiles};
+  }
+
+  invalidateNode(node: OldAssetGraphNode) {
+    this.invalidNodes.set(node.id, node);
+  }
+
+  invalidateFile(filePath: FilePath) {
+    let node = this.getNode(filePath);
+    if (!node || node.type !== 'file') {
+      return;
+    }
+
+    // Invalidate all file nodes connected to this node.
+    for (let connectedNode of this.getNodesConnectedTo(node)) {
+      if (connectedNode.type === 'transformer_request') {
+        this.invalidateNode(connectedNode);
+      }
+    }
+  }
+
+  getDependencies(asset: Asset): Array<IDependency> {
+    let node = this.getNode(asset.id);
+    if (!node) {
+      return [];
+    }
+
+    return this.getNodesConnectedFrom(node).map(node => {
+      invariant(node.type === 'dependency');
+      return node.value;
+    });
+  }
+
+  getDependencyResolution(dep: IDependency): ?Asset {
+    let depNode = this.getNode(dep.id);
+    if (!depNode) {
+      return null;
+    }
+
+    let res: ?Asset = null;
+    this.traverse((node, ctx, traversal) => {
+      // Prefer real assets when resolving dependencies, but use the first
+      // asset reference in absence of a real one.
+      if (node.type === 'asset_reference' && !res) {
+        res = node.value;
+      }
+
+      if (node.type === 'asset') {
+        res = node.value;
+        traversal.stop();
+      }
+    }, depNode);
+
+    return res;
+  }
+
+  getAncestorDependencies(asset: Asset): Array<IDependency> {
+    let node = this.getNode(asset.id);
+    if (!node) {
+      return [];
+    }
+
+    return this.findAncestors(node, node => node.type === 'dependency').map(
+      node => {
+        invariant(node.type === 'dependency');
+        return node.value;
+      }
+    );
+  }
+
+  traverseAssets<TContext>(
+    visit: GraphVisitor<Asset, TContext>,
+    startNode: ?OldAssetGraphNode
+  ): ?TContext {
+    return this.filteredTraverse(
+      node => (node.type === 'asset' ? node.value : null),
+      visit,
+      startNode
+    );
+  }
+
+  getTotalSize(asset?: ?Asset): number {
+    let size = 0;
+    let assetNode = asset ? this.getNode(asset.id) : null;
+    this.traverseAssets(asset => {
+      size += asset.stats.size;
+    }, assetNode);
+
+    return size;
+  }
+
+  getEntryAssets(): Array<Asset> {
+    let entries = [];
+    this.traverseAssets((asset, ctx, traversal) => {
+      entries.push(asset);
+      traversal.skipChildren();
+    });
+
+    return entries;
+  }
+
+  removeAsset(asset: Asset): ?NodeId {
+    let assetNode = this.getNode(asset.id);
+    if (!assetNode) {
+      return;
+    }
+
+    let referenceId = 'asset_reference:' + assetNode.id;
+    this.replaceNode(assetNode, {
+      type: 'asset_reference',
+      id: referenceId,
+      value: asset
+    });
+
+    return referenceId;
+  }
+
+  resolveSymbol(asset: Asset, symbol: Symbol): SymbolResolution {
+    if (symbol === '*') {
+      return {asset, exportSymbol: '*', symbol: '*'};
+    }
+
+    let identifier = asset.symbols.get(symbol);
+
+    let deps = this.getDependencies(asset).reverse();
+    for (let dep of deps) {
+      // If this is a re-export, find the original module.
+      let symbolLookup = new Map(
+        [...dep.symbols].map(([key, val]) => [val, key])
+      );
+      let depSymbol = symbolLookup.get(identifier);
+      if (depSymbol != null) {
+        let resolved = nullthrows(this.getDependencyResolution(dep));
+        return this.resolveSymbol(resolved, depSymbol);
+      }
+
+      // If this module exports wildcards, resolve the original module.
+      // Default exports are excluded from wildcard exports.
+      if (dep.symbols.get('*') === '*' && symbol !== 'default') {
+        let resolved = nullthrows(this.getDependencyResolution(dep));
+        let result = this.resolveSymbol(resolved, symbol);
+        if (result.symbol != null) {
+          return result;
+        }
+      }
+    }
+
+    return {asset, exportSymbol: symbol, symbol: identifier};
+  }
+
+  clone() {
+    let nodes = clone([...this.nodes]);
+    let edges = clone(this.getAllEdges());
+    let rootNodeId = this.rootNodeId;
+    return new OldAssetGraph({nodes, edges, rootNodeId});
+  }
+}

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -30,23 +30,17 @@ export default async function dumpGraphToGraphViz(
   ) {
     return;
   }
-
   const graphviz = require('graphviz');
   const tempy = require('tempy');
-
   let g = graphviz.digraph('G');
-
   let nodes = Array.from(graph.nodes.values());
   for (let node of nodes) {
     let n = g.addNode(node.id);
-
     // $FlowFixMe default is fine. Not every type needs to be in the map.
     n.set('color', COLORS[node.type || 'default']);
     n.set('shape', 'box');
     n.set('style', 'filled');
-
     let label = `${node.type || 'No Type'}: `;
-
     if (node.type === 'dependency') {
       label += node.value.moduleSpecifier;
       let parts = [];
@@ -75,7 +69,6 @@ export default async function dumpGraphToGraphViz(
           if (index >= 0) {
             return parts[index + 1];
           }
-
           return path.basename(asset.value.filePath);
         })
         .join(', ');
@@ -83,20 +76,15 @@ export default async function dumpGraphToGraphViz(
       // label += node.id;
       label = node.type;
     }
-
     n.set('label', label);
   }
-
-  for (let edge of graph.edges) {
+  for (let edge of graph.getAllEdges()) {
     g.addEdge(edge.from, edge.to);
   }
-
   let tmp = tempy.file({name: `${name}.png`});
-
   await g.output('png', tmp);
   // eslint-disable-next-line no-console
   console.log('Dumped', tmp);
-
   if (graph instanceof BundleGraph) {
     graph.traverseBundles(bundle => {
       dumpGraphToGraphViz(bundle.assetGraph, bundle.id);

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
 import type {
+  AssetGroup,
   BundleGroup,
   Dependency,
   Environment,
@@ -49,14 +50,28 @@ export type TransformerRequestNode = {|
   +type: 'transformer_request',
   value: TransformerRequest
 |};
+export type AssetGroupNode = {|
+  id: string,
+  +type: 'asset_group',
+  value: AssetGroup
+|};
 
-export type AssetGraphNode =
+export type OldAssetGraphNode =
   | AssetNode
   | AssetReferenceNode
   | DependencyNode
   | FileNode
   | RootNode
   | TransformerRequestNode
+  | BundleGroupNode
+  | BundleReferenceNode;
+
+export type AssetGraphNode =
+  | AssetGroupNode
+  | AssetNode
+  | AssetReferenceNode
+  | DependencyNode
+  | RootNode
   | BundleGroupNode
   | BundleReferenceNode;
 

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -1,7 +1,7 @@
 // @flow
 
 import assert from 'assert';
-import AssetGraph, {nodeFromTransformerRequest} from '../src/AssetGraph';
+import AssetGraph, {nodeFromTransformerRequest} from '../src/OldAssetGraph';
 import Dependency from '../src/Dependency';
 import Asset from '../src/Asset';
 import Environment from '../src/Environment';

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -227,6 +227,11 @@ export type TransformerRequest = {
   code?: string
 };
 
+export type AssetGroup = {|
+  filePath: FilePath,
+  env: Environment
+|};
+
 interface BaseAsset {
   +ast: ?AST;
   +env: Environment;


### PR DESCRIPTION
# ↪️ Pull Request

While working on adding config loading to the graph, which necessitated adding 4 more types to the graph, all of which no longer matter once we hit the bundling phase, I came up with the idea of building multiple graphs at the same time. One graph will still be called the `AssetGraph`, but it will only have nodes needed for Bundling onward (Assets and Dependencies). The other graph will be named the `RequestGraph` which keeps track of all of the requests that give us results that make up the `AssetGraph`. Eventually they will be built along side each other (in progress), but for now I am just converting the` OldAssetGraph` to the new `AssetGraph`, so that we can start working with the new `AssetGraph` as soon as possible, while I'm working on the multi graph approach.

## 🚨 Test instructions

`yarn test`/`yarn flow`/`yarn lint`

Run examples with `PARCEL_DUMP_GRAPHVIZ=1` and make sure graphs make sense