### PR TITLE
Copy devserver templates during build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,8 @@ const paths = {
   packageOther: [
     'packages/*/scope-hoisting/src/helpers.js',
     'packages/*/*/src/**/loaders/**',
-    'packages/*/*/src/**/prelude.js'
+    'packages/*/*/src/**/prelude.js',
+    'packages/*/dev-server/src/templates/**'
   ],
   packageJson: ['packages/*/*/package.json', ...IGNORED_PACKAGES],
   packages: 'packages/'


### PR DESCRIPTION
These are static resources that need to by copied as-is during build. We should probably reconfigure the build to exclude things rather than require everything to be specified.

Test Plan: `yarn build` and `ls packages/reporters/dev-server/lib/templates`