### PR TITLE
Cache graph in watch mode

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -137,12 +137,8 @@ export default class AssetGraphBuilder extends EventEmitter {
     this.assetGraph.resolveDependency(requestNode.value, result);
   }
 
-  isInvalid() {
-    return this.requestGraph.isInvalid();
-  }
-
   respondToFSEvents(events: Array<Event>) {
-    this.requestGraph.respondToFSEvents(events);
+    return this.requestGraph.respondToFSEvents(events);
   }
 
   initFarm() {

--- a/packages/core/core/src/InternalConfig.js
+++ b/packages/core/core/src/InternalConfig.js
@@ -1,0 +1,82 @@
+// @flow strict-local
+
+import type {
+  FilePath,
+  Glob,
+  PackageName,
+  Config as ThirdPartyConfig
+} from '@parcel/types';
+
+import type {Config} from './types';
+
+type ConfigOpts = {|
+  searchPath: FilePath,
+  resolvedPath?: FilePath,
+  result?: ThirdPartyConfig,
+  includedFiles?: Set<FilePath>,
+  watchGlob?: Glob,
+  devDeps?: Map<PackageName, ?string>,
+  shouldRehydrate?: boolean,
+  shouldReload?: boolean,
+  shouldInvalidateOnStartup?: boolean
+|};
+
+export function createConfig({
+  searchPath,
+  resolvedPath,
+  result,
+  includedFiles,
+  watchGlob,
+  devDeps,
+  shouldRehydrate,
+  shouldReload,
+  shouldInvalidateOnStartup
+}: ConfigOpts): Config {
+  return {
+    searchPath,
+    resolvedPath,
+    result: result ?? null,
+    resultHash: null,
+    includedFiles: includedFiles ?? new Set(),
+    pkg: null,
+    watchGlob,
+    devDeps: devDeps ?? new Map(),
+    shouldRehydrate: shouldRehydrate ?? false,
+    shouldReload: shouldReload ?? false,
+    shouldInvalidateOnStartup: shouldInvalidateOnStartup ?? false
+  };
+}
+
+export function addDevDependency(
+  config: Config,
+  name: PackageName,
+  version?: string
+) {
+  config.devDeps.set(name, version);
+}
+
+// TODO: start using edge types for more flexible invalidations
+export function getInvalidations(config: Config) {
+  let invalidations = [];
+
+  if (config.watchGlob != null) {
+    invalidations.push({
+      action: 'add',
+      pattern: config.watchGlob
+    });
+  }
+
+  for (let filePath of [config.resolvedPath, ...config.includedFiles]) {
+    invalidations.push({
+      action: 'change',
+      pattern: filePath
+    });
+
+    invalidations.push({
+      action: 'unlink',
+      pattern: filePath
+    });
+  }
+
+  return invalidations;
+}

--- a/packages/core/core/src/RequestGraph.js
+++ b/packages/core/core/src/RequestGraph.js
@@ -508,7 +508,8 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
   }
 
   // TODO: add edge types to make invalidation more flexible and less precarious
-  respondToFSEvents(events: Array<Event>) {
+  respondToFSEvents(events: Array<Event>): boolean {
+    let isInvalid = false;
     for (let {path, type} of events) {
       if (path === this.options.lockFile) {
         for (let id of this.depVersionRequestNodeIds) {
@@ -519,6 +520,7 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
           );
 
           this.invalidateNode(depVersionRequestNode);
+          isInvalid = true;
         }
       }
 
@@ -537,6 +539,7 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
               connectedNode.type === 'config_request'
             ) {
               this.invalidateNode(connectedNode);
+              isInvalid = true;
             }
           }
         }
@@ -552,6 +555,7 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
                 connectedNode.type !== 'file' && connectedNode.type !== 'glob'
               );
               this.invalidateNode(connectedNode);
+              isInvalid = true;
             }
           }
         }
@@ -562,13 +566,12 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
             connectedNode.type === 'config_request'
           ) {
             this.invalidateNode(connectedNode);
+            isInvalid = true;
           }
         }
       }
     }
-  }
 
-  isInvalid() {
-    return this.invalidNodeIds.size > 0;
+    return isInvalid;
   }
 }

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -8,10 +8,10 @@ import type {
   TransformerResult,
   PackageName
 } from '@parcel/types';
