### PR TITLE
Add --root-dir CLI option

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -131,7 +131,10 @@ class Bundler extends EventEmitter {
       logLevel: isNaN(options.logLevel) ? 3 : options.logLevel,
       entryFiles: this.entryFiles,
       hmrPort: options.hmrPort || 0,
-      rootDir: getRootDir(this.entryFiles),
+      rootDir:
+        options.rootDir !== undefined
+          ? Path.resolve(options.rootDir)
+          : getRootDir(this.entryFiles),
       sourceMaps:
         (typeof options.sourceMaps === 'boolean' ? options.sourceMaps : true) &&
         !scopeHoist,

--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -67,6 +67,10 @@ program
     /^([0-5])$/
   )
   .option('--cache-dir <path>', 'set the cache directory. defaults to ".cache"')
+  .option(
+    '--root-dir <path>',
+    'set directory which will be used as root for resource resolving'
+  )
   .action(bundle);
 
 program
@@ -116,6 +120,10 @@ program
     /^([0-5])$/
   )
   .option('--cache-dir <path>', 'set the cache directory. defaults to ".cache"')
+  .option(
+    '--root-dir <path>',
+    'set directory which will be used as root for resource resolving'
+  )
   .action(bundle);
 
 program
@@ -163,6 +171,10 @@ program
     /^([0-5])$/
   )
   .option('--cache-dir <path>', 'set the cache directory. defaults to ".cache"')
+  .option(
+    '--root-dir <path>',
+    'set directory which will be used as root for resource resolving'
+  )
   .action(bundle);
 
 program


### PR DESCRIPTION
# ↪️ Pull Request
Added `--root-dir` command line option to `serve`, `build` and `watch` commands. For more info see issue https://github.com/parcel-bundler/parcel/issues/2413.

## 💻 Examples
```bash
parcel src/entries/**/*.html --root-dir src
```

## 🚨 Test instructions
Specify `--root-dir` command option with desired path and it should be used instead of default Parcels root directory resolving strategy.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
