### PR TITLE
Refactor CLI reporter

### DIFF
--- a/packages/core/logger/src/Logger.js
+++ b/packages/core/logger/src/Logger.js
@@ -3,6 +3,7 @@
 import type {IDisposable, LogEvent} from '@parcel/types';
 
 import {ValueEmitter} from '@parcel/events';
+import {inspect} from 'util';
 
 class Logger {
   #logEmitter = new ValueEmitter<LogEvent>();
@@ -58,3 +59,44 @@ class Logger {
 
 const logger = new Logger();
 export default logger;
+
+let consolePatched = false;
+
+// Patch `console` APIs within workers to forward their messages to the Logger
+// at the appropriate levels.
+// TODO: Implement the rest of the console api as needed.
+// TODO: Does this need to be disposable/reversible?
+export function patchConsole() {
+  if (consolePatched) {
+    return;
+  }
+
+  /* eslint-disable no-console */
+  // $FlowFixMe
+  console.log = console.info = (...messages: Array<mixed>) => {
+    logger.info(joinLogMessages(messages));
+  };
+
+  // $FlowFixMe
+  console.debug = (...messages: Array<mixed>) => {
+    // TODO: dedicated debug level?
+    logger.verbose(joinLogMessages(messages));
+  };
+
+  // $FlowFixMe
+  console.warn = (...messages: Array<mixed>) => {
+    logger.warn(joinLogMessages(messages));
+  };
+
+  // $FlowFixMe
+  console.error = (...messages: Array<mixed>) => {
+    logger.error(joinLogMessages(messages));
+  };
+
+  /* eslint-enable no-console */
+  consolePatched = true;
+}
+
+function joinLogMessages(messages: Array<mixed>): string {
+  return messages.map(m => (typeof m === 'string' ? m : inspect(m))).join(' ');
+}

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@parcel/config-default": "^2.0.0-alpha.0",
     "@parcel/core": "^2.0.0-alpha.0",
+    "@parcel/logger": "^2.0.0-alpha.0",
     "chalk": "^2.1.0",
     "commander": "^2.19.0",
     "get-port": "^4.2.0",

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -2,6 +2,7 @@
 
 import type {ParcelConfigFile, InitialParcelOptions} from '@parcel/types';
 import {BuildError} from '@parcel/core';
+import {patchConsole} from '@parcel/logger';
 
 require('v8-compile-cache');
 
@@ -141,6 +142,8 @@ async function run(entries: Array<string>, command: any) {
     },
     ...(await normalizeOptions(command))
   });
