### PR TITLE
Rename package versions to 2.0.0-alpha.0

### DIFF
--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/bundler-default",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/DefaultBundler",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0"
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0"
   }
 }

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/bundler-default",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/DefaultBundler",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0"
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0"
   }
 }

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/config-default",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,24 +10,24 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@parcel/bundler-default": "^2.0.0",
-    "@parcel/namer-default": "^2.0.0",
-    "@parcel/packager-css": "^2.0.0",
-    "@parcel/packager-html": "^2.0.0",
-    "@parcel/packager-js": "^2.0.0",
-    "@parcel/packager-raw": "^2.0.0",
-    "@parcel/reporter-cli": "^2.0.0",
-    "@parcel/resolver-default": "^2.0.0",
-    "@parcel/runtime-js": "^2.0.0",
-    "@parcel/transformer-babel": "^2.0.0",
-    "@parcel/transformer-css": "^2.0.0",
-    "@parcel/transformer-html": "^2.0.0",
-    "@parcel/transformer-js": "^2.0.0",
-    "@parcel/transformer-postcss": "^2.0.0",
-    "@parcel/transformer-raw": "^2.0.0",
-    "@parcel/transformer-terser": "^2.0.0",
-    "@parcel/reporter-dev-server": "^2.0.0",
-    "@parcel/reporter-hmr-server": "^2.0.0",
-    "@parcel/runtime-browser-hmr": "^2.0.0"
+    "@parcel/bundler-default": "^2.0.0-prealpha0",
+    "@parcel/namer-default": "^2.0.0-prealpha0",
+    "@parcel/packager-css": "^2.0.0-prealpha0",
+    "@parcel/packager-html": "^2.0.0-prealpha0",
+    "@parcel/packager-js": "^2.0.0-prealpha0",
+    "@parcel/packager-raw": "^2.0.0-prealpha0",
+    "@parcel/reporter-cli": "^2.0.0-prealpha0",
+    "@parcel/resolver-default": "^2.0.0-prealpha0",
+    "@parcel/runtime-js": "^2.0.0-prealpha0",
+    "@parcel/transformer-babel": "^2.0.0-prealpha0",
+    "@parcel/transformer-css": "^2.0.0-prealpha0",
+    "@parcel/transformer-html": "^2.0.0-prealpha0",
+    "@parcel/transformer-js": "^2.0.0-prealpha0",
+    "@parcel/transformer-postcss": "^2.0.0-prealpha0",
+    "@parcel/transformer-raw": "^2.0.0-prealpha0",
+    "@parcel/transformer-terser": "^2.0.0-prealpha0",
+    "@parcel/reporter-dev-server": "^2.0.0-prealpha0",
+    "@parcel/reporter-hmr-server": "^2.0.0-prealpha0",
+    "@parcel/runtime-browser-hmr": "^2.0.0-prealpha0"
   }
 }

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/config-default",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,24 +10,24 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@parcel/bundler-default": "^2.0.0-prealpha0",
-    "@parcel/namer-default": "^2.0.0-prealpha0",
-    "@parcel/packager-css": "^2.0.0-prealpha0",
-    "@parcel/packager-html": "^2.0.0-prealpha0",
-    "@parcel/packager-js": "^2.0.0-prealpha0",
-    "@parcel/packager-raw": "^2.0.0-prealpha0",
-    "@parcel/reporter-cli": "^2.0.0-prealpha0",
-    "@parcel/resolver-default": "^2.0.0-prealpha0",
-    "@parcel/runtime-js": "^2.0.0-prealpha0",
-    "@parcel/transformer-babel": "^2.0.0-prealpha0",
-    "@parcel/transformer-css": "^2.0.0-prealpha0",
-    "@parcel/transformer-html": "^2.0.0-prealpha0",
-    "@parcel/transformer-js": "^2.0.0-prealpha0",
-    "@parcel/transformer-postcss": "^2.0.0-prealpha0",
-    "@parcel/transformer-raw": "^2.0.0-prealpha0",
-    "@parcel/transformer-terser": "^2.0.0-prealpha0",
-    "@parcel/reporter-dev-server": "^2.0.0-prealpha0",
-    "@parcel/reporter-hmr-server": "^2.0.0-prealpha0",
-    "@parcel/runtime-browser-hmr": "^2.0.0-prealpha0"
+    "@parcel/bundler-default": "^2.0.0-alpha.0",
+    "@parcel/namer-default": "^2.0.0-alpha.0",
+    "@parcel/packager-css": "^2.0.0-alpha.0",
+    "@parcel/packager-html": "^2.0.0-alpha.0",
+    "@parcel/packager-js": "^2.0.0-alpha.0",
+    "@parcel/packager-raw": "^2.0.0-alpha.0",
+    "@parcel/reporter-cli": "^2.0.0-alpha.0",
+    "@parcel/resolver-default": "^2.0.0-alpha.0",
+    "@parcel/runtime-js": "^2.0.0-alpha.0",
+    "@parcel/transformer-babel": "^2.0.0-alpha.0",
+    "@parcel/transformer-css": "^2.0.0-alpha.0",
+    "@parcel/transformer-html": "^2.0.0-alpha.0",
+    "@parcel/transformer-js": "^2.0.0-alpha.0",
+    "@parcel/transformer-postcss": "^2.0.0-alpha.0",
+    "@parcel/transformer-raw": "^2.0.0-alpha.0",
+    "@parcel/transformer-terser": "^2.0.0-alpha.0",
+    "@parcel/reporter-dev-server": "^2.0.0-alpha.0",
+    "@parcel/reporter-hmr-server": "^2.0.0-alpha.0",
+    "@parcel/runtime-browser-hmr": "^2.0.0-alpha.0"
   }
 }

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/cache",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,8 +12,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0"
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0"
   }
 }

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/cache",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,8 +12,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0",
-    "@parcel/logger": "^2.0.0",
-    "@parcel/utils": "^2.0.0"
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0"
   }
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/core",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "main": "./src/Parcel.js",
   "repository": {
@@ -13,16 +13,16 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/cache": "^2.0.0",
-    "@parcel/events": "^2.0.0",
-    "@parcel/fs": "^2.0.0",
-    "@parcel/local-require": "^2.0.0",
-    "@parcel/logger": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/types": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/cache": "^2.0.0-prealpha0",
+    "@parcel/events": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/local-require": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/types": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "@parcel/watcher": "^2.0.0-alpha.3",
-    "@parcel/workers": "^2.0.0",
+    "@parcel/workers": "^2.0.0-prealpha0",
     "abortcontroller-polyfill": "^1.1.9",
     "browserslist": "^4.1.0",
     "clone": "^2.1.1",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/core",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "main": "./src/Parcel.js",
   "repository": {
@@ -13,16 +13,16 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/cache": "^2.0.0-prealpha0",
-    "@parcel/events": "^2.0.0-prealpha0",
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/local-require": "^2.0.0-prealpha0",
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/types": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/cache": "^2.0.0-alpha.0",
+    "@parcel/events": "^2.0.0-alpha.0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/local-require": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/types": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "@parcel/watcher": "^2.0.0-alpha.3",
-    "@parcel/workers": "^2.0.0-prealpha0",
+    "@parcel/workers": "^2.0.0-alpha.0",
     "abortcontroller-polyfill": "^1.1.9",
     "browserslist": "^4.1.0",
     "clone": "^2.1.1",

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/fs",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/index.js",
   "license": "MIT",

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/fs",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/index.js",
   "license": "MIT",

--- a/packages/core/install-package/package.json
+++ b/packages/core/install-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/install-package",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/installPackage.js",
   "license": "MIT",
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
-    "@parcel/workers": "^2.0.0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/workers": "^2.0.0-prealpha0",
     "command-exists": "^1.2.6",
     "cross-spawn": "^6.0.4",
     "nullthrows": "^1.1.1",

--- a/packages/core/install-package/package.json
+++ b/packages/core/install-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/install-package",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/installPackage.js",
   "license": "MIT",
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
-    "@parcel/workers": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
+    "@parcel/workers": "^2.0.0-alpha.0",
     "command-exists": "^1.2.6",
     "cross-spawn": "^6.0.4",
     "nullthrows": "^1.1.1",

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/integration-tests",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/integration-tests",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "private": true,
   "license": "MIT",
   "repository": {

--- a/packages/core/is-v2-ready-yet/package.json
+++ b/packages/core/is-v2-ready-yet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/is-v2-ready-yet",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "private": true,
   "license": "MIT",
   "repository": {
@@ -13,7 +13,7 @@
     "build-app": "yarn parcel build index.html"
   },
   "dependencies": {
-    "@parcel/integration-tests": "^2.0.0",
+    "@parcel/integration-tests": "^2.0.0-prealpha0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "victory": "^31.0.1"

--- a/packages/core/is-v2-ready-yet/package.json
+++ b/packages/core/is-v2-ready-yet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/is-v2-ready-yet",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "private": true,
   "license": "MIT",
   "repository": {
@@ -13,7 +13,7 @@
     "build-app": "yarn parcel build index.html"
   },
   "dependencies": {
-    "@parcel/integration-tests": "^2.0.0-prealpha0",
+    "@parcel/integration-tests": "^2.0.0-alpha.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "victory": "^31.0.1"

--- a/packages/core/local-require/package.json
+++ b/packages/core/local-require/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/local-require",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/localRequire.js",
   "license": "MIT",
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@parcel/install-package": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0"
+    "@parcel/install-package": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0"
   }
 }

--- a/packages/core/local-require/package.json
+++ b/packages/core/local-require/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/local-require",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/localRequire.js",
   "license": "MIT",
@@ -15,7 +15,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@parcel/install-package": "^2.0.0",
-    "@parcel/utils": "^2.0.0"
+    "@parcel/install-package": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0"
   }
 }

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/logger",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/Logger.js",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/events": "^2.0.0-prealpha0"
+    "@parcel/events": "^2.0.0-alpha.0"
   }
 }

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/logger",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/Logger.js",
   "license": "MIT",
