### PR TITLE
Accept an object of target descriptors in new Parcel

### DIFF
--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -70,7 +70,10 @@ export default class Environment implements IEnvironment {
   }
 
   merge(env: ?EnvironmentOpts) {
-    return new Environment(Object.assign({}, this, env));
+    return new Environment({
+      ...this,
+      ...env
+    });
   }
 
   isBrowser() {

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -18,7 +18,8 @@ const TARGETS = [
     name: 'test',
     distDir: 'dist',
     distEntry: 'out.js',
-    env: DEFAULT_ENV
+    env: DEFAULT_ENV,
+    publicUrl: null
   }
 ];
 

--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -24,7 +24,8 @@ const TARGETS = [
     name: 'test',
     distDir: 'dist',
     distEntry: 'out.js',
-    env: DEFAULT_ENV
+    env: DEFAULT_ENV,
+    publicUrl: null
   }
 ];
 

--- a/packages/core/core/test/Environment.test.js
+++ b/packages/core/core/test/Environment.test.js
@@ -1,0 +1,59 @@
+// @flow strict-local
+
+import assert from 'assert';
+import Environment from '../src/Environment';
+
+describe('Environment', () => {
+  it('assigns a default environment with nothing passed', () => {
+    assert.deepEqual(new Environment(), {
+      context: 'browser',
+      engines: {
+        browsers: ['> 0.25%']
+      },
+      includeNodeModules: true
+    });
+  });
+
+  it('assigns a node context if a node engine is given', () => {
+    assert.deepEqual(new Environment({engines: {node: '>= 10.0.0'}}), {
+      context: 'node',
+      engines: {
+        node: '>= 10.0.0'
+      },
+      includeNodeModules: false
+    });
+  });
+
+  it('assigns a browser context if browser engines are given', () => {
+    assert.deepEqual(
+      new Environment({engines: {browsers: ['last 1 version']}}),
+      {
+        context: 'browser',
+        engines: {
+          browsers: ['last 1 version']
+        },
+        includeNodeModules: true
+      }
+    );
+  });
+
+  it('assigns default engines for node', () => {
+    assert.deepEqual(new Environment({context: 'node'}), {
+      context: 'node',
+      engines: {
+        node: '>= 8.0.0'
+      },
+      includeNodeModules: false
+    });
+  });
+
+  it('assigns default engines for browsers', () => {
+    assert.deepEqual(new Environment({context: 'browser'}), {
+      context: 'browser',
+      engines: {
+        browsers: ['> 0.25%']
+      },
+      includeNodeModules: true
+    });
+  });
+});

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -1,0 +1,212 @@
+// @flow
+
+import assert from 'assert';
+import path from 'path';
+import tempy from 'tempy';
+import {rimraf} from '@parcel/fs';
+
+import TargetResolver from '../src/TargetResolver';
+
+const COMMON_TARGETS_FIXTURE_PATH = path.join(
+  __dirname,
+  'fixtures/common-targets'
+);
+
+const CUSTOM_TARGETS_FIXTURE_PATH = path.join(
+  __dirname,
+  'fixtures/custom-targets'
+);
+
+describe('TargetResolver', () => {
+  let targetResolver;
+  let cacheDir;
+  beforeEach(() => {
+    targetResolver = new TargetResolver();
+    cacheDir = tempy.directory();
+  });
+
+  afterEach(() => {
+    return rimraf(cacheDir);
+  });
+
+  it('resolves exactly specified targets', async () => {
+    assert.deepEqual(
+      await targetResolver.resolve(COMMON_TARGETS_FIXTURE_PATH, cacheDir, {
+        targets: {
+          customA: {
+            context: 'browser',
+            distDir: 'customA'
+          },
+          customB: {
+            distDir: 'customB',
+            engines: {
+              node: '>= 8.0.0'
+            }
+          }
+        }
+      }),
+      [
+        {
+          name: 'customA',
+          publicUrl: undefined,
+          distDir: path.resolve('customA'),
+          env: {
+            context: 'browser',
+            includeNodeModules: true,
+            engines: {
+              browsers: ['> 0.25%']
+            }
+          }
+        },
+        {
+          name: 'customB',
+          publicUrl: undefined,
+          distDir: path.resolve('customB'),
+          env: {
+            context: 'node',
+            includeNodeModules: false,
+            engines: {
+              node: '>= 8.0.0'
+            }
+          }
+        }
+      ]
+    );
+  });
+
+  it('resolves common targets from package.json', async () => {
+    assert.deepEqual(
+      await targetResolver.resolve(COMMON_TARGETS_FIXTURE_PATH, cacheDir, {}),
+      [
+        {
+          name: 'main',
+          distDir: path.join(__dirname, 'fixtures/common-targets/dist/main'),
+          distEntry: 'index.js',
+          publicUrl: '/',
+          env: {
+            context: 'node',
+            engines: {
+              node: '>= 8.0.0'
+            },
+            includeNodeModules: false
+          }
+        },
+        {
+          name: 'module',
+          distDir: path.join(__dirname, 'fixtures/common-targets/dist/module'),
+          distEntry: 'index.js',
+          publicUrl: '/',
+          env: {
+            context: 'node',
+            engines: {
+              node: '>= 12.0.0'
+            },
+            includeNodeModules: false
+          }
+        },
+        {
+          name: 'browser',
+          distDir: path.join(__dirname, 'fixtures/common-targets/dist/browser'),
+          distEntry: 'index.js',
+          publicUrl: '/assets',
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: ['last 1 version']
+            },
+            includeNodeModules: true
+          }
+        }
+      ]
+    );
+  });
+
+  it('resolves custom targets from package.json', async () => {
+    assert.deepEqual(
+      await targetResolver.resolve(CUSTOM_TARGETS_FIXTURE_PATH, cacheDir, {}),
+      [
+        {
+          name: 'main',
+          distDir: path.join(__dirname, 'fixtures/custom-targets/dist/main'),
+          distEntry: 'index.js',
+          publicUrl: '/',
+          env: {
+            context: 'node',
+            engines: {
+              node: '>= 8.0.0'
+            },
+            includeNodeModules: false
+          }
+        },
+        {
+          name: 'browserModern',
+          distDir: path.join(
+            __dirname,
+            'fixtures/custom-targets/dist/browserModern'
+          ),
+          distEntry: 'index.js',
+          publicUrl: '/',
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: ['last 1 version']
+            },
+            includeNodeModules: true
+          }
+        },
+        {
+          name: 'browserLegacy',
+          distDir: path.join(
+            __dirname,
+            'fixtures/custom-targets/dist/browserLegacy'
+          ),
+          distEntry: 'index.js',
+          publicUrl: '/',
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: ['ie11']
+            },
+            includeNodeModules: true
+          }
+        }
+      ]
+    );
+  });
+
+  it('resolves a subset of package.json targets when given a list of names', async () => {
+    assert.deepEqual(
+      await targetResolver.resolve(COMMON_TARGETS_FIXTURE_PATH, cacheDir, {
+        targets: ['main', 'browser']
+      }),
+      [
+        {
+          name: 'main',
+          distDir: path.join(__dirname, 'fixtures/common-targets/dist/main'),
+          distEntry: 'index.js',
+          publicUrl: '/',
+          env: {
+            context: 'node',
+            engines: {
+              node: '>= 8.0.0'
+            },
+            includeNodeModules: false
+          }
+        },
+        {
+          name: 'browser',
+          distDir: path.join(__dirname, 'fixtures/common-targets/dist/browser'),
+          distEntry: 'index.js',
+          publicUrl: '/assets',
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: ['last 1 version']
+            },
+            includeNodeModules: true
+          }
+        }
+      ]
+    );
+  });
+});

