### PR TITLE
Use v8 serializer instead of JSON

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,6 +6,8 @@
 <PROJECT_ROOT>/.nyc_output/.*
 .*/tmp/**/.*
 .*/.parcel-cache/.*
+<PROJECT_ROOT>/packages/core/integration-tests/dist/**
+<PROJECT_ROOT>/packages/core/integration-tests/test/input/**
 
 [include]
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -8,6 +8,8 @@ jobs:
           node_version: 8.x
         node_10_x:
           node_version: 10.x
+        node_12_x:
+          node_version: 12.x
       maxParallel: 3
     steps:
       - task: NodeTool@0

--- a/flow-libs/worker_threads.js.flow
+++ b/flow-libs/worker_threads.js.flow
@@ -1,0 +1,143 @@
+// @flow
+
+// Derived from the TypeScript definitions https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/worker_threads.d.ts
+// TODO: contribute this to flow core
+
+declare module "worker_threads" {
+  declare var isMainThread: boolean;
+  declare var parentPort: null | MessagePort;
+  declare var threadId: number;
+  declare var workerData: any;
+
+  declare class MessageChannel {
+    +port1: MessagePort;
+    +port2: MessagePort;
+  }
+
+  declare class MessagePort extends events$EventEmitter {
+    close(): void;
+    postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+    ref(): void;
+    unref(): void;
+    start(): void;
+
+    addListener(event: "close", listener: () => void): this;
+    addListener(event: "message", listener: (value: any) => void): this;
+    addListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    emit(event: "close"): boolean;
+    emit(event: "message", value: any): boolean;
+    emit(event: string | Symbol, ...args: any[]): boolean;
+
+    on(event: "close", listener: () => void): this;
+    on(event: "message", listener: (value: any) => void): this;
+    on(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    once(event: "close", listener: () => void): this;
+    once(event: "message", listener: (value: any) => void): this;
+    once(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependListener(event: "close", listener: () => void): this;
+    prependListener(event: "message", listener: (value: any) => void): this;
+    prependListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependOnceListener(event: "close", listener: () => void): this;
+    prependOnceListener(event: "message", listener: (value: any) => void): this;
+    prependOnceListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    removeListener(event: "close", listener: () => void): this;
+    removeListener(event: "message", listener: (value: any) => void): this;
+    removeListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    off(event: "close", listener: () => void): this;
+    off(event: "message", listener: (value: any) => void): this;
+    off(event: string | Symbol, listener: (...args: any[]) => void): this;
+  }
+
+  declare type WorkerOptions = {|
+    env?: Object,
+    eval?: boolean,
+    workerData?: any,
+    stdin?: boolean,
+    stdout?: boolean,
+    stderr?: boolean,
+    execArgv?: string[]
+  |}
+
+  declare class Worker extends events$EventEmitter {
+    +stdin: stream$Writable | null;
+    +stdout: stream$Readable;
+    +stderr: stream$Readable;
+    +threadId: number;
+
+    constructor(filename: string, options?: WorkerOptions): void;
+
+    postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+    ref(): void;
+    unref(): void;
+    terminate(callback?: (err: Error, exitCode: number) => void): void;
+    /**
+     * Transfer a `MessagePort` to a different `vm` Context. The original `port`
+     * object will be rendered unusable, and the returned `MessagePort` instance will
+     * take its place.
+     *
+     * The returned `MessagePort` will be an object in the target context, and will
+     * inherit from its global `Object` class. Objects passed to the
+     * `port.onmessage()` listener will also be created in the target context
+     * and inherit from its global `Object` class.
+     *
+     * However, the created `MessagePort` will no longer inherit from
+     * `EventEmitter`, and only `port.onmessage()` can be used to receive
+     * events using it.
+     */
+    moveMessagePortToContext(port: MessagePort, context: vm$Context): MessagePort;
+
+    addListener(event: "error", listener: (err: Error) => void): this;
+    addListener(event: "exit", listener: (exitCode: number) => void): this;
+    addListener(event: "message", listener: (value: any) => void): this;
+    addListener(event: "online", listener: () => void): this;
+    addListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    emit(event: "error", err: Error): boolean;
+    emit(event: "exit", exitCode: number): boolean;
+    emit(event: "message", value: any): boolean;
+    emit(event: "online"): boolean;
+    emit(event: string | Symbol, ...args: any[]): boolean;
+
+    on(event: "error", listener: (err: Error) => void): this;
+    on(event: "exit", listener: (exitCode: number) => void): this;
+    on(event: "message", listener: (value: any) => void): this;
+    on(event: "online", listener: () => void): this;
+    on(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    once(event: "error", listener: (err: Error) => void): this;
+    once(event: "exit", listener: (exitCode: number) => void): this;
+    once(event: "message", listener: (value: any) => void): this;
+    once(event: "online", listener: () => void): this;
+    once(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependListener(event: "error", listener: (err: Error) => void): this;
+    prependListener(event: "exit", listener: (exitCode: number) => void): this;
+    prependListener(event: "message", listener: (value: any) => void): this;
+    prependListener(event: "online", listener: () => void): this;
+    prependListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependOnceListener(event: "error", listener: (err: Error) => void): this;
+    prependOnceListener(event: "exit", listener: (exitCode: number) => void): this;
+    prependOnceListener(event: "message", listener: (value: any) => void): this;
+    prependOnceListener(event: "online", listener: () => void): this;
+    prependOnceListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    removeListener(event: "error", listener: (err: Error) => void): this;
+    removeListener(event: "exit", listener: (exitCode: number) => void): this;
+    removeListener(event: "message", listener: (value: any) => void): this;
+    removeListener(event: "online", listener: () => void): this;
+    removeListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    off(event: "error", listener: (err: Error) => void): this;
+    off(event: "exit", listener: (exitCode: number) => void): this;
+    off(event: "message", listener: (value: any) => void): this;
+    off(event: "online", listener: () => void): this;
+    off(event: string | Symbol, listener: (...args: any[]) => void): this;
+  }
+}

--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -6,7 +6,6 @@ import type {FilePath} from '@parcel/types';
 
 import * as fs from '@parcel/fs';
 import {createReadStream, createWriteStream} from 'fs';