@@ -21,6 +21,6 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/events": "^2.0.0"
+    "@parcel/events": "^2.0.0-prealpha0"
   }
 }

--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -32,7 +32,7 @@
     "@parcel/logger": "^1.11.0",
     "@parcel/utils": "^1.11.0",
     "@parcel/watcher": "^1.12.0",
-    "@parcel/workers": "^2.0.0-prealpha0",
+    "@parcel/workers": "^2.0.0-alpha.0",
     "ansi-to-html": "^0.6.4",
     "babylon-walk": "^1.0.2",
     "browserslist": "^4.1.0",

--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -32,7 +32,7 @@
     "@parcel/logger": "^1.11.0",
     "@parcel/utils": "^1.11.0",
     "@parcel/watcher": "^1.12.0",
-    "@parcel/workers": "^2.0.0",
+    "@parcel/workers": "^2.0.0-prealpha0",
     "ansi-to-html": "^0.6.4",
     "babylon-walk": "^1.0.2",
     "browserslist": "^4.1.0",

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,8 +10,8 @@
     "parcel2": "src/bin.js"
   },
   "dependencies": {
-    "@parcel/config-default": "^2.0.0-prealpha0",
-    "@parcel/core": "^2.0.0-prealpha0",
+    "@parcel/config-default": "^2.0.0-alpha.0",
+    "@parcel/core": "^2.0.0-alpha.0",
     "chalk": "^2.1.0",
     "commander": "^2.19.0",
     "get-port": "^4.2.0",

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -10,8 +10,8 @@
     "parcel2": "src/bin.js"
   },
   "dependencies": {
-    "@parcel/config-default": "^2.0.0",
-    "@parcel/core": "^2.0.0",
+    "@parcel/config-default": "^2.0.0-prealpha0",
+    "@parcel/core": "^2.0.0-prealpha0",
     "chalk": "^2.1.0",
     "commander": "^2.19.0",
     "get-port": "^4.2.0",

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/plugin",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,6 +12,6 @@
   },
   "main": "./src/PluginAPI.js",
   "dependencies": {
-    "@parcel/types": "^2.0.0"
+    "@parcel/types": "^2.0.0-prealpha0"
   }
 }

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/plugin",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,6 +12,6 @@
   },
   "main": "./src/PluginAPI.js",
   "dependencies": {
-    "@parcel/types": "^2.0.0-prealpha0"
+    "@parcel/types": "^2.0.0-alpha.0"
   }
 }

