### PR TITLE
Preserve hashbangs and file modes from entry assets to bundles

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -50,10 +50,14 @@ export default class PackagerRunner {
       this.distExists.add(dir);
     }
 
-    // Use the file mode from the entry asset as the file mode for the bundle
-    let options = {
-      mode: (await fs.stat(bundle.assetGraph.getEntryAssets()[0].filePath)).mode
-    };
+    // Use the file mode from the entry asset as the file mode for the bundle.
+    // Don't do this for browser builds, as the executable bit in particular is unnecessary.
+    let options = nullthrows(bundle.target).env.isBrowser()
+      ? undefined
+      : {
+          mode: (await fs.stat(bundle.assetGraph.getEntryAssets()[0].filePath))
+            .mode
+        };
 
     let size;
     if (contents instanceof Readable) {

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -8,7 +8,7 @@ import type InternalBundleGraph from './BundleGraph';
 
 import {Readable} from 'stream';
 import invariant from 'assert';
-import {mkdirp, writeFile, writeFileStream} from '@parcel/fs';
+import * as fs from '@parcel/fs';
 import {urlJoin} from '@parcel/utils';
 import {NamedBundle} from './public/Bundle';
 import nullthrows from 'nullthrows';
@@ -46,15 +46,20 @@ export default class PackagerRunner {
     let filePath = nullthrows(bundle.filePath);
     let dir = path.dirname(filePath);
     if (!this.distExists.has(dir)) {
-      await mkdirp(dir);
+      await fs.mkdirp(dir);
       this.distExists.add(dir);
     }
 
+    // Use the file mode from the entry asset as the file mode for the bundle
+    let options = {
+      mode: (await fs.stat(bundle.assetGraph.getEntryAssets()[0].filePath)).mode
+    };
+
     let size;
     if (contents instanceof Readable) {
-      size = await writeFileStream(filePath, contents);
+      size = await fs.writeFileStream(filePath, contents, options);
     } else {
-      await writeFile(filePath, contents);
+      await fs.writeFile(filePath, contents, options);
       size = contents.length;
     }
 
@@ -91,7 +96,7 @@ export default class PackagerRunner {
       }
 
       let mapFilename = filePath + '.map';
-      await writeFile(
+      await fs.writeFile(
         mapFilename,
         await map.stringify({
           file: path.basename(mapFilename),

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -69,10 +69,11 @@ export const ncp: (
 
 export function writeFileStream(
   filePath: FilePath,
-  stream: Readable
+  stream: Readable,
+  options: ?mixed
 ): Promise<number> {
   return new Promise((resolve, reject) => {
-    let fsStream = fs.createWriteStream(filePath);
+    let fsStream = fs.createWriteStream(filePath, options);
     stream
       .pipe(fsStream)
       // $FlowFixMe

--- a/packages/core/integration-tests/test/integration/node_hashbang/local.js
+++ b/packages/core/integration-tests/test/integration/node_hashbang/local.js
@@ -1,0 +1,1 @@
+exports.b = 2;

--- a/packages/core/integration-tests/test/integration/node_hashbang/main.js
+++ b/packages/core/integration-tests/test/integration/node_hashbang/main.js
@@ -2,6 +2,4 @@
 
 var {b} = require('./local');
 
-module.exports = function () {
-  return b;
-};
+console.log(b);

--- a/packages/core/integration-tests/test/integration/node_hashbang/main.js
+++ b/packages/core/integration-tests/test/integration/node_hashbang/main.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+var {b} = require('./local');
+
+module.exports = function () {
+  return b;
+};

--- a/packages/core/integration-tests/test/integration/node_hashbang/package.json
+++ b/packages/core/integration-tests/test/integration/node_hashbang/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "node_require",
+  "engines": {
+    "node": "8"
+  }
+}

--- a/packages/core/integration-tests/test/integration/node_hashbang/package.json
+++ b/packages/core/integration-tests/test/integration/node_hashbang/package.json
@@ -1,6 +1,20 @@
 {
   "name": "node_require",
+  "main": "dist/node/main.js",
+  "browser": "dist/browser/main.js",
   "engines": {
     "node": "8"
+  },
+  "targets": {
+    "main": {
+      "engines": {
+        "node": "8"
+      }
+    },
+    "browser": {
+      "engines": {
+        "browsers": "last 1 version"
+      }
+    }
   }
 }

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -126,12 +126,21 @@ describe('javascript', function() {
     assert.equal(output(), 7);
   });
 
-  it('should preserve hashbangs in bundles', async () => {
-    await bundle(path.join(__dirname, '/integration/node_hashbang/main.js'));
+  it('should preserve hashbangs in bundles and preserve executable file mode', async () => {
+    let mainEntryPath = path.join(
+      __dirname,
+      '/integration/node_hashbang/main.js'
+    );
+    await bundle(mainEntryPath);
 
-    let main = await fs.readFile(path.join(distDir, 'main.js'), 'utf8');
-    // console.log(main);
+    let mainPath = path.join(distDir, 'main.js');
+    let main = await fs.readFile(mainPath, 'utf8');
+
     assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
+    assert.equal(
+      (await fs.stat(mainPath)).mode,
+      (await fs.stat(mainEntryPath)).mode
+    );
   });
 
   it('should preserve hashbangs in scopehoisted bundles', async () => {
@@ -140,7 +149,6 @@ describe('javascript', function() {
     });
 
     let main = await fs.readFile(path.join(distDir, 'main.js'), 'utf8');
-    // console.log(main);
     assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
   });
 

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -127,29 +127,43 @@ describe('javascript', function() {
   });
 
   it('should preserve hashbangs in bundles and preserve executable file mode', async () => {
-    let mainEntryPath = path.join(
-      __dirname,
-      '/integration/node_hashbang/main.js'
-    );
-    await bundle(mainEntryPath);
+    let fixturePath = path.join(__dirname, '/integration/node_hashbang');
+    await bundle(path.join(fixturePath, 'main.js'));
 
-    let mainPath = path.join(distDir, 'main.js');
+    let mainPath = path.join(fixturePath, 'dist', 'node', 'main.js');
     let main = await fs.readFile(mainPath, 'utf8');
-
     assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
     assert.equal(
       (await fs.stat(mainPath)).mode,
-      (await fs.stat(mainEntryPath)).mode
+      (await fs.stat(path.join(fixturePath, 'main.js'))).mode
     );
+    await fs.rimraf(path.join(fixturePath, 'dist'));
+  });
+
+  it('should not preserve hashbangs in browser bundles', async () => {
+    let fixturePath = path.join(__dirname, '/integration/node_hashbang');
+    await bundle(path.join(fixturePath, 'main.js'));
+
+    let main = await fs.readFile(
+      path.join(fixturePath, 'dist', 'browser', 'main.js'),
+      'utf8'
+    );
+    assert(!main.includes('#!/usr/bin/env node\n'));
+    await fs.rimraf(path.join(fixturePath, 'dist'));
   });
 
   it('should preserve hashbangs in scopehoisted bundles', async () => {
+    let fixturePath = path.join(__dirname, '/integration/node_hashbang');
     await bundle(path.join(__dirname, '/integration/node_hashbang/main.js'), {
       scopeHoist: true
     });
 
-    let main = await fs.readFile(path.join(distDir, 'main.js'), 'utf8');
+    let main = await fs.readFile(
+      path.join(fixturePath, 'dist', 'node', 'main.js'),
+      'utf8'
+    );
     assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
+    await fs.rimraf(path.join(fixturePath, 'dist'));
   });
 
   it('should bundle node_modules for a node environment if includeNodeModules is specified', async function() {

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -126,6 +126,24 @@ describe('javascript', function() {
     assert.equal(output(), 7);
   });
 
+  it('should preserve hashbangs in bundles', async () => {
+    await bundle(path.join(__dirname, '/integration/node_hashbang/main.js'));
+
+    let main = await fs.readFile(path.join(distDir, 'main.js'), 'utf8');
+    // console.log(main);
+    assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
+  });
+
+  it('should preserve hashbangs in scopehoisted bundles', async () => {
+    await bundle(path.join(__dirname, '/integration/node_hashbang/main.js'), {
+      scopeHoist: true
+    });
+
+    let main = await fs.readFile(path.join(distDir, 'main.js'), 'utf8');
+    // console.log(main);
+    assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
+  });
+
   it('should bundle node_modules for a node environment if includeNodeModules is specified', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/include_node_modules/main.js')

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -104,24 +104,30 @@ export default new Packager({
       }
     });
 
+    let entryAsset = bundle.getEntryAssets()[0];
+    // $FlowFixMe
+    let interpreter: ?string = entryAsset.meta.interpreter;
+
     return {
       contents:
-        PRELUDE +
-        '({' +
-        assets +
-        '},{},' +
-        JSON.stringify(
-          bundle
-            .getEntryAssets()
-            .reverse()
-            .map(asset => asset.id)
-        ) +
-        ', ' +
-        'null' +
-        ')\n\n' +
-        '//# sourceMappingURL=' +
-        sourceMapPath +
-        '\n',
+        // If the entry asset included a hashbang, repeat it at the top of the bundle
+        (interpreter != null ? `#!${interpreter}\n` : '') +
+        (PRELUDE +
+          '({' +
+          assets +
+          '},{},' +
+          JSON.stringify(
+            bundle
+              .getEntryAssets()
+              .reverse()
+              .map(asset => asset.id)
+          ) +
+          ', ' +
+          'null' +
+          ')\n\n' +
+          '//# sourceMappingURL=' +
+          sourceMapPath +
+          '\n'),
       map
     };
   }

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -106,7 +106,9 @@ export default new Packager({
 
     let entryAsset = bundle.getEntryAssets()[0];
     // $FlowFixMe
-    let interpreter: ?string = entryAsset.meta.interpreter;
+    let interpreter: ?string = bundle.target.env.isBrowser()
+      ? null
+      : entryAsset.meta.interpreter;
 
     return {
       contents:

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -13,5 +13,12 @@ export function generate(bundle: Bundle, ast: AST, options: ParcelOptions) {
     code = `\n${code}\n`;
   }
 
-  return {contents: `(function(){${code}})();`};
+  let entryAsset = bundle.getEntryAssets()[0];
+  // $FlowFixMe
+  let interpreter: ?string = entryAsset.meta.interpreter;
+  return {
+    contents: `${
+      interpreter != null ? `#!${interpreter}\n` : ''
+    }(function(){${code}})();`
+  };
 }

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -15,7 +15,9 @@ export function generate(bundle: Bundle, ast: AST, options: ParcelOptions) {
 
   let entryAsset = bundle.getEntryAssets()[0];
   // $FlowFixMe
-  let interpreter: ?string = entryAsset.meta.interpreter;
+  let interpreter: ?string = bundle.target.env.isBrowser()
+    ? null
+    : entryAsset.meta.interpreter;
   return {
     contents: `${
       interpreter != null ? `#!${interpreter}\n` : ''

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -84,7 +84,15 @@ export default new Transformer({
       walk.ancestor(ast.program, collectDependencies, asset);
     }
 
-    if (!asset.env.isNode()) {
+    if (asset.env.isNode()) {
+      // If there's a hashbang, remove it and store it on the asset meta.
+      // During packaging, if this is the entry asset, it will be prepended to the
+      // packaged output.
+      if (ast.program.program.interpreter != null) {
+        asset.meta.interpreter = ast.program.program.interpreter.value;
+        delete ast.program.program.interpreter;
+      }
+    } else {
       // Inline fs calls
       let fsDep = asset
         .getDependencies()

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -84,15 +84,15 @@ export default new Transformer({
       walk.ancestor(ast.program, collectDependencies, asset);
     }
 
-    if (asset.env.isNode()) {
-      // If there's a hashbang, remove it and store it on the asset meta.
-      // During packaging, if this is the entry asset, it will be prepended to the
-      // packaged output.
-      if (ast.program.program.interpreter != null) {
-        asset.meta.interpreter = ast.program.program.interpreter.value;
-        delete ast.program.program.interpreter;
-      }
-    } else {
+    // If there's a hashbang, remove it and store it on the asset meta.
+    // During packaging, if this is the entry asset, it will be prepended to the
+    // packaged output.
+    if (ast.program.program.interpreter != null) {
+      asset.meta.interpreter = ast.program.program.interpreter.value;
+      delete ast.program.program.interpreter;
+    }
+
+    if (!asset.env.isNode()) {
       // Inline fs calls
       let fsDep = asset
         .getDependencies()


### PR DESCRIPTION
This is necessary for Parcel 2 to build node cli executables like Parcel's own cli.

For hashbangs in JavaScript, we extract the `interpreter` value from the Babel AST, and store it in `asset.meta.interpreter`. We then read from this during packaging and, if present, prepend it to the bundle output. We do the same in scope hoisting.

For file modes (unix-style numeric permission values), a `fileMode` property is attached to each asset. After packaging and optimizing, before the file is written, we use the `fileMode` associated with the entry asset as the file mode for the file written to disk.

Test Plan: Added integration tests for hashbangs, hashbangs in scope hoisting, and preserving file modes.