### PR TITLE
Adds --hmr-proxy-url CLI argument.

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
+++ b/packages/core/parcel-bundler/src/builtins/hmr-runtime.js
@@ -24,9 +24,15 @@ var checkedAssets, assetsToAccept;
 
 var parent = module.bundle.parent;
 if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
-  var hostname = process.env.HMR_HOSTNAME || location.hostname;
-  var protocol = location.protocol === 'https:' ? 'wss' : 'ws';
-  var ws = new WebSocket(protocol + '://' + hostname + ':' + process.env.HMR_PORT + '/');
+  var hmrUrl = '';
+  if (process.env.HMR_PROXY_URL) {
+    hmrUrl =  process.env.HMR_PROXY_URL;
+  } else {
+    var hostname = process.env.HMR_HOSTNAME || location.hostname;
+    var protocol = location.protocol === 'https:' ? 'wss' : 'ws';
+    hmrUrl = protocol + '://' + hostname + ':' + process.env.HMR_PORT + '/';
+  }
+  var ws = new WebSocket(hmrUrl);
   ws.onmessage = function(event) {
     checkedAssets = {};
     assetsToAccept = [];

--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -27,6 +27,10 @@ program
     '--hmr-hostname <hostname>',
     'set the hostname of HMR websockets, defaults to location.hostname of current window'
   )
+  .option(
+    '--hmr-proxy-url <url>',
+    'overrides the hmr websocket url used by the client.'
+  )
   .option('--https', 'serves files over HTTPS')
   .option('--cert <path>', 'path to certificate to use with HTTPS')
   .option('--key <path>', 'path to private key to use with HTTPS')
@@ -93,6 +97,10 @@ program
   .option(
     '--hmr-hostname <hostname>',
     'set the hostname of HMR websockets, defaults to location.hostname of current window'
+  )
+  .option(
+    '--hmr-proxy-url <url>',
+    'overrides the hmr websocket url used by the client.'
   )
   .option('--https', 'listen on HTTPS for HMR connections')
   .option('--cert <path>', 'path to certificate to use with HTTPS')

--- a/packages/core/parcel-bundler/src/packagers/JSPackager.js
+++ b/packages/core/parcel-bundler/src/packagers/JSPackager.js
@@ -24,7 +24,9 @@ class JSPackager extends Packager {
           this.options.hmrPort
         };process.env.HMR_HOSTNAME=${JSON.stringify(
           this.options.hmrHostname
-        )};` + preludeCode;
+        )};process.env.HMR_PROXY_URL=${JSON.stringify(
+          this.options.hmrProxyUrl
+          )};` + preludeCode;
     }
     await this.write(preludeCode + '({');
     this.lineOffset = lineCounter(preludeCode);

--- a/packages/core/parcel-bundler/src/worker.js
+++ b/packages/core/parcel-bundler/src/worker.js
@@ -8,6 +8,7 @@ function init(options) {
   Object.assign(process.env, options.env || {});
   process.env.HMR_PORT = options.hmrPort;
   process.env.HMR_HOSTNAME = options.hmrHostname;
+  process.env.HMR_PROXY_URL = options.hmrProxyUrl;
 }
 
 async function run(path, isWarmUp) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

We're trying to run parcel in [Gitpod](https://gitpod.io) and HMR was not working.
In Gitpod, web servers are exposed via a proxy, and something running on ```0.0.0.0:1337``` needs to be accessed via a special URL like ```1337-<Workspace ID>.<Region>.gitpod.io:443/``` . We made it work by connecting to it via special proxy like ```1337-abcd-1234.ws-eu0.gitpod.io:443``` 

Unfortunately ```parcel ./src/index.html --hmr-proxy-url="<our proxy url>"``` didnt worked  but  ```HMR_PROXY_URL="<our proxy url>" parcel ./src/index.html``` (command prefixed with an enviroment variable) worked we're not sure Why?