### PR TITLE
start server when --target=electron

### DIFF
--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -264,4 +264,21 @@ describe('server', function() {
     logger._log.restore();
     logger.setOptions({logLevel: 3});
   });
+
+  it('should start the dev server when --target=electron', async function() {
+    let b = await bundler(
+      path.join(__dirname, '/integration/html/index.html'),
+      {
+        target: 'node'
+      }
+    );
+
+    server = await b.serve(0);
+
+    let data = await get('/');
+    assert.equal(
+      data,
+      await fs.readFile(path.join(__dirname, '/dist/index.html'), 'utf8')
+    );
+  });
 });

--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -236,7 +236,7 @@ async function bundle(main, command) {
   const bundler = new Bundler(main, command);
 
   command.target = command.target || 'browser';
-  if (command.name() === 'serve' && command.target === 'browser') {
+  if (command.name() === 'serve' && command.target !== 'node') {
     const port = command.port || process.env.PORT || 1234;
     const server = await bundler.serve(port, command.https, command.host);
     if (server && command.open) {


### PR DESCRIPTION

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This starts the web server when `--target=electron|browser`.   It was originally the case, but broken with [this pr](https://github.com/parcel-bundler/parcel/commit/9064b3b6b34cba08d6c33e5d88298485b1ee87f7).

Tests included. 

Unfortunately, I still haven't quite been able to get HMR working with my electron + typescript + react project.   It fails with not finding `tslib`, which AFIKT is an issue with the way parcel overwrites `require`.. but ran out of time to diagnose. 

Hopefully this helps someone, nonetheless. :)