-import type Config from './public/Config';
 import type {
   Asset as AssetValue,
   AssetRequest,
+  Config,
   NodeId,
   ConfigRequest,
   ParcelOptions
@@ -26,6 +26,7 @@ import ResolverRunner from './ResolverRunner';
 import {report} from './ReporterRunner';
 import {MutableAsset, assetToInternalAsset} from './public/Asset';
 import InternalAsset, {createAsset} from './InternalAsset';
+import ParcelConfig from './ParcelConfig';
 import summarizeRequest from './summarizeRequest';
 import PluginOptions from './public/PluginOptions';
 
@@ -240,7 +241,8 @@ export default class Transformation {
     let configs = new Map();
 
     let config = await this.loadConfig(configRequest);
-    let parcelConfig = nullthrows(config.result);
+    let result = nullthrows(config.result);
+    let parcelConfig = new ParcelConfig(result);
 
     configs.set('parcel', config);
 
@@ -251,7 +253,7 @@ export default class Transformation {
         let thirdPartyConfig = await this.loadTransformerConfig(
           filePath,
           moduleName,
-          parcelConfig.resolvedPath
+          result.resolvedPath
         );
         configs.set(moduleName, thirdPartyConfig);
       }

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -1,7 +1,13 @@
 // @flow strict-local
+
 import nullthrows from 'nullthrows';
-import type Config from './public/Config';
-import type {AssetRequest, NodeId, ConfigRequest, ParcelOptions} from './types';
+import type {
+  AssetRequest,
+  Config,
+  NodeId,
+  ConfigRequest,
+  ParcelOptions
+} from './types';
 
 import path from 'path';
 import {resolveConfig} from '@parcel/utils';

--- a/packages/core/core/src/public/Config.js
+++ b/packages/core/core/src/public/Config.js
@@ -13,8 +13,6 @@ import type {Config, ParcelOptions} from '../types';
 import path from 'path';
 import {loadConfig} from '@parcel/utils';
 
-import Environment from './Environment';
-
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 
 export default class PublicConfig implements IConfig {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -12,17 +12,18 @@ import type {
   Meta,
   ModuleSpecifier,
   PackageName,
+  PackageJSON,
   ResolvedParcelConfigFile,
   Semver,
   ServerOptions,
   SourceLocation,
   Stats,
   Symbol,
-  TargetSourceMapOptions
+  TargetSourceMapOptions,
+  Config as ThirdPartyConfig
 } from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import type Cache from '@parcel/cache';
-import type Config from './public/Config';
 
 export type Environment = {|
   context: EnvironmentContext,
@@ -173,6 +174,20 @@ export type ConfigRequestNode = {|
   id: string,
   +type: 'config_request',
   value: ConfigRequest
+|};
+
+export type Config = {|
+  searchPath: FilePath,
+  resolvedPath: ?FilePath,
+  resultHash: ?string,
+  result: ThirdPartyConfig,
+  includedFiles: Set<FilePath>,
+  pkg: ?PackageJSON,
+  watchGlob: ?Glob,
+  devDeps: Map<PackageName, ?string>,
+  shouldRehydrate: boolean,
+  shouldReload: boolean,
+  shouldInvalidateOnStartup: boolean
 |};
 
 export type ConfigRequest = {|

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -146,11 +146,28 @@ async function run(entries: Array<string>, command: any) {
   patchConsole();
 
   if (command.name() === 'watch' || command.name() === 'serve') {
-    await parcel.watch(err => {
+    let {unsubscribe} = await parcel.watch(err => {
       if (err) {
         throw err;
       }
     });
+
+    // Detect the ctrl+c key, and gracefully exit after writing the asset graph to the cache.
+    // We don't use the SIGINT event for this because when run inside yarn, it seems we aren't
+    // given an opportunity to cleanup before being forcefully exited.
+    // Handling events from stdin seems to prevent this.
+    if (process.stdin.isTTY) {
+      // $FlowFixMe
+      process.stdin.setRawMode(true);
+      require('readline').emitKeypressEvents(process.stdin);
+
+      process.stdin.on('keypress', async (char, key) => {
+        if (key.ctrl && key.name === 'c') {
+          await unsubscribe();
+          process.exit();
+        }
+      });
+    }
   } else {
     try {
       await parcel.run();
@@ -200,11 +217,9 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
 
   let hmr = false;
   if (command.name() !== 'build' && command.hmr !== false) {
-    let port = command.hmrPort;
+    let port = command.hmrPort || 12345;
     let host = command.hmrHost || command.host;
-    if (!port) {
-      port = await getPort({port, host});
-    }
+    port = await getPort({port, host});
 
     process.env.HMR_HOSTNAME = host || '';
     process.env.HMR_PORT = port;


### PR DESCRIPTION
This implements asset/request graph caching in watch and serve mode. Previously it only worked in build mode. When the user exits Parcel in watch mode, it now gracefully shuts down and writes the graphs to disk.

It also fixes serializing the graph when in an invalid state, so you can e.g. make a syntax error, restart Parcel, and it will restore back into that state. This is accomplished by keeping the `invalidNodeIds` in the request graph up to date and serializing them along with the graph.

Additional fixes:

* Config -> plain objects cherry picked from #3261.
* If a watch event happened while the request graph is already in an invalid state, it would always trigger a build even if no actual known files in the graph changed. It now only triggers if a node is invalidated based on the events.
* The HMR server gets a consistent port. Otherwise it would invalidate the cache on every restart. Really we should make this more granular so it doesn't invalidate every asset when some HMR option changes.