--- a/packages/core/register/example/package.json
+++ b/packages/core/register/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "register-example",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "main": "./index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/core/register/example/package.json
+++ b/packages/core/register/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "register-example",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "main": "./index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/register",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "main": "./src/register.js",
   "license": "MIT",
   "scripts": {
@@ -10,8 +10,8 @@
     "clean": "rm -rf .parcel-cache"
   },
   "dependencies": {
-    "@parcel/core": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/core": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "pirates": "^4.0.0"
   }
 }

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/register",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "main": "./src/register.js",
   "license": "MIT",
   "scripts": {
@@ -10,8 +10,8 @@
     "clean": "rm -rf .parcel-cache"
   },
   "dependencies": {
-    "@parcel/core": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/core": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "pirates": "^4.0.0"
   }
 }

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/test-utils",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/utils.js",
   "license": "MIT",
@@ -13,10 +13,10 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "@parcel/config-default": "^2.0.0-prealpha0",
-    "@parcel/core": "^2.0.0-prealpha0",
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/config-default": "^2.0.0-alpha.0",
+    "@parcel/core": "^2.0.0-alpha.0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "chalk": "^2.1.0",
     "ncp": "^2.0.0",
     "nullthrows": "^1.1.1",

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/test-utils",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/utils.js",
   "license": "MIT",
