### PR TITLE
Support loading runtimes from multiple inbound dependencies

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -57,6 +57,7 @@ export default new Bundler({
 
         return {
           bundleGroup,
+          bundleGroupDependency: dependency,
           bundleByType,
           parentNode: node
         };
@@ -90,7 +91,7 @@ export default new Bundler({
             bundle = bundleGraph.createBundle({
               entryAsset: asset,
               target: context.bundleGroup.target,
-              isEntry: context.bundleGroup.dependency.isEntry
+              isEntry: context.bundleGroupDependency.isEntry
             });
             bundleGraph.addBundleToBundleGroup(bundle, context.bundleGroup);
             context.bundleByType.set(bundle.type, bundle);

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -9,7 +9,13 @@ import type {
   TraversalActions
 } from '@parcel/types';
 
-import type {AssetNode, Bundle, BundleGraphNode, DependencyNode} from './types';
+import type {
+  AssetNode,
+  Bundle,
+  BundleGraphNode,
+  BundleGroupNode,
+  DependencyNode
+} from './types';
 import type Asset from './Asset';
 import type Graph from './Graph';
 
@@ -292,6 +298,61 @@ export default class BundleGraph {
         invariant(node.type === 'bundle');
         return node.value;
       });
+  }
+
+  getBundleGroupsReferencedByBundle(
+    bundle: Bundle
+  ): Array<{bundleGroup: BundleGroup, dependency: IDependency}> {
+    let node = nullthrows(
+      this._graph.getNode(bundle.id),
+      'Bundle graph must contain bundle'
+    );
+
+    let groupNodes: Array<BundleGroupNode> = [];
+    this._graph.traverse(
+      (node, context, actions) => {
+        if (node.type === 'bundle_group') {
+          groupNodes.push(node);
+          actions.skipChildren();
+        }
+      },
+      node,
+      'bundle'
+    );
+
+    return (
+      groupNodes
+        .map(groupNode => {
+          let dependencyNode = this._graph
+            .getNodesConnectedTo(groupNode)
+            .find(
+              node =>
+                node.type === 'dependency' &&
+                this._graph.hasEdge(bundle.id, node.id, 'contains')
+            );
+
+          // TODO: Enforce non-null when bundle groups have the correct bundles
+          // pointing to them
+          invariant(
+            dependencyNode == null || dependencyNode.type === 'dependency'
+          );
+
+          return {
+            bundleGroup: groupNode.value,
+            dependency: dependencyNode?.value
+          };
+        })
+        // TODO: Remove this filter when bundle groups have the correct bundles
+        // pointing to them
+        .filter(({dependency}) => dependency != null)
+        .map(({bundleGroup, dependency}) => {
+          invariant(dependency != null);
+          return {
+            bundleGroup,
+            dependency
+          };
+        })
+    );
   }
 
   getIncomingDependencies(asset: Asset): Array<IDependency> {

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -12,8 +12,6 @@ import type {
 import type InternalBundleGraph from '../BundleGraph';
 
 import invariant from 'assert';
-import nullthrows from 'nullthrows';
-
 import {assetToInternalAsset, Asset} from './Asset';
 import {Bundle, bundleToInternalBundle} from './Bundle';
 import {mapVisitor} from '../Graph';
@@ -42,20 +40,12 @@ export default class BundleGraph implements IBundleGraph {
     );
   }
 
-  getBundleGroupsReferencedByBundle(bundle: IBundle): Array<BundleGroup> {
-    let node = nullthrows(
-      this.#graph._graph.getNode(bundle.id),
-      'Bundle graph must contain bundle'
+  getBundleGroupsReferencedByBundle(
+    bundle: IBundle
+  ): Array<{bundleGroup: BundleGroup, dependency: IDependency}> {
+    return this.#graph.getBundleGroupsReferencedByBundle(
+      bundleToInternalBundle(bundle)
     );
-
-    let groups = [];
-    this.#graph._graph.traverse((node, context, actions) => {
-      if (node.type === 'bundle_group') {
-        groups.push(node.value);
-        actions.skipChildren();
-      }
-    }, node);
-    return groups;
   }
 
   getDependencies(asset: IAsset): Array<IDependency> {

--- a/packages/core/core/src/public/BundlerBundleGraph.js
+++ b/packages/core/core/src/public/BundlerBundleGraph.js
@@ -54,7 +54,6 @@ export class BundlerBundleGraph implements IBundlerBundleGraph {
     }
 
     let bundleGroup: BundleGroup = {
-      dependency,
       target,
       entryAssetId: resolved.id
     };

--- a/packages/core/integration-tests/test/integration/shared-bundlegroup/a.js
+++ b/packages/core/integration-tests/test/integration/shared-bundlegroup/a.js
@@ -1,0 +1,1 @@
+export default import('./c.js').then(mod => 'hello from a ' + mod.default);

--- a/packages/core/integration-tests/test/integration/shared-bundlegroup/b.js
+++ b/packages/core/integration-tests/test/integration/shared-bundlegroup/b.js
@@ -1,0 +1,1 @@
+export default import('./c.js').then(mod => 'hello from b ' + mod.default);

--- a/packages/core/integration-tests/test/integration/shared-bundlegroup/c.js
+++ b/packages/core/integration-tests/test/integration/shared-bundlegroup/c.js
@@ -1,0 +1,1 @@
+export default 'test';

--- a/packages/core/integration-tests/test/integration/shared-bundlegroup/index.js
+++ b/packages/core/integration-tests/test/integration/shared-bundlegroup/index.js
@@ -1,0 +1,2 @@
+export default Promise.all([import('./a.js'), import('./b.js')])
+  .then(modules => Promise.all(modules.map(mod => mod.default)));

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1372,4 +1372,36 @@ describe('javascript', function() {
 
     await run(b);
   });
+
+  it('supports async importing the same module from different bundles', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/shared-bundlegroup/index.js')
+    );
+
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'index.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'bundle-url.js',
+          'bundle-loader.js',
+          'js-loader.js'
+        ]
+      },
+      {
+        assets: ['a.js', 'JSRuntime.js']
+      },
+      {
+        assets: ['b.js', 'JSRuntime.js']
+      },
+      {
+        assets: ['c.js']
+      }
+    ]);
+
+    let {default: promise} = await run(b);
+    assert.deepEqual(await promise, ['hello from a test', 'hello from b test']);
+  });
 });

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -467,7 +467,6 @@ export interface NamedBundle extends Bundle {
 }
 
 export type BundleGroup = {
-  dependency: Dependency,
   target: Target,
   entryAssetId: string
 };
