### PR TITLE
Update flow to v0.101

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -31,4 +31,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.98.1
+0.101.0

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0",
-    "flow-bin": "0.98.1",
+    "flow-bin": "0.101.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",

--- a/packages/configs/default/test/config.test.js
+++ b/packages/configs/default/test/config.test.js
@@ -47,14 +47,14 @@ function collectConfigPackageReferences(
   configSection: mixed,
   references: Set<string> = new Set()
 ): Set<string> {
-  if (!isPlainObject(configSection) && !Array.isArray(configSection)) {
+  if (configSection == null || typeof configSection !== 'object') {
     throw new TypeError('Expected config section to be an object or an array');
   }
 
   for (let value of Object.values(configSection)) {
     if (typeof value === 'string') {
       references.add(value);
-    } else if (isPlainObject(value) || Array.isArray(value)) {
+    } else if (configSection != null && typeof configSection === 'object') {
       collectConfigPackageReferences(value, references);
     } else {
       throw new Error(
@@ -64,10 +64,4 @@ function collectConfigPackageReferences(
   }
 
   return references;
-}
-
-function isPlainObject(maybeObj: any): boolean {
-  // This won't work with Objects with a null prototype, but those aren't produced
-  // by JSON.parse
-  return maybeObj != null && maybeObj.constructor === Object;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,10 +5317,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@0.98.1:
-  version "0.98.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.98.1.tgz#a8d781621c91703df69928acc83c9777e2fcbb49"
-  integrity sha512-y1YzQgbFUX4EG6h2EO8PhyJeS0VxNgER8XsTwU8IXw4KozfneSmGVgw8y3TwAOza7rVhTlHEoli1xNuNW1rhPw==
+flow-bin@0.101.0:
+  version "0.101.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.101.0.tgz#c56fa0afb9c151eeba7954136e9066d408691063"
+  integrity sha512-2xriPEOSrGQklAArNw1ixoIUiLTWhIquYV26WqnxEu7IcXWgoZUcfJXufG9kIvrNbdwCNd5RBjTwbB0p6L6XaA==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
Updates to the latest flow version. Also updates two cases where our code was not flow-safe:

* Makes the config test refine objects using `typeof` and a null check
* Makes `Graph`'s checking of visitors first check that the visitor is a function before using `visitor.enter` (or exit), since it's possible there could be a mixed `enter` property on a function.

Test Plan: `yarn flow`, `yarn test`