### PR TITLE
Fix pipeline id identity in workers

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -414,7 +414,7 @@ describe('html', function() {
     ]);
   });
 
-  it.skip('should support bundling HTM', async function() {
+  it('should support bundling HTM', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/htm-extension/index.htm')
     );


### PR DESCRIPTION
This fixes a small bug in the transformation pipeline when run in workers where the pipeline ids (which are arrays) do not have equal object identity. This is due to the reverse handle being used to get the Parcel config, which means the config is copied across IPC each time and therefore has different object identity. This is fixed by joining the pipeline into a string and using that as an id instead.

A future optimization could be to not go across IPC every time we switch pipelines at all. We only need to re-resolve the parcel config if the directory changes, which will never happen for an asset. So we really only need to resolve the config once at the start of a transformation rather than for each individual pipeline.

Left a few other comments inline for some other things I noticed:

* Are we reading/writing from the cache every time we jump a pipeline? This seems probably unnecessary. I think we might only need to store the first and last pipelines.
* There might be a further bug related to this where the asset type changes but it still resolves to the same pipeline. It should finish that pipeline rather than stopping. That would require some further refactoring, and I wasn't sure how @padmaia wanted to do it.