### PR TITLE
Use fsStream.bytesWritten

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -8,7 +8,7 @@ import type InternalBundleGraph from './BundleGraph';
 
 import invariant from 'assert';
 import {mkdirp, writeFile, writeFileStream} from '@parcel/fs';
-import {TapStream, urlJoin} from '@parcel/utils';
+import {urlJoin} from '@parcel/utils';
 import {NamedBundle} from './public/Bundle';
 import nullthrows from 'nullthrows';
 import path from 'path';
@@ -46,11 +46,7 @@ export default class PackagerRunner {
 
     let size;
     if (contents instanceof Readable) {
-      size = 0;
-      await writeFileStream(
-        filePath,
-        contents.pipe(new TapStream(chunk => (size += chunk.length)))
-      );
+      size = await writeFileStream(filePath, contents);
     } else {
       await writeFile(filePath, contents);
       size = contents.length;

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -71,6 +71,7 @@ export function writeFileStream(
     let fsStream = fs.createWriteStream(filePath);
     stream
       .pipe(fsStream)
+      // $FlowFixMe
       .on('finish', () => resolve(fsStream.bytesWritten))
       .on('error', reject);
   });

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -66,11 +66,12 @@ export const ncp: (
 export function writeFileStream(
   filePath: FilePath,
   stream: Readable
-): Promise<void> {
+): Promise<number> {
   return new Promise((resolve, reject) => {
+    let fsStream = fs.createWriteStream(filePath);
     stream
-      .pipe(fs.createWriteStream(filePath))
-      .on('finish', resolve)
+      .pipe(fsStream)
+      .on('finish', () => resolve(fsStream.bytesWritten))
       .on('error', reject);
   });
 }


### PR DESCRIPTION
Use https://nodejs.org/api/fs.html#fs_writestream_byteswritten instead of homebrew TapStream in `writeFileStream`

The equivalent part in TransfomerRunner can't be converted so easily:
https://github.com/parcel-bundler/parcel/blob/ef9b9772eea6504520ba8b3fbf3fbee1536c123d/packages/core/core/src/TransformerRunner.js#L341-L354