### PR TITLE
Implement edge types in Graph

### DIFF
--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -21,9 +21,10 @@ import type Config from './public/Config';
 
 export type NodeId = string;
 
-export type Edge = {|
+export type Edge<TEdgeType: string | null> = {|
   from: NodeId,
-  to: NodeId
+  to: NodeId,
+  type: TEdgeType
 |};
 
 export interface Node {

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -62,14 +62,16 @@ describe('AssetGraph', () => {
         to: new Dependency({
           moduleSpecifier: '/path/to/index1',
           env: DEFAULT_ENV
-        }).id
+        }).id,
+        type: null
       },
       {
         from: '@@root',
         to: new Dependency({
           moduleSpecifier: '/path/to/index2',
           env: DEFAULT_ENV
-        }).id
+        }).id,
+        type: null
       }
     ]);
   });

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -36,11 +36,14 @@ describe('Graph', () => {
     let graph = new Graph();
     let nodeA = {id: 'a', value: 'a'};
     let nodeB = {id: 'b', value: 'b'};
+    let nodeC = {id: 'c', value: 'c'};
     graph.addNode(nodeA);
     graph.addNode(nodeB);
     graph.addEdge('a', 'b');
+    graph.addEdge('a', 'c', 'edgetype');
     assert(graph.isOrphanedNode(nodeA));
     assert(!graph.isOrphanedNode(nodeB));
+    assert(!graph.isOrphanedNode(nodeC));
   });
 
   it('removeEdge should prune the graph at that edge', () => {
@@ -81,5 +84,30 @@ describe('Graph', () => {
       {from: 'a', to: 'b', type: null},
       {from: 'a', to: 'd', type: null}
     ]);
+  });
+
+  it('traverses along edge types if a filter is given', () => {
+    let graph = new Graph();
+    graph.addNode({id: 'a', value: 'a'});
+    graph.addNode({id: 'b', value: 'b'});
+    graph.addNode({id: 'c', value: 'c'});
+    graph.addNode({id: 'd', value: 'd'});
+
+    graph.addEdge('a', 'b', 'edgetype');
+    graph.addEdge('a', 'd');
+    graph.addEdge('b', 'c');
+    graph.addEdge('b', 'd', 'edgetype');
+
+    graph.rootNodeId = 'a';
+
+    let visited = [];
+    graph.traverse(
+      node => {
+        visited.push(node.id);
+      },
+      null, // use root as startNode
+      'edgetype'
+    );
+    assert.deepEqual(visited, ['a', 'b', 'd']);
   });
 });

--- a/packages/core/core/test/Graph.test.js
+++ b/packages/core/core/test/Graph.test.js
@@ -59,7 +59,7 @@ describe('Graph', () => {
     assert(graph.nodes.has('d'));
     assert(!graph.nodes.has('b'));
     assert(!graph.nodes.has('c'));
-    assert.deepEqual(graph.getAllEdges(), [{from: 'a', to: 'd'}]);
+    assert.deepEqual(graph.getAllEdges(), [{from: 'a', to: 'd', type: null}]);
   });
 
   it("replaceNodesConnectedTo should update a node's downstream nodes", () => {
@@ -78,8 +78,8 @@ describe('Graph', () => {
     assert(!graph.nodes.has('c'));
     assert(graph.nodes.has('d'));
     assert.deepEqual(graph.getAllEdges(), [
-      {from: 'a', to: 'b'},
-      {from: 'a', to: 'd'}
+      {from: 'a', to: 'b', type: null},
+      {from: 'a', to: 'd', type: null}
     ]);
   });
 });


### PR DESCRIPTION
This implements basic support for edge types in the graph. This allows for multiple edges between nodes, along differing edge types.

This also implements a basic filter for traversal, which allows traversal to only traverse along a path of a given edge type. In the future we may expand this to considering multiple types, only edge types between certain types of nodes, etc.

This is implemented by expanding `AdjacencyList` to be a `Map<FromId, Map<EdgeType, Set<ToId>>>`, which slightly complicates the internal structure.

This is fully backwards compatible, as it only adds a single optional parameter to most existing interfaces. If the `type` parameter is not provided, internally it falls back to `null` which is an acceptable edge type indicating nothing was provided.

Alternate designs:
* Use a sentinel symbol value rather than `null` to indicate the absence of an edge type

Test Plan: Added unit tests