@@ -13,10 +13,10 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
-    "@parcel/config-default": "^2.0.0",
-    "@parcel/core": "^2.0.0",
-    "@parcel/fs": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/config-default": "^2.0.0-prealpha0",
+    "@parcel/core": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "chalk": "^2.1.0",
     "ncp": "^2.0.0",
     "nullthrows": "^1.1.1",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/types",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/types",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/utils",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/index.js",
   "license": "MIT",
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.0",
-    "@parcel/fs": "^2.0.0",
-    "@parcel/logger": "^2.0.0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-prealpha0",
     "clone": "^2.1.1",
     "deasync": "^0.1.14",
     "fast-glob": "^2.2.2",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/utils",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/index.js",
   "license": "MIT",
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "@iarna/toml": "^2.2.0",
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
     "clone": "^2.1.1",
     "deasync": "^0.1.14",
     "fast-glob": "^2.2.2",

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/workers",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/WorkerFarm.js",
   "license": "MIT",
@@ -22,8 +22,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "physical-cpu-count": "^2.0.0",
     "nullthrows": "^1.1.1"
   }

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/workers",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/WorkerFarm.js",
   "license": "MIT",
@@ -22,8 +22,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "physical-cpu-count": "^2.0.0",
     "nullthrows": "^1.1.1"
   }

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/babel-preset",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.1.0",

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/babel-preset",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.1.0",

--- a/packages/dev/babel-register/package.json
+++ b/packages/dev/babel-register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/babel-register",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "license": "MIT",
   "private": true,
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "@babel/register": "^7.0.0",
-    "@parcel/babel-preset": "^2.0.0-prealpha0"
+    "@parcel/babel-preset": "^2.0.0-alpha.0"
   }
 }

--- a/packages/dev/babel-register/package.json
+++ b/packages/dev/babel-register/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/babel-register",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "license": "MIT",
   "private": true,
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "@babel/register": "^7.0.0",
-    "@parcel/babel-preset": "^2.0.0"
+    "@parcel/babel-preset": "^2.0.0-prealpha0"
   }
 }

--- a/packages/dev/eslint-config-browser/package.json
+++ b/packages/dev/eslint-config-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/eslint-config-browser",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "dependencies": {
     "@parcel/eslint-config": "^1.10.3"
   }

