### PR TITLE
Ensure that HMR runtime is added as an entry to the bundle

### DIFF
--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -187,7 +187,7 @@ export default class BundlerRunner {
     bundleGraph: InternalBundleGraph,
     runtimeAssets: Array<RuntimeAsset>
   ) {
-    for (let {code, filePath, dependency} of runtimeAssets) {
+    for (let {code, filePath, dependency, isEntry} of runtimeAssets) {
       let builder = new AssetGraphBuilder();
       await builder.init({
         options: this.options,
@@ -251,6 +251,10 @@ export default class BundlerRunner {
         entry.id,
         entryIsReference ? 'references' : null
       );
+
+      if (isEntry) {
+        bundle.entryAssetIds.unshift(entry.id);
+      }
     }
   }
 }

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -88,8 +88,9 @@ export default class PackagerRunner {
     let options = publicBundle.env.isBrowser()
       ? undefined
       : {
-          mode: (await inputFS.stat(publicBundle.getEntryAssets()[0].filePath))
-            .mode
+          mode: (await inputFS.stat(
+            nullthrows(publicBundle.getMainEntry()).filePath
+          )).mode
         };
 
     let size;

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -87,13 +87,16 @@ export class Bundle implements IBundle {
   }
 
   getEntryAssets(): Array<IAsset> {
-    if (this.#bundle.entryAssetId == null) {
-      return [];
-    }
+    return this.#bundle.entryAssetIds.map(id => {
+      let assetNode = this.#bundleGraph._graph.getNode(id);
+      invariant(assetNode != null && assetNode.type === 'asset');
+      return assetFromValue(assetNode.value, this.#options);
+    });
+  }
 
-    let assetNode = this.#bundleGraph._graph.getNode(this.#bundle.entryAssetId);
-    invariant(assetNode != null && assetNode.type === 'asset');
-    return [assetFromValue(assetNode.value, this.#options)];
+  getMainEntry(): ?IAsset {
+    // The main entry is the last one to execute
+    return this.getEntryAssets().pop();
   }
 
   traverse<TContext>(

--- a/packages/core/core/src/public/BundlerBundleGraph.js
+++ b/packages/core/core/src/public/BundlerBundleGraph.js
@@ -120,7 +120,7 @@ export class BundlerBundleGraph implements IBundlerBundleGraph {
         env: environmentToInternalEnvironment(
           opts.env ?? nullthrows(opts.entryAsset).env
         ),
-        entryAssetId: opts.entryAsset?.id,
+        entryAssetIds: opts.entryAsset ? [opts.entryAsset.id] : [],
         filePath: null,
         isEntry: opts.isEntry,
         target: targetToInternalTarget(opts.target),

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -215,7 +215,7 @@ export type Bundle = {|
   id: string,
   type: string,
   env: Environment,
-  entryAssetId: ?string,
+  entryAssetIds: Array<string>,
   isEntry: ?boolean,
   target: Target,
   filePath: ?FilePath,

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -938,7 +938,7 @@ describe('scope hoisting', function() {
           traversal.stop();
         }
       });
-      let entryAsset = entryBundle.getEntryAssets()[0];
+      let entryAsset = entryBundle.getMainEntry();
 
       // TODO: this test doesn't currently work in older browsers since babel
       // replaces the typeof calls before we can get to them.

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -130,7 +130,7 @@ export async function run(
   });
 
   let bundle = nullthrows(bundles.find(b => b.isEntry));
-  let entryAsset = bundle.getEntryAssets()[0];
+  let entryAsset = nullthrows(bundle.getMainEntry());
   let target = entryAsset.env.context;
 
   var ctx;

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -465,6 +465,7 @@ export interface Bundle {
   +name: ?string;
   +stats: Stats;
   getEntryAssets(): Array<Asset>;
+  getMainEntry(): ?Asset;
   hasAsset(Asset): boolean;
   hasChildBundles(): boolean;
   getHash(): string;
@@ -536,7 +537,8 @@ export type Namer = {|
 export type RuntimeAsset = {|
   filePath: FilePath,
   code: string,
-  dependency?: Dependency
+  dependency?: Dependency,
+  isEntry?: boolean
 |};
 
 export type Runtime = {|

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -5,6 +5,7 @@ import type {Bundle, FilePath} from '@parcel/types';
 import {Namer} from '@parcel/plugin';
 import assert from 'assert';
 import path from 'path';
+import nullthrows from 'nullthrows';
 
 const COMMON_NAMES = new Set(['index', 'src', 'lib']);
 
@@ -55,8 +56,7 @@ export default new Namer({
 });
 
 function nameFromContent(bundle: Bundle, rootDir: FilePath): string {
-  let entryAsset = bundle.getEntryAssets()[0];
-  let entryFilePath = entryAsset.filePath;
+  let entryFilePath = nullthrows(bundle.getMainEntry()).filePath;
   let name = path.basename(entryFilePath, path.extname(entryFilePath));
 
   // If this is an entry bundle, use the original relative path.

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -106,7 +106,8 @@ export default new Packager({
       first = false;
     });
 
-    let entryAsset = bundle.getEntryAssets()[0];
+    let entries = bundle.getEntryAssets();
+    let entryAsset = entries[entries.length - 1];
     // $FlowFixMe
     let interpreter: ?string = bundle.target.env.isBrowser()
       ? null
@@ -120,12 +121,7 @@ export default new Packager({
           '({' +
           assets +
           '},{},' +
-          JSON.stringify(
-            bundle
-              .getEntryAssets()
-              .reverse()
-              .map(asset => asset.id)
-          ) +
+          JSON.stringify(entries.map(asset => asset.id)) +
           ', ' +
           'null' +
           ')\n\n' +

--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -26,7 +26,8 @@ export default new Runtime({
       filePath: __filename,
       code:
         `var __PARCEL_HMR_ENV_HASH = "${md5FromObject(bundle.env)}";` +
-        HMR_RUNTIME
+        HMR_RUNTIME,
+      isEntry: true
     };
   }
 });

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -84,7 +84,7 @@ export default new Runtime({
         });
       } else {
         for (let bundle of bundles) {
-          let filePath = bundle.getEntryAssets()[0].filePath;
+          let filePath = nullthrows(bundle.getMainEntry()).filePath;
           if (bundle.target == null) {
             throw new Error('JSRuntime: Bundle did not have a target');
           }

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -118,7 +118,7 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
     }
   });
 
-  let entry = bundle.getEntryAssets()[0];
+  let entry = bundle.getMainEntry();
   if (entry && bundle.isEntry) {
     let exportsIdentifier = getName(entry, 'exports');
     let code = await entry.getCode();

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -2,6 +2,7 @@
 
 import type {AST, Bundle, PluginOptions} from '@parcel/types';
 import babelGenerate from '@babel/generator';
+import nullthrows from 'nullthrows';
 
 export function generate(bundle: Bundle, ast: AST, options: PluginOptions) {
   let {code} = babelGenerate(ast, {
@@ -13,11 +14,10 @@ export function generate(bundle: Bundle, ast: AST, options: PluginOptions) {
     code = `\n${code}\n`;
   }
 
-  let entryAsset = bundle.getEntryAssets()[0];
   // $FlowFixMe
   let interpreter: ?string = bundle.target.env.isBrowser()
     ? null
-    : entryAsset.meta.interpreter;
+    : nullthrows(bundle.getMainEntry()).meta.interpreter;
   return {
     contents: `${
       interpreter != null ? `#!${interpreter}\n` : ''


### PR DESCRIPTION
HMR was broken due to the change to support only one entry asset per bundle. For the runtime to work, it needs to run before the main entry to override some things in the module runtime.

This PR changes `bundle.entryAssetId` to be `bundle.entryAssetIds` instead, and adds an `isEntry` option to the return value of Runtime plugins. When set, the resulting asset will be added as an entry to the bundle, before the real entry.

A new `getMainEntry` method is also added to `Bundle` objects to retrieve the last entry in the list, which is typically what you want. `getEntryAssets` is retained to get the full list.