--- a/packages/core/core/test/fixtures/common-targets/package.json
+++ b/packages/core/core/test/fixtures/common-targets/package.json
@@ -1,0 +1,21 @@
+{
+  "main": "dist/main/index.js",
+  "module": "dist/module/index.js",
+  "browser": "dist/browser/index.js",
+  "engines": {
+    "node": ">= 8.0.0"
+  },
+  "targets": {
+    "module": {
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "browser": {
+      "engines": {
+        "browsers": ["last 1 version"]
+      },
+      "publicUrl": "/assets"
+    }
+  }
+}

--- a/packages/core/core/test/fixtures/custom-targets/package.json
+++ b/packages/core/core/test/fixtures/custom-targets/package.json
@@ -1,0 +1,20 @@
+{
+  "main": "dist/main/index.js",
+  "browserModern": "dist/browserModern/index.js",
+  "browserLegacy": "dist/browserLegacy/index.js",
+  "engines": {
+    "node": ">= 8.0.0"
+  },
+  "targets": {
+    "browserModern": {
+      "engines": {
+        "browsers": ["last 1 version"]
+      }
+    },
+    "browserLegacy": {
+      "engines": {
+        "browsers": ["ie11"]
+      }
+    }
+  }
+}

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -64,7 +64,7 @@ export type Target = {|
   distDir: FilePath,
   env: Environment,
   name: string,
-  publicUrl?: string
+  publicUrl: ?string
 |};
 
 export type EnvironmentContext =
@@ -74,11 +74,23 @@ export type EnvironmentContext =
   | 'node'
   | 'electron';
 
-export type EnvironmentOpts = {
+export type PackageTargetDescriptor = {|
   context?: EnvironmentContext,
   engines?: Engines,
   includeNodeModules?: boolean,
-  publicUrl?: string
+  publicUrl?: string,
+  distDir?: FilePath
+|};
+
+export type TargetDescriptor = {|
+  ...PackageTargetDescriptor,
+  distDir: FilePath
+|};
+
+export type EnvironmentOpts = {
+  context?: EnvironmentContext,
+  engines?: Engines,
+  includeNodeModules?: boolean
 };
 
 export interface Environment {
@@ -110,7 +122,7 @@ export type PackageJSON = {
   browserslist?: Array<string>,
   engines?: Engines,
   targets?: {
-    [string]: EnvironmentOpts
+    [string]: PackageTargetDescriptor
   },
   dependencies?: PackageDependencies,
   devDependencies?: PackageDependencies,
@@ -126,7 +138,7 @@ export type InitialParcelOptions = {|
   config?: ParcelConfig,
   defaultConfig?: ParcelConfig,
   env?: {[string]: ?string},
-  targets?: ?Array<string | Target>,
+  targets?: ?(Array<string> | {+[string]: TargetDescriptor}),
 
   cache?: boolean,
   cacheDir?: FilePath,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -75,8 +75,8 @@ export type EnvironmentContext =
   | 'electron';
 
 export type EnvironmentOpts = {
-  context: EnvironmentContext,
-  engines: Engines,
+  context?: EnvironmentContext,
+  engines?: Engines,
   includeNodeModules?: boolean,
   publicUrl?: string
 };


### PR DESCRIPTION
This:

* Allows `new Parcel` to accept an object mapping of targets to descriptors. Target descriptors have been formally separated from EnvironmentOpts, as they have always been a superset of them.
* The user now provides target descriptors either through `new Parcel` or through package.json, and we normalize everything and separate it into `Target` and `Environment`.
* Setting defaults for `Environment` has been moved to the `Environment` constructor
* Tests added for `Environment` and `TargetResolver`

Test Plan: Added new unit tests.