### PR TITLE
Pass minimum versions to @babel/preset-env

### DIFF
--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -157,6 +157,20 @@ describe('babel', function() {
     );
   });
 
+  it('can build using @babel/preset-env when engines have semver ranges', async () => {
+    await bundle(
+      path.join(__dirname, '/integration/babel-semver-engine/index.js')
+    );
+
+    let legacy = await fs.readFile('dist/legacy.js', 'utf8');
+    assert(legacy.includes('function Foo'));
+    assert(legacy.includes('function Bar'));
+
+    let modern = await fs.readFile('dist/modern.js', 'utf8');
+    assert(modern.includes('class Foo'));
+    assert(modern.includes('class Bar'));
+  });
+
   it('should not compile node_modules by default', async function() {
     await bundle(
       path.join(__dirname, '/integration/babel-node-modules/index.js')

--- a/packages/core/integration-tests/test/integration/babel-semver-engine/foo.js
+++ b/packages/core/integration-tests/test/integration/babel-semver-engine/foo.js
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/packages/core/integration-tests/test/integration/babel-semver-engine/index.js
+++ b/packages/core/integration-tests/test/integration/babel-semver-engine/index.js
@@ -1,0 +1,4 @@
+import Foo from './foo';
+
+export {Foo};
+export class Bar {}

--- a/packages/core/integration-tests/test/integration/babel-semver-engine/package.json
+++ b/packages/core/integration-tests/test/integration/babel-semver-engine/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "babel-semver-engine",
+  "main": "dist/legacy.js",
+  "modern": "dist/modern.js",
+  "engines": {
+    "node": ">= 0.12.0"
+  },
+  "targets": {
+    "modern": {
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  }
+}

--- a/packages/transformers/babel/src/getTargetEngines.js
+++ b/packages/transformers/babel/src/getTargetEngines.js
@@ -1,7 +1,8 @@
 // @flow
-import type {MutableAsset} from '@parcel/types';
+
+import type {Engines, MutableAsset} from '@parcel/types';
+
 import browserslist from 'browserslist';
-import semver from 'semver';
 
 const BROWSER_CONTEXT = new Set(['browser', 'web-worker', 'service-worker']);
 
@@ -11,16 +12,16 @@ const BROWSER_CONTEXT = new Set(['browser', 'web-worker', 'service-worker']);
  *   - package.json browserslist field
  *   - browserslist or .browserslistrc files
  */
-export default async function getTargetEngines(asset: MutableAsset) {
+export default async function getTargetEngines(asset: MutableAsset): Engines {
   let targets = {};
   let compileTarget = BROWSER_CONTEXT.has(asset.env.context)
     ? 'browsers'
     : asset.env.context;
   let pkg = await asset.getPackage();
   let engines = pkg && pkg.engines;
-  let nodeVersion = engines && engines.node && getMinSemver(engines.node);
 
   if (compileTarget === 'node') {
+    let nodeVersion = engines?.node;
     // Use package.engines.node by default if we are compiling for node.
     if (typeof nodeVersion === 'string') {
       targets.node = nodeVersion;
@@ -65,16 +66,6 @@ export default async function getTargetEngines(asset: MutableAsset) {
   }
 
   return targets;
-}
-
-function getMinSemver(version) {
-  try {
-    let range = new semver.Range(version);
-    let sorted = range.set.sort((a, b) => a[0].semver.compare(b[0].semver));
-    return sorted[0][0].semver.version;
-  } catch (err) {
-    return null;
-  }
 }
 
 async function loadBrowserslist(asset) {


### PR DESCRIPTION
Currently in v2, we pass semver ranges. `@babel/preset-env` expects browserslist-style minimum versions instead of semver ranges.

I discovered this when building Parcel 2 with Parcel 2.

Test Plan: Added an integration test