### PR TITLE
Display server URL in CLI reporter

### DIFF
--- a/flow-libs/ink.js.flow
+++ b/flow-libs/ink.js.flow
@@ -23,6 +23,7 @@ declare module 'ink' {
     gray?: boolean,
     green?: boolean,
     keyword?: string,
+    cyan?: boolean,
     magenta?: boolean,
     reset?: boolean,
     yellow?: boolean

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -182,8 +182,13 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
   if (command.name() === 'serve') {
     let port = command.port || 1234;
     let host = command.host;
-    if (!port) {
-      port = await getPort({port, host});
+    port = await getPort({port, host});
+
+    if (command.port && port !== command.port) {
+      // Parcel logger is not set up at this point, so just use native console.
+      console.warn(
+        chalk.bold.yellowBright(`⚠️  Port ${command.port} could not be used.`)
+      );
     }
 
     serve = {

--- a/packages/reporters/cli/src/Log.js
+++ b/packages/reporters/cli/src/Log.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {LogEvent} from '@parcel/types';
+import type {LogEvent, ServerOptions} from '@parcel/types';
 
 import {prettyError} from '@parcel/utils';
 import {Box, Text, Color} from 'ink';
@@ -16,6 +16,10 @@ type StringLogProps = {|
   event: {
     +message: string
   }
+|};
+
+type ServerInfoProps = {|
+  options: ServerOptions
 |};
 
 export function Log({event}: StringOrErrorLogProps) {
@@ -90,5 +94,15 @@ export function Progress({event}: StringLogProps) {
         <Spinner /> {event.message}
       </Color>
     </Box>
+  );
+}
+
+export function ServerInfo({options}: ServerInfoProps) {
+  let url = `${options.https ? 'https' : 'http'}://${options.host ??
+    'localhost'}:${options.port}`;
+  return (
+    <Color bold>
+      Server running at <Color cyan>{url}</Color>
+    </Color>
   );
 }

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -11,7 +11,7 @@ import type {ValueEmitter} from '@parcel/events';
 
 import {Color} from 'ink';
 import React, {useEffect, useReducer} from 'react';
-import {Log, Progress} from './Log';
+import {Log, Progress, ServerInfo} from './Log';
 import BundleReport from './BundleReport';
 import {getProgressMessage} from './utils';
 import logLevels from './logLevels';
@@ -49,6 +49,7 @@ export default function UI({events, options}: Props) {
   return (
     <Color reset>
       <div>
+        {options.serve && <ServerInfo options={options.serve} />}
         {logs.map((log, i) => (
           <Log key={i} event={log} />
         ))}

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -216,18 +216,6 @@ export default class Server extends EventEmitter {
       });
 
       this.server.once('listening', () => {
-        let addon =
-          this.server.address().port !== this.options.port
-            ? `- configured port ${this.options.port.toString()} could not be used.`
-            : '';
-
-        logger.log(
-          `Server running at ${this.options.https ? 'https' : 'http'}://${this
-            .options.host || 'localhost'}:${
-            this.server.address().port
-          } ${addon}`
-        );
-
         resolve(this.server);
       });
     });


### PR DESCRIPTION
The log in the server reporter to display what url the server is running on didn't work because the logs were reset on the `buildStart` event and that log happened before. Also, we want that line to be persistent and not reset on every build. There is also special formatting for the url, so we now do this in the CLI reporter directly instead of going through the logger at all.

Additionally, if the requested port cannot be used, we fall back to a different port automatically in the CLI and display a warning. 