### PR TITLE
Limit concurrency when reading assets in packagers

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -2,7 +2,7 @@
 import EventEmitter from 'events';
 
 import type {ParcelOptions, Target} from './types';
-import {PromiseQueue, md5FromObject, md5FromString} from '@parcel/utils';
+import {md5FromObject, md5FromString} from '@parcel/utils';
 import watcher, {type Event} from '@parcel/watcher';
 
 import type {Asset} from './types';
@@ -30,7 +30,6 @@ type Opts = {|
 export default class AssetGraphBuilder extends EventEmitter {
   assetGraph: AssetGraph;
   requestGraph: RequestGraph;
-  queue: PromiseQueue;
   controller: AbortController;
   changedAssets: Map<string, Asset> = new Map();
   options: ParcelOptions;

--- a/packages/core/core/src/RequestGraph.js
+++ b/packages/core/core/src/RequestGraph.js
@@ -106,8 +106,8 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
   configLoader: ConfigLoader;
   onAssetRequestComplete: (AssetRequestNode, Array<AssetValue>) => mixed;
   onDepPathRequestComplete: (DepPathRequestNode, AssetRequest | null) => mixed;
-  queue: PromiseQueue;
-  validationQueue: PromiseQueue;
+  queue: PromiseQueue<mixed>;
+  validationQueue: PromiseQueue<mixed>;
   farm: WorkerFarm;
   config: ParcelConfig;
   options: ParcelOptions;

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -12,6 +12,7 @@
     "parcel": "^2.0.0-alpha.0"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-alpha.0"
+    "@parcel/plugin": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0"
   }
 }

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -1,10 +1,11 @@
 // @flow
 
 import {Packager} from '@parcel/plugin';
+import {PromiseQueue} from '@parcel/utils';
 
 export default new Packager({
   async package({bundle, bundleGraph}) {
-    let promises = [];
+    let queue = new PromiseQueue({maxConcurrent: 32});
     bundle.traverseAssets({
       exit: asset => {
         // Figure out which media types this asset was imported with.
@@ -19,7 +20,7 @@ export default new Packager({
           media.push(dep.meta.media);
         }
 
-        promises.push(
+        queue.add(() =>
           asset.getCode().then((css: string) => {
             if (media.length) {
               return `@media ${media.join(', ')} {\n${css.trim()}\n}\n`;
@@ -31,7 +32,7 @@ export default new Packager({
       }
     });
 
-    let outputs = await Promise.all(promises);
+    let outputs = await queue.run();
     return {contents: await outputs.map(output => output).join('\n')};
   }
 });

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -5,7 +5,7 @@ import {Packager} from '@parcel/plugin';
 import fs from 'fs';
 import {concat, link, generate} from '@parcel/scope-hoisting';
 import SourceMap from '@parcel/source-map';
-import {countLines} from '@parcel/utils';
+import {countLines, PromiseQueue} from '@parcel/utils';
 import path from 'path';
 
 const PRELUDE = fs
@@ -24,19 +24,16 @@ export default new Packager({
 
     // For development, we just concatenate all of the code together
     // rather then enabling scope hoisting, which would be too slow.
-    let codePromises = [];
-    let mapPromises = [];
+    let codeQueue = new PromiseQueue({maxConcurrent: 32});
+    let mapQueue = new PromiseQueue({maxConcurrent: 32});
     bundle.traverse(node => {
       if (node.type === 'asset') {
-        codePromises.push(node.value.getCode());
-        mapPromises.push(node.value.getMap());
+        codeQueue.add(() => node.value.getCode());
+        mapQueue.add(() => node.value.getMap());
       }
     });
 
-    let [code, maps] = await Promise.all([
-      Promise.all(codePromises),
-      Promise.all(mapPromises)
-    ]);
+    let [code, maps] = await Promise.all([codeQueue.run(), mapQueue.run()]);
 
     let assets = '';
     let i = 0;

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -20,7 +20,7 @@
     "@babel/traverse": "^7.2.3",
     "@babel/parser": "^7.0.0",
     "@babel/types": "^7.3.3",
-    "@parcel/types": "^2.0.0-alpha.0",
+    "@parcel/utils": "^2.0.0-alpha.0",
     "babylon-walk": "^1.0.2",
     "micromatch": "^3.1.10",
     "nullthrows": "^1.1.1"

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -9,6 +9,7 @@ import * as walk from 'babylon-walk';
 import {getName, getIdentifier} from './utils';
 import fs from 'fs';
 import nullthrows from 'nullthrows';
+import {PromiseQueue} from '@parcel/utils';
 
 const HELPERS_PATH = path.join(__dirname, 'helpers.js');
 const HELPERS = fs.readFileSync(HELPERS_PATH, 'utf8');
@@ -24,7 +25,7 @@ type TraversalContext = {|
 
 // eslint-disable-next-line no-unused-vars
 export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
-  let assets = [];
+  let queue = new PromiseQueue({maxConcurrent: 32});
   bundle.traverse((node, shouldWrap) => {
     switch (node.type) {
       case 'dependency':
@@ -38,12 +39,11 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
         }
         break;
       case 'asset':
-        assets.push(node.value);
+        queue.add(() => processAsset(bundle, node.value));
     }
   });
 
-  let promises = assets.map(asset => processAsset(bundle, asset));
-  let outputs = new Map(await Promise.all(promises));
+  let outputs = new Map(await queue.run());
   let result = [...parse(HELPERS, HELPERS_PATH)];
 
   // If this is an entry bundle and it has child bundles, we need to add the prelude code, which allows


### PR DESCRIPTION
Currently, when packaging assets in the JS and CSS packagers, we use `Promise.all` to read all of the assets in parallel with unbounded concurrency. For large apps, this results in `EMFILE` errors due to too many open file descriptors.

This PR limits concurrency in the packagers by using a `PromiseQueue` instead of `Promise.all`. This required a few changes to `PromiseQueue` to make it behave like `Promise.all` and return an array of results.