-import invariant from 'assert';
 import path from 'path';
 import logger from '@parcel/logger';
 import {serialize, deserialize, registerSerializableClass} from '@parcel/utils';
@@ -20,17 +19,7 @@ export default class Cache {
     this.dir = cacheDir;
   }
 
-  static deserialize(opts: {cacheDir: FilePath}) {
-    return new Cache(opts.cacheDir);
-  }
-
-  serialize() {
-    return {
-      cacheDir: this.dir
-    };
-  }
-
-  _getCachePath(cacheId: string, extension: string = '.json'): FilePath {
+  _getCachePath(cacheId: string, extension: string = '.v8'): FilePath {
     return path.join(
       this.dir,
       cacheId.slice(0, 2),
@@ -53,9 +42,7 @@ export default class Cache {
 
   async get(key: string) {
     try {
-      let data = await fs.readFile(this._getCachePath(key), {encoding: 'utf8'});
-
-      invariant(typeof data === 'string');
+      let data = await fs.readFile(this._getCachePath(key));
       return deserialize(data);
     } catch (err) {
       if (err.code === 'ENOENT') {

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -54,15 +54,7 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
   onNodeAdded: ?(node: AssetGraphNode) => mixed;
   onNodeRemoved: ?(node: AssetGraphNode) => mixed;
 
-  constructor(
-    {onNodeAdded, onNodeRemoved, ...graphOpts}: AssetGraphOpts = {
-      nodes: [],
-      edges: [],
-      rootNodeId: null,
-      onNodeAdded: undefined, // flow is dumb
-      onNodeRemoved: undefined
-    }
-  ) {
+  constructor({onNodeAdded, onNodeRemoved, ...graphOpts}: AssetGraphOpts = {}) {
     super(graphOpts);
     this.onNodeAdded = onNodeAdded;
     this.onNodeRemoved = onNodeRemoved;

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -46,7 +46,7 @@ export default class Dependency implements IDependency {
     this.target = opts.target;
     this.env = opts.env;
     this.sourcePath = opts.sourcePath || ''; // TODO: get from graph?
-    this.symbols = new Map(opts.symbols || []);
+    this.symbols = opts.symbols || new Map();
     this.id =
       opts.id ||
       md5FromString(
@@ -57,23 +57,5 @@ export default class Dependency implements IDependency {
   merge(other: IDependency) {
     Object.assign(this.meta, other.meta);
     this.symbols = new Map([...this.symbols, ...other.symbols]);
-  }
-
-  serialize() {
-    return {
-      moduleSpecifier: this.moduleSpecifier,
-      isAsync: this.isAsync,
-      isEntry: this.isEntry,
-      isOptional: this.isOptional,
-      isURL: this.isURL,
-      isWeak: this.isWeak,
-      loc: this.loc,
-      meta: this.meta,
-      target: this.target,
-      env: this.env,
-      sourcePath: this.sourcePath,
-      symbols: [...this.symbols],
-      id: this.id
-    };
   }
 }

--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -70,6 +70,11 @@ export default class Environment implements IEnvironment {
   }
 
   merge(env: ?EnvironmentOpts) {
+    // If merging the same object, avoid copying.
+    if (env === this) {
+      return this;
+    }
+
     return new Environment({
       ...this,
       ...env

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -7,7 +7,7 @@ import {DefaultMap} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 
 export type GraphOpts<TNode> = {|
-  nodes?: Array<[NodeId, TNode]>,
+  nodes?: Map<NodeId, TNode>,
   edges?: Array<Edge>,
   rootNodeId?: ?NodeId
 |};
@@ -21,9 +21,9 @@ export default class Graph<TNode: Node> {
   rootNodeId: ?NodeId;
 
   constructor(
-    opts: GraphOpts<TNode> = {nodes: [], edges: [], rootNodeId: null}
+    opts: GraphOpts<TNode> = ({}: any) // flow is dumb
   ) {
-    this.nodes = new Map(opts.nodes);
+    this.nodes = opts.nodes || new Map();
     this.rootNodeId = opts.rootNodeId;
 
     if (opts.edges) {
@@ -33,9 +33,13 @@ export default class Graph<TNode: Node> {
     }
   }
 
+  static deserialize(opts: GraphOpts<TNode>) {
+    return new this(opts);
+  }
+
   serialize(): GraphOpts<TNode> {
     return {
-      nodes: [...this.nodes],
+      nodes: this.nodes,
       edges: this.getAllEdges(),
       rootNodeId: this.rootNodeId
     };

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -286,7 +286,7 @@ function mergeBundleGraphIntoBundleAssetGraph(
   }
 }
 
-class BundleReference implements IBundleReference {
+export class BundleReference implements IBundleReference {
   #bundle;
 
   constructor(bundle: InternalBundle) {

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -295,7 +295,7 @@ export class BundleReference implements IBundleReference {
 
   // Once serialized, BundleReferences are frozen as a copy and no longer
   // continue to update to reflect the properties of the bundle they reference.
-  static deserialize(props): IBundleReference {
+  static deserialize(props: IBundleReference): IBundleReference {
     return props;
   }
 

--- a/packages/core/core/src/public/Config.js
+++ b/packages/core/core/src/public/Config.js
@@ -5,9 +5,9 @@ type ConfigOpts = {|
   searchPath: FilePath,
   resolvedPath?: FilePath,
   result?: any,
-  includedFiles?: Iterator<FilePath>,
+  includedFiles?: Set<FilePath>,
   watchGlob?: Glob,
-  devDeps?: Iterator<[PackageName, ?string]>
+  devDeps?: Map<PackageName, ?string>
 |};
 
 export default class Config {
@@ -30,20 +30,9 @@ export default class Config {
     this.searchPath = searchPath;
     this.resolvedPath = resolvedPath;
     this.result = result || null;
-    this.includedFiles = new Set(includedFiles);
+    this.includedFiles = includedFiles || new Set();
     this.watchGlob = watchGlob;
-    this.devDeps = new Map(devDeps);
-  }
-
-  serialize() {
-    return {
-      searchPath: this.searchPath,
-      resolvedPath: this.resolvedPath,
-      result: this.result,
-      includedFiles: [...this.includedFiles],
-      watchGlob: this.watchGlob,
-      devDeps: [...this.devDeps]
-    };
+    this.devDeps = devDeps || new Map();
   }
 
   setResolvedPath(filePath: FilePath) {

--- a/packages/core/core/src/registerCoreWithSerializer.js
+++ b/packages/core/core/src/registerCoreWithSerializer.js
@@ -7,6 +7,7 @@ import BundleGraph from './BundleGraph';
 import ParcelConfig from './ParcelConfig';
 import Dependency from './Dependency';
 import Environment from './Environment';
+import {BundleReference} from './public/BundleGraph';
 // $FlowFixMe this is untyped
 import packageJson from '../package.json';
 
@@ -27,7 +28,8 @@ export default function registerCoreWithSerializer() {
     BundleGraph,
     ParcelConfig,
     Dependency,
-    Environment
+    Environment,
+    BundleReference
   ]) {
     register(ctor);
   }

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -127,7 +127,7 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#1',
         stats,
-        dependencies: [
+        dependencies: new Map([
           [
             'utils',
             new Dependency({
@@ -136,9 +136,9 @@ describe('AssetGraph', () => {
               sourcePath
             })
           ]
-        ],
+        ]),
         env: DEFAULT_ENV,
-        connectedFiles: []
+        connectedFiles: new Map()
       }),
       new Asset({
         id: '2',
@@ -147,7 +147,7 @@ describe('AssetGraph', () => {
         cache,
         hash: '#2',
         stats,
-        dependencies: [
+        dependencies: new Map([
           [
             'styles',
             new Dependency({
@@ -156,9 +156,9 @@ describe('AssetGraph', () => {
               sourcePath
             })
           ]
-        ],
+        ]),
         env: DEFAULT_ENV,
-        connectedFiles: []
+        connectedFiles: new Map()
       }),
       new Asset({
         id: '3',
@@ -166,10 +166,10 @@ describe('AssetGraph', () => {
         cache,
         type: 'js',
         hash: '#3',
-        dependencies: [],
+        dependencies: new Map(),
         env: DEFAULT_ENV,
         stats,
-        connectedFiles: []
+        connectedFiles: new Map()
       })
     ];
 
@@ -193,7 +193,7 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#1',
         stats,
-        dependencies: [
+        dependencies: new Map([
           [
             'utils',
             new Dependency({
@@ -202,9 +202,9 @@ describe('AssetGraph', () => {
               sourcePath
             })
           ]
-        ],
+        ]),
         env: DEFAULT_ENV,
-        connectedFiles: []
+        connectedFiles: new Map()
       }),
       new Asset({
         id: '2',
@@ -213,9 +213,9 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#2',
         stats,
-        dependencies: [],
+        dependencies: new Map(),
         env: DEFAULT_ENV,
-        connectedFiles: []
+        connectedFiles: new Map()
       })
     ];
 
@@ -252,7 +252,7 @@ describe('AssetGraph', () => {
         type: 'js',
         hash: '#1',
         stats,
-        dependencies: [
+        dependencies: new Map([
           [
             'utils',
             new Dependency({
@@ -261,7 +261,7 @@ describe('AssetGraph', () => {
               sourcePath
             })
           ]
-        ],
+        ]),
         env: DEFAULT_ENV,
         connectedFiles: new Map([
           [

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -213,7 +213,7 @@ export type DependencyOptions = {|
   env?: EnvironmentOpts,
   meta?: Meta,
   target?: Target,
-  symbols?: Map<Symbol, Symbol> | Array<[Symbol, Symbol]>
+  symbols?: Map<Symbol, Symbol>
 |};
 
 export interface Dependency {

--- a/packages/core/utils/src/serializer.js
+++ b/packages/core/utils/src/serializer.js
@@ -1,4 +1,5 @@
 // @flow
+import v8 from 'v8';
 
 const nameToCtor: Map<string, Class<*>> = new Map();
 const ctorToName: Map<Class<*>, string> = new Map();
@@ -16,37 +17,160 @@ export function registerSerializableClass(name: string, ctor: Class<*>) {
   ctorToName.set(ctor, name);
 }
 
-export function serialize(object: any): string {
-  return JSON.stringify(object, (key, value) => {
-    let serialized;
-    if (value && typeof value.serialize === 'function') {
-      // If the object has a serialize method, call it
-      serialized = value.serialize();
-    } else {
-      serialized = value;
+export function unregisterSerializableClass(name: string, ctor: Class<*>) {
+  if (nameToCtor.get(name) === ctor) {
+    nameToCtor.delete(name);
+  }
+
+  if (ctorToName.get(ctor) === name) {
+    ctorToName.delete(ctor);
+  }
+}
+
+function shallowCopy(object: any) {
+  if (object && typeof object === 'object') {
+    if (Array.isArray(object)) {
+      return [...object];
     }
 
-    // Add a $$type property with the name of this class, if any is registered.
-    if (
-      value &&
-      typeof value === 'object' &&
-      typeof value.constructor === 'function'
-    ) {
-      let type = ctorToName.get(value.constructor);
-      if (type != null) {
-        return {
-          $$type: type,
-          value: {...serialized}
-        };
+    if (object instanceof Map) {
+      return new Map(object);
+    }
+
+    if (object instanceof Set) {
+      return new Set(object);
+    }
+
+    return Object.create(
+      Object.getPrototypeOf(object),
+      Object.getOwnPropertyDescriptors(object)
+    );
+  }
+
+  return object;
+}
+
+function mapObject(object: any, fn: (val: any) => any, preOrder = false) {
+  let cache = new Map();
+  let memo = new Map();
+
+  // Memoize the passed function to ensure it always returns the exact same
+  // output by reference for the same input. This is important to maintain
+  // reference integrity when deserializing rather than cloning.
+  let memoizedFn = (val: any) => {
+    if (memo.has(val)) {
+      return memo.get(val);
+    }
+
+    let res = fn(val);
+    memo.set(val, res);
+    return res;
+  };
+
+  let walk = (object: any, shouldCopy = false) => {
+    // Check the cache first, both for performance and cycle detection.
+    if (cache.has(object)) {
+      return cache.get(object);
+    }
+
+    let result = object;
+    cache.set(object, result);
+
+    let processKey = (key: any, value: any) => {
+      let newValue = value;
+      if (preOrder) {
+        newValue = memoizedFn(value);
+      }
+
+      // Recursively walk the children
+      if (newValue && typeof newValue === 'object') {
+        newValue = walk(newValue, newValue === value);
+      }
+
+      if (!preOrder) {
+        newValue = memoizedFn(newValue);
+      }
+
+      if (newValue !== value) {
+        // Copy on write. We only need to do this when serializing, not deserializing.
+        if (object === result && preOrder && shouldCopy) {
+          result = shallowCopy(object);
+          cache.set(object, result);
+        }
+
+        // Replace the key with the new value
+        if (result instanceof Map) {
+          result.set(key, newValue);
+        } else if (result instanceof Set) {
+          // TODO: do we care about iteration order??
+          result.delete(value);
+          result.add(newValue);
+        } else {
+          result[key] = newValue;
+        }
+      }
+    };
+
+    // Iterate in various ways depending on type.
+    if (Array.isArray(object)) {
+      for (let i = 0; i < object.length; i++) {
+        processKey(i, object[i]);
+      }
+    } else if (object instanceof Map || object instanceof Set) {
+      for (let [key, val] of object.entries()) {
+        processKey(key, val);
+      }
+    } else {
+      for (let key in object) {
+        processKey(key, object[key]);
       }
     }
 
-    return serialized;
-  });
+    return result;
+  };
+
+  let mapped = memoizedFn(object);
+  return walk(mapped, mapped === object);
 }
 
-export function deserialize(string: string) {
-  return JSON.parse(string, (key, value) => {
+export function serialize(object: any): Buffer {
+  let mapped = mapObject(
+    object,
+    value => {
+      let serialized = value;
+      if (value && typeof value.serialize === 'function') {
+        // If the object has a serialize method, call it
+        serialized = value.serialize();
+      }
+
+      // Add a $$type property with the name of this class, if any is registered.
+      if (
+        value &&
+        typeof value === 'object' &&
+        typeof value.constructor === 'function'
+      ) {
+        let type = ctorToName.get(value.constructor);
+        if (type != null) {
+          return {
+            $$type: type,
+            value: {...serialized}
+          };
+        }
+      }
+
+      return serialized;
+    },
+    true
+  );
+
+  // $FlowFixMe - flow doesn't know about this method yet
+  return v8.serialize(mapped);
+}
+
+export function deserialize(buffer: Buffer): any {
+  // $FlowFixMe - flow doesn't know about this method yet
+  let obj = v8.deserialize(buffer);
+  return mapObject(obj, value => {
     // If the value has a $$type property, use it to restore the object type
     if (value && value.$$type) {
       let ctor = nameToCtor.get(value.$$type);
@@ -62,7 +186,8 @@ export function deserialize(string: string) {
         return ctor.deserialize(value.value);
       }
 
-      return new ctor(value.value);
+      value = value.value;
+      Object.setPrototypeOf(value, ctor.prototype);
     }
 
     return value;

--- a/packages/core/utils/src/serializer.js
+++ b/packages/core/utils/src/serializer.js
@@ -137,12 +137,6 @@ export function serialize(object: any): Buffer {
   let mapped = mapObject(
     object,
     value => {
-      let serialized = value;
-      if (value && typeof value.serialize === 'function') {
-        // If the object has a serialize method, call it
-        serialized = value.serialize();
-      }
-
       // Add a $$type property with the name of this class, if any is registered.
       if (
         value &&
@@ -151,6 +145,12 @@ export function serialize(object: any): Buffer {
       ) {
         let type = ctorToName.get(value.constructor);
         if (type != null) {
+          let serialized = value;
+          if (value && typeof value.serialize === 'function') {
+            // If the object has a serialize method, call it
+            serialized = value.serialize();
+          }
+
           return {
             $$type: type,
             value: {...serialized}
@@ -158,7 +158,7 @@ export function serialize(object: any): Buffer {
         }
       }
 
-      return serialized;
+      return value;
     },
     true
   );

--- a/packages/core/utils/test/serializer.test.js
+++ b/packages/core/utils/test/serializer.test.js
@@ -1,0 +1,252 @@
+// @flow
+import {
+  serialize,
+  deserialize,
+  registerSerializableClass,
+  unregisterSerializableClass
+} from '../src/serializer';
+import assert from 'assert';
+
+describe('serializer', () => {
+  it('should serialize a basic object', () => {
+    let serialized = serialize({foo: 2, bar: 3});
+    assert(Buffer.isBuffer(serialized));
+    let deserialized = deserialize(serialized);
+    assert.equal(typeof deserialized, 'object');
+    assert.deepEqual(deserialized, {foo: 2, bar: 3});
+  });
+
+  it('should serialize an object with multiple references', () => {
+    let a = {foo: 2};
+    let b = {bar: a, baz: a};
+    let res = deserialize(serialize(b));
+    assert.deepEqual(res, b);
+    assert.equal(res.bar, res.baz);
+  });
+
+  it('should serialize a cyclic object', () => {
+    let a = {foo: 2, bar: {}};
+    a.bar = a;
+    let res = deserialize(serialize(a));
+    assert.deepEqual(res, a);
+    assert.equal(res.bar, res);
+    assert.equal(a.bar, a);
+  });
+
+  it('should serialize a Map', () => {
+    let a = new Map([[2, 3]]);
+    let res = deserialize(serialize(a));
+    assert(res instanceof Map);
+    assert.equal(res.get(2), 3);
+  });
+
+  it('should serialize a Set', () => {
+    let a = new Set([2, 3]);
+    let res = deserialize(serialize(a));
+    assert(res instanceof Set);
+    assert(res.has(2));
+    assert(res.has(3));
+  });
+
+  it('should serialize a class', () => {
+    class Test {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+    }
+
+    registerSerializableClass('Test', Test);
+
+    let x = new Test(2);
+    let res = deserialize(serialize(x));
+    assert(res instanceof Test);
+    assert.equal(res.x, x.x);
+
+    unregisterSerializableClass('Test', Test);
+  });
+
+  it('should serialize a class with a custom serialize method', () => {
+    class Test {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+
+      serialize() {
+        return {
+          x: this.x,
+          serialized: true
+        };
+      }
+    }
+
+    registerSerializableClass('Test', Test);
+
+    let x = new Test(2);
+    let res = deserialize(serialize(x));
+    assert(res instanceof Test);
+    assert.equal(res.x, x.x);
+    assert.equal(res.serialized, true);
+
+    unregisterSerializableClass('Test', Test);
+  });
+
+  it('should serialize a class with a custom deserialize method', () => {
+    class Test {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+
+      static deserialize(x: any) {
+        return {
+          deserialized: true,
+          value: x
+        };
+      }
+    }
+
+    registerSerializableClass('Test', Test);
+
+    let x = new Test(2);
+    let res = deserialize(serialize(x));
+    assert(!(res instanceof Test));
+    assert.equal(res.value.x, x.x);
+    assert.equal(res.deserialized, true);
+
+    unregisterSerializableClass('Test', Test);
+  });
+
+  it('should serialize a class recursively', () => {
+    class Foo {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+    }
+
+    class Bar {
+      foo: Foo;
+      constructor(foo: Foo) {
+        this.foo = foo;
+      }
+    }
+
+    registerSerializableClass('Foo', Foo);
+    registerSerializableClass('Bar', Bar);
+
+    let x = new Bar(new Foo(2));
+    let res = deserialize(serialize(x));
+    assert(res instanceof Bar);
+    assert(res.foo instanceof Foo);
+    assert.equal(res.foo.x, 2);
+
+    unregisterSerializableClass('Foo', Foo);
+    unregisterSerializableClass('Bar', Bar);
+  });
+
+  it('should serialize a cyclic class', () => {
+    class Foo {
+      x: ?Foo;
+      constructor(x: ?Foo) {
+        this.x = x;
+      }
+    }
+
+    registerSerializableClass('Foo', Foo);
+
+    let x = new Foo();
+    x.x = x;
+
+    let res = deserialize(serialize(x));
+    assert(res instanceof Foo);
+    assert(res.x instanceof Foo);
+    assert.equal(res.x, res);
+
+    assert.equal(x.x, x);
+
+    unregisterSerializableClass('Foo', Foo);
+  });
+
+  it('should copy on write', () => {
+    class Foo {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+    }
+
+    registerSerializableClass('Foo', Foo);
+
+    let x = {y: {foo: new Foo(2)}};
+
+    let res = deserialize(serialize(x));
+    assert(res.y.foo instanceof Foo);
+    assert(x.y.foo instanceof Foo);
+
+    unregisterSerializableClass('Foo', Foo);
+  });
+
+  it('should serialize a cyclic class and copy on write', () => {
+    class Foo {
+      x: ?Foo;
+      constructor(x: ?Foo) {
+        this.x = x;
+      }
+    }
+
+    registerSerializableClass('Foo', Foo);
+
+    let x = new Foo();
+    x.x = x;
+    let y = {x: {y: x}};
+
+    let res = deserialize(serialize(y));
+    assert(res.x.y instanceof Foo);
+    assert(res.x.y.x instanceof Foo);
+    assert(y.x.y instanceof Foo);
+    assert(y.x.y.x instanceof Foo);
+    assert.equal(res.x.y.x, res.x.y);
+
+    assert.equal(x.x, x);
+
+    unregisterSerializableClass('Foo', Foo);
+  });
+
+  it('should serialize a class inside a Map', () => {
+    class Test {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+    }
+
+    registerSerializableClass('Test', Test);
+
+    let x = new Map([[2, new Test(2)]]);
+    let res = deserialize(serialize(x));
+    assert(res instanceof Map);
+    assert(res.get(2) instanceof Test);
+
+    unregisterSerializableClass('Test', Test);
+  });
+
+  it('should serialize a class inside a Set', () => {
+    class Test {
+      x: number;
+      constructor(x: number) {
+        this.x = x;
+      }
+    }
+
+    registerSerializableClass('Test', Test);
+
+    let x = new Set([new Test(2)]);
+    let res = deserialize(serialize(x));
+    assert(res instanceof Set);
+    assert(res.values().next().value instanceof Test);
+
+    unregisterSerializableClass('Test', Test);
+  });
+});

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/workers",
   "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "main": "src/WorkerFarm.js",
+  "main": "src/index.js",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/workers/src/Handle.js
+++ b/packages/core/workers/src/Handle.js
@@ -1,4 +1,6 @@
 import WorkerFarm from './WorkerFarm';
+import packageJson from '../package.json';
+import {registerSerializableClass} from '@parcel/utils';
 
 let HANDLE_ID = 0;
 
@@ -13,3 +15,7 @@ export default class Handle {
     };
   }
 }
+
+// Register the Handle as a serializable class so that it will properly be deserialized
+// by anything that uses WorkerFarm.
+registerSerializableClass(`${packageJson.version}:Handle`, Handle);

--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -100,7 +100,7 @@ export default class Worker extends EventEmitter {
       return;
     }
 
-    let result = this.child.send(serialize(data), error => {
+    let result = this.child.send(serialize(data).toString('base64'), error => {
       if (error && error instanceof Error) {
         // Ignore this, the workerfarm handles child errors
         return;
@@ -143,8 +143,7 @@ export default class Worker extends EventEmitter {
       return;
     }
 
-    let message: WorkerMessage = deserialize(data);
-
+    let message: WorkerMessage = deserialize(Buffer.from(data, 'base64'));
     if (message.type === 'request') {
       this.emit('request', message);
     } else if (message.type === 'response') {

--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -1,14 +1,12 @@
 // @flow
 
 import type {FilePath} from '@parcel/types';
-import type {WorkerMessage} from './types';
+import type {WorkerMessage, WorkerImpl, BackendType} from './types';
 
-import childProcess, {type ChildProcess} from 'child_process';
 import EventEmitter from 'events';
 import {jsonToError} from '@parcel/utils';
 import {serialize, deserialize} from '@parcel/utils';
-
-const childModule = require.resolve('./child');
+import {getWorkerBackend} from './backend';
 
 export type WorkerCall = {|
   method: string,
@@ -19,16 +17,15 @@ export type WorkerCall = {|
 |};
 
 type WorkerOpts = {|
-  forcedKillTime: number
+  forcedKillTime: number,
+  backend: BackendType
 |};
 
 let WORKER_ID = 0;
 export default class Worker extends EventEmitter {
   +options: WorkerOpts;
-  child: ChildProcess;
+  worker: WorkerImpl;
   id: number = WORKER_ID++;
-  processQueue: boolean = true;
-  sendQueue: Array<any> = [];
 
   calls: Map<number, WorkerCall> = new Map();
   exitCode = null;
@@ -59,26 +56,19 @@ export default class Worker extends EventEmitter {
       }
     }
 
-    this.child = childProcess.fork(childModule, process.argv, {
-      execArgv: filteredArgs,
-      env: process.env,
-      cwd: process.cwd()
-    });
-
-    // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
-    this.child.unref();
-    this.child.channel.unref();
-
-    this.child.on('message', data => this.receive(data));
-
-    this.child.once('exit', code => {
+    let onMessage = data => this.receive(data);
+    let onExit = code => {
       this.exitCode = code;
       this.emit('exit', code);
-    });
+    };
 
-    this.child.on('error', err => {
+    let onError = err => {
       this.emit('error', err);
-    });
+    };
+
+    let WorkerBackend = getWorkerBackend(this.options.backend);
+    this.worker = new WorkerBackend(filteredArgs, onMessage, onError, onExit);
+    await this.worker.start();
 
     await new Promise((resolve, reject) => {
       this.call({
@@ -95,30 +85,7 @@ export default class Worker extends EventEmitter {
   }
 
   send(data: WorkerMessage): void {
-    if (!this.processQueue) {
-      this.sendQueue.push(data);
-      return;
-    }
-
-    let result = this.child.send(serialize(data).toString('base64'), error => {
-      if (error && error instanceof Error) {
-        // Ignore this, the workerfarm handles child errors
-        return;
-      }
-
-      this.processQueue = true;
-
-      if (this.sendQueue.length > 0) {
-        let queueCopy = this.sendQueue.slice(0);
-        this.sendQueue = [];
-        queueCopy.forEach(entry => this.send(entry));
-      }
-    });
-
-    if (!result || /^win/.test(process.platform)) {
-      // Queue is handling too much messages throttle it
-      this.processQueue = false;
-    }
+    this.worker.send(serialize(data));
   }
 
   call(call: WorkerCall): void {
@@ -138,12 +105,12 @@ export default class Worker extends EventEmitter {
     });
   }
 
-  receive(data: string): void {
+  receive(data: Buffer): void {
     if (this.stopped || this.isStopping) {
       return;
     }
 
-    let message: WorkerMessage = deserialize(Buffer.from(data, 'base64'));
+    let message: WorkerMessage = deserialize(data);
     if (message.type === 'request') {
       this.emit('request', message);
     } else if (message.type === 'response') {
@@ -173,18 +140,8 @@ export default class Worker extends EventEmitter {
     if (!this.stopped) {
       this.stopped = true;
 
-      if (this.child) {
-        this.child.send('die');
-
-        let forceKill = setTimeout(
-          () => this.child.kill('SIGINT'),
-          this.options.forcedKillTime
-        );
-        await new Promise(resolve => {
-          this.child.once('exit', resolve);
-        });
-
-        clearTimeout(forceKill);
+      if (this.worker) {
+        await this.worker.stop();
       }
     }
   }

--- a/packages/core/workers/src/backend.js
+++ b/packages/core/workers/src/backend.js
@@ -1,0 +1,22 @@
+// @flow
+import type {BackendType, WorkerImpl} from './types';
+
+export function detectBackend(): BackendType {
+  try {
+    require('worker_threads');
+    return 'threads';
+  } catch (err) {
+    return 'process';
+  }
+}
+
+export function getWorkerBackend(backend: BackendType): Class<WorkerImpl> {
+  switch (backend) {
+    case 'threads':
+      return require('./threads/ThreadsWorker').default;
+    case 'process':
+      return require('./process/ProcessWorker').default;
+    default:
+      throw new Error(`Invalid backend: ${backend}`);
+  }
+}

--- a/packages/core/workers/src/bus.js
+++ b/packages/core/workers/src/bus.js
@@ -20,5 +20,4 @@ class Bus extends EventEmitter {
   }
 }
 
-// TODO: Move to an ESM default export
-module.exports = new Bus();
+export default new Bus();

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -53,7 +53,7 @@ class Child {
       return this.end();
     }
 
-    let message: WorkerMessage = deserialize(data);
+    let message: WorkerMessage = deserialize(Buffer.from(data, 'base64'));
     if (message.type === 'response') {
       return this.handleResponse(message);
     } else if (message.type === 'request') {
@@ -63,7 +63,7 @@ class Child {
 
   async send(data: WorkerMessage): Promise<void> {
     let processSend = nullthrows(process.send).bind(process);
-    processSend(serialize(data), err => {
+    processSend(serialize(data).toString('base64'), err => {
       if (err && err instanceof Error) {
         if (err.code === 'ERR_IPC_CHANNEL_CLOSED') {
           // IPC connection closed

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -6,7 +6,8 @@ import type {
   WorkerErrorResponse,
   WorkerMessage,
   WorkerRequest,
-  WorkerResponse
+  WorkerResponse,
+  ChildImpl
 } from './types';
 
 import type {IDisposable} from '@parcel/types';
@@ -16,7 +17,6 @@ import nullthrows from 'nullthrows';
 import {inspect} from 'util';
 import Logger from '@parcel/logger';
 import {errorToJson, jsonToError, serialize, deserialize} from '@parcel/utils';
-
 import bus from './bus';
 
 type ChildCall = WorkerRequest & {|
@@ -26,7 +26,7 @@ type ChildCall = WorkerRequest & {|
 
 let consolePatched;
 
-class Child {
+export class Child {
   callQueue: Array<ChildCall> = [];
   childId: ?number;
   maxConcurrentCalls: number = 10;
@@ -34,11 +34,13 @@ class Child {
   responseId = 0;
   responseQueue: Map<number, ChildCall> = new Map();
   loggerDisposable: IDisposable;
+  child: ChildImpl;
 
-  constructor() {
-    if (!process.send) {
-      throw new Error('Only create Child instances in a worker!');
-    }
+  constructor(ChildBackend: Class<ChildImpl>) {
+    this.child = new ChildBackend(
+      this.messageListener.bind(this),
+      this.handleEnd.bind(this)
+    );
 
     patchConsoleToLogger();
     // Monitior all logging events inside this child process and forward to
@@ -48,12 +50,8 @@ class Child {
     });
   }
 
-  messageListener(data: string): void | Promise<void> {
-    if (data === 'die') {
-      return this.end();
-    }
-
-    let message: WorkerMessage = deserialize(Buffer.from(data, 'base64'));
+  messageListener(data: Buffer): void | Promise<void> {
+    let message: WorkerMessage = deserialize(data);
     if (message.type === 'response') {
       return this.handleResponse(message);
     } else if (message.type === 'request') {
@@ -62,16 +60,7 @@ class Child {
   }
 
   async send(data: WorkerMessage): Promise<void> {
-    let processSend = nullthrows(process.send).bind(process);
-    processSend(serialize(data).toString('base64'), err => {
-      if (err && err instanceof Error) {
-        if (err.code === 'ERR_IPC_CHANNEL_CLOSED') {
-          // IPC connection closed
-          // no need to keep the worker running if it can't send or receive data
-          return this.end();
-        }
-      }
-    });
+    this.child.send(serialize(data));
   }
 
   childInit(module: string, childId: number): void {
@@ -197,16 +186,10 @@ class Child {
     }
   }
 
-  end(): void {
+  handleEnd(): void {
     this.loggerDisposable.dispose();
-    process.exit();
   }
 }
-
-let child = new Child();
-process.on('message', child.messageListener.bind(child));
-
-export default child;
 
 // Patch `console` APIs within workers to forward their messages to the Logger
 // at the appropriate levels.

--- a/packages/core/workers/src/childState.js
+++ b/packages/core/workers/src/childState.js
@@ -1,0 +1,10 @@
+// @flow
+import type {Child} from './child';
+
+// This file is imported by both the WorkerFarm and child implementation.
+// When a worker is inited, it sets the state in this file.
+// This way, WorkerFarm can access the state without directly importing the child code.
+export let child: ?Child = null;
+export function setChild(c: Child) {
+  child = c;
+}

--- a/packages/core/workers/src/index.js
+++ b/packages/core/workers/src/index.js
@@ -1,0 +1,37 @@
+// @flow
+import type {LogEvent} from '@parcel/types';
+import invariant from 'assert';
+import WorkerFarm from './WorkerFarm';
+import Logger from '@parcel/logger';
+import bus from './bus';
+
+if (!WorkerFarm.isWorker()) {
+  // Forward all logger events originating from workers into the main process
+  bus.on('logEvent', (e: LogEvent) => {
+    switch (e.level) {
+      case 'info':
+        invariant(typeof e.message === 'string');
+        Logger.info(e.message);
+        break;
+      case 'progress':
+        invariant(typeof e.message === 'string');
+        Logger.progress(e.message);
+        break;
+      case 'verbose':
+        invariant(typeof e.message === 'string');
+        Logger.verbose(e.message);
+        break;
+      case 'warn':
+        Logger.warn(e.message);
+        break;
+      case 'error':
+        Logger.error(e.message);
+        break;
+      default:
+        throw new Error('Unknown log level');
+    }
+  });
+}
+
+export default WorkerFarm;
+export {bus};

--- a/packages/core/workers/src/process/ProcessChild.js
+++ b/packages/core/workers/src/process/ProcessChild.js
@@ -1,0 +1,49 @@
+// @flow
+
+import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
+import nullthrows from 'nullthrows';
+import {setChild} from '../childState';
+import {Child} from '../child';
+
+export default class ProcessChild implements ChildImpl {
+  onMessage: MessageHandler;
+  onExit: ExitHandler;
+
+  constructor(onMessage: MessageHandler, onExit: ExitHandler) {
+    if (!process.send) {
+      throw new Error('Only create ProcessChild instances in a worker!');
+    }
+
+    this.onMessage = onMessage;
+    this.onExit = onExit;
+    process.on('message', data => this.handleMessage(data));
+  }
+
+  handleMessage(data: string) {
+    if (data === 'die') {
+      return this.stop();
+    }
+
+    this.onMessage(Buffer.from(data, 'base64'));
+  }
+
+  send(data: Buffer) {
+    let processSend = nullthrows(process.send).bind(process);
+    processSend(data.toString('base64'), err => {
+      if (err && err instanceof Error) {
+        if (err.code === 'ERR_IPC_CHANNEL_CLOSED') {
+          // IPC connection closed
+          // no need to keep the worker running if it can't send or receive data
+          return this.stop();
+        }
+      }
+    });
+  }
+
+  stop() {
+    this.onExit(0);
+    process.exit();
+  }
+}
+
+setChild(new Child(ProcessChild));

--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -1,0 +1,91 @@
+// @flow
+
+import type {
+  WorkerImpl,
+  MessageHandler,
+  ErrorHandler,
+  ExitHandler
+} from '../types';
+import childProcess, {type ChildProcess} from 'child_process';
+import path from 'path';
+
+const WORKER_PATH = path.join(__dirname, 'ProcessChild.js');
+
+export default class ProcessWorker implements WorkerImpl {
+  execArgv: Object;
+  onMessage: MessageHandler;
+  onError: ErrorHandler;
+  onExit: ExitHandler;
+  child: ChildProcess;
+  processQueue: boolean = true;
+  sendQueue: Array<any> = [];
+
+  constructor(
+    execArgv: Object,
+    onMessage: MessageHandler,
+    onError: ErrorHandler,
+    onExit: ExitHandler
+  ) {
+    this.execArgv = execArgv;
+    this.onMessage = onMessage;
+    this.onError = onError;
+    this.onExit = onExit;
+  }
+
+  async start() {
+    this.child = childProcess.fork(WORKER_PATH, process.argv, {
+      execArgv: this.execArgv,
+      env: process.env,
+      cwd: process.cwd()
+    });
+
+    // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
+    this.child.unref();
+    this.child.channel.unref();
+
+    this.child.on('message', (data: string) => {
+      this.onMessage(Buffer.from(data, 'base64'));
+    });
+
+    this.child.once('exit', this.onExit);
+    this.child.on('error', this.onError);
+  }
+
+  async stop() {
+    this.child.send('die');
+
+    let forceKill = setTimeout(() => this.child.kill('SIGINT'), 500);
+    await new Promise(resolve => {
+      this.child.once('exit', resolve);
+    });
+
+    clearTimeout(forceKill);
+  }
+
+  send(data: Buffer) {
+    if (!this.processQueue) {
+      this.sendQueue.push(data);
+      return;
+    }
+
+    let result = this.child.send(data.toString('base64'), error => {
+      if (error && error instanceof Error) {
+        // Ignore this, the workerfarm handles child errors
+        return;
+      }
+
+      this.processQueue = true;
+
+      if (this.sendQueue.length > 0) {
+        let queueCopy = this.sendQueue.slice(0);
+        this.sendQueue = [];
+        queueCopy.forEach(entry => this.send(entry));
+      }
+    });
+
+    if (!result || /^win/.test(process.platform)) {
+      // Queue is handling too much messages throttle it
+      this.processQueue = false;
+    }
+  }
+}

--- a/packages/core/workers/src/threads/ThreadsChild.js
+++ b/packages/core/workers/src/threads/ThreadsChild.js
@@ -1,0 +1,29 @@
+// @flow
+
+import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
+import {isMainThread, parentPort} from 'worker_threads';
+import nullthrows from 'nullthrows';
+import {setChild} from '../childState';
+import {Child} from '../child';
+
+export default class ThreadsChild implements ChildImpl {
+  onMessage: MessageHandler;
+  onExit: ExitHandler;
+
+  constructor(onMessage: MessageHandler, onExit: ExitHandler) {
+    if (isMainThread || !parentPort) {
+      throw new Error('Only create ThreadsChild instances in a worker!');
+    }
+
+    this.onMessage = onMessage;
+    this.onExit = onExit;
+    parentPort.on('message', data => this.onMessage(Buffer.from(data.buffer)));
+    parentPort.on('close', this.onExit);
+  }
+
+  send(data: Buffer) {
+    nullthrows(parentPort).postMessage(data, [data.buffer]);
+  }
+}
+
+setChild(new Child(ThreadsChild));

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -1,0 +1,57 @@
+// @flow
+
+import type {
+  WorkerImpl,
+  MessageHandler,
+  ErrorHandler,
+  ExitHandler
+} from '../types';
+import {Worker} from 'worker_threads';
+import path from 'path';
+
+const WORKER_PATH = path.join(__dirname, 'ThreadsChild.js');
+
+export default class ThreadsWorker implements WorkerImpl {
+  execArgv: Object;
+  onMessage: MessageHandler;
+  onError: ErrorHandler;
+  onExit: ExitHandler;
+  worker: Worker;
+
+  constructor(
+    execArgv: Object,
+    onMessage: MessageHandler,
+    onError: ErrorHandler,
+    onExit: ExitHandler
+  ) {
+    this.execArgv = execArgv;
+    this.onMessage = onMessage;
+    this.onError = onError;
+    this.onExit = onExit;
+  }
+
+  async start() {
+    this.worker = new Worker(WORKER_PATH, {
+      execArgv: this.execArgv,
+      env: process.env
+    });
+
+    this.worker.on('message', this.onMessage);
+    this.worker.on('error', this.onError);
+    this.worker.on('exit', this.onExit);
+
+    this.worker.unref();
+
+    return new Promise(resolve => {
+      this.worker.on('online', resolve);
+    });
+  }
+
+  async stop() {
+    return this.worker.terminate();
+  }
+
+  send(data: Buffer) {
+    this.worker.postMessage(data, [data.buffer]);
+  }
+}

--- a/packages/core/workers/src/types.js
+++ b/packages/core/workers/src/types.js
@@ -44,3 +44,25 @@ export type WorkerErrorResponse = {|
 
 export type WorkerResponse = WorkerDataResponse | WorkerErrorResponse;
 export type WorkerMessage = WorkerRequest | WorkerResponse;
+
+export type MessageHandler = (data: Buffer) => void;
+export type ErrorHandler = (err: Error) => void;
+export type ExitHandler = (code: number) => void;
+export interface WorkerImpl {
+  constructor(
+    execArgv: Object,
+    onMessage: MessageHandler,
+    onError: ErrorHandler,
+    onExit: ExitHandler
+  ): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  send(data: Buffer): void;
+}
+
+export interface ChildImpl {
+  constructor(onMessage: MessageHandler, onExit: ExitHandler): void;
+  send(data: Buffer): void;
+}
+
+export type BackendType = 'threads' | 'process';

--- a/packages/core/workers/test/workerfarm.js
+++ b/packages/core/workers/test/workerfarm.js
@@ -92,7 +92,8 @@ describe('WorkerFarm', () => {
     await workerfarm.end();
   });
 
-  it('Bi-directional call should return masters pid', async () => {
+  it.skip('Bi-directional call should return masters pid', async () => {
+    // TODO: this test is only good for processes not threads
     let workerfarm = new WorkerFarm({
       warmWorkers: false,
       useLocalWorker: false,


### PR DESCRIPTION
This updates the serializer to use the native v8 serializer instead of JSON for the cache and worker IPC. This has several benefits:

* Many more native JS types are supported including Maps, Sets, Dates, etc.
* Reference integrity is maintained. Multiple references pointing to the same object will only be serialized once, and the reference will still point to the same object when deserialized.
* Cyclic objects are supported.
* It should be significantly smaller in many cases due to duplicate objects only being serialized once and the binary format instead of plain text.
* A bunch of unnecessary copying was removed in various places because we can serialize maps and sets directly now instead of converting to and from arrays. Might be a bit faster.

One downside is that the current worker farm has to convert the serialized buffers to base64 and back since node only supports sending strings over IPC (it's JSON based). When we swap to using node's new worker threads instead of processes this won't be an issue (we'll actually be able to do zero-copy transfers).