--- a/packages/dev/eslint-config-browser/package.json
+++ b/packages/dev/eslint-config-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/eslint-config-browser",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "dependencies": {
     "@parcel/eslint-config": "^1.10.3"
   }

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/eslint-config",
   "version": "1.10.3",
   "dependencies": {
-    "@parcel/eslint-plugin": "^2.0.0-prealpha0",
+    "@parcel/eslint-plugin": "^2.0.0-alpha.0",
     "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-flowtype": "^3.1.1",

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/eslint-config",
   "version": "1.10.3",
   "dependencies": {
-    "@parcel/eslint-plugin": "^2.0.0",
+    "@parcel/eslint-plugin": "^2.0.0-prealpha0",
     "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-flowtype": "^3.1.1",

--- a/packages/dev/eslint-plugin/package.json
+++ b/packages/dev/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/eslint-plugin",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "main": "index.js",
   "scripts": {
     "test": "mocha test test/rules"

--- a/packages/dev/eslint-plugin/package.json
+++ b/packages/dev/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/eslint-plugin",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "main": "index.js",
   "scripts": {
     "test": "mocha test test/rules"

--- a/packages/examples/html/package.json
+++ b/packages/examples/html/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@parcel/html-example",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
   "scripts": {
     "demo": "parcel2 serve src/index.html"
   },
   "devDependencies": {
-    "@parcel/babel-register": "^2.0.0-prealpha0",
-    "parcel": "^2.0.0-prealpha0"
+    "@parcel/babel-register": "^2.0.0-alpha.0",
+    "parcel": "^2.0.0-alpha.0"
   },
   "browser": "dist/legacy/index.html",
   "browserModern": "dist/modern/index.html",

--- a/packages/examples/html/package.json
+++ b/packages/examples/html/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@parcel/html-example",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "private": true,
   "scripts": {
     "demo": "parcel2 serve src/index.html"
   },
   "devDependencies": {
-    "@parcel/babel-register": "^2.0.0",
-    "parcel": "^2.0.0"
+    "@parcel/babel-register": "^2.0.0-prealpha0",
+    "parcel": "^2.0.0-prealpha0"
   },
   "browser": "dist/legacy/index.html",
   "browserModern": "dist/modern/index.html",

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@parcel/kitchen-sink-example",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "private": true,
   "scripts": {
     "demo": "parcel2 build src/index.js"
   },
   "devDependencies": {
-    "@parcel/babel-register": "^2.0.0",
-    "@parcel/config-default": "^2.0.0",
-    "parcel": "^2.0.0"
+    "@parcel/babel-register": "^2.0.0-prealpha0",
+    "@parcel/config-default": "^2.0.0-prealpha0",
+    "parcel": "^2.0.0-prealpha0"
   },
   "browser": "dist/legacy/index.js",
   "browserModern": "dist/modern/index.js",

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@parcel/kitchen-sink-example",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
   "scripts": {
     "demo": "parcel2 build src/index.js"
   },
   "devDependencies": {
-    "@parcel/babel-register": "^2.0.0-prealpha0",
-    "@parcel/config-default": "^2.0.0-prealpha0",
-    "parcel": "^2.0.0-prealpha0"
+    "@parcel/babel-register": "^2.0.0-alpha.0",
+    "@parcel/config-default": "^2.0.0-alpha.0",
+    "parcel": "^2.0.0-alpha.0"
   },
   "browser": "dist/legacy/index.js",
   "browserModern": "dist/modern/index.js",

--- a/packages/examples/react-hmr/package.json
+++ b/packages/examples/react-hmr/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@parcel/react-hmr-example",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "private": true,
   "scripts": {
     "demo": "parcel2 serve src/index.html"
   },
   "devDependencies": {
-    "parcel": "^2.0.0"
+    "parcel": "^2.0.0-prealpha0"
   },
   "browser": "dist/legacy/index.html",
   "browserModern": "dist/modern/index.html",

--- a/packages/examples/react-hmr/package.json
+++ b/packages/examples/react-hmr/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@parcel/react-hmr-example",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
   "scripts": {
     "demo": "parcel2 serve src/index.html"
   },
   "devDependencies": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "browser": "dist/legacy/index.html",
   "browserModern": "dist/modern/index.html",

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/simple-example",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -8,8 +8,8 @@
     "clean-demo": "rm -rf .parcel-cache dist && yarn demo"
   },
   "devDependencies": {
-    "@parcel/babel-register": "^2.0.0",
-    "@parcel/core": "^2.0.0"
+    "@parcel/babel-register": "^2.0.0-prealpha0",
+    "@parcel/core": "^2.0.0-prealpha0"
   },
   "browser": "dist/legacy/index.js",
   "browserModern": "dist/modern/index.js",

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/simple-example",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -8,8 +8,8 @@
     "clean-demo": "rm -rf .parcel-cache dist && yarn demo"
   },
   "devDependencies": {
-    "@parcel/babel-register": "^2.0.0-prealpha0",
-    "@parcel/core": "^2.0.0-prealpha0"
+    "@parcel/babel-register": "^2.0.0-alpha.0",
+    "@parcel/core": "^2.0.0-alpha.0"
   },
   "browser": "dist/legacy/index.js",
   "browserModern": "dist/modern/index.js",

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/namer-default",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/DefaultNamer",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/namer-default",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/DefaultNamer",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-css",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/CSSPackager",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0"
+    "@parcel/plugin": "^2.0.0-alpha.0"
   }
 }

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-css",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/CSSPackager",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0"
+    "@parcel/plugin": "^2.0.0-prealpha0"
   }
 }

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-html",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/HTMLPackager",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0"
+    "@parcel/plugin": "^2.0.0-prealpha0"
   }
 }

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-html",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/HTMLPackager",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0"
+    "@parcel/plugin": "^2.0.0-alpha.0"
   }
 }

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-js",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/JSPackager",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/scope-hoisting": "^2.0.0-prealpha0"
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/scope-hoisting": "^2.0.0-alpha.0"
   }
 }

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-js",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/JSPackager",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/scope-hoisting": "^2.0.0"
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/scope-hoisting": "^2.0.0-prealpha0"
   }
 }

