### PR TITLE
Config: resolve all entries and rootDir to absolute paths

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -24,9 +24,9 @@ export default async function resolveOptions(
   if (initialOptions.entries == null || initialOptions.entries === '') {
     entries = [];
   } else if (Array.isArray(initialOptions.entries)) {
-    entries = initialOptions.entries;
+    entries = initialOptions.entries.map(entry => path.resolve(entry));
   } else {
-    entries = [initialOptions.entries];
+    entries = [path.resolve(initialOptions.entries)];
   }
 
   let inputFS = initialOptions.inputFS || new NodeFS();
@@ -34,7 +34,7 @@ export default async function resolveOptions(
 
   let rootDir =
     initialOptions.rootDir != null
-      ? initialOptions.rootDir
+      ? path.resolve(initialOptions.rootDir)
       : getRootDir(entries);
 
   let projectRootFile =


### PR DESCRIPTION
This makes `rootDir` always an absolute path by:
* Resolving it relative to cwd if specified by programmatic api
* Resolving all entries (which should also be absolute paths anyway), so that `getRootDir` also returns an absolute path

Test Plan: 
* Use the programmatic api and pass relative entries, and verify that the resulting `rootDir` is absolute. Note that bundle names are correct since they relied on finding a the path between `rootDir` and the entry asset path.
* Use the programmatic api and pass a relative `rootDir`. Verify it is resolved to an absolute path.