### PR TITLE
Disposable: Free disposables after disposal

### DIFF
--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "babel src -d lib",
     "prepublish": "yarn build",
-    "test": "mocha"
+    "test": "mocha",
+    "test-ci": "yarn test"
   }
 }

--- a/packages/utils/events/test/Disposable.test.js
+++ b/packages/utils/events/test/Disposable.test.js
@@ -2,6 +2,7 @@
 
 import assert from 'assert';
 import Disposable from '../src/Disposable';
+import {AlreadyDisposedError} from '../src/errors';
 
 describe('Disposable', () => {
   it('can wrap an IDisposable', () => {
@@ -103,12 +104,9 @@ describe('Disposable', () => {
   it('throws if `add` is called after it has been disposed', () => {
     let disposable = new Disposable();
     disposable.dispose();
-    assert.throws(
-      () => {
-        disposable.add(() => {});
-      },
-      {name: 'AlreadyDisposedError'}
-    );
+    assert.throws(() => {
+      disposable.add(() => {});
+    }, AlreadyDisposedError);
   });
 
   it('can be checked for disposal state', () => {

--- a/packages/utils/events/test/Disposable.test.js
+++ b/packages/utils/events/test/Disposable.test.js
@@ -81,4 +81,40 @@ describe('Disposable', () => {
     assert.equal(disposed3, true);
     assert.equal(disposed4, true);
   });
+
+  it(
+    'does not dispose inner disposables more than once,' +
+      ' and does not throw on subsequent disposals',
+    () => {
+      let disposed;
+      let disposable = new Disposable(() => {
+        if (disposed) {
+          // $FlowFixMe
+          assert.fail();
+        }
+        disposed = true;
+      });
+
+      disposable.dispose();
+      disposable.dispose();
+    }
+  );
+
+  it('throws if `add` is called after it has been disposed', () => {
+    let disposable = new Disposable();
+    disposable.dispose();
+    assert.throws(
+      () => {
+        disposable.add(() => {});
+      },
+      {name: 'AlreadyDisposedError'}
+    );
+  });
+
+  it('can be checked for disposal state', () => {
+    let disposable = new Disposable();
+    assert.equal(disposable.disposed, false);
+    disposable.dispose();
+    assert.equal(disposable.disposed, true);
+  });
 });


### PR DESCRIPTION
Some things missed in the initial PR:
* Frees the reference to the `Set` containing the inner disposables after the Disposable has been disposed.
* Allows for silent, no-op additional disposals
* Ensures that `.add()` cannot be called after the disposable has been disposed.
* Exposes a public property for checking the disposal state.

Test Plan: Unit tests