### PR TITLE
Persist and restore sourcemaps in Asset

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -20,6 +20,7 @@
     "@parcel/local-require": "^2.0.0-alpha.0",
     "@parcel/logger": "^2.0.0-alpha.0",
     "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/source-map": "^2.0.0-alpha.0",
     "@parcel/types": "^2.0.0-alpha.0",
     "@parcel/utils": "^2.0.0-alpha.0",
     "@parcel/watcher": "^2.0.0-alpha.3",

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -16,10 +16,10 @@ import type {
   Symbol,
   TransformerResult
 } from '@parcel/types';
-import type SourceMap from '@parcel/source-map';
 
 import {Readable} from 'stream';
 import crypto from 'crypto';
+import SourceMap from '@parcel/source-map';
 import {
   bufferStream,
   loadConfig,
@@ -100,6 +100,7 @@ export default class Asset {
     this.ast = options.ast || null;
     this.cache = options.cache;
     this.map = options.map;
+    this.mapKey = options.mapKey;
     this.dependencies = options.dependencies
       ? new Map(options.dependencies)
       : new Map();
@@ -130,6 +131,7 @@ export default class Asset {
       meta: this.meta,
       stats: this.stats,
       contentKey: this.contentKey,
+      mapKey: this.mapKey,
       symbols: [...this.symbols],
       sideEffects: this.sideEffects
     };
@@ -231,7 +233,10 @@ export default class Asset {
 
   async getMap(): Promise<?SourceMap> {
     if (this.mapKey != null) {
-      this.map = await this.cache.get(this.mapKey);
+      let cached = await this.cache.get(this.mapKey);
+      if (cached != null) {
+        this.map = SourceMap.deserialize(cached);
+      }
     }
 
     return this.map;

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -43,8 +43,6 @@ function checkSourceMapping({
   let mapping = map.mappings[index];
   assert(mapping, "no mapping for '" + str + "'" + msg);
 
-  console.log({mapping, nextMapping: map.mappings[index + 1]});
-
   let generatedDiff = {
     line: generatedPosition.line - mapping.generated.line,
     column: generatedPosition.column - mapping.generated.column

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -43,6 +43,8 @@ function checkSourceMapping({
   let mapping = map.mappings[index];
   assert(mapping, "no mapping for '" + str + "'" + msg);
 
+  console.log({mapping, nextMapping: map.mappings[index + 1]});
+
   let generatedDiff = {
     line: generatedPosition.line - mapping.generated.line,
     column: generatedPosition.column - mapping.generated.column
@@ -119,7 +121,7 @@ describe('sourcemaps', function() {
       map: sourceMap,
       source: input,
       generated: raw,
-      str: 'hello world',
+      str: '"hello world"',
       sourcePath
     });
   });
@@ -178,7 +180,7 @@ describe('sourcemaps', function() {
       map: sourceMap,
       source: input,
       generated: raw,
-      str: 'hello world',
+      str: '"hello world"',
       sourcePath
     });
   });

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -22,6 +22,7 @@ export {default as syncPromise} from './syncPromise';
 export {default as TapStream} from './TapStream';
 export {default as urlJoin} from './urlJoin';
 export {default as loadSourceMapUrl} from './loadSourceMapUrl';
+export {default as relativeUrl} from './relativeUrl';
 
 export * from './collection';
 export * from './config';

--- a/packages/core/utils/src/relativeUrl.js
+++ b/packages/core/utils/src/relativeUrl.js
@@ -1,0 +1,7 @@
+// @flow
+import path from 'path';
+import url from 'url';
+
+export default function relativeUrl(from: string, to: string): string {
+  return url.format(url.parse(path.relative(from, to)));
+}

--- a/packages/transformers/babel/src/BabelTransformer.js
+++ b/packages/transformers/babel/src/BabelTransformer.js
@@ -6,7 +6,7 @@ import semver from 'semver';
 import babel6 from './babel6';
 import babel7 from './babel7';
 import getBabelConfig from './config';
-import path from 'path';
+import {relativeUrl} from '@parcel/utils';
 
 export default new Transformer({
   async getConfig({asset}) {
@@ -32,7 +32,7 @@ export default new Transformer({
   },
 
   async generate({asset, options}) {
-    let sourceFileName: string = path.relative(
+    let sourceFileName: string = relativeUrl(
       options.projectRoot,
       asset.filePath
     );

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -12,8 +12,8 @@ import traverse from '@babel/traverse';
 import * as walk from 'babylon-walk';
 import * as babelCore from '@babel/core';
 import {hoist} from '@parcel/scope-hoisting';
+import {relativeUrl} from '@parcel/utils';
 import SourceMap from '@parcel/source-map';
-import path from 'path';
 
 const IMPORT_RE = /\b(?:import\b|export\b|require\s*\()/;
 const ENV_RE = /\b(?:process\.env)\b/;
@@ -139,7 +139,7 @@ export default new Transformer({
 
     let ast = asset.ast;
     if (ast && ast.isDirty !== false) {
-      let sourceFileName: string = path.relative(
+      let sourceFileName: string = relativeUrl(
         options.projectRoot,
         asset.filePath
       );


### PR DESCRIPTION
This fixes an issue where source maps were not properly persisted nor restored during the commit phase and constructor in Asset.

Test Plan: 
* yarn test for sourcemap integration tests
* run the kitchen sink example before, verify empty sourcemaps. Run it after, and verify source maps have content.