### PR TITLE
Don't create shared bundles from entry bundles

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -147,8 +147,12 @@ export default new Bundler({
       }
 
       let asset = node.value;
-      let containingBundles = bundleGraph.findBundlesWithAsset(asset);
-
+      let containingBundles = bundleGraph
+        .findBundlesWithAsset(asset)
+        // Don't create shared bundles from entry bundles, as that would require
+        // another entry bundle depending on these conditions, making it difficult
+        // to predict and reference.
+        .filter(b => !b.isEntry);
       if (containingBundles.length > OPTIONS.minBundles) {
         let id = containingBundles
           .map(b => b.id)

--- a/packages/core/integration-tests/test/integration/no-shared-bundles-from-entries/a.js
+++ b/packages/core/integration-tests/test/integration/no-shared-bundles-from-entries/a.js
@@ -1,0 +1,3 @@
+import _ from 'lodash'
+
+export default _.map([2, 3, 4], x => x + 1);

--- a/packages/core/integration-tests/test/integration/no-shared-bundles-from-entries/b.js
+++ b/packages/core/integration-tests/test/integration/no-shared-bundles-from-entries/b.js
@@ -1,0 +1,3 @@
+import _ from 'lodash'
+
+export default _.map([1, 2, 3], x => x + 1);

--- a/packages/core/integration-tests/test/integration/no-shared-bundles-from-entries/package.json
+++ b/packages/core/integration-tests/test/integration/no-shared-bundles-from-entries/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "lodash": "*"
+  }
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1373,7 +1373,7 @@ describe('javascript', function() {
     await run(b);
   });
 
-  it('supports async importing the same module from different bundles', async () => {
+  it('should support async importing the same module from different bundles', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/shared-bundlegroup/index.js')
     );
@@ -1403,5 +1403,25 @@ describe('javascript', function() {
 
     let {default: promise} = await run(b);
     assert.deepEqual(await promise, ['hello from a test', 'hello from b test']);
+  });
+
+  it('should not create shared bundles from contents of entries', async () => {
+    let b = await bundle(
+      [
+        '/integration/no-shared-bundles-from-entries/a.js',
+        '/integration/no-shared-bundles-from-entries/b.js'
+      ].map(entry => path.join(__dirname, entry))
+    );
+
+    await assertBundles(b, [
+      {
+        name: 'a.js',
+        assets: ['a.js', 'lodash.js']
+      },
+      {
+        name: 'b.js',
+        assets: ['b.js', 'lodash.js']
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Resolves #3303

This makes sure that we don't create shared bundles from entry bundles, since they would also need to be entries, and are conditionally created based on bundler options and bundler input, making them unpredictable and difficult to reference.

Test Plan: Added integration test