### PR TITLE
Remove usage of Bundle#traverseAncestors

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -128,7 +128,7 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
         assets[0].type === 'asset' || assets[0].type === 'asset_reference'
       );
       let resolvedAsset = assets[0].value;
-      let deps = this.getAncestorDependencies(resolvedAsset);
+      let deps = this.getIncomingDependencies(resolvedAsset);
       defer = deps.every(
         d =>
           !d.symbols.has('*') &&
@@ -197,7 +197,7 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
     return res;
   }
 
-  getAncestorDependencies(asset: Asset): Array<Dependency> {
+  getIncomingDependencies(asset: Asset): Array<IDependency> {
     let node = this.getNode(asset.id);
     if (!node) {
       return [];

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 // flowlint unsafe-getters-setters:off
 
-import type {Bundle as InternalBundle, AssetGraphNode} from '../types';
+import type {Bundle as InternalBundle} from '../types';
 import type {
   Asset as IAsset,
   Bundle as IBundle,
@@ -82,6 +82,12 @@ export class Bundle implements IBundle {
     }
   }
 
+  getIncomingDependencies(asset: IAsset): Array<Dependency> {
+    return this.#bundle.assetGraph.getIncomingDependencies(
+      getInternalAsset(this.#bundle.assetGraph, asset)
+    );
+  }
+
   getEntryAssets(): Array<IAsset> {
     return this.#bundle.assetGraph
       .getEntryAssets()
@@ -106,6 +112,8 @@ export class Bundle implements IBundle {
         return {type: 'asset', value: node.value};
       } else if (node.type === 'asset_reference') {
         return {type: 'asset_reference', value: node.value};
+      } else if (node.type === 'dependency') {
+        return {type: 'dependency', value: node.value};
       }
     }, visit);
   }
@@ -114,17 +122,6 @@ export class Bundle implements IBundle {
     return this.#bundle.assetGraph.traverseAssets(
       assetGraphVisitorToInternal(visit)
     );
-  }
-
-  traverseAncestors<TContext>(
-    asset: IAsset,
-    visit: GraphVisitor<AssetGraphNode, TContext>
-  ) {
-    let node = nullthrows(
-      this.#bundle.assetGraph.getNode(asset.id),
-      'Bundle does not contain asset'
-    );
-    return this.#bundle.assetGraph.traverseAncestors(node, visit);
   }
 
   resolveSymbol(asset: IAsset, symbol: Symbol) {

--- a/packages/core/core/src/public/MainAssetGraph.js
+++ b/packages/core/core/src/public/MainAssetGraph.js
@@ -72,6 +72,10 @@ export default class MainAssetGraph implements IMainAssetGraph {
     }
   }
 
+  getIncomingDependencies(asset: IAsset): Array<Dependency> {
+    return this.#graph.getIncomingDependencies(assetToInternalAsset(asset));
+  }
+
   traverse<TContext>(
     visit: GraphVisitor<MainAssetGraphTraversable, TContext>
   ): ?TContext {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -376,12 +376,14 @@ export type GraphTraversalCallback<TNode, TContext> = (
 interface AssetGraphLike {
   getDependencies(asset: Asset): Array<Dependency>;
   getDependencyResolution(dependency: Dependency): ?Asset;
+  getIncomingDependencies(asset: Asset): Array<Dependency>;
   traverseAssets<TContext>(visit: GraphVisitor<Asset, TContext>): ?TContext;
 }
 
 export type BundleTraversable =
   | {|+type: 'asset', value: Asset|}
-  | {|+type: 'asset_reference', value: Asset|};
+  | {|+type: 'asset_reference', value: Asset|}
+  | {|+type: 'dependency', value: Dependency|};
 
 export type MainAssetGraphTraversable =
   | {|+type: 'asset', value: Asset|}
@@ -415,10 +417,6 @@ export interface Bundle extends AssetGraphLike {
   hasChildBundles(): boolean;
   traverse<TContext>(
     visit: GraphVisitor<BundleTraversable, TContext>
-  ): ?TContext;
-  traverseAncestors<TContext>(
-    asset: Asset,
-    visit: GraphVisitor<*, TContext>
   ): ?TContext;
   resolveSymbol(asset: Asset, symbol: Symbol): SymbolResolution;
 }

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -1,4 +1,4 @@
-// @flow strict-local
+// @flow
 
 import {Packager} from '@parcel/plugin';
 
@@ -10,18 +10,14 @@ export default new Packager({
         // Figure out which media types this asset was imported with.
         // We only want to import the asset once, so group them all together.
         let media = [];
-        bundle.traverseAncestors(asset, (node, _, {skipChildren}) => {
-          if (node.type === 'dependency') {
-            let dep = node.value;
-            if (!dep.meta || !dep.meta.media) {
-              // Asset was imported without a media type. Don't wrap in @media.
-              media.length = 0;
-              skipChildren();
-              return;
-            }
-            media.push(dep.meta.media);
+        for (let dep of bundle.getIncomingDependencies(asset)) {
+          if (!dep.meta.media) {
+            // Asset was imported without a media type. Don't wrap in @media.
+            media.length = 0;
+            break;
           }
-        });
+          media.push(dep.meta.media);
+        }
 
         promises.push(
           asset.getCode().then((css: string) => {


### PR DESCRIPTION
The `traverseAncestors` method of `Bundle` objects was problematic because it leaked internal details of the asset graph, and also for performance reasons. There were only two uses of it, and this PR replaces them both:

* The CSS packager's use was to determine if any incoming dependencies had a media attached to them. This has been replaced by exposing the `getIncomingDependencies` method on the bundle instead (previously called `getAncestorDependencies` which was incorrect since it only retrieves a single level up).
* The scope hoisting packager used it to determine if any ancestor dependencies were marked as needing to be wrapped in a function (e.g. require in an if statement). This is replaced by marking the assets are part of an initial traversal downward rather than traversing back up when reaching an asset. This required exposing dependencies to the `traverse` method of Bundles, but I think that's ok.