### PR TITLE
Add Disposable

### DIFF
--- a/packages/utils/events/src/Disposable.js
+++ b/packages/utils/events/src/Disposable.js
@@ -1,0 +1,34 @@
+// @flow strict-local
+
+import type {IDisposable} from './types';
+
+type DisposableLike = IDisposable | (() => mixed);
+
+/*
+ * A general-purpose disposable class. It can normalize disposable-like values
+ * (such as single functions or IDisposables), as well as hold multiple
+ * disposable-like values to be disposed of at once.
+ */
+export default class Disposable implements IDisposable {
+  #disposables; // Set<DisposableLike>
+
+  constructor(...disposables: Array<DisposableLike>) {
+    this.#disposables = new Set(disposables);
+  }
+
+  add(...disposables: Array<DisposableLike>) {
+    for (let disposable of disposables) {
+      this.#disposables.add(disposable);
+    }
+  }
+
+  dispose() {
+    for (let disposable of this.#disposables) {
+      if (typeof disposable === 'function') {
+        disposable();
+      } else {
+        disposable.dispose();
+      }
+    }
+  }
+}

--- a/packages/utils/events/src/index.js
+++ b/packages/utils/events/src/index.js
@@ -1,4 +1,5 @@
 // @flow strict-local
 
+export {default as Disposable} from './Disposable';
 export {default as ValueEmitter} from './ValueEmitter';
 export {AlreadyDisposedError} from './errors';

--- a/packages/utils/events/test/Disposable.test.js
+++ b/packages/utils/events/test/Disposable.test.js
@@ -1,0 +1,84 @@
+// @flow strict-local
+
+import assert from 'assert';
+import Disposable from '../src/Disposable';
+
+describe('Disposable', () => {
+  it('can wrap an IDisposable', () => {
+    let disposed;
+
+    new Disposable({
+      dispose() {
+        disposed = true;
+      }
+    }).dispose();
+    assert.equal(disposed, true);
+  });
+
+  it('can wrap a function to dispose', () => {
+    let disposed;
+    new Disposable(() => {
+      disposed = true;
+    }).dispose();
+    assert.equal(disposed, true);
+  });
+
+  it('can wrap many disposable-likes', () => {
+    let disposed1;
+    let disposed2;
+
+    new Disposable(
+      {
+        dispose() {
+          disposed1 = true;
+        }
+      },
+      () => {
+        disposed2 = true;
+      }
+    ).dispose();
+    assert.equal(disposed1, true);
+    assert.equal(disposed2, true);
+  });
+
+  it('can add disposables after construction', () => {
+    let disposed1;
+    let disposed2;
+    let disposed3;
+    let disposed4;
+
+    let disposable = new Disposable(
+      {
+        dispose() {
+          disposed1 = true;
+        }
+      },
+      () => {
+        disposed2 = true;
+      }
+    );
+
+    disposable.add(
+      () => {
+        disposed3 = true;
+      },
+      {
+        dispose() {
+          disposed4 = true;
+        }
+      }
+    );
+
+    assert.notEqual(disposed1, true);
+    assert.notEqual(disposed2, true);
+    assert.notEqual(disposed3, true);
+    assert.notEqual(disposed4, true);
+
+    disposable.dispose();
+
+    assert.equal(disposed1, true);
+    assert.equal(disposed2, true);
+    assert.equal(disposed3, true);
+    assert.equal(disposed4, true);
+  });
+});


### PR DESCRIPTION
This adds `Disposable`, a class for wrapping other disposables or disposable-likes such as functions to dispose of resources.

This will allow us to add multiple disposables to the same object and manage the lifecycle of our own structures by disposing of a `Disposable` when our own structures are disposed.

Test Plan: Added unit tests.