### PR TITLE
No longer use unref in Workers

### DIFF
--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -41,10 +41,6 @@ export default class ProcessWorker implements WorkerImpl {
       cwd: process.cwd()
     });
 
-    // Unref the child and IPC channel so that the workers don't prevent the main process from exiting
-    this.child.unref();
-    this.child.channel.unref();
-
     this.child.on('message', (data: string) => {
       this.onMessage(deserialize(Buffer.from(data, 'base64')));
     });

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -45,8 +45,6 @@ export default class ThreadsWorker implements WorkerImpl {
     this.worker.on('error', this.onError);
     this.worker.on('exit', this.onExit);
 
-    this.worker.unref();
-
     return new Promise(resolve => {
       this.worker.on('online', resolve);
     });


### PR DESCRIPTION
The deleted code was originally added for @parcel/register so processes would not hang, but it also caused a weird issue where Parcel could potentially exit early with a clean exit code. It is also not even beneficial for @parcel/register to use Workers because it is hooking into require which is synchronous and cannot be parallelized.