### PR TITLE
Cache asset graph, bundle graph, and packager/optimizer results

### DIFF
--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -41,6 +41,19 @@ export default class Cache {
     });
   }
 
+  async blobExists(key: string): Promise<boolean> {
+    return this.fs.exists(this._getCachePath(key, '.blob'));
+  }
+
+  async getBlob(key: string, encoding?: buffer$Encoding) {
+    return this.fs.readFile(this._getCachePath(key, '.blob'), encoding);
+  }
+
+  async setBlob(key: string, contents: Buffer | string) {
+    await this.fs.writeFile(this._getCachePath(key, '.blob'), contents);
+    return key;
+  }
+
   async get(key: string) {
     try {
       let data = await this.fs.readFile(this._getCachePath(key));

--- a/packages/core/core/src/Asset.js
+++ b/packages/core/core/src/Asset.js
@@ -26,7 +26,7 @@ import {
   loadConfig,
   md5FromFilePath,
   md5FromString,
-  readableFromStringOrBuffer,
+  blobToStream,
   TapStream
 } from '@parcel/utils';
 import Dependency from './Dependency';
@@ -209,11 +209,7 @@ export default class Asset {
       this.content = this.cache.getStream(this.contentKey);
     }
 
-    if (this.content instanceof Readable) {
-      return this.content;
-    }
-
-    return readableFromStringOrBuffer(this.content);
+    return blobToStream(this.content);
   }
 
   setCode(code: string) {
@@ -230,10 +226,7 @@ export default class Asset {
 
   async getMap(): Promise<?SourceMap> {
     if (this.mapKey != null) {
-      let cached = await this.cache.get(this.mapKey);
-      if (cached != null) {
-        this.map = SourceMap.deserialize(cached);
-      }
+      this.map = await this.cache.get(this.mapKey);
     }
 
     return this.map;

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -2,8 +2,8 @@
 import EventEmitter from 'events';
 
 import type {AssetRequest, ParcelOptions, Target} from '@parcel/types';
-import {PromiseQueue} from '@parcel/utils';
-import type {Event} from '@parcel/watcher';
+import {PromiseQueue, md5FromObject, md5FromString} from '@parcel/utils';
+import watcher, {type Event} from '@parcel/watcher';
 
 import type Asset from './Asset';
 import AssetGraph from './AssetGraph';
@@ -16,6 +16,8 @@ import type {
 } from './types';
 
 import dumpToGraphViz from './dumpGraphToGraphViz';
+import Cache from '@parcel/cache';
+import path from 'path';
 
 type Opts = {|
   options: ParcelOptions,
@@ -30,43 +32,64 @@ export default class AssetGraphBuilder extends EventEmitter {
   requestGraph: RequestGraph;
   queue: PromiseQueue;
   controller: AbortController;
-  changedAssets: Map<string, Asset>;
+  changedAssets: Map<string, Asset> = new Map();
+  options: ParcelOptions;
+  cacheKey: string;
+  cache: Cache;
 
-  constructor({config, options, entries, targets, assetRequest}: Opts) {
-    super();
+  async init({config, options, entries, targets, assetRequest}: Opts) {
+    this.options = options;
+    let {minify, hot, scopeHoist} = options;
+    this.cacheKey = md5FromObject({
+      options: {minify, hot, scopeHoist},
+      entries,
+      targets
+    });
 
-    this.changedAssets = new Map();
+    this.cache = new Cache(options.outputFS, options.cacheDir);
 
-    this.assetGraph = new AssetGraph({
+    let changes = await this.readFromCache();
+    if (!changes) {
+      this.assetGraph = new AssetGraph();
+      this.requestGraph = new RequestGraph();
+    }
+
+    this.assetGraph.initOptions({
       onNodeAdded: node => this.handleNodeAddedToAssetGraph(node),
       onNodeRemoved: node => this.handleNodeRemovedFromAssetGraph(node)
     });
-    this.requestGraph = new RequestGraph({
+
+    this.requestGraph.initOptions({
       config,
       options,
       onAssetRequestComplete: this.handleCompletedAssetRequest.bind(this),
       onDepPathRequestComplete: this.handleCompletedDepPathRequest.bind(this)
     });
 
-    this.assetGraph.initialize({
-      entries,
-      targets,
-      assetGroup: assetRequest
-    });
+    if (changes) {
+      this.respondToFSEvents(changes);
+    } else {
+      this.assetGraph.initialize({
+        entries,
+        targets,
+        assetGroup: assetRequest
+      });
+    }
   }
 
   async build(): Promise<{|
     assetGraph: AssetGraph,
     changedAssets: Map<string, Asset>
   |}> {
-    this.changedAssets = new Map();
-
     await this.requestGraph.completeRequests();
 
     dumpToGraphViz(this.assetGraph, 'AssetGraph');
     dumpToGraphViz(this.requestGraph, 'RequestGraph');
 
-    return {assetGraph: this.assetGraph, changedAssets: this.changedAssets};
+    let changedAssets = this.changedAssets;
+    this.changedAssets = new Map();
+
+    return {assetGraph: this.assetGraph, changedAssets: changedAssets};
   }
 
   handleNodeAddedToAssetGraph(node: AssetGraphNode) {
@@ -101,6 +124,9 @@ export default class AssetGraphBuilder extends EventEmitter {
     assets: Array<Asset>
   ) {
     this.assetGraph.resolveAssetGroup(requestNode.value, assets);
+    for (let asset of assets) {
+      this.changedAssets.set(asset.id, asset); // ? Is this right?
+    }
   }
 
   handleCompletedDepPathRequest(
@@ -120,6 +146,61 @@ export default class AssetGraphBuilder extends EventEmitter {
 
   initFarm() {
     return this.requestGraph.initFarm();
+  }
+
+  getWatcherOptions() {
+    let targetDirs = this.options.targets.map(target => target.distDir);
+    let vcsDirs = ['.git', '.hg'].map(dir =>
+      path.join(this.options.projectRoot, dir)
+    );
+    let ignore = [this.options.cacheDir, ...targetDirs, ...vcsDirs];
+    return {ignore};
+  }
+
+  getCacheKeys() {
+    let assetGraphKey = md5FromString(`${this.cacheKey}:assetGraph`);
+    let requestGraphKey = md5FromString(`${this.cacheKey}:requestGraph`);
+    let snapshotKey = md5FromString(`${this.cacheKey}:snapshot`);
+    return {assetGraphKey, requestGraphKey, snapshotKey};
+  }
+
+  async readFromCache(): Promise<?Array<Event>> {
+    if (this.options.cache === false) {
+      return null;
+    }
+
+    let {assetGraphKey, requestGraphKey, snapshotKey} = this.getCacheKeys();
+    let assetGraph = await this.cache.get(assetGraphKey);
+    let requestGraph = await this.cache.get(requestGraphKey);
+
+    if (assetGraph && requestGraph) {
+      this.assetGraph = assetGraph;
+      this.requestGraph = requestGraph;
+
+      let opts = this.getWatcherOptions();
+      let snapshotPath = this.cache._getCachePath(snapshotKey, '.txt');
+      return watcher.getEventsSince(
+        this.options.projectRoot,
+        snapshotPath,
+        opts
+      );
+    }
+
+    return null;
+  }
+
+  async writeToCache() {
+    if (this.options.cache === false) {
+      return;
+    }
+
+    let {assetGraphKey, requestGraphKey, snapshotKey} = this.getCacheKeys();
+    await this.cache.set(assetGraphKey, this.assetGraph);
+    await this.cache.set(requestGraphKey, this.requestGraph);
+
+    let opts = this.getWatcherOptions();
+    let snapshotPath = this.cache._getCachePath(snapshotKey, '.txt');
+    await watcher.writeSnapshot(this.options.projectRoot, snapshotPath, opts);
   }
 }
 

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -228,13 +228,7 @@ export default class Graph<TNode: Node, TEdgeType: string | null = null> {
         : outboundEdges
     );
     for (let toNode of toNodes) {
-      let existingNode = this.getNode(toNode.id);
-      if (!existingNode) {
-        this.addNode(toNode);
-      } else {
-        existingNode.value = toNode.value;
-      }
-
+      this.addNode(toNode);
       childrenToRemove.delete(toNode.id);
 
       if (!this.hasEdge(fromNode.id, toNode.id, type)) {

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -88,7 +88,8 @@ export default class Parcel {
       options: resolvedOptions
     });
 
-    this.#assetGraphBuilder = new AssetGraphBuilder({
+    this.#assetGraphBuilder = new AssetGraphBuilder();
+    await this.#assetGraphBuilder.init({
       options: resolvedOptions,
       config,
       entries: resolvedOptions.entries,
@@ -106,13 +107,18 @@ export default class Parcel {
   }
 
   async run(): Promise<IBundleGraph> {
+    let startTime = Date.now();
     if (!this.#initialized) {
       await this.init();
     }
 
-    let result = await this.build();
+    let result = await this.build(startTime);
 
     let resolvedOptions = nullthrows(this.#resolvedOptions);
+    if (result.type === 'buildSuccess') {
+      await this.#assetGraphBuilder.writeToCache();
+    }
+
     if (resolvedOptions.killWorkers !== false) {
       await this.#farm.end();
     }
@@ -172,13 +178,12 @@ export default class Parcel {
     };
   }
 
-  async build(): Promise<BuildEvent> {
+  async build(startTime: number = Date.now()): Promise<BuildEvent> {
     try {
       this.#reporterRunner.report({
         type: 'buildStart'
       });
 
-      let startTime = Date.now();
       let {assetGraph, changedAssets} = await this.#assetGraphBuilder.build();
       dumpGraphToGraphViz(assetGraph, 'MainAssetGraph');
 
@@ -265,11 +270,7 @@ export default class Parcel {
     invariant(this.#watcherSubscription == null);
 
     let resolvedOptions = nullthrows(this.#resolvedOptions);
-    let targetDirs = resolvedOptions.targets.map(target => target.distDir);
-    let vcsDirs = ['.git', '.hg'].map(dir =>
-      path.join(resolvedOptions.projectRoot, dir)
-    );
-    let ignore = [resolvedOptions.cacheDir, ...targetDirs, ...vcsDirs];
+    let opts = this.#assetGraphBuilder.getWatcherOptions();
 
     return watcher.subscribe(
       resolvedOptions.projectRoot,
@@ -293,7 +294,7 @@ export default class Parcel {
           }
         }
       },
-      {ignore}
+      opts
     );
   }
 }

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -142,6 +142,10 @@ export class Bundle implements IBundle {
 
     return result;
   }
+
+  getHash(): string {
+    return this.#bundle.assetGraph.getHash();
+  }
 }
 
 export class MutableBundle extends Bundle implements IMutableBundle {

--- a/packages/core/core/src/public/MainAssetGraph.js
+++ b/packages/core/core/src/public/MainAssetGraph.js
@@ -91,4 +91,8 @@ export default class MainAssetGraph implements IMainAssetGraph {
   traverseAssets<TContext>(visit: GraphVisitor<IAsset, TContext>): ?TContext {
     return this.#graph.traverseAssets(assetGraphVisitorToInternal(visit));
   }
+
+  getHash(): string {
+    return this.#graph.getHash();
+  }
 }

--- a/packages/core/core/src/registerCoreWithSerializer.js
+++ b/packages/core/core/src/registerCoreWithSerializer.js
@@ -8,6 +8,8 @@ import ParcelConfig from './ParcelConfig';
 import Dependency from './Dependency';
 import Environment from './Environment';
 import {BundleReference} from './public/BundleGraph';
+import RequestGraph from './RequestGraph';
+import Config from './public/Config';
 // $FlowFixMe this is untyped
 import packageJson from '../package.json';
 
@@ -29,7 +31,9 @@ export default function registerCoreWithSerializer() {
     ParcelConfig,
     Dependency,
     Environment,
-    BundleReference
+    BundleReference,
+    RequestGraph,
+    Config
   ]) {
     register(ctor);
   }

--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -51,7 +51,7 @@ describe('AssetGraphBuilder', () => {
       .config;
 
     builder = new AssetGraphBuilder();
-    builder.init({
+    await builder.init({
       options: DEFAULT_OPTIONS,
       config,
       entries: ['./module-b'],

--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -50,7 +50,8 @@ describe('AssetGraphBuilder', () => {
     config = nullthrows(await resolve(inputFS, path.join(CONFIG_DIR, 'index')))
       .config;
 
-    builder = new AssetGraphBuilder({
+    builder = new AssetGraphBuilder();
+    builder.init({
       options: DEFAULT_OPTIONS,
       config,
       entries: ['./module-b'],

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -2,12 +2,11 @@
 import type {FileSystem} from './types';
 import type {FilePath} from '@parcel/types';
 
-import {promisify} from 'util';
 import fs from 'fs';
 import ncp from 'ncp';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
-import {registerSerializableClass} from '@parcel/utils';
+import {registerSerializableClass, promisify} from '@parcel/utils';
 import packageJSON from '../package.json';
 
 // Most of this can go away once we only support Node 10+, which includes

--- a/packages/core/source-map/src/SourceMap.js
+++ b/packages/core/source-map/src/SourceMap.js
@@ -2,9 +2,11 @@
 import type {Mapping, Position, MappingItem, RawSourceMap} from 'source-map';
 import type {FileSystem} from '@parcel/fs';
 import {SourceMapConsumer, SourceMapGenerator} from 'source-map';
-import {countLines} from '@parcel/utils';
+import {countLines, registerSerializableClass} from '@parcel/utils';
 import path from 'path';
 import nullthrows from 'nullthrows';
+// $FlowFixMe
+import pkg from '../package.json';
 
 type RawMapInput = SourceMapConsumer | string | RawSourceMap;
 
@@ -384,14 +386,6 @@ export default class SourceMap {
 
     return generator.toString();
   }
-
-  static deserialize({
-    mappings,
-    sources
-  }: {
-    mappings: Array<Mapping>,
-    sources: Sources
-  }) {
-    return new SourceMap(mappings, sources);
-  }
 }
+
+registerSerializableClass(`${pkg.version}:SourceMap`, SourceMap);

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -385,6 +385,7 @@ interface AssetGraphLike {
   getDependencyResolution(dependency: Dependency): ?Asset;
   getIncomingDependencies(asset: Asset): Array<Dependency>;
   traverseAssets<TContext>(visit: GraphVisitor<Asset, TContext>): ?TContext;
+  getHash(): string;
 }
 
 export type BundleTraversable =
@@ -470,6 +471,12 @@ export interface MutableBundleGraph {
   ): ?TContext;
 }
 
+export type BundleResult = {|
+  contents: Blob,
+  ast?: AST,
+  map?: ?SourceMap
+|};
+
 export type Bundler = {|
   bundle({
     assetGraph: MainAssetGraph,
@@ -506,7 +513,7 @@ export type Packager = {|
     bundleGraph: BundleGraph,
     options: ParcelOptions,
     sourceMapPath: FilePath
-  }): Async<{|contents: Blob, map?: ?SourceMap|}>
+  }): Async<BundleResult>
 |};
 
 export type Optimizer = {|
@@ -515,7 +522,7 @@ export type Optimizer = {|
     contents: Blob,
     map: ?SourceMap,
     options: ParcelOptions
-  }): Async<{|contents: Blob, map?: ?SourceMap|}>
+  }): Async<BundleResult>
 |};
 
 export type Resolver = {|

--- a/packages/core/utils/src/stream.js
+++ b/packages/core/utils/src/stream.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
 import {Readable} from 'stream';
+import type {Blob} from '@parcel/types';
 
 export async function measureStreamLength(stream: Readable): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -32,4 +33,12 @@ export async function bufferStream(stream: Readable): Promise<Buffer> {
     });
     stream.on('error', reject);
   });
+}
+
+export function blobToStream(blob: Blob): Readable {
+  if (blob instanceof Readable) {
+    return blob;
+  }
+
+  return readableFromStringOrBuffer(blob);
 }

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -4,7 +4,6 @@ import type {Bundle, FilePath} from '@parcel/types';
 
 import {Namer} from '@parcel/plugin';
 import assert from 'assert';
-import crypto from 'crypto';
 import path from 'path';
 
 const COMMON_NAMES = new Set(['index', 'src', 'lib']);
@@ -49,7 +48,7 @@ export default new Namer({
     //      `index.css`.
     let name = nameFromContent(firstBundleInGroup, options.rootDir);
     if (!bundle.isEntry) {
-      name += '.' + getHash(bundle).slice(-8);
+      name += '.' + bundle.getHash().slice(-8);
     }
     return name + '.' + bundle.type;
   }
@@ -75,13 +74,4 @@ function nameFromContent(bundle: Bundle, rootDir: FilePath): string {
 
     return name;
   }
-}
-
-function getHash(bundle: Bundle): string {
-  let hash = crypto.createHash('md5');
-  bundle.traverseAssets(asset => {
-    hash.update(asset.outputHash);
-  });
-
-  return hash.digest('hex');
 }


### PR DESCRIPTION
Currently, the Parcel cache only stores individual assets, but there are now a few other things that can be cached. This PR adds caching for the asset graph as a whole, the bundle graph, and the results of packaging and optimizing individual bundles.

## Asset Graph

When Parcel exits, it now writes the full asset graph and request graph into the cache. When it starts up again, it can simply load them from disk rather than rebuild them from scratch. Even with individual asset transformations cached, it was still slow to build the entire graph for large applications due to resolving and checking the cache individually for each asset.

To make this work, we also use the new watcher to store a snapshot of the current filesystem into the cache along side the graphs. When Parcel starts up, it loads the graphs, and checks with the watcher to see what files have changed since the snapshot. Then, it applies those changes to the graph just like it does in watch mode. This means that if nothing changes between parcel runs, no work will occur. If only one file changes, then only that file will be re-transformed.

Since we store the entire graph in the cache now, and that includes the individual asset nodes (though not their contents), it raises the question of whether we need to store the individual assets at all. I guess the intermediary assets between pipelines might make that useful still, but there is some duplication now.

## Bundle Graph

We also now cache the bundle graph. If the asset graph does not change, then the bundle graph will also not change, so we can just reuse the same bundle graph from the cache. This is currently really only a performance gain if you restart parcel without changing anything. Perhaps it won't be necessary if the new bundler is sufficiently fast as well. In the future, I could see us caching the bundle graph and somehow only rebuilding bundles that changed, but that requires further thought.

## Packagers and Optimizers

We now cache the result of packaging and optimizing individual bundles. This is based on a hash of the bundle's asset graph, along with the parcel plugins + versions that were used to create it. Eventually, this should also include any third party configs used by those plugins, similar to what we're doing for transformers.

## Performance

I tested this on a relatively small app that just imported something from material-ui. Output size after minifying was ~86kb.

* Uncached (v2): 5.96s
* Cached (v2): 3.78s
* Cached (cache-graph): 402ms

About 200ms of the remaining time is actually just requiring plugins (specifically the reporter). Perhaps that will be reduced once we start bundling plugins for publishing.

## Follow up

* **Garbage collection**: this is needed in general, but this PR adds a bunch more things to the cache which will need to be garbage collected. Would be good to discuss this. One way to avoid it would be to not make the hash part of the cache key, and instead move it inside the cache entry and check it after retrieving. This would mean the cache key would not change every time. But perhaps there is a better way.
* **Third party config**: we need third party config support like we have to transformers in all of our other plugins as well, and we need to track when that changes and invalidate bundling/packaging/optimizing.
* **Abstract watcher**: we should probably abstract the watcher as part of the filesystem implementations so it works e.g. in the browser.