### PR TITLE
Insert sibling bundle references into HTML

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -72,7 +72,7 @@ describe('html', function() {
     ]);
   });
 
-  it.skip('should insert sibling CSS bundles for JS files in the HEAD', async function() {
+  it('should insert sibling CSS bundles for JS files in the HEAD', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-css/index.html')
     );
@@ -84,7 +84,7 @@ describe('html', function() {
       },
       {
         type: 'js',
-        assets: ['index.js', 'index.css']
+        assets: ['index.js']
       },
       {
         type: 'css',
@@ -100,35 +100,25 @@ describe('html', function() {
     );
   });
 
-  it.skip('should insert sibling bundles before body element if no HEAD', async function() {
+  it('should insert sibling bundles before body element if no HEAD', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-css-head/index.html')
     );
 
-    await assertBundleTree(b, {
-      name: 'index.html',
-      assets: ['index.html'],
-      childBundles: [
-        {
-          type: 'js',
-          assets: ['index.js', 'index.css'],
-          childBundles: [
-            {
-              type: 'css',
-              assets: ['index.css'],
-              childBundles: [
-                {
-                  type: 'map'
-                }
-              ]
-            },
-            {
-              type: 'map'
-            }
-          ]
-        }
-      ]
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html']
+      },
+      {
+        type: 'js',
+        assets: ['index.js']
+      },
+      {
+        type: 'css',
+        assets: ['index.css']
+      }
+    ]);
 
     let html = await outputFS.readFile(path.join(distDir, 'index.html'));
     assert(
@@ -146,73 +136,53 @@ describe('html', function() {
       }
     );
 
-    await assertBundleTree(b, {
-      name: 'index.html',
-      assets: ['index.html'],
-      childBundles: [
-        {
-          type: 'css',
-          assets: ['index.css'],
-          childBundles: [
-            {
-              type: 'js',
-              assets: [
-                'index.css',
-                'bundle-url.js',
-                'css-loader.js',
-                'hmr-runtime.js'
-              ],
-              childBundles: [
-                {
-                  type: 'map'
-                }
-              ]
-            },
-            {
-              type: 'map'
-            }
-          ]
-        }
-      ]
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html']
+      },
+      {
+        type: 'css',
+        assets: ['index.css']
+      },
+      {
+        type: 'js',
+        assets: [
+          'index.css',
+          'bundle-url.js',
+          'css-loader.js',
+          'hmr-runtime.js'
+        ]
+      }
+    ]);
 
     let html = await outputFS.readFile(path.join(distDir, 'index.html'));
     assert(/<script src="[/\\]{1}html-css-js\.[a-f0-9]+\.js">/.test(html));
   });
 
-  it.skip('should insert sibling bundles at correct location in tree when optional elements are absent', async function() {
+  it('should insert sibling bundles at correct location in tree when optional elements are absent', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-css-optional-elements/index.html')
     );
 
-    await assertBundleTree(b, {
-      name: 'index.html',
-      assets: ['index.html'],
-      childBundles: [
-        {
-          type: 'js',
-          assets: ['index.js', 'index.css'],
-          childBundles: [
-            {
-              type: 'css',
-              assets: ['index.css'],
-              childBundles: [
-                {
-                  type: 'map'
-                }
-              ]
-            },
-            {
-              type: 'map'
-            }
-          ]
-        },
-        {
-          type: 'js',
-          assets: ['other.js']
-        }
-      ]
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html']
+      },
+      {
+        type: 'js',
+        assets: ['index.js']
+      },
+      {
+        type: 'css',
+        assets: ['index.css']
+      },
+      {
+        type: 'js',
+        assets: ['other.js']
+      }
+    ]);
 
     let html = await outputFS.readFile(path.join(distDir, 'index.html'));
     assert(

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -12,6 +12,9 @@
     "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-alpha.0"
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
+    "posthtml": "^0.11.3",
+    "nullthrows": "^1.1.1"
   }
 }

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -2,9 +2,24 @@
 
 import assert from 'assert';
 import {Packager} from '@parcel/plugin';
+import posthtml from 'posthtml';
+import {urlJoin} from '@parcel/utils';
+import nullthrows from 'nullthrows';
+
+// https://www.w3.org/TR/html5/dom.html#metadata-content-2
+const metadataContent = new Set([
+  'base',
+  'link',
+  'meta',
+  'noscript',
+  'script',
+  'style',
+  'template',
+  'title'
+]);
 
 export default new Packager({
-  async package({bundle}) {
+  async package({bundle, bundleGraph}) {
     let assets = [];
     bundle.traverseAssets(asset => {
       assets.push(asset);
@@ -12,6 +27,96 @@ export default new Packager({
 
     assert.equal(assets.length, 1, 'HTML bundles must only contain one asset');
 
-    return {contents: await assets[0].getCode()};
+    let asset = assets[0];
+    let code = await asset.getCode();
+
+    // Insert references to sibling bundles. For example, a <script> tag in the original HTML
+    // may import CSS files. This will result in a sibling bundle in the same bundle group as the
+    // JS. This will be inserted as a <link> element into the HTML here.
+    let bundleGroups = bundleGraph.getBundleGroupsReferencedByBundle(bundle);
+    let bundles = bundleGroups.reduce((p, {bundleGroup}) => {
+      let bundles = bundleGraph
+        .getBundlesInBundleGroup(bundleGroup)
+        .filter(
+          bundle =>
+            !bundle
+              .getEntryAssets()
+              .some(asset => asset.id === bundleGroup.entryAssetId)
+        );
+      return p.concat(bundles);
+    }, []);
+
+    let {html} = await posthtml([
+      insertBundleReferences.bind(this, bundles)
+    ]).process(code);
+
+    return {contents: html};
   }
 });
+
+function insertBundleReferences(siblingBundles, tree) {
+  const bundles = [];
+
+  for (let bundle of siblingBundles) {
+    if (bundle.type === 'css') {
+      bundles.push({
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          href: urlJoin(
+            nullthrows(bundle.target).publicUrl ?? '/',
+            nullthrows(bundle.name)
+          )
+        }
+      });
+    } else if (bundle.type === 'js') {
+      bundles.push({
+        tag: 'script',
+        attrs: {
+          src: urlJoin(
+            nullthrows(bundle.target).publicUrl ?? '/',
+            nullthrows(bundle.name)
+          )
+        }
+      });
+    }
+  }
+
+  addBundlesToTree(bundles, tree);
+}
+
+function addBundlesToTree(bundles, tree) {
+  const head = find(tree, 'head');
+  if (head) {
+    const content = head.content || (head.content = []);
+    content.push(...bundles);
+    return;
+  }
+
+  const html = find(tree, 'html');
+  const content = html ? html.content || (html.content = []) : tree;
+  const index = findBundleInsertIndex(content);
+
+  content.splice(index, 0, ...bundles);
+}
+
+function find(tree, tag) {
+  let res;
+  tree.match({tag}, node => {
+    res = node;
+    return node;
+  });
+
+  return res;
+}
+
+function findBundleInsertIndex(content) {
+  for (let index = 0; index < content.length; index++) {
+    const node = content[index];
+    if (node && node.tag && !metadataContent.has(node.tag)) {
+      return index;
+    }
+  }
+
+  return 0;
+}

--- a/packages/transformers/html/src/HTMLTransformer.js
+++ b/packages/transformers/html/src/HTMLTransformer.js
@@ -6,7 +6,7 @@ import nullthrows from 'nullthrows';
 import render from 'posthtml-render';
 import semver from 'semver';
 import collectDependencies from './dependencies';
-import extractInlineAssets from './inline';
+// import extractInlineAssets from './inline';
 
 export default new Transformer({
   canReuseAST({ast}) {
@@ -27,7 +27,9 @@ export default new Transformer({
     // Handle .htm
     asset.type = 'html';
     collectDependencies(asset);
-    return [asset, ...extractInlineAssets(asset)];
+    // TODO: re-enable once inline assets are re-inserted into the HTML
+    // return [asset, ...extractInlineAssets(asset)];
+    return [asset];
   },
 
   generate({asset}) {


### PR DESCRIPTION
This ports the logic to insert sibling bundles into HTML in the packager from Parcel 1, and re-enables the tests. For example, a <script> tag in the original HTML may import CSS files. This will result in a sibling bundle in the same bundle group as the JS, which will be inserted as a <link> element into the HTML by the packager.

This also disables inline assets in HTML for now, as they were resulting in separate bundles being generated. Will be re-enabled once the work on #3301 is done.