--- a/packages/packagers/raw/package.json
+++ b/packages/packagers/raw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-raw",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/RawPackager",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0"
+    "@parcel/plugin": "^2.0.0-alpha.0"
   }
 }

--- a/packages/packagers/raw/package.json
+++ b/packages/packagers/raw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/packager-raw",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/RawPackager",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0"
+    "@parcel/plugin": "^2.0.0-prealpha0"
   }
 }

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@parcel/reporter-cli",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "main": "src/index.js",
   "engines": {
-    "parcel": "^2.0.0"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha",
@@ -12,10 +12,10 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/types": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/types": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "cli-spinners": "^2.0.0",
     "filesize": "^3.6.0",
     "grapheme-breaker": "^0.3.2",

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@parcel/reporter-cli",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "main": "src/index.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "test": "cross-env NODE_ENV=test mocha",
@@ -12,10 +12,10 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/types": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/types": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "cli-spinners": "^2.0.0",
     "filesize": "^3.6.0",
     "grapheme-breaker": "^0.3.2",

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/reporter-dev-server",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/ServerReporter.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": ">= 6.0.0",
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
@@ -19,17 +19,17 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/reporter-cli": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/reporter-cli": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "ansi-html": "^0.0.7",
     "ejs": "^2.6.1",
     "serve-static": "^1.13.2"
   },
   "devDependencies": {
-    "@parcel/babel-preset": "^2.0.0-prealpha0",
-    "@parcel/types": "^2.0.0-prealpha0"
+    "@parcel/babel-preset": "^2.0.0-alpha.0",
+    "@parcel/types": "^2.0.0-alpha.0"
   }
 }

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/reporter-dev-server",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/ServerReporter.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": ">= 6.0.0",
-    "parcel": "^2.0.0"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
@@ -19,17 +19,17 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0",
-    "@parcel/logger": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/reporter-cli": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/reporter-cli": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "ansi-html": "^0.0.7",
     "ejs": "^2.6.1",
     "serve-static": "^1.13.2"
   },
   "devDependencies": {
-    "@parcel/babel-preset": "^2.0.0",
-    "@parcel/types": "^2.0.0"
+    "@parcel/babel-preset": "^2.0.0-prealpha0",
+    "@parcel/types": "^2.0.0-prealpha0"
   }
 }

--- a/packages/reporters/hmr-server/package.json
+++ b/packages/reporters/hmr-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/reporter-hmr-server",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/HMRReporter.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": ">= 6.0.0",
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
@@ -19,14 +19,14 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/reporter-cli": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/reporter-cli": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "ansi-html": "^0.0.7",
     "ws": "^6.2.0"
   },
   "devDependencies": {
-    "@parcel/babel-preset": "^2.0.0-prealpha0"
+    "@parcel/babel-preset": "^2.0.0-alpha.0"
   }
 }

