### PR TITLE
Account for core version and impactful options when reusing cacheEntries

### DIFF
--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -90,17 +90,11 @@ export default class Cache {
   }
 }
 
-// Cache for whether a cache dir exists
-const existsCache: Set<FilePath> = new Set();
 const cacheByDir: DefaultMap<FilePath, Cache> = new DefaultMap(dir => {
   return new Cache(dir);
 });
 
 export async function createCacheDir(dir: FilePath): Promise<void> {
-  if (existsCache.has(dir)) {
-    return;
-  }
-
   // First, create the main cache directory if necessary.
   await fs.mkdirp(dir);
 
@@ -114,7 +108,6 @@ export async function createCacheDir(dir: FilePath): Promise<void> {
   }
 
   await dirPromises;
-  existsCache.add(dir);
 }
 
 export function getCacheByDir(dir: FilePath): Cache {

--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -11,13 +11,27 @@ import path from 'path';
 import logger from '@parcel/logger';
 import {DefaultMap, serialize, deserialize} from '@parcel/utils';
 
-class Cache {
+// Do not construct this directly! This is the default export only so that it
+// can be referenced by the deserializer.
+// Instead, use the exported `getCacheByDir` below to get the unique instance
+// corresponding to a given cache directory.
+export default class Cache {
   dir: FilePath;
   invalidated: Set<FilePath>;
 
   constructor(cacheDir: FilePath) {
     this.dir = cacheDir;
     this.invalidated = new Set();
+  }
+
+  static deserialize(opts: {cacheDir: FilePath}) {
+    return getCacheByDir(opts.cacheDir);
+  }
+
+  serialize() {
+    return {
+      cacheDir: this.dir
+    };
   }
 
   getCachePath(cacheId: string, extension: string = '.json'): FilePath {
@@ -106,5 +120,3 @@ export async function createCacheDir(dir: FilePath): Promise<void> {
 export function getCacheByDir(dir: FilePath): Cache {
   return cacheByDir.get(dir);
 }
-
-export type {Cache};

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -33,7 +33,8 @@
     "micromatch": "^3.0.4",
     "nullthrows": "^1.1.1",
     "pirates": "^4.0.0",
-    "semver": "^5.4.1"
+    "semver": "^5.4.1",
+    "shallowequal": "^1.1.0"
   },
   "devDependencies": {
     "graphviz": "^0.0.9",

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Cache} from '@parcel/cache';
+import type Cache from '@parcel/cache';
 
 import type {
   AST,
@@ -29,13 +29,12 @@ import {
   TapStream
 } from '@parcel/utils';
 import Dependency from './Dependency';
-import {getCacheByDir} from '@parcel/cache';
 
 type AssetOptions = {|
   id?: string,
   hash?: ?string,
   idBase?: string,
-  cacheDir: string,
+  cache: Cache,
   filePath: FilePath,
   type: string,
   content?: Blob,
@@ -99,7 +98,7 @@ export default class Asset {
     this.content = options.content || '';
     this.contentKey = options.contentKey;
     this.ast = options.ast || null;
-    this.cache = getCacheByDir(options.cacheDir);
+    this.cache = options.cache;
     this.map = options.map;
     this.dependencies = options.dependencies
       ? new Map(options.dependencies)
@@ -121,7 +120,7 @@ export default class Asset {
       id: this.id,
       hash: this.hash,
       filePath: this.filePath,
-      cacheDir: this.cache.dir,
+      cache: this.cache,
       type: this.type,
       dependencies: Array.from(this.dependencies),
       connectedFiles: Array.from(this.connectedFiles),
@@ -181,6 +180,7 @@ export default class Asset {
 
   async getCode(): Promise<string> {
     if (this.contentKey != null) {
+      // console.log('c', this.cache);
       this.content = this.cache.getStream(this.contentKey);
     }
 
@@ -300,7 +300,7 @@ export default class Asset {
       filePath: this.filePath,
       type: result.type,
       content,
-      cacheDir: this.cache.dir,
+      cache: this.cache,
       ast: result.ast,
       isIsolated: result.isIsolated,
       env: this.env.merge(result.env),

--- a/packages/core/core/src/TransformerRunner.js
+++ b/packages/core/core/src/TransformerRunner.js
@@ -84,7 +84,7 @@ export default class TransformerRunner {
       idBase: req.code ? hash : req.filePath,
       filePath: req.filePath,
       type: path.extname(req.filePath).slice(1),
-      cacheDir: cache.dir,
+      cache,
       ast: null,
       content,
       hash,

--- a/packages/core/core/test/Asset.test.js
+++ b/packages/core/core/test/Asset.test.js
@@ -3,7 +3,7 @@
 import assert from 'assert';
 import Asset from '../src/Asset';
 import Environment from '../src/Environment';
-import {createCacheDir} from '@parcel/cache';
+import {createCacheDir, getCacheByDir} from '@parcel/cache';
 // $FlowFixMe this is untyped
 import tempy from 'tempy';
 
@@ -11,12 +11,13 @@ const stats = {time: 0, size: 0};
 
 let cacheDir = tempy.directory();
 createCacheDir(cacheDir);
+let cache = getCacheByDir(cacheDir);
 
 describe('Asset', () => {
   it('only includes connected files once per filePath', () => {
     let asset = new Asset({
       filePath: '/foo/asset.js',
-      cacheDir,
+      cache,
       env: new Environment(),
       stats,
       type: 'js'
@@ -34,7 +35,7 @@ describe('Asset', () => {
   it('only includes dependencies once per id', () => {
     let asset = new Asset({
       filePath: '/foo/asset.js',
-      cacheDir,
+      cache,
       env: new Environment(),
       stats,
       type: 'js'
@@ -50,7 +51,7 @@ describe('Asset', () => {
   it('includes different dependencies if their id differs', () => {
     let asset = new Asset({
       filePath: '/foo/asset.js',
-      cacheDir,
+      cache,
       env: new Environment(),
       stats,
       type: 'js'

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -6,10 +6,11 @@ import Dependency from '../src/Dependency';
 import Asset from '../src/Asset';
 import Environment from '../src/Environment';
 import tempy from 'tempy';
-import {createCacheDir} from '@parcel/cache';
+import {createCacheDir, getCacheByDir} from '@parcel/cache';
 
 let cacheDir = tempy.directory();
 createCacheDir(cacheDir);
+let cache = getCacheByDir(cacheDir);
 
 const DEFAULT_ENV = new Environment({
   context: 'browser',
@@ -121,7 +122,7 @@ describe('AssetGraph', () => {
       new Asset({
         id: '1',
         filePath,
-        cacheDir,
+        cache,
         type: 'js',
         hash: '#1',
         stats,
@@ -142,7 +143,7 @@ describe('AssetGraph', () => {
         id: '2',
         filePath,
         type: 'js',
-        cacheDir,
+        cache,
         hash: '#2',
         stats,
         dependencies: [
@@ -161,7 +162,7 @@ describe('AssetGraph', () => {
       new Asset({
         id: '3',
         filePath,
-        cacheDir,
+        cache,
         type: 'js',
         hash: '#3',
         dependencies: [],
@@ -195,7 +196,7 @@ describe('AssetGraph', () => {
       new Asset({
         id: '1',
         filePath,
-        cacheDir,
+        cache,
         type: 'js',
         hash: '#1',
         stats,
@@ -215,7 +216,7 @@ describe('AssetGraph', () => {
       new Asset({
         id: '2',
         filePath,
-        cacheDir,
+        cache,
         type: 'js',
         hash: '#2',
         stats,
@@ -262,7 +263,7 @@ describe('AssetGraph', () => {
       new Asset({
         id: '1',
         filePath,
-        cacheDir,
+        cache,
         type: 'js',
         hash: '#1',
         stats,

--- a/packages/core/utils/src/collection.js
+++ b/packages/core/utils/src/collection.js
@@ -5,9 +5,31 @@ export function unique<T>(array: Array<T>): Array<T> {
 }
 
 export function objectSortedEntries(obj: {
-  [string]: mixed
+  +[string]: mixed
 }): Array<[string, mixed]> {
   return Object.entries(obj).sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+}
+
+export function objectSortedEntriesDeep(object: {
+  +[string]: mixed
+}): Array<[string, mixed]> {
+  let sortedEntries = objectSortedEntries(object);
+  for (let i = 0; i < sortedEntries.length; i++) {
+    sortedEntries[i][1] = sortEntry(sortedEntries[i][1]);
+  }
+  return sortedEntries;
+}
+
+function sortEntry(entry: mixed) {
+  if (Array.isArray(entry)) {
+    return entry.map(sortEntry);
+  }
+
+  if (typeof entry === 'object' && entry != null) {
+    return objectSortedEntriesDeep(entry);
+  }
+
+  return entry;
 }
 
 // $FlowFixMe

--- a/packages/core/utils/src/collection.js
+++ b/packages/core/utils/src/collection.js
@@ -3,3 +3,26 @@
 export function unique<T>(array: Array<T>): Array<T> {
   return [...new Set(array)];
 }
+
+export function objectSortedEntries(obj: {
+  [string]: mixed
+}): Array<[string, mixed]> {
+  return Object.entries(obj).sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+}
+
+// $FlowFixMe
+type PickableObject = Object;
+
+export function pick(
+  obj: PickableObject,
+  keysToPick: Array<string>
+): {[string]: mixed} {
+  let picked = {};
+  for (let [key, value] of Object.entries(obj)) {
+    if (keysToPick.includes(key)) {
+      picked[key] = value;
+    }
+  }
+
+  return picked;
+}

--- a/packages/core/utils/src/md5.js
+++ b/packages/core/utils/src/md5.js
@@ -2,9 +2,9 @@
 
 import type {Readable} from 'stream';
 
-import invariant from 'assert';
 import crypto from 'crypto';
 import fs from 'fs';
+import {objectSortedEntriesDeep} from './collection';
 
 type StringHashEncoding = 'hex' | 'latin1' | 'binary' | 'base64';
 
@@ -29,32 +29,11 @@ export function md5FromReadableStream(stream: Readable): Promise<string> {
   });
 }
 
-function isObject(a) {
-  return Object.prototype.toString.call(a) === '[object Object]';
-}
-
-function sortObject<T>(object: T): T {
-  if (isObject(object)) {
-    invariant(typeof object === 'object' && object != null);
-    let newObj = {};
-    let keysSorted = Object.keys(object).sort();
-    for (let key of keysSorted) {
-      newObj[key] = sortObject(object[key]);
-    }
-    // $FlowFixMe
-    return newObj;
-  } else if (Array.isArray(object)) {
-    return object.map(sortObject);
-  } else {
-    return object;
-  }
-}
-
 export function md5FromObject(
-  obj: {[string]: mixed},
+  obj: {+[string]: mixed},
   encoding: StringHashEncoding = 'hex'
 ): string {
-  return md5FromString(JSON.stringify(sortObject(obj)), encoding);
+  return md5FromString(JSON.stringify(objectSortedEntriesDeep(obj)), encoding);
 }
 
 export function md5FromFilePath(filePath: string): Promise<string> {

--- a/packages/core/utils/test/collection.test.js
+++ b/packages/core/utils/test/collection.test.js
@@ -1,7 +1,11 @@
 // @flow
 
 import assert from 'assert';
-import {pick, objectSortedEntries} from '../src/collection';
+import {
+  pick,
+  objectSortedEntries,
+  objectSortedEntriesDeep
+} from '../src/collection';
 
 describe('pick', () => {
   it('returns a new object with a subset of key/value pairs', () =>
@@ -19,6 +23,19 @@ describe('objectSortedEntries', () => {
     assert.deepEqual(
       objectSortedEntries({foo: 'foo', baz: 'baz', bar: 'bar'}),
       [['bar', 'bar'], ['baz', 'baz'], ['foo', 'foo']]
+    );
+  });
+});
+
+describe('objectSortedEntriesDeep', () => {
+  it('returns a deeply sorted list of key/value tuples', () => {
+    assert.deepEqual(
+      objectSortedEntriesDeep({
+        foo: 'foo',
+        baz: ['d', 'c'],
+        bar: {g: 'g', b: 'b'}
+      }),
+      [['bar', [['b', 'b'], ['g', 'g']]], ['baz', ['d', 'c']], ['foo', 'foo']]
     );
   });
 });

--- a/packages/core/utils/test/collection.test.js
+++ b/packages/core/utils/test/collection.test.js
@@ -1,0 +1,24 @@
+// @flow
+
+import assert from 'assert';
+import {pick, objectSortedEntries} from '../src/collection';
+
+describe('pick', () => {
+  it('returns a new object with a subset of key/value pairs', () =>
+    assert.deepEqual(
+      pick({foo: 'foo', bar: 'baz', baz: 'baz'}, ['foo', 'baz']),
+      {
+        foo: 'foo',
+        baz: 'baz'
+      }
+    ));
+});
+
+describe('objectSortedEntries', () => {
+  it('returns a sorted list of key/value tuples', () => {
+    assert.deepEqual(
+      objectSortedEntries({foo: 'foo', baz: 'baz', bar: 'bar'}),
+      [['bar', 'bar'], ['baz', 'baz'], ['foo', 'foo']]
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10470,6 +10470,11 @@ shallow-copy@0.0.1, shallow-copy@~0.0.1:
   resolved "https://registry.yarnpkg.com/shallow-copy/-/shallow-copy-0.0.1.tgz#415f42702d73d810330292cc5ee86eae1a11a170"
   integrity sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"


### PR DESCRIPTION
Depends on #3093

When we made the changes to cache not aware of Parcel specifics, we didn't update the ability to ignore cache entries based on changes in parcel options like minify and scope hoisting.

This restores them, and also stores the version of core on the entry as well, in the case changes to core could impact the transform output.

Open question:
* How should we invalidate the cache based on changes to parcel plugin versions and plugin configs?

Test Plan: Run parcel with scope hoisting. Run parcel without scope hoisting. Verify the bundle output does not include hoisted contents.