### PR TITLE
Add --profile option for multi threaded profiling

### DIFF
--- a/flow-libs/chrome-trace-event.js.flow
+++ b/flow-libs/chrome-trace-event.js.flow
@@ -1,0 +1,24 @@
+// @flow
+
+// Based on https://github.com/samccone/chrome-trace-event/blob/master/lib/trace-event.ts
+declare module 'chrome-trace-event' {
+  declare type TracerOptions = {|
+    parent?: Tracer | null,
+    fields?: Fields | null,
+    objectMode?: boolean | null,
+    noStream?: boolean
+  |};
+
+  declare type Fields = {
+    cat?: any,
+    args?: any
+  };
+
+  declare export class Tracer extends stream$Readable {
+    constructor(opts?: TracerOptions): Tracer;
+    begin(fields: Fields): void;
+    completeEvent(fields: Fields): void;
+    instantEvent(fields: Fields): void;
+    flush(): void;
+  }
+}

--- a/flow-libs/inspector.js.flow
+++ b/flow-libs/inspector.js.flow
@@ -1,0 +1,10 @@
+// @flow
+
+// based on https://nodejs.org/api/inspector.html
+declare module 'inspector' {
+  declare export class Session {
+    connect(): void;
+    disconnect(): void;
+    post(method: string, params?: mixed, callback?: (err: Error, result: any) => void): void;
+  }
+}

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -178,6 +178,8 @@ export default class Parcel {
 
   async build(startTime: number = Date.now()): Promise<BuildEvent> {
     try {
+      // await this.#farm.startProfile();
+
       this.#reporterRunner.report({
         type: 'buildStart'
       });
@@ -210,6 +212,7 @@ export default class Parcel {
       this.#reporterRunner.report(event);
 
       await this.#assetGraphBuilder.validate();
+      // await this.#farm.endProfile();
 
       return event;
     } catch (e) {

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -177,8 +177,11 @@ export default class Parcel {
   }
 
   async build(startTime: number = Date.now()): Promise<BuildEvent> {
+    let options = nullthrows(this.#resolvedOptions);
     try {
-      // await this.#farm.startProfile();
+      if (options.profile) {
+        await this.#farm.startProfile();
+      }
 
       this.#reporterRunner.report({
         type: 'buildStart'
@@ -190,7 +193,6 @@ export default class Parcel {
       let bundleGraph = await this.#bundlerRunner.bundle(assetGraph);
       dumpGraphToGraphViz(bundleGraph._graph, 'BundleGraph');
 
-      let options = nullthrows(this.#resolvedOptions);
       await packageBundles({
         bundleGraph,
         config: this.#config,
@@ -212,8 +214,6 @@ export default class Parcel {
       this.#reporterRunner.report(event);
 
       await this.#assetGraphBuilder.validate();
-      // await this.#farm.endProfile();
-
       return event;
     } catch (e) {
       if (e instanceof BuildAbortError) {
@@ -226,6 +226,10 @@ export default class Parcel {
       };
       await this.#reporterRunner.report(event);
       return event;
+    } finally {
+      if (options.profile) {
+        await this.#farm.endProfile();
+      }
     }
   }
 

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -77,6 +77,7 @@ export default async function resolveOptions(
     serve: initialOptions.serve ?? false,
     disableCache: initialOptions.disableCache ?? false,
     killWorkers: initialOptions.killWorkers ?? false,
+    profile: initialOptions.profile ?? false,
     cacheDir,
     entries,
     rootDir,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -95,6 +95,7 @@ export type ParcelOptions = {|
   logLevel: LogLevel,
   projectRoot: FilePath,
   lockFile: ?FilePath,
+  profile: boolean,
 
   inputFS: FileSystem,
   outputFS: FileSystem,

--- a/packages/core/core/test/utils.js
+++ b/packages/core/core/test/utils.js
@@ -25,6 +25,7 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
   env: {},
   disableCache: false,
   sourceMaps: false,
+  profile: false,
   inputFS,
   outputFS,
   cache

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -36,6 +36,7 @@ const commonOptions = {
     'set the log level, either "none", "error", "warn", "info", or "verbose".',
     /^(none|error|warn|info|verbose)$/
   ],
+  '--profile': 'enable build profiling',
   '-V, --version': 'output the version number'
 };
 
@@ -227,6 +228,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     serve,
     targets: command.target.length > 0 ? command.target : null,
     autoinstall: command.autoinstall !== false,
-    logLevel: command.logLevel
+    logLevel: command.logLevel,
+    profile: command.profile
   };
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -164,6 +164,7 @@ export type InitialParcelOptions = {|
   serve?: ServerOptions | false,
   autoinstall?: boolean,
   logLevel?: LogLevel,
+  profile?: boolean,
 
   inputFS?: FileSystem,
   outputFS?: FileSystem

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@parcel/logger": "^2.0.0-alpha.0",
     "@parcel/utils": "^2.0.0-alpha.0",
-    "physical-cpu-count": "^2.0.0",
-    "nullthrows": "^1.1.1"
+    "chrome-trace-event": "^1.0.2",
+    "nullthrows": "^1.1.1",
+    "physical-cpu-count": "^2.0.0"
   }
 }

--- a/packages/core/workers/src/Profiler.js
+++ b/packages/core/workers/src/Profiler.js
@@ -1,16 +1,46 @@
-import inspector from 'inspector';
+// @flow
+import {Session} from 'inspector';
+import invariant from 'assert';
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-Profile
+export type Profile = {|
+  nodes: Array<ProfileNode>,
+  startTime: number,
+  endTime: number,
+  samples?: Array<number>,
+  timeDeltas?: Array<number>
+|};
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-ProfileNode
+type ProfileNode = {|
+  id: number,
+  callFrame: CallFrame,
+  hitCount?: number,
+  children?: Array<number>,
+  deoptReason?: string,
+  positionTicks?: PositionTickInfo
+|};
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-CallFrame
+type CallFrame = {|
+  functionName: string,
+  scriptId: string,
+  url: string,
+  lineNumber: string,
+  columnNumber: string
+|};
+
+// https://chromedevtools.github.io/devtools-protocol/tot/Profiler#type-PositionTickInfo
+type PositionTickInfo = {|
+  line: number,
+  ticks: number
+|};
 
 export default class Profiler {
-  constructor() {
-    this.session = undefined;
-  }
-
-  hasSession() {
-    return this.session != null;
-  }
+  session: Session;
 
   async startProfiling() {
-    this.session = new inspector.Session();
+    this.session = new Session();
     this.session.connect();
 
     return Promise.all([
@@ -18,31 +48,30 @@ export default class Profiler {
         interval: 100
       }),
       this.sendCommand('Profiler.enable'),
-      this.sendCommand('Profiler.start'),
+      this.sendCommand('Profiler.start')
     ]);
   }
 
-  async sendCommand(method, params) {
-    if (this.hasSession()) {
-      return new Promise((resolve, reject) => {
-        this.session.post(method, params, (err, params) => {
-          if (err == null) {
-            resolve(params);
-          } else {
-            reject(err);
-          }
-        });
+  async sendCommand(method: string, params: mixed) {
+    invariant(this.session != null);
+    return new Promise((resolve, reject) => {
+      this.session.post(method, params, (err, params) => {
+        if (err == null) {
+          resolve(params);
+        } else {
+          reject(err);
+        }
       });
-    }
+    });
   }
 
   destroy() {
-    if (this.hasSession()) {
+    if (this.session != null) {
       this.session.disconnect();
     }
   }
 
-  async stopProfiling() {
+  async stopProfiling(): Promise<Profile> {
     let res = await this.sendCommand('Profiler.stop');
     this.destroy();
     return res.profile;

--- a/packages/core/workers/src/Profiler.js
+++ b/packages/core/workers/src/Profiler.js
@@ -1,0 +1,50 @@
+import inspector from 'inspector';
+
+export default class Profiler {
+  constructor() {
+    this.session = undefined;
+  }
+
+  hasSession() {
+    return this.session != null;
+  }
+
+  async startProfiling() {
+    this.session = new inspector.Session();
+    this.session.connect();
+
+    return Promise.all([
+      this.sendCommand('Profiler.setSamplingInterval', {
+        interval: 100
+      }),
+      this.sendCommand('Profiler.enable'),
+      this.sendCommand('Profiler.start'),
+    ]);
+  }
+
+  async sendCommand(method, params) {
+    if (this.hasSession()) {
+      return new Promise((resolve, reject) => {
+        this.session.post(method, params, (err, params) => {
+          if (err == null) {
+            resolve(params);
+          } else {
+            reject(err);
+          }
+        });
+      });
+    }
+  }
+
+  destroy() {
+    if (this.hasSession()) {
+      this.session.disconnect();
+    }
+  }
+
+  async stopProfiling() {
+    let res = await this.sendCommand('Profiler.stop');
+    this.destroy();
+    return res.profile;
+  }
+}

--- a/packages/core/workers/src/Trace.js
+++ b/packages/core/workers/src/Trace.js
@@ -1,0 +1,111 @@
+import {Tracer} from 'chrome-trace-event';
+
+export default class Trace {
+  constructor() {
+    this.chromeTrace = new Tracer();
+    this.tid = 0;
+    this.eventId = 0;
+    this.init();
+  }
+
+  getEventId() {
+    const id = this.eventId;
+    this.eventId++;
+    return id;
+  }
+
+  init() {
+    this.chromeTrace.instantEvent({
+      name: 'TracingStartedInPage',
+      id: this.getEventId(),
+      cat: ['disabled-by-default-devtools.timeline'],
+      args: {
+        data: {
+          sessionId: '-1',
+          page: '0xfff',
+          frames: [{
+            frame: '0xfff',
+            url: 'parcel',
+            name: ''
+          }]
+        }
+      }
+    });
+
+    this.chromeTrace.instantEvent({
+      name: 'TracingStartedInBrowser',
+      id: this.getEventId(),
+      cat: ['disabled-by-default-devtools.timeline'],
+      args: {
+        data: {
+          sessionId: '-1'
+        },
+      }
+    });
+  }
+
+  addCPUProfile(name, profile) {
+    const trace = this.chromeTrace;
+    const tid = this.tid;
+    this.tid++;
+
+    const cpuStartTime = profile.startTime;
+    const cpuEndTime = profile.endTime;
+
+    trace.instantEvent({
+      tid,
+      id: this.getEventId(),
+      cat: ['toplevel'],
+      name: 'TaskQueueManager::ProcessTaskFromWorkQueue',
+      args: {
+        src_file: '../../ipc/ipc_moji_bootstrap.cc',
+        src_func: 'Accept'
+      },
+      ts: cpuStartTime,
+      // dur: cpuEndTime - cpuStartTime,
+    }));
+
+    trace.completeEvent({
+      tid,
+      name: 'EvaluateScript',
+      id: this.getEventId(),
+      cat: ['devtools.timeline'],
+      ts: cpuStartTime,
+      dur: cpuEndTime - cpuStartTime,
+      args: {
+        data: {
+          url: 'parcel',
+          lineNumber: 1,
+          columnNumber: 1,
+          frame: '0xFFF'
+        }
+      }
+    }));
+
+    trace.instantEvent({
+      tid,
+      ts: 0,
+      ph: 'M',
+      cat: ['__metadata'],
+      name: 'thread_name',
+      args: {name},
+    }));
+
+    trace.instantEvent({
+      tid,
+      name: 'CpuProfile',
+      id: this.getEventId(),
+      cat: ['disabled-by-default-devtools.timeline'],
+      ts: cpuEndTime,
+      args: {
+        data: {
+          cpuProfile: profile,
+        },
+      },
+    }));
+  }
+
+  build() {
+    return this.chromeTrace.events;
+  }
+}

--- a/packages/core/workers/src/Trace.js
+++ b/packages/core/workers/src/Trace.js
@@ -16,9 +16,7 @@ export default class Trace {
   }
 
   getEventId() {
-    const id = this.eventId;
-    this.eventId++;
-    return id;
+    return this.eventId++;
   }
 
   init() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3389,6 +3389,13 @@ chownr@^1.0.1, chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
   integrity sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
 
+chrome-trace-event@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
+  integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
+  dependencies:
+    tslib "^1.9.0"
+
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
@@ -6080,6 +6087,11 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
+
+graceful-fs@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
+  integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
 
 grapheme-breaker@^0.3.2:
   version "0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6088,11 +6088,6 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
   integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
 
-graceful-fs@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
-  integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
-
 grapheme-breaker@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/grapheme-breaker/-/grapheme-breaker-0.3.2.tgz#5b9e6b78c3832452d2ba2bb1cb830f96276410ac"


### PR DESCRIPTION
This adds support for multi threaded/multi process profiling of Parcel. You just add the `--profile` flag to the CLI or the `profile` option to the Parcel API, and it will begin outputting trace files in the CWD as builds are performed. These trace files can be loaded in the Performance tab of the chrome dev tools to view the profiles. You can expand the timelines for each process to view a detailed flame chart.

![image-1](https://user-images.githubusercontent.com/19409/62830014-6b995480-bbbb-11e9-8c25-bae7e957e68f.png)

The profiles are done using the builtin [inspector](https://nodejs.org/api/inspector.html) module of Node, and combined together with the [chrome-trace-event](https://github.com/samccone/chrome-trace-event) library. The WorkerFarm adds two methods to start and stop a profile, and broadcasts this to all workers.