+
+  patchConsole();
 
   if (command.name() === 'watch' || command.name() === 'serve') {
     await parcel.watch(err => {

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -61,7 +61,7 @@ export default class WorkerFarm extends EventEmitter {
       maxConcurrentWorkers: WorkerFarm.getNumWorkers(),
       maxConcurrentCallsPerWorker: WorkerFarm.getConcurrentCallsPerWorker(),
       forcedKillTime: 500,
-      warmWorkers: true,
+      warmWorkers: false,
       useLocalWorker: true,
       backend: detectBackend(),
       ...farmOptions

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -13,8 +13,7 @@ import type {IDisposable} from '@parcel/types';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
-import {inspect} from 'util';
-import Logger from '@parcel/logger';
+import Logger, {patchConsole} from '@parcel/logger';
 import {errorToJson, jsonToError} from '@parcel/utils';
 import bus from './bus';
 
@@ -22,8 +21,6 @@ type ChildCall = WorkerRequest & {|
   resolve: (result: Promise<any> | any) => void,
   reject: (error: any) => void
 |};
-
-let consolePatched;
 
 export class Child {
   callQueue: Array<ChildCall> = [];
@@ -41,7 +38,7 @@ export class Child {
       this.handleEnd.bind(this)
     );
 
-    patchConsoleToLogger();
+    patchConsole();
     // Monitior all logging events inside this child process and forward to
     // the main process via the bus.
     this.loggerDisposable = Logger.onLog(event => {
@@ -187,41 +184,4 @@ export class Child {
   handleEnd(): void {
     this.loggerDisposable.dispose();
   }
-}
-
-// Patch `console` APIs within workers to forward their messages to the Logger
-// at the appropriate levels.
-// TODO: Implement the rest of the console api as needed.
-// TODO: Does this need to be disposable/reversible?
-function patchConsoleToLogger() {
-  if (consolePatched) {
-    return;
-  }
-  /* eslint-disable no-console */
-  // $FlowFixMe
-  console.log = console.info = (...messages: Array<mixed>) => {
-    Logger.info(joinLogMessages(messages));
-  };
-
-  // $FlowFixMe
-  console.debug = (...messages: Array<mixed>) => {
-    // TODO: dedicated debug level?
-    Logger.verbose(joinLogMessages(messages));
-  };
-
-  // $FlowFixMe
-  console.warn = (...messages: Array<mixed>) => {
-    Logger.warn(joinLogMessages(messages));
-  };
-
-  // $FlowFixMe
-  console.error = (...messages: Array<mixed>) => {
-    Logger.error(joinLogMessages(messages));
-  };
-  /* eslint-enable no-console */
-  consolePatched = true;
-}
-
-function joinLogMessages(messages: Array<mixed>): string {
-  return messages.map(m => (typeof m === 'string' ? m : inspect(m))).join(' ');
 }

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -10,6 +10,7 @@
     "test-ci": "yarn test"
   },
   "dependencies": {
+    "@parcel/events": "^2.0.0-alpha.0",
     "@parcel/logger": "^2.0.0-alpha.0",
     "@parcel/plugin": "^2.0.0-alpha.0",
     "@parcel/types": "^2.0.0-alpha.0",

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -1,149 +1,24 @@
 // @flow strict-local
 
-import type {
-  BundleGraph,
-  LogEvent,
-  PluginOptions,
-  ProgressLogEvent,
-  ReporterEvent
-} from '@parcel/types';
-import type {RerenderFunc} from 'ink';
+import type {ReporterEvent} from '@parcel/types';
 
-import {prettifyTime} from '@parcel/utils';
 import {render} from 'ink';
 import {Reporter} from '@parcel/plugin';
 import React from 'react';
+import {ValueEmitter} from '@parcel/events';
 
-import {getProgressMessage} from './utils';
-import logLevels from './logLevels';
 import UI from './UI';
 
-type State = {|
-  progress: ?ProgressLogEvent,
-  logs: Array<LogEvent>,
-  bundleGraph: ?BundleGraph
-|};
-
-let state: State = {
-  progress: null,
-  logs: [],
-  bundleGraph: null
-};
-let rerender: RerenderFunc;
+let rendered = false;
+let events = new ValueEmitter<ReporterEvent>();
 
 export default new Reporter({
   report(event, options) {
-    let newState = reducer(state, event, options);
-    let uiElement = <UI {...newState} options={options} />;
-    if (rerender) {
-      rerender(uiElement);
-    } else {
-      render(uiElement);
+    if (!rendered) {
+      render(<UI options={options} events={events} />);
+      rendered = true;
     }
+
+    events.emit(event);
   }
 });
-
-function reducer(
-  state: State,
-  event: ReporterEvent,
-  options: PluginOptions
-): State {
-  let logLevel = logLevels[options.logLevel];
-
-  switch (event.type) {
-    case 'buildStart':
-      if (logLevel < logLevels.info) {
-        break;
-      }
-
-      return {
-        ...state,
-        logs: [],
-        bundleGraph: null
-      };
-
-    case 'buildProgress': {
-      if (logLevel < logLevels.progress) {
-        break;
-      }
-
-      let message = getProgressMessage(event);
-      let progress = state.progress;
-      if (message != null) {
-        progress = {
-          type: 'log',
-          level: 'progress',
-          message
-        };
-      }
-
-      return {
-        ...state,
-        progress
-      };
-    }
-
-    case 'buildSuccess':
-      if (logLevel < logLevels.info) {
-        break;
-      }
-
-      return {
-        ...state,
-        progress: null,
-        bundleGraph: event.bundleGraph,
-        logs: [
-          ...state.logs,
-          {
-            type: 'log',
-            level: 'success',
-            message: `Built in ${prettifyTime(event.buildTime)}.`
-          }
-        ]
-      };
-
-    case 'buildFailure':
-      if (logLevel < logLevels.error) {
-        break;
-      }
-
-      return {
-        ...state,
-        progress: null,
-        logs: [
-          ...state.logs,
-          {
-            type: 'log',
-            level: 'error',
-            message: event.error
-          }
-        ]
-      };
-
-    case 'log': {
-      if (logLevel < logLevels[event.level]) {
-        break;
-      }
-
-      if (event.level === 'progress') {
-        return {
-          ...state,
-          progress: event
-        };
-      }
-
-      // Skip duplicate logs
-      let messages = new Set(state.logs.map(l => l.message));
-      if (messages.has(event.message)) {
-        break;
-      }
-
-      return {
-        ...state,
-        logs: [...state.logs, event]
-      };
-    }
-  }
-
-  return state;
-}

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -4,22 +4,48 @@ import type {
   BundleGraph,
   LogEvent,
   PluginOptions,
-  ProgressLogEvent
+  ProgressLogEvent,
+  ReporterEvent
 } from '@parcel/types';
+import type {ValueEmitter} from '@parcel/events';
 
 import {Color} from 'ink';
-import React from 'react';
+import React, {useEffect, useReducer} from 'react';
 import {Log, Progress} from './Log';
 import BundleReport from './BundleReport';
+import {getProgressMessage} from './utils';
+import logLevels from './logLevels';
+import {prettifyTime} from '@parcel/utils';
 
 type Props = {|
-  bundleGraph: ?BundleGraph,
-  logs: Array<LogEvent>,
-  options: PluginOptions,
-  progress: ?ProgressLogEvent
+  events: ValueEmitter<ReporterEvent>,
+  options: PluginOptions
 |};
 
-export default function UI({logs, progress, bundleGraph, options}: Props) {
+type State = {|
+  progress: ?ProgressLogEvent,
+  logs: Array<LogEvent>,
+  bundleGraph: ?BundleGraph
+|};
+
+const defaultState: State = {
+  progress: null,
+  logs: [],
+  bundleGraph: null
+};
+
+export default function UI({events, options}: Props) {
+  let [state, dispatch] = useReducer(
+    (state, event) => reducer(state, event, options),
+    defaultState
+  );
+
+  useEffect(() => {
+    let {dispose} = events.addListener(dispatch);
+    return dispose;
+  }, [events]);
+
+  let {logs, progress, bundleGraph} = state;
   return (
     <Color reset>
       <div>
@@ -33,4 +59,109 @@ export default function UI({logs, progress, bundleGraph, options}: Props) {
       </div>
     </Color>
   );
+}
+
+function reducer(
+  state: State,
+  event: ReporterEvent,
+  options: PluginOptions
+): State {
+  let logLevel = logLevels[options.logLevel];
+
+  switch (event.type) {
+    case 'buildStart':
+      if (logLevel < logLevels.info) {
+        break;
+      }
+
+      return {
+        ...state,
+        logs: [],
+        bundleGraph: null
+      };
+
+    case 'buildProgress': {
+      if (logLevel < logLevels.progress) {
+        break;
+      }
+
+      let message = getProgressMessage(event);
+      let progress = state.progress;
+      if (message != null) {
+        progress = {
+          type: 'log',
+          level: 'progress',
+          message
+        };
+      }
+
+      return {
+        ...state,
+        progress
+      };
+    }
+
+    case 'buildSuccess':
+      if (logLevel < logLevels.info) {
+        break;
+      }
+
+      return {
+        ...state,
+        progress: null,
+        bundleGraph: event.bundleGraph,
+        logs: [
+          ...state.logs,
+          {
+            type: 'log',
+            level: 'success',
+            message: `Built in ${prettifyTime(event.buildTime)}.`
+          }
+        ]
+      };
+
+    case 'buildFailure':
+      if (logLevel < logLevels.error) {
+        break;
+      }
+
+      return {
+        ...state,
+        progress: null,
+        logs: [
+          ...state.logs,
+          {
+            type: 'log',
+            level: 'error',
+            message: event.error
+          }
+        ]
+      };
+
+    case 'log': {
+      if (logLevel < logLevels[event.level]) {
+        break;
+      }
+
+      if (event.level === 'progress') {
+        return {
+          ...state,
+          progress: event
+        };
+      }
+
+      // Skip duplicate logs
+      let messages = new Set(state.logs.map(l => l.message));
+      if (messages.has(event.message)) {
+        break;
+      }
+
+      return {
+        ...state,
+        logs: [...state.logs, event]
+      };
+    }
+  }
+
+  return state;
 }


### PR DESCRIPTION
This refactors the CLI reporter slightly to fix a few issues.

1. The console is now patched in the main process again, but only when using the Parcel CLI. The code moved into the logger package with an exported function to enable it.
2. The reducer is moved back into the React component for the CLI reporter.
3. `warmWorkers` is turned off to avoid duplicate and out of order reporter events being sent. This actually increased perf of the react-hmr example under worker threads, so maybe we don't need it anymore.