### PR TITLE
Use parentNode.removeChild instead of remove to support IE11

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/css-loader.js
+++ b/packages/core/parcel-bundler/src/builtins/css-loader.js
@@ -3,7 +3,9 @@ var bundle = require('./bundle-url');
 function updateLink(link) {
   var newLink = link.cloneNode();
   newLink.onload = function () {
-    link.remove();
+    if (link.parentNode !== null) {
+        link.parentNode.removeChild(link);
+    }
   };
   newLink.href = link.href.split('?')[0] + '?' + Date.now();
   link.parentNode.insertBefore(newLink, link.nextSibling);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
Try to fix #3291 by using `parentNode.removeChild` instead of `remove` because it's not supported by IE11.
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
