### PR TITLE
Remove duplicate graph traversal

### DIFF
--- a/packages/core/core/src/public/MainAssetGraph.js
+++ b/packages/core/core/src/public/MainAssetGraph.js
@@ -48,19 +48,6 @@ export default class MainAssetGraph implements IMainAssetGraph {
       }
     });
 
-    // Prune assets that don't match the bundle type when including the asset's
-    // subgraph. These are replaced with asset references, but the concrete assets
-    // cannot exist in this bundle.
-    //
-    // The concrete assets are visited when traversing the MainAssetGraph, so they
-    // will have their own opportunity to be bundled in a bundle of the appropriate
-    // type.
-    graph.traverseAssets(currentAsset => {
-      if (currentAsset.type !== asset.type) {
-        graph.removeAsset(currentAsset);
-      }
-    });
-
     return new MutableBundle({
       id: 'bundle:' + asset.id,
       filePath: null,


### PR DESCRIPTION
This removes an unnecessary traversal of the asset graph when creating a bundle. Looks like it was the result of a bad merge.