### PR TITLE
Fix #3156

### DIFF
--- a/packages/core/parcel-bundler/src/transforms/posthtml.js
+++ b/packages/core/parcel-bundler/src/transforms/posthtml.js
@@ -45,7 +45,10 @@ async function getConfig(asset) {
           asset.addDependency(name, {includedInParent: true})
       }
     };
-    Object.keys(plugins).forEach(p => Object.assign(plugins[p], depConfig));
+    
+    Object.keys(plugins).forEach(p => {
+        plugins[p] = Object.assign({}, plugins[p], depConfig);
+    });
   }
   config.plugins = await loadPlugins(plugins, asset.name);
   config.skipParse = true;


### PR DESCRIPTION
`.posthtmlrc` plugins can now have `true` instead of an empty object when no configuration is needed.
This conforms to the documentation: https://parceljs.org/html.html#posthtml.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This resolves #3156 (That is already closed, but not fixed).

So when using posthtml plugins, sometimes no configuration is required, and according to [parcel's official documentation](https://parceljs.org/html.html#posthtml)
> If there are no options for a plugin, just set it to `true` instead.

The problem was that for some reason(I don't know why) the object for the settings of each plugin is modified by using `Object.assign(pluginsSettings, settingsToAdd)`.
However, when `Object.assign` is passed a boolean as the first argument it fails silently(technically the operation is performed, but its still a boolean, so there is no access to those props anymore).

You can see the code for the fix, but basically, I did it that way in order to avoid an `if` check.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
To be honest im not familiar enough with the internals of Parcel to do a good test.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
