### PR TITLE
Implement node worker_threads backend

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -6,7 +6,8 @@
 <PROJECT_ROOT>/.nyc_output/.*
 .*/tmp/**/.*
 .*/.parcel-cache/.*
-.*/dist/.*
+<PROJECT_ROOT>/packages/core/integration-tests/dist/**
+<PROJECT_ROOT>/packages/core/integration-tests/test/input/**
 
 [include]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -6,6 +6,7 @@
 <PROJECT_ROOT>/.nyc_output/.*
 .*/tmp/**/.*
 .*/.parcel-cache/.*
+.*/dist/.*
 
 [include]
 

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -8,6 +8,8 @@ jobs:
           node_version: 8.x
         node_10_x:
           node_version: 10.x
+        node_12_x:
+          node_version: 12.x
       maxParallel: 3
     steps:
       - task: NodeTool@0

--- a/flow-libs/worker_threads.js.flow
+++ b/flow-libs/worker_threads.js.flow
@@ -1,0 +1,143 @@
+// @flow
+
+// Derived from the TypeScript definitions https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/worker_threads.d.ts
+// TODO: contribute this to flow core
+
+declare module "worker_threads" {
+  declare var isMainThread: boolean;
+  declare var parentPort: null | MessagePort;
+  declare var threadId: number;
+  declare var workerData: any;
+
+  declare class MessageChannel {
+    +port1: MessagePort;
+    +port2: MessagePort;
+  }
+
+  declare class MessagePort extends events$EventEmitter {
+    close(): void;
+    postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+    ref(): void;
+    unref(): void;
+    start(): void;
+
+    addListener(event: "close", listener: () => void): this;
+    addListener(event: "message", listener: (value: any) => void): this;
+    addListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    emit(event: "close"): boolean;
+    emit(event: "message", value: any): boolean;
+    emit(event: string | Symbol, ...args: any[]): boolean;
+
+    on(event: "close", listener: () => void): this;
+    on(event: "message", listener: (value: any) => void): this;
+    on(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    once(event: "close", listener: () => void): this;
+    once(event: "message", listener: (value: any) => void): this;
+    once(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependListener(event: "close", listener: () => void): this;
+    prependListener(event: "message", listener: (value: any) => void): this;
+    prependListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependOnceListener(event: "close", listener: () => void): this;
+    prependOnceListener(event: "message", listener: (value: any) => void): this;
+    prependOnceListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    removeListener(event: "close", listener: () => void): this;
+    removeListener(event: "message", listener: (value: any) => void): this;
+    removeListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    off(event: "close", listener: () => void): this;
+    off(event: "message", listener: (value: any) => void): this;
+    off(event: string | Symbol, listener: (...args: any[]) => void): this;
+  }
+
+  declare type WorkerOptions = {|
+    env?: Object,
+    eval?: boolean,
+    workerData?: any,
+    stdin?: boolean,
+    stdout?: boolean,
+    stderr?: boolean,
+    execArgv?: string[]
+  |}
+
+  declare class Worker extends events$EventEmitter {
+    +stdin: stream$Writable | null;
+    +stdout: stream$Readable;
+    +stderr: stream$Readable;
+    +threadId: number;
+
+    constructor(filename: string, options?: WorkerOptions): void;
+
+    postMessage(value: any, transferList?: Array<ArrayBuffer | MessagePort>): void;
+    ref(): void;
+    unref(): void;
+    terminate(callback?: (err: Error, exitCode: number) => void): void;
+    /**
+     * Transfer a `MessagePort` to a different `vm` Context. The original `port`
+     * object will be rendered unusable, and the returned `MessagePort` instance will
+     * take its place.
+     *
+     * The returned `MessagePort` will be an object in the target context, and will
+     * inherit from its global `Object` class. Objects passed to the
+     * `port.onmessage()` listener will also be created in the target context
+     * and inherit from its global `Object` class.
+     *
+     * However, the created `MessagePort` will no longer inherit from
+     * `EventEmitter`, and only `port.onmessage()` can be used to receive
+     * events using it.
+     */
+    moveMessagePortToContext(port: MessagePort, context: vm$Context): MessagePort;
+
+    addListener(event: "error", listener: (err: Error) => void): this;
+    addListener(event: "exit", listener: (exitCode: number) => void): this;
+    addListener(event: "message", listener: (value: any) => void): this;
+    addListener(event: "online", listener: () => void): this;
+    addListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    emit(event: "error", err: Error): boolean;
+    emit(event: "exit", exitCode: number): boolean;
+    emit(event: "message", value: any): boolean;
+    emit(event: "online"): boolean;
+    emit(event: string | Symbol, ...args: any[]): boolean;
+
+    on(event: "error", listener: (err: Error) => void): this;
+    on(event: "exit", listener: (exitCode: number) => void): this;
+    on(event: "message", listener: (value: any) => void): this;
+    on(event: "online", listener: () => void): this;
+    on(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    once(event: "error", listener: (err: Error) => void): this;
+    once(event: "exit", listener: (exitCode: number) => void): this;
+    once(event: "message", listener: (value: any) => void): this;
+    once(event: "online", listener: () => void): this;
+    once(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependListener(event: "error", listener: (err: Error) => void): this;
+    prependListener(event: "exit", listener: (exitCode: number) => void): this;
+    prependListener(event: "message", listener: (value: any) => void): this;
+    prependListener(event: "online", listener: () => void): this;
+    prependListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependOnceListener(event: "error", listener: (err: Error) => void): this;
+    prependOnceListener(event: "exit", listener: (exitCode: number) => void): this;
+    prependOnceListener(event: "message", listener: (value: any) => void): this;
+    prependOnceListener(event: "online", listener: () => void): this;
+    prependOnceListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    removeListener(event: "error", listener: (err: Error) => void): this;
+    removeListener(event: "exit", listener: (exitCode: number) => void): this;
+    removeListener(event: "message", listener: (value: any) => void): this;
+    removeListener(event: "online", listener: () => void): this;
+    removeListener(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    off(event: "error", listener: (err: Error) => void): this;
+    off(event: "exit", listener: (exitCode: number) => void): this;
+    off(event: "message", listener: (value: any) => void): this;
+    off(event: "online", listener: () => void): this;
+    off(event: string | Symbol, listener: (...args: any[]) => void): this;
+  }
+}

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -414,7 +414,7 @@ describe('html', function() {
     ]);
   });
 
-  it('should support bundling HTM', async function() {
+  it.skip('should support bundling HTM', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/htm-extension/index.htm')
     );

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -414,7 +414,7 @@ describe('html', function() {
     ]);
   });
 
-  it.skip('should support bundling HTM', async function() {
+  it('should support bundling HTM', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/htm-extension/index.htm')
     );

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -2,7 +2,7 @@
   "name": "@parcel/workers",
   "version": "2.0.0-alpha.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "main": "src/WorkerFarm.js",
+  "main": "src/index.js",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/workers/src/Handle.js
+++ b/packages/core/workers/src/Handle.js
@@ -1,4 +1,6 @@
 import WorkerFarm from './WorkerFarm';
+import packageJson from '../package.json';
+import {registerSerializableClass} from '@parcel/utils';
 
 let HANDLE_ID = 0;
 
@@ -13,3 +15,7 @@ export default class Handle {
     };
   }
 }
+
+// Register the Handle as a serializable class so that it will properly be deserialized
+// by anything that uses WorkerFarm.
+registerSerializableClass(`${packageJson.version}:Handle`, Handle);

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -234,6 +234,11 @@ export default class WorkerFarm extends EventEmitter {
         result = errorResponseFromError(e);
       }
     } else {
+      // ESModule default interop
+      if (mod.__esModule && !mod[method] && mod.default) {
+        mod = mod.default;
+      }
+
       try {
         result = responseFromContent(await mod[method](...args));
       } catch (e) {
@@ -350,7 +355,13 @@ export default class WorkerFarm extends EventEmitter {
   }
 
   static isWorker() {
-    return process.send && require.main.filename === require.resolve('./child');
+    try {
+      return !require('worker_threads').isMainThread;
+    } catch (err) {
+      return (
+        process.send && require.main.filename === require.resolve('./child')
+      );
+    }
   }
 
   static getConcurrentCallsPerWorker() {

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {ErrorWithCode, FilePath, LogEvent} from '@parcel/types';
+import type {ErrorWithCode, FilePath} from '@parcel/types';
 import type {
   CallRequest,
   WorkerRequest,
@@ -8,26 +8,12 @@ import type {
   WorkerErrorResponse
 } from './types';
 
-import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import EventEmitter from 'events';
-import {
-  deserialize,
-  errorToJson,
-  jsonToError,
-  registerSerializableClass,
-  serialize
-} from '@parcel/utils';
-import Logger from '@parcel/logger';
-import bus from './bus';
+import {deserialize, errorToJson, jsonToError, serialize} from '@parcel/utils';
 import Worker, {type WorkerCall} from './Worker';
 import cpuCount from './cpuCount';
 import Handle from './Handle';
-import packageJson from '../package.json';
-
-// Register the Handle as a serializable class so that it will properly be deserialized
-// by anything that uses WorkerFarm.
-registerSerializableClass(`${packageJson.version}:Handle`, Handle);
 
 let shared = null;
 
@@ -378,33 +364,3 @@ export default class WorkerFarm extends EventEmitter {
     return nullthrows(shared).createReverseHandle(fn);
   }
 }
-
-if (!WorkerFarm.isWorker()) {
-  // Forward all logger events originating from workers into the main process
-  bus.on('logEvent', (e: LogEvent) => {
-    switch (e.level) {
-      case 'info':
-        invariant(typeof e.message === 'string');
-        Logger.info(e.message);
-        break;
-      case 'progress':
-        invariant(typeof e.message === 'string');
-        Logger.progress(e.message);
-        break;
-      case 'verbose':
-        invariant(typeof e.message === 'string');
-        Logger.verbose(e.message);
-        break;
-      case 'warn':
-        Logger.warn(e.message);
-        break;
-      case 'error':
-        Logger.error(e.message);
-        break;
-      default:
-        throw new Error('Unknown log level');
-    }
-  });
-}
-
-export {bus};

--- a/packages/core/workers/src/backend.js
+++ b/packages/core/workers/src/backend.js
@@ -1,0 +1,22 @@
+// @flow
+import type {BackendType, WorkerImpl} from './types';
+
+export function detectBackend(): BackendType {
+  try {
+    require('worker_threads');
+    return 'threads';
+  } catch (err) {
+    return 'process';
+  }
+}
+
+export function getWorkerBackend(backend: BackendType): Class<WorkerImpl> {
+  switch (backend) {
+    case 'threads':
+      return require('./threads/ThreadsWorker').default;
+    case 'process':
+      return require('./process/ProcessWorker').default;
+    default:
+      throw new Error(`Invalid backend: ${backend}`);
+  }
+}

--- a/packages/core/workers/src/bus.js
+++ b/packages/core/workers/src/bus.js
@@ -20,5 +20,4 @@ class Bus extends EventEmitter {
   }
 }
 
-// TODO: Move to an ESM default export
-module.exports = new Bus();
+export default new Bus();

--- a/packages/core/workers/src/bus.js
+++ b/packages/core/workers/src/bus.js
@@ -1,9 +1,14 @@
 // @flow
 import EventEmitter from 'events';
-import WorkerFarm from './WorkerFarm';
+
+let WorkerFarm;
 
 class Bus extends EventEmitter {
   emit(event: string, ...args: Array<any>): boolean {
+    if (!WorkerFarm) {
+      WorkerFarm = require('./WorkerFarm').default; // circular dep
+    }
+
     if (WorkerFarm.isWorker()) {
       WorkerFarm.callMaster(
         {

--- a/packages/core/workers/src/bus.js
+++ b/packages/core/workers/src/bus.js
@@ -1,14 +1,9 @@
 // @flow
 import EventEmitter from 'events';
-
-let WorkerFarm;
+import WorkerFarm from './WorkerFarm';
 
 class Bus extends EventEmitter {
   emit(event: string, ...args: Array<any>): boolean {
-    if (!WorkerFarm) {
-      WorkerFarm = require('./WorkerFarm').default; // circular dep
-    }
-
     if (WorkerFarm.isWorker()) {
       WorkerFarm.callMaster(
         {

--- a/packages/core/workers/src/childState.js
+++ b/packages/core/workers/src/childState.js
@@ -1,0 +1,10 @@
+// @flow
+import type {Child} from './child';
+
+// This file is imported by both the WorkerFarm and child implementation.
+// When a worker is inited, it sets the state in this file.
+// This way, WorkerFarm can access the state without directly importing the child code.
+export let child: ?Child = null;
+export function setChild(c: Child) {
+  child = c;
+}

--- a/packages/core/workers/src/index.js
+++ b/packages/core/workers/src/index.js
@@ -1,0 +1,37 @@
+// @flow
+import type {LogEvent} from '@parcel/types';
+import invariant from 'assert';
+import WorkerFarm from './WorkerFarm';
+import Logger from '@parcel/logger';
+import bus from './bus';
+
+if (!WorkerFarm.isWorker()) {
+  // Forward all logger events originating from workers into the main process
+  bus.on('logEvent', (e: LogEvent) => {
+    switch (e.level) {
+      case 'info':
+        invariant(typeof e.message === 'string');
+        Logger.info(e.message);
+        break;
+      case 'progress':
+        invariant(typeof e.message === 'string');
+        Logger.progress(e.message);
+        break;
+      case 'verbose':
+        invariant(typeof e.message === 'string');
+        Logger.verbose(e.message);
+        break;
+      case 'warn':
+        Logger.warn(e.message);
+        break;
+      case 'error':
+        Logger.error(e.message);
+        break;
+      default:
+        throw new Error('Unknown log level');
+    }
+  });
+}
+
+export default WorkerFarm;
+export {bus};

--- a/packages/core/workers/src/process/ProcessChild.js
+++ b/packages/core/workers/src/process/ProcessChild.js
@@ -1,0 +1,45 @@
+// @flow
+
+import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
+import nullthrows from 'nullthrows';
+
+export default class ProcessChild implements ChildImpl {
+  onMessage: MessageHandler;
+  onExit: ExitHandler;
+
+  constructor(onMessage: MessageHandler, onExit: ExitHandler) {
+    if (!process.send) {
+      throw new Error('Only create ProcessChild instances in a worker!');
+    }
+
+    this.onMessage = onMessage;
+    this.onExit = onExit;
+    process.on('message', data => this.handleMessage(data));
+  }
+
+  handleMessage(data: string) {
+    if (data === 'die') {
+      return this.stop();
+    }
+
+    this.onMessage(Buffer.from(data, 'base64'));
+  }
+
+  send(data: Buffer) {
+    let processSend = nullthrows(process.send).bind(process);
+    processSend(data.toString('base64'), err => {
+      if (err && err instanceof Error) {
+        if (err.code === 'ERR_IPC_CHANNEL_CLOSED') {
+          // IPC connection closed
+          // no need to keep the worker running if it can't send or receive data
+          return this.stop();
+        }
+      }
+    });
+  }
+
+  stop() {
+    this.onExit(0);
+    process.exit();
+  }
+}

--- a/packages/core/workers/src/process/ProcessChild.js
+++ b/packages/core/workers/src/process/ProcessChild.js
@@ -2,6 +2,8 @@
 
 import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
 import nullthrows from 'nullthrows';
+import {setChild} from '../childState';
+import {Child} from '../child';
 
 export default class ProcessChild implements ChildImpl {
   onMessage: MessageHandler;
@@ -43,3 +45,5 @@ export default class ProcessChild implements ChildImpl {
     process.exit();
   }
 }
+
+setChild(new Child(ProcessChild));

--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -1,6 +1,5 @@
 // @flow
 
-import type {FilePath} from '@parcel/types';
 import type {
   WorkerImpl,
   MessageHandler,
@@ -8,9 +7,11 @@ import type {
   ExitHandler
 } from '../types';
 import childProcess, {type ChildProcess} from 'child_process';
+import path from 'path';
+
+const WORKER_PATH = path.join(__dirname, 'ProcessChild.js');
 
 export default class ProcessWorker implements WorkerImpl {
-  workerPath: FilePath;
   execArgv: Object;
   onMessage: MessageHandler;
   onError: ErrorHandler;
@@ -20,13 +21,11 @@ export default class ProcessWorker implements WorkerImpl {
   sendQueue: Array<any> = [];
 
   constructor(
-    workerPath: FilePath,
     execArgv: Object,
     onMessage: MessageHandler,
     onError: ErrorHandler,
     onExit: ExitHandler
   ) {
-    this.workerPath = workerPath;
     this.execArgv = execArgv;
     this.onMessage = onMessage;
     this.onError = onError;
@@ -34,7 +33,7 @@ export default class ProcessWorker implements WorkerImpl {
   }
 
   async start() {
-    this.child = childProcess.fork(this.workerPath, process.argv, {
+    this.child = childProcess.fork(WORKER_PATH, process.argv, {
       execArgv: this.execArgv,
       env: process.env,
       cwd: process.cwd()

--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -1,0 +1,92 @@
+// @flow
+
+import type {FilePath} from '@parcel/types';
+import type {
+  WorkerImpl,
+  MessageHandler,
+  ErrorHandler,
+  ExitHandler
+} from '../types';
+import childProcess, {type ChildProcess} from 'child_process';
+
+export default class ProcessWorker implements WorkerImpl {
+  workerPath: FilePath;
+  execArgv: Object;
+  onMessage: MessageHandler;
+  onError: ErrorHandler;
+  onExit: ExitHandler;
+  child: ChildProcess;
+  processQueue: boolean = true;
+  sendQueue: Array<any> = [];
+
+  constructor(
+    workerPath: FilePath,
+    execArgv: Object,
+    onMessage: MessageHandler,
+    onError: ErrorHandler,
+    onExit: ExitHandler
+  ) {
+    this.workerPath = workerPath;
+    this.execArgv = execArgv;
+    this.onMessage = onMessage;
+    this.onError = onError;
+    this.onExit = onExit;
+  }
+
+  async start() {
+    this.child = childProcess.fork(this.workerPath, process.argv, {
+      execArgv: this.execArgv,
+      env: process.env,
+      cwd: process.cwd()
+    });
+
+    // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
+    this.child.unref();
+    this.child.channel.unref();
+
+    this.child.on('message', (data: string) => {
+      this.onMessage(Buffer.from(data, 'base64'));
+    });
+
+    this.child.once('exit', this.onExit);
+    this.child.on('error', this.onError);
+  }
+
+  async stop() {
+    this.child.send('die');
+
+    let forceKill = setTimeout(() => this.child.kill('SIGINT'), 500);
+    await new Promise(resolve => {
+      this.child.once('exit', resolve);
+    });
+
+    clearTimeout(forceKill);
+  }
+
+  send(data: Buffer) {
+    if (!this.processQueue) {
+      this.sendQueue.push(data);
+      return;
+    }
+
+    let result = this.child.send(data.toString('base64'), error => {
+      if (error && error instanceof Error) {
+        // Ignore this, the workerfarm handles child errors
+        return;
+      }
+
+      this.processQueue = true;
+
+      if (this.sendQueue.length > 0) {
+        let queueCopy = this.sendQueue.slice(0);
+        this.sendQueue = [];
+        queueCopy.forEach(entry => this.send(entry));
+      }
+    });
+
+    if (!result || /^win/.test(process.platform)) {
+      // Queue is handling too much messages throttle it
+      this.processQueue = false;
+    }
+  }
+}

--- a/packages/core/workers/src/threads/ThreadsChild.js
+++ b/packages/core/workers/src/threads/ThreadsChild.js
@@ -1,0 +1,25 @@
+// @flow
+
+import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
+import {isMainThread, parentPort} from 'worker_threads';
+import nullthrows from 'nullthrows';
+
+export default class ThreadsChild implements ChildImpl {
+  onMessage: MessageHandler;
+  onExit: ExitHandler;
+
+  constructor(onMessage: MessageHandler, onExit: ExitHandler) {
+    if (isMainThread || !parentPort) {
+      throw new Error('Only create ThreadsChild instances in a worker!');
+    }
+
+    this.onMessage = onMessage;
+    this.onExit = onExit;
+    parentPort.on('message', data => this.onMessage(Buffer.from(data.buffer)));
+    parentPort.on('close', this.onExit);
+  }
+
+  send(data: Buffer) {
+    nullthrows(parentPort).postMessage(data, [data.buffer]);
+  }
+}

--- a/packages/core/workers/src/threads/ThreadsChild.js
+++ b/packages/core/workers/src/threads/ThreadsChild.js
@@ -3,6 +3,8 @@
 import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
 import {isMainThread, parentPort} from 'worker_threads';
 import nullthrows from 'nullthrows';
+import {setChild} from '../childState';
+import {Child} from '../child';
 
 export default class ThreadsChild implements ChildImpl {
   onMessage: MessageHandler;
@@ -23,3 +25,5 @@ export default class ThreadsChild implements ChildImpl {
     nullthrows(parentPort).postMessage(data, [data.buffer]);
   }
 }
+
+setChild(new Child(ThreadsChild));

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -1,0 +1,58 @@
+// @flow
+
+import type {FilePath} from '@parcel/types';
+import type {
+  WorkerImpl,
+  MessageHandler,
+  ErrorHandler,
+  ExitHandler
+} from '../types';
+import {Worker} from 'worker_threads';
+
+export default class ThreadsWorker implements WorkerImpl {
+  workerPath: FilePath;
+  execArgv: Object;
+  onMessage: MessageHandler;
+  onError: ErrorHandler;
+  onExit: ExitHandler;
+  worker: Worker;
+
+  constructor(
+    workerPath: FilePath,
+    execArgv: Object,
+    onMessage: MessageHandler,
+    onError: ErrorHandler,
+    onExit: ExitHandler
+  ) {
+    this.workerPath = workerPath;
+    this.execArgv = execArgv;
+    this.onMessage = onMessage;
+    this.onError = onError;
+    this.onExit = onExit;
+  }
+
+  async start() {
+    this.worker = new Worker(this.workerPath, {
+      execArgv: this.execArgv,
+      env: process.env
+    });
+
+    this.worker.on('message', this.onMessage);
+    this.worker.on('error', this.onError);
+    this.worker.on('exit', this.onExit);
+
+    this.worker.unref();
+
+    return new Promise(resolve => {
+      this.worker.on('online', resolve);
+    });
+  }
+
+  async stop() {
+    return this.worker.terminate();
+  }
+
+  send(data: Buffer) {
+    this.worker.postMessage(data, [data.buffer]);
+  }
+}

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -1,6 +1,5 @@
 // @flow
 
-import type {FilePath} from '@parcel/types';
 import type {
   WorkerImpl,
   MessageHandler,
@@ -8,9 +7,11 @@ import type {
   ExitHandler
 } from '../types';
 import {Worker} from 'worker_threads';
+import path from 'path';
+
+const WORKER_PATH = path.join(__dirname, 'ThreadsChild.js');
 
 export default class ThreadsWorker implements WorkerImpl {
-  workerPath: FilePath;
   execArgv: Object;
   onMessage: MessageHandler;
   onError: ErrorHandler;
@@ -18,13 +19,11 @@ export default class ThreadsWorker implements WorkerImpl {
   worker: Worker;
 
   constructor(
-    workerPath: FilePath,
     execArgv: Object,
     onMessage: MessageHandler,
     onError: ErrorHandler,
     onExit: ExitHandler
   ) {
-    this.workerPath = workerPath;
     this.execArgv = execArgv;
     this.onMessage = onMessage;
     this.onError = onError;
@@ -32,7 +31,7 @@ export default class ThreadsWorker implements WorkerImpl {
   }
 
   async start() {
-    this.worker = new Worker(this.workerPath, {
+    this.worker = new Worker(WORKER_PATH, {
       execArgv: this.execArgv,
       env: process.env
     });

--- a/packages/core/workers/src/types.js
+++ b/packages/core/workers/src/types.js
@@ -44,3 +44,24 @@ export type WorkerErrorResponse = {|
 
 export type WorkerResponse = WorkerDataResponse | WorkerErrorResponse;
 export type WorkerMessage = WorkerRequest | WorkerResponse;
+
+export type MessageHandler = (data: Buffer) => void;
+export type ErrorHandler = (err: Error) => void;
+export type ExitHandler = (code: number) => void;
+export interface WorkerImpl {
+  constructor(
+    workerPath: FilePath,
+    execArgv: Object,
+    onMessage: MessageHandler,
+    onError: ErrorHandler,
+    onExit: ExitHandler
+  ): void;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  send(data: Buffer): void;
+}
+
+export interface ChildImpl {
+  constructor(onMessage: MessageHandler, onExit: ExitHandler): void;
+  send(data: Buffer): void;
+}

--- a/packages/core/workers/src/types.js
+++ b/packages/core/workers/src/types.js
@@ -50,7 +50,6 @@ export type ErrorHandler = (err: Error) => void;
 export type ExitHandler = (code: number) => void;
 export interface WorkerImpl {
   constructor(
-    workerPath: FilePath,
     execArgv: Object,
     onMessage: MessageHandler,
     onError: ErrorHandler,
@@ -65,3 +64,5 @@ export interface ChildImpl {
   constructor(onMessage: MessageHandler, onExit: ExitHandler): void;
   send(data: Buffer): void;
 }
+
+export type BackendType = 'threads' | 'process';

--- a/packages/core/workers/test/workerfarm.js
+++ b/packages/core/workers/test/workerfarm.js
@@ -92,7 +92,8 @@ describe('WorkerFarm', () => {
     await workerfarm.end();
   });
 
-  it('Bi-directional call should return masters pid', async () => {
+  it.skip('Bi-directional call should return masters pid', async () => {
+    // TODO: this test is only good for processes not threads
     let workerfarm = new WorkerFarm({
       warmWorkers: false,
       useLocalWorker: false,


### PR DESCRIPTION
This builds on #3228 and implements a worker farm backend based on the node 10 [worker_threads](https://nodejs.org/api/worker_threads.html) module. It will still continue to fall back to child processes on older versions of node.

Most of the implementation is the same, it just abstracts away the details into backends that each implement the same interface. The worker threads implementation should be faster in theory (I haven't fully tested yet) since it is much faster to spin up threads than processes, and the memory space is shared which means that messages are not copied between threads as they are with processes. Instead, [transferrable objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable) are used to implement zero-copy array buffer sharing.

Some additional testing is still needed to determine the performance characteristics of threads vs processes on a larger app. We also should determine whether to adjust some options depending on if threads are available, such as using the local worker or not, and warming up the workers or not. I'm not sure if workers share a require cache.