### PR TITLE
Don't deduplicate or share bundles in isolated environments

### DIFF
--- a/packages/core/integration-tests/test/integration/worker-no-deduplicate/index.js
+++ b/packages/core/integration-tests/test/integration/worker-no-deduplicate/index.js
@@ -1,0 +1,3 @@
+import _ from 'lodash';
+
+new Worker('worker-a.js');

--- a/packages/core/integration-tests/test/integration/worker-no-deduplicate/worker-a.js
+++ b/packages/core/integration-tests/test/integration/worker-no-deduplicate/worker-a.js
@@ -1,0 +1,3 @@
+import _ from 'lodash'
+
+new Worker('worker-b.js')

--- a/packages/core/integration-tests/test/integration/worker-no-deduplicate/worker-b.js
+++ b/packages/core/integration-tests/test/integration/worker-no-deduplicate/worker-b.js
@@ -1,0 +1,1 @@
+import _ from 'lodash'

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -423,6 +423,25 @@ describe('javascript', function() {
     });
   });
 
+  it('should not deduplicate assets from a parent bundle in workers', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/worker-no-deduplicate/index.js')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'lodash.js']
+      },
+      {
+        assets: ['worker-a.js', 'lodash.js']
+      },
+      {
+        assets: ['worker-b.js', 'lodash.js']
+      }
+    ]);
+  });
+
   it('should dynamic import files which import raw files', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/dynamic-references-raw/index.js')

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -175,10 +175,10 @@ export async function run(
 
 export async function assertBundles(
   bundleGraph: BundleGraph,
-  bundles: Array<{|
+  expectedBundles: Array<{|
     name?: string | RegExp,
     type?: string,
-    assets?: Array<string>
+    assets: Array<string>
   |}>
 ) {
   let actualBundles = [];
@@ -196,22 +196,25 @@ export async function assertBundles(
     });
   });
 
-  for (let bundle of bundles) {
-    // $FlowFixMe
+  for (let bundle of expectedBundles) {
+    if (!Array.isArray(bundle.assets)) {
+      throw new Error(
+        'Expected bundle must include an array of expected assets'
+      );
+    }
     bundle.assets.sort((a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1));
   }
 
-  // $FlowFixMe
-  bundles.sort((a, b) => (a.assets[0] < b.assets[0] ? -1 : 1));
+  expectedBundles.sort((a, b) => (a.assets[0] < b.assets[0] ? -1 : 1));
   actualBundles.sort((a, b) => (a.assets[0] < b.assets[0] ? -1 : 1));
   assert.equal(
     actualBundles.length,
-    bundles.length,
+    expectedBundles.length,
     'expected number of bundles mismatched'
   );
 
   let i = 0;
-  for (let bundle of bundles) {
+  for (let bundle of expectedBundles) {
     let actualBundle = actualBundles[i++];
     let name = bundle.name;
     if (name) {
@@ -235,8 +238,6 @@ export async function assertBundles(
     if (bundle.assets) {
       assert.deepEqual(actualBundle.assets, bundle.assets);
     }
-
-    // assert(await fs.exists(bundle.filePath), 'expected file does not exist');
   }
 }
 


### PR DESCRIPTION
Resolves #3327

This opts bundles with isolated environments out of optimizations in the bundler, as they are unable to access assets in parent bundles or load shared bundles.

Test Plan: Added integration test