--- a/packages/reporters/hmr-server/package.json
+++ b/packages/reporters/hmr-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/reporter-hmr-server",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/HMRReporter.js",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "engines": {
     "node": ">= 6.0.0",
-    "parcel": "^2.0.0"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
@@ -19,14 +19,14 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/logger": "^2.0.0",
-    "@parcel/reporter-cli": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/reporter-cli": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "ansi-html": "^0.0.7",
     "ws": "^6.2.0"
   },
   "devDependencies": {
-    "@parcel/babel-preset": "^2.0.0"
+    "@parcel/babel-preset": "^2.0.0-prealpha0"
   }
 }

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@parcel/reporter-json",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "main": "src/JSONReporter.js",
   "engines": {
-    "parcel": "^2.0.0"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "test": "echo this package has no tests yet",
     "test-ci": "yarn test"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/types": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/types": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@parcel/reporter-json",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "main": "src/JSONReporter.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "test": "echo this package has no tests yet",
     "test-ci": "yarn test"
   },
   "dependencies": {
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/types": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/types": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/resolver-default",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,16 +8,16 @@
   },
   "main": "src/DefaultResolver",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "micromatch": "^3.0.4",
     "node-libs-browser": "^2.1.0"
   },

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/resolver-default",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,16 +8,16 @@
   },
   "main": "src/DefaultResolver",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "micromatch": "^3.0.4",
     "node-libs-browser": "^2.1.0"
   },

--- a/packages/runtimes/hmr/package.json
+++ b/packages/runtimes/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/runtime-browser-hmr",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,11 +8,11 @@
   },
   "main": "src/HMRRuntime",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0"
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0"
   }
 }

--- a/packages/runtimes/hmr/package.json
+++ b/packages/runtimes/hmr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/runtime-browser-hmr",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,11 +8,11 @@
   },
   "main": "src/HMRRuntime",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0"
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0"
   }
 }

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/runtime-js",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,11 +8,11 @@
   },
   "main": "src/JSRuntime",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/runtime-js",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,11 +8,11 @@
   },
   "main": "src/JSRuntime",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/scope-hoisting",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/index.js",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "@babel/traverse": "^7.2.3",
     "@babel/parser": "^7.0.0",
     "@babel/types": "^7.3.3",
-    "@parcel/types": "^2.0.0",
+    "@parcel/types": "^2.0.0-prealpha0",
     "babylon-walk": "^1.0.2",
     "micromatch": "^3.1.10",
     "nullthrows": "^1.1.1"

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/scope-hoisting",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "src/index.js",
   "license": "MIT",
@@ -24,7 +24,7 @@
     "@babel/traverse": "^7.2.3",
     "@babel/parser": "^7.0.0",
     "@babel/types": "^7.3.3",
-    "@parcel/types": "^2.0.0-prealpha0",
+    "@parcel/types": "^2.0.0-alpha.0",
     "babylon-walk": "^1.0.2",
     "micromatch": "^3.1.10",
     "nullthrows": "^1.1.1"

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-babel",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "main": "src/BabelTransformer.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "build": "babel src -d lib",
@@ -21,12 +21,12 @@
     "@babel/plugin-transform-react-jsx": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/traverse": "^7.0.0",
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/install-package": "^2.0.0-prealpha0",
-    "@parcel/local-require": "^2.0.0-prealpha0",
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/install-package": "^2.0.0-alpha.0",
+    "@parcel/local-require": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "browserslist": "^4.1.0",
     "micromatch": "^3.0.4",
     "semver": "^5.4.1"

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-babel",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "main": "src/BabelTransformer.js",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "build": "babel src -d lib",
@@ -21,12 +21,12 @@
     "@babel/plugin-transform-react-jsx": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/traverse": "^7.0.0",
-    "@parcel/fs": "^2.0.0",
-    "@parcel/install-package": "^2.0.0",
-    "@parcel/local-require": "^2.0.0",
-    "@parcel/logger": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/install-package": "^2.0.0-prealpha0",
+    "@parcel/local-require": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "browserslist": "^4.1.0",
     "micromatch": "^3.0.4",
     "semver": "^5.4.1"

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-css",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/CSSTransformer.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
     "postcss": "^7.0.5",
     "postcss-value-parser": "^3.3.1",
     "semver": "^5.4.1"

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-css",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,10 +8,10 @@
   },
   "main": "src/CSSTransformer.js",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "2.0.0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
     "postcss": "^7.0.5",
     "postcss-value-parser": "^3.3.1",
     "semver": "^5.4.1"

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-html",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,11 +8,11 @@
   },
   "main": "src/HTMLTransformer.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.11.3",
     "posthtml-parser": "^0.4.1",

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-html",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,11 +8,11 @@
   },
   "main": "src/HTMLTransformer.js",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.11.3",
     "posthtml-parser": "^0.4.1",

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-js",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "main": "src/JSTransformer",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "build": "babel src -d lib",
@@ -22,10 +22,10 @@
     "@babel/template": "^7.0.0",
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
-    "@parcel/logger": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/scope-hoisting": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/logger": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/scope-hoisting": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "babylon-walk": "^1.0.2",
     "node-libs-browser": "^2.0.0",
     "semver": "^5.4.1"

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-js",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,7 +8,7 @@
   },
   "main": "src/JSTransformer",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "build": "babel src -d lib",
