### PR TITLE
Fix failing multitarget builds

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -10,7 +10,7 @@ import type {
   SymbolResolution,
   Target
 } from '@parcel/types';
-import {md5FromString} from '@parcel/utils';
+import {md5FromObject} from '@parcel/utils';
 
 import type Asset from './Asset';
 import Dependency from './Dependency';
@@ -29,10 +29,6 @@ type InitOpts = {|
   assetGroup?: AssetGroup
 |};
 
-const hashObject = obj => {
-  return md5FromString(JSON.stringify(obj));
-};
-
 const invertMap = <K, V>(map: Map<K, V>): Map<V, K> =>
   new Map([...map].map(([key, val]) => [val, key]));
 
@@ -43,7 +39,7 @@ const nodeFromDep = (dep: Dependency): DependencyNode => ({
 });
 
 export const nodeFromAssetGroup = (assetGroup: AssetGroup) => ({
-  id: hashObject(assetGroup),
+  id: md5FromObject(assetGroup),
   type: 'asset_group',
   value: assetGroup
 });

--- a/packages/core/core/src/ResolverRunner.js
+++ b/packages/core/core/src/ResolverRunner.js
@@ -10,18 +10,13 @@ type Opts = {|
   options: ParcelOptions
 |};
 
-const getCacheKey = (filename, parent) =>
-  (parent ? path.dirname(parent) : '') + ':' + filename;
-
 export default class ResolverRunner {
   config: ParcelConfig;
   options: ParcelOptions;
-  cache: Map<string, AssetRequest>;
 
   constructor({config, options}: Opts) {
     this.config = config;
     this.options = options;
-    this.cache = new Map();
   }
 
   async resolve(dependency: Dependency): Promise<AssetRequest> {
@@ -31,22 +26,12 @@ export default class ResolverRunner {
       dependency
     });
 
-    // Check the cache first
-    let key = getCacheKey(dependency.moduleSpecifier, dependency.sourcePath);
-    let cached = this.cache.get(key);
-
-    if (cached) {
-      return cached;
-    }
-
     let resolvers = await this.config.getResolvers();
 
     for (let resolver of resolvers) {
       let result = await resolver.resolve({dependency, options: this.options});
 
       if (result) {
-        this.cache.set(key, result);
-
         return result;
       }
     }


### PR DESCRIPTION
Currently, multitarget builds after the first begin to fail, as ResolverRunner resolutions are reused, keyed by source path and module specifier.

They also would need to be keyed by environment. However, since this cache logic is being moved into the request graph (the resolver runner would be avoided entirely), simply remove it from the resolver runner.

Test Plan: Enable async imports in the kitchen sink example. Build with visualization and verify that dependencies for different environments do not resolve to the same asset group.