@@ -475,7 +474,9 @@ export type BundleGroup = {
 export interface BundleGraph {
   getBundles(): Array<Bundle>;
   getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
-  getBundleGroupsReferencedByBundle(bundle: Bundle): Array<BundleGroup>;
+  getBundleGroupsReferencedByBundle(
+    bundle: Bundle
+  ): Array<{bundleGroup: BundleGroup, dependency: Dependency}>;
   getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<Bundle>;
   getDependencies(asset: Asset): Array<Dependency>;
   getIncomingDependencies(asset: Asset): Array<Dependency>;

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -41,11 +41,12 @@ export default new Runtime({
       return assets;
     }
 
-    for (let bundleGroup of bundleGraph.getBundleGroupsReferencedByBundle(
-      bundle
-    )) {
+    for (let {
+      bundleGroup,
+      dependency
+    } of bundleGraph.getBundleGroupsReferencedByBundle(bundle)) {
       // Ignore deps with native loaders, e.g. workers.
-      if (bundleGroup.dependency.isURL) {
+      if (dependency.isURL) {
         continue;
       }
 
@@ -79,7 +80,7 @@ export default new Runtime({
           code: `module.exports = require('./bundle-loader')([${loaderModules.join(
             ', '
           )}, ${JSON.stringify(bundleGroup.entryAssetId)}]);`,
-          dependency: bundleGroup.dependency
+          dependency
         });
       } else {
         for (let bundle of bundles) {
@@ -100,7 +101,7 @@ export default new Runtime({
               bundle.target.publicUrl,
               nullthrows(bundle.name)
             )}'`,
-            dependency: bundleGroup.dependency
+            dependency
           });
         }
       }


### PR DESCRIPTION
This corrects a bug when multiple bundles attempted to async import a module, only one would receive the necessary runtime code to load it.

As a concrete example:

`index.js`:
```js
import('./a');
import('./b');
```

`a.js`:
```js
import('./c');
```

`b.js`:
```js
import('./c');
```

(And some `c.js`, but contents don't matter)

Fails to run, as one of `a` or `b` does not get the necessary runtime code.

Both bundles would have dependencies pointing to the bundle group containing the bundled async module, but because bundle groups had only one reference to an inbound dependency, only the dependency referenced there would have runtime code inserted.

This is fixed by using the relationship between dependencies and bundle groups encoded in the bundlegraph, rather than using a property on bundle groups. The `dependency` property on bundle groups has been removed.

Test Plan: Run the added unit test without this patch, and verify it fails. Add this patch and verify it passes.