### PR TITLE
Fixes 3076: HMR update breaks in webworker

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
+++ b/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
@@ -59,8 +59,8 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
         assetsToAccept.forEach(function (v) {
           hmrAcceptRun(v[0], v[1]);
         });
-      } else {
-        window.location.reload();
+      } else if (location.reload) { // `location` global exists in a web worker context but lacks `.reload()` function.
+        location.reload();
       }
     }
 


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #3076 by using a web worker-safe alternative to `window.reload()`.
Fixes #2908

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

1. Clone [https://github.com/clintharris/parcel-hrm-bug-demo](https://github.com/clintharris/parcel-hrm-bug-demo)
1. `npm install && npm start`
1. Load http://localhost:1234, open browser JS console.
1. Edit `src/index.js` to trigger HMR `update`.
1. JS console error: `ReferenceError: window is not defined`

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