@@ -22,10 +22,10 @@
     "@babel/template": "^7.0.0",
     "@babel/traverse": "^7.0.0",
     "@babel/types": "^7.0.0",
-    "@parcel/logger": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/scope-hoisting": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/logger": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/scope-hoisting": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "babylon-walk": "^1.0.2",
     "node-libs-browser": "^2.0.0",
     "semver": "^5.4.1"

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-postcss",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,13 +8,13 @@
   },
   "main": "src/PostCSSTransformer.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0-prealpha0",
-    "@parcel/local-require": "^2.0.0-prealpha0",
-    "@parcel/plugin": "^2.0.0-prealpha0",
-    "@parcel/utils": "^2.0.0-prealpha0",
+    "@parcel/fs": "^2.0.0-alpha.0",
+    "@parcel/local-require": "^2.0.0-alpha.0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "css-modules-loader-core": "^1.1.0",
     "nullthrows": "^1.1.1",
     "postcss": "^7.0.5",

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-postcss",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,13 +8,13 @@
   },
   "main": "src/PostCSSTransformer.js",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/fs": "^2.0.0",
-    "@parcel/local-require": "^2.0.0",
-    "@parcel/plugin": "^2.0.0",
-    "@parcel/utils": "^2.0.0",
+    "@parcel/fs": "^2.0.0-prealpha0",
+    "@parcel/local-require": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/utils": "^2.0.0-prealpha0",
     "css-modules-loader-core": "^1.1.0",
     "nullthrows": "^1.1.1",
     "postcss": "^7.0.5",

--- a/packages/transformers/raw/package.json
+++ b/packages/transformers/raw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-raw",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/RawTransformer.js",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0"
+    "@parcel/plugin": "^2.0.0-prealpha0"
   }
 }

--- a/packages/transformers/raw/package.json
+++ b/packages/transformers/raw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-raw",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,9 +8,9 @@
   },
   "main": "src/RawTransformer.js",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0"
+    "@parcel/plugin": "^2.0.0-alpha.0"
   }
 }

--- a/packages/transformers/terser/package.json
+++ b/packages/transformers/terser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-terser",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,14 +8,14 @@
   },
   "main": "src/TerserTransformer",
   "engines": {
-    "parcel": "^2.0.0-prealpha0"
+    "parcel": "^2.0.0-alpha.0"
   },
   "scripts": {
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-prealpha0",
+    "@parcel/plugin": "^2.0.0-alpha.0",
     "nullthrows": "^1.1.1",
     "terser": "^3.7.3"
   }

--- a/packages/transformers/terser/package.json
+++ b/packages/transformers/terser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/transformer-terser",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -8,14 +8,14 @@
   },
   "main": "src/TerserTransformer",
   "engines": {
-    "parcel": "2.x"
+    "parcel": "^2.0.0-prealpha0"
   },
   "scripts": {
     "build": "babel src -d lib",
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0",
+    "@parcel/plugin": "^2.0.0-prealpha0",
     "nullthrows": "^1.1.1",
     "terser": "^3.7.3"
   }

--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/events",
-  "version": "2.0.0",
+  "version": "2.0.0-prealpha0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parcel/events",
-  "version": "2.0.0-prealpha0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updates:
* The version field in parcel 2 `package.json`s
* The required semver fields in `dependencies` and `devDependencies`
* The semver `engines` field for `parcel`

This is so we can begin publishing very early builds of Parcel to get the bootstrapping process started.

I'm definitely open to changing the prerelease name, ~~but we should avoid `alpha` since we plan on using that for more official releases~~ Let's try going with `alpha.0` (before our more public `alpha.1`), and we can publish canary releases with Lerna as `alpha.0+$SHA`.

Test Plan: 
* Run `yarn` and verify the top-level and package-level `node_modules/@parcel` have only symlinks
* Flow, lint, test