### PR TITLE
Add objectSortedEntries for stringify stability

### DIFF
--- a/packages/core/utils/src/collection.js
+++ b/packages/core/utils/src/collection.js
@@ -3,3 +3,31 @@
 export function unique<T>(array: Array<T>): Array<T> {
   return [...new Set(array)];
 }
+
+export function objectSortedEntries(obj: {
+  +[string]: mixed
+}): Array<[string, mixed]> {
+  return Object.entries(obj).sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+}
+
+export function objectSortedEntriesDeep(object: {
+  +[string]: mixed
+}): Array<[string, mixed]> {
+  let sortedEntries = objectSortedEntries(object);
+  for (let i = 0; i < sortedEntries.length; i++) {
+    sortedEntries[i][1] = sortEntry(sortedEntries[i][1]);
+  }
+  return sortedEntries;
+}
+
+function sortEntry(entry: mixed) {
+  if (Array.isArray(entry)) {
+    return entry.map(sortEntry);
+  }
+
+  if (typeof entry === 'object' && entry != null) {
+    return objectSortedEntriesDeep(entry);
+  }
+
+  return entry;
+}

--- a/packages/core/utils/src/md5.js
+++ b/packages/core/utils/src/md5.js
@@ -2,9 +2,9 @@
 
 import type {Readable} from 'stream';
 
-import invariant from 'assert';
 import crypto from 'crypto';
 import fs from 'fs';
+import {objectSortedEntriesDeep} from './collection';
 
 type StringHashEncoding = 'hex' | 'latin1' | 'binary' | 'base64';
 
@@ -29,32 +29,11 @@ export function md5FromReadableStream(stream: Readable): Promise<string> {
   });
 }
 
-function isObject(a) {
-  return Object.prototype.toString.call(a) === '[object Object]';
-}
-
-function sortObject<T>(object: T): T {
-  if (isObject(object)) {
-    invariant(typeof object === 'object' && object != null);
-    let newObj = {};
-    let keysSorted = Object.keys(object).sort();
-    for (let key of keysSorted) {
-      newObj[key] = sortObject(object[key]);
-    }
-    // $FlowFixMe
-    return newObj;
-  } else if (Array.isArray(object)) {
-    return object.map(sortObject);
-  } else {
-    return object;
-  }
-}
-
 export function md5FromObject(
-  obj: {[string]: mixed},
+  obj: {+[string]: mixed},
   encoding: StringHashEncoding = 'hex'
 ): string {
-  return md5FromString(JSON.stringify(sortObject(obj)), encoding);
+  return md5FromString(JSON.stringify(objectSortedEntriesDeep(obj)), encoding);
 }
 
 export function md5FromFilePath(filePath: string): Promise<string> {

--- a/packages/core/utils/test/collection.test.js
+++ b/packages/core/utils/test/collection.test.js
@@ -1,0 +1,26 @@
+// @flow
+
+import assert from 'assert';
+import {objectSortedEntries, objectSortedEntriesDeep} from '../src/collection';
+
+describe('objectSortedEntries', () => {
+  it('returns a sorted list of key/value tuples', () => {
+    assert.deepEqual(
+      objectSortedEntries({foo: 'foo', baz: 'baz', bar: 'bar'}),
+      [['bar', 'bar'], ['baz', 'baz'], ['foo', 'foo']]
+    );
+  });
+});
+
+describe('objectSortedEntriesDeep', () => {
+  it('returns a deeply sorted list of key/value tuples', () => {
+    assert.deepEqual(
+      objectSortedEntriesDeep({
+        foo: 'foo',
+        baz: ['d', 'c'],
+        bar: {g: 'g', b: 'b'}
+      }),
+      [['bar', [['b', 'b'], ['g', 'g']]], ['baz', ['d', 'c']], ['foo', 'foo']]
+    );
+  });
+});


### PR DESCRIPTION
This adds `objectSortedEntries` and `objectSortedEntriesDeep` which return a predictably sorted list of key/value tuples given an object.

We use objects frequently for deriving keys, often by stringifying and hashing them. Given differing key orders can represent the same object, and that JavaScript (by spec at least) doesn't guarantee stable key order, use this sorted list before stringifying.

Test Plan: Added unit tests.