### PR TITLE
Process Pug output with PostHTML

### DIFF
--- a/packages/core/integration-tests/test/integration/pug-posthtml/.posthtmlrc.js
+++ b/packages/core/integration-tests/test/integration/pug-posthtml/.posthtmlrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+	plugins: [
+		// Admittedly, using PostHTML for includes in Pug is unnecessary,
+		// but posthtml-include is already a development dependency of Parcel,
+		// so it's an easy pick for this example.
+    require('posthtml-include')({
+      root: __dirname
+    })
+  ]
+}

--- a/packages/core/integration-tests/test/integration/pug-posthtml/included.html
+++ b/packages/core/integration-tests/test/integration/pug-posthtml/included.html
@@ -1,0 +1,1 @@
+<div>I'm included!</div>

--- a/packages/core/integration-tests/test/integration/pug-posthtml/index.pug
+++ b/packages/core/integration-tests/test/integration/pug-posthtml/index.pug
@@ -1,0 +1,6 @@
+doctype html
+html
+  head
+    title Pug with PostHTML
+  body
+    | <include src="included.html"></include>

--- a/packages/core/integration-tests/test/pug.js
+++ b/packages/core/integration-tests/test/pug.js
@@ -123,6 +123,24 @@ describe('pug', function() {
     assert(html.includes('FILTERED: Hello!'));
   });
 
+  it('should support post-processing with PostHTML', async function() {
+    const b = await bundle(
+      path.join(__dirname, '/integration/pug-posthtml/index.pug')
+    );
+
+    await assertBundleTree(b, {
+      name: 'index.html',
+      assets: ['index.pug']
+    });
+
+    const html = await fs.readFile(
+      path.join(__dirname, '/dist/index.html'),
+      'utf-8'
+    );
+    assert(html.includes(`I'm included!`));
+    assert(!html.includes('<include src="included.html"></include>'));
+  });
+
   it('should minify HTML in production mode', async function() {
     const b = await bundle(
       path.join(__dirname, '/integration/pug-minify/index.pug'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,10 +2861,29 @@ charenc@~0.0.1:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-chokidar@^2.0.0, chokidar@^2.0.3, chokidar@^2.0.4:
+chokidar@^2.0.0, chokidar@^2.0.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.5.tgz#0ae8434d962281a5f56c72869e79cb6d9d86ad4d"
   integrity sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+chokidar@^2.1.5:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
+  integrity sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -3931,10 +3950,10 @@ dot-prop@^4.1.1, dot-prop@^4.2.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv-expand@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-4.2.0.tgz#def1f1ca5d6059d24a766e587942c21106ce1275"
-  integrity sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=
+dotenv-expand@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
 dotenv@^5.0.0:
   version "5.0.1"
@@ -4049,6 +4068,11 @@ entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+envinfo@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.3.1.tgz#892e42f7bf858b3446d9414ad240dbaf8da52f09"
+  integrity sha512-GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A==
 
 err-code@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull request

This processes the output of Pug files with PostHTML. It does this by using `HTMLAsset` as the base class of `PugAsset`, instead of `Asset`. The `parse()` method on the refactored `PugAsset` class simply compiles the Pug files into HTML before passing them off to `HTMLAsset.parse()` to convert the result into an AST. The existing functionality of `HTMLAsset` takes care of the rest, as if the Pug files had been HTML files all along.

This fixes #3252.

## 💻 Examples

Consider the following project directory:

```
📂 example
├ 📄 .posthtmlrc.js
├ 📄 included.html
├ 📄 index.pug
```
```js
// .posthtmlrc.js
module.exports = {
  plugins: [
    require('posthtml-include')({
      root: __dirname
    })
  ]
}
```

```html
<!-- included.html -->
<div>I'm included!</div>
```

```pug
//- index.pug
doctype html
html
  head
    title Pug with PostHTML
  body
    | <include src="included.html"></include>
```

With this change, Parcel will now output an `index.html` file with the contents of `included.html`, instead of leaving `<include src="included.html"></include>` in place. (This is a trivial example, considering Pug has a built-in includes system, but this will allow all PostHTML plugins to process Pug output.)

## 🚨 Test instructions

I have added an integration test for this change, and all other integration tests for `PugAsset` still pass as well. As far as I know, there are no other tests affected by this change.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
