### PR TITLE
Requeue inserted globals when hoisting

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/globals-polyfills/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/globals-polyfills/a.js
@@ -1,0 +1,3 @@
+const test = require('./b');
+
+output = !test("abc");

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/globals-polyfills/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/globals-polyfills/b.js
@@ -1,0 +1,10 @@
+;(function () {
+  module.exports = test
+
+  function test(data) {
+    if (typeof Buffer === 'function' && typeof Buffer.isBuffer === 'function' && Buffer.isBuffer(data)) {
+      return true;
+    }
+    return false;
+  }
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/globals-polyfills/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/globals-polyfills/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": ["last 1 Chrome versions"]
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1263,5 +1263,17 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, 2);
     });
+
+    it('should also hoist inserted polyfills of globals', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/globals-polyfills/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.equal(output, true);
+    });
   });
 });

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -215,9 +215,11 @@ const VISITOR = {
 
     let globalCode = globals.get(path.node.name);
     if (globalCode) {
-      path.scope
+      let decl = path.scope
         .getProgramParent()
-        .path.unshiftContainer('body', [template(globalCode.code)()]);
+        .path.unshiftContainer('body', [template(globalCode.code)()])[0];
+
+      path.requeue(decl);
 
       globals.delete(path.node.name);
     }


### PR DESCRIPTION
Globals (e.g. `var Buffer = require("buffer").Buffer;` inserted during hoisting need to be requeued to ensure traversal.
Test case is reduced from https://unpkg.com/sax@1.2.4/lib/sax.js