### PR TITLE
Add reverse handle functionality to WorkerFarm

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -120,7 +120,7 @@ export default class Parcel {
 
     await this.#assetGraphBuilder.initFarm();
 
-    this.#runPackage = this.#farm.mkhandle('runPackage');
+    this.#runPackage = this.#farm.createHandle('runPackage');
     this.#initialized = true;
   }
 

--- a/packages/core/core/src/RequestGraph.js
+++ b/packages/core/core/src/RequestGraph.js
@@ -84,7 +84,7 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
     // This expects the worker farm to already be initialized by Parcel prior to calling
     // AssetGraphBuilder, which avoids needing to pass the options through here.
     this.farm = await WorkerFarm.getShared();
-    this.runTransform = this.farm.mkhandle('runTransform');
+    this.runTransform = this.farm.createHandle('runTransform');
   }
 
   async completeRequests() {

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -293,6 +293,25 @@ class BundleReference implements IBundleReference {
     this.#bundle = bundle;
   }
 
+  // Once serialized, BundleReferences are frozen as a copy and no longer
+  // continue to update to reflect the properties of the bundle they reference.
+  static deserialize(props): IBundleReference {
+    return props;
+  }
+
+  serialize(): IBundleReference {
+    return {
+      id: this.id,
+      type: this.type,
+      env: this.env,
+      isEntry: this.isEntry,
+      target: this.target,
+      filePath: this.filePath,
+      name: this.name,
+      stats: this.stats
+    };
+  }
+
   get id() {
     return this.#bundle.id;
   }

--- a/packages/core/workers/src/Handle.js
+++ b/packages/core/workers/src/Handle.js
@@ -1,0 +1,15 @@
+import WorkerFarm from './WorkerFarm';
+
+let HANDLE_ID = 0;
+
+export default class Handle {
+  constructor(opts) {
+    this.id = opts ? opts.id : ++HANDLE_ID;
+  }
+
+  static deserialize(opts) {
+    return function(...args) {
+      return WorkerFarm.callMaster({handle: opts.id, args}, true);
+    };
+  }
+}

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -180,6 +180,7 @@ class Child {
       child: call.child,
       type: call.type,
       location: call.location,
+      handle: call.handle,
       method: call.method,
       args: call.args,
       awaitResponse: call.awaitResponse

--- a/packages/core/workers/src/types.js
+++ b/packages/core/workers/src/types.js
@@ -22,7 +22,8 @@ export type WorkerRequest = {|
   idx?: number,
   location?: FilePath,
   method?: ?string,
-  type: 'request'
+  type: 'request',
+  handle?: number
 |};
 
 export type WorkerDataResponse = {|

--- a/packages/core/workers/test/integration/workerfarm/reverse-handle.js
+++ b/packages/core/workers/test/integration/workerfarm/reverse-handle.js
@@ -1,0 +1,10 @@
+function run(handle) {
+  return handle();
+}
+
+function init() {
+  // do nothing
+}
+
+exports.run = run;
+exports.init = init;

--- a/packages/core/workers/test/workerfarm.js
+++ b/packages/core/workers/test/workerfarm.js
@@ -256,4 +256,21 @@ describe('WorkerFarm', () => {
     logDisposable.dispose();
     await workerfarm.end();
   });
+
+  it('Should support reverse handle functions in main process that can be called in workers', async () => {
+    let workerfarm = new WorkerFarm(
+      {},
+      {
+        warmWorkers: true,
+        useLocalWorker: false,
+        workerPath: require.resolve(
+          './integration/workerfarm/reverse-handle.js'
+        )
+      }
+    );
+
+    let handle = workerfarm.createReverseHandle(() => 42);
+    let result = await workerfarm.run(handle);
+    assert.equal(result, 42);
+  });
 });


### PR DESCRIPTION
# ↪️ Pull Request

Reverse handles are functions defined in the main process that can be called in worker processes. We will need this functionality for config requests because the main process will be in charge of loading configuration for plugins, so that the graph can be used to avoid rework.

## 🚨 Test instructions

`yarn test`/`yarn flow`/`yarn lint`
