### PR TITLE
Implement basic json transformer

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -6,6 +6,7 @@
       "@parcel/transformer-js",
       "@parcel/transformer-terser"
     ],
+    "*.json": ["@parcel/transformer-json"],
     "*.css": ["@parcel/transformer-css", "@parcel/transformer-postcss"],
     "*.{htm,html}": ["@parcel/transformer-html"],
     "*.{jpg,jpeg,png,gif,svg,webm,webp,pdf,txt}": ["@parcel/transformer-raw"]

--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -6,7 +6,7 @@
       "@parcel/transformer-js",
       "@parcel/transformer-terser"
     ],
-    "*.json": ["@parcel/transformer-json"],
+    "*.{json,json5}": ["@parcel/transformer-json"],
     "*.css": ["@parcel/transformer-css", "@parcel/transformer-postcss"],
     "*.{htm,html}": ["@parcel/transformer-html"],
     "*.{jpg,jpeg,png,gif,svg,webm,webp,pdf,txt}": ["@parcel/transformer-raw"]

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -23,6 +23,7 @@
     "@parcel/transformer-css": "^2.0.0-alpha.0",
     "@parcel/transformer-html": "^2.0.0-alpha.0",
     "@parcel/transformer-js": "^2.0.0-alpha.0",
+    "@parcel/transformer-json": "^2.0.0-alpha.0",
     "@parcel/transformer-postcss": "^2.0.0-alpha.0",
     "@parcel/transformer-raw": "^2.0.0-alpha.0",
     "@parcel/transformer-terser": "^2.0.0-alpha.0",

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -560,18 +560,15 @@ describe('javascript', function() {
     assert.deepEqual(output, {default: {asdf: 1}});
   });
 
-  it.skip('should support requiring JSON files', async function() {
+  it('should support requiring JSON files', async function() {
     let b = await bundle(path.join(__dirname, '/integration/json/index.js'));
 
-    await assertBundles(b, {
-      name: 'index.js',
-      assets: ['index.js', 'local.json'],
-      childBundles: [
-        {
-          type: 'map'
-        }
-      ]
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'local.json']
+      }
+    ]);
 
     let output = await run(b);
     assert.equal(typeof output, 'function');

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -575,18 +575,15 @@ describe('javascript', function() {
     assert.equal(output(), 3);
   });
 
-  it.skip('should support requiring JSON5 files', async function() {
+  it('should support requiring JSON5 files', async function() {
     let b = await bundle(path.join(__dirname, '/integration/json5/index.js'));
 
-    await assertBundles(b, {
-      name: 'index.js',
-      assets: ['index.js', 'local.json5'],
-      childBundles: [
-        {
-          type: 'map'
-        }
-      ]
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'local.json5']
+      }
+    ]);
 
     let output = await run(b);
     assert.equal(typeof output, 'function');

--- a/packages/transformers/json/.babelrc
+++ b/packages/transformers/json/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@parcel/babel-preset"]
+}

--- a/packages/transformers/json/package.json
+++ b/packages/transformers/json/package.json
@@ -15,6 +15,7 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-alpha.0"
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "json5": "^2.1.0"
   }
 }

--- a/packages/transformers/json/package.json
+++ b/packages/transformers/json/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@parcel/transformer-json",
+  "version": "2.0.0-alpha.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "src/JSONTransformer",
+  "engines": {
+    "parcel": "^2.0.0-alpha.0"
+  },
+  "scripts": {
+    "build": "babel src -d lib",
+    "prepublish": "yarn build"
+  },
+  "dependencies": {
+    "@parcel/plugin": "^2.0.0-alpha.0"
+  }
+}

--- a/packages/transformers/json/src/JSONTransformer.js
+++ b/packages/transformers/json/src/JSONTransformer.js
@@ -1,0 +1,11 @@
+// @flow
+
+import {Transformer} from '@parcel/plugin';
+
+export default new Transformer({
+  async transform({asset}) {
+    asset.type = 'js';
+    asset.setCode(`module.exports = ${await asset.getCode()};`);
+    return [asset];
+  }
+});

--- a/packages/transformers/json/src/JSONTransformer.js
+++ b/packages/transformers/json/src/JSONTransformer.js
@@ -1,11 +1,18 @@
 // @flow
 
 import {Transformer} from '@parcel/plugin';
+import json5 from 'json5';
 
 export default new Transformer({
   async transform({asset}) {
     asset.type = 'js';
-    asset.setCode(`module.exports = ${await asset.getCode()};`);
+    asset.setCode(
+      `module.exports = ${JSON.stringify(
+        json5.parse(await asset.getCode()),
+        null,
+        2
+      )};`
+    );
     return [asset];
   }
 });


### PR DESCRIPTION
This implements a basic JSON transformer. It currently turns JSON the asset into a JavaScript one, which could become problematic should other assets need to import JSON. However, this is what Parcel 1 does, and it addresses our need to build Parcel 2 with Parcel 2.

Test Plan: Restored one integration test.