### PR TITLE
Add a missing clearScope to hoisting

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/class-selfreference/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/class-selfreference/a.js
@@ -1,0 +1,11 @@
+class Bar {
+  constructor() {
+    this.foo = 'bar';
+  }
+
+  duplicate() {
+    return new Bar();
+  }
+}
+
+output = new Bar().duplicate();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/class-selfreference/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/class-selfreference/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": ["last 1 Chrome version"]
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -569,6 +569,17 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output.foo, 'bar');
     });
+
+    it('should correctly rename references to a class in the class body', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/class-selfreference/a.js'
+        )
+      );
+      let output = await run(b);
+      assert.deepEqual(output.foo, 'bar');
+    });
   });
 
   describe('commonjs', function() {

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -130,6 +130,7 @@ const VISITOR = {
         asset.meta.isES6Module = false;
       } else {
         // Re-crawl scope so we are sure to have all bindings.
+        traverse.cache.clearScope();
         scope.crawl();
 
         // Rename each binding in the top-level scope to something unique.


### PR DESCRIPTION
# ↪️ Pull Request

Another call to `traverse.cache.clearScope();` is needed to correctly rename references to classes in their own class body.

## 💻 Example of bug

```js

class Bar {
  constructor() {
    this.foo = 'bar';
  }

  duplicate() {
    return new Bar();
  }
}

output = new Bar().duplicate();
```
would get hoisted into:
```js

class xyz {
  constructor() {
    this.foo = 'bar';
  }

  duplicate() {
    return new Bar(); // <-----
  }
}

output = new xyz().duplicate();
```