### PR TITLE
Throw user friendly errors if resolver detects webpack load imports

### DIFF
--- a/packages/core/integration-tests/test/integration/webpack-import-syntax-error/index.js
+++ b/packages/core/integration-tests/test/integration/webpack-import-syntax-error/index.js
@@ -1,0 +1,5 @@
+import test from 'node-loader!./index.js';
+
+export default function() {
+  return 'test';
+}

--- a/packages/core/integration-tests/test/integration/webpack-import-syntax-error/package.json
+++ b/packages/core/integration-tests/test/integration/webpack-import-syntax-error/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -24,7 +24,7 @@ describe('resolver', function() {
     assert.strictEqual(output.default, 1234);
   });
 
-  it('should correctly resolve tilde in node_modules', async function() {
+  it('should throw an error on Webpack loader imports', async function() {
     let didThrow = false;
     try {
       await bundle(

--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -23,4 +23,24 @@ describe('resolver', function() {
     let output = await run(b);
     assert.strictEqual(output.default, 1234);
   });
+
+  it('should correctly resolve tilde in node_modules', async function() {
+    let didThrow = false;
+    try {
+      await bundle(
+        path.join(
+          __dirname,
+          '/integration/webpack-import-syntax-error/index.js'
+        )
+      );
+    } catch (e) {
+      didThrow = true;
+      assert.equal(
+        e.message,
+        `The import path: node-loader!./index.js is using webpack specific loader import syntax, which isn't supported by Parcel.`
+      );
+    }
+
+    assert(didThrow);
+  });
 });

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -14,8 +14,20 @@ import micromatch from 'micromatch';
 import builtins from './builtins';
 // import nodeBuiltins from 'node-libs-browser';
 
+// Throw user friendly errors on special webpack loader syntax
+// ex. `imports-loader?$=jquery!./example.js`
+const WEBPACK_IMPORT_REGEX = /\S+-loader\S*!\S+/g;
+
 export default new Resolver({
   async resolve({dependency, options}) {
+    if (WEBPACK_IMPORT_REGEX.test(dependency.moduleSpecifier)) {
+      throw new Error(
+        `The import path: ${
+          dependency.moduleSpecifier
+        } is using webpack specific loader import syntax, which isn't supported by Parcel.`
+      );
+    }
+
     const resolved = await new NodeResolver({
       extensions: ['ts', 'tsx', 'js', 'json', 'css', 'styl'],
       options


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR adds a regex check in the resolver to detect webpack's loader import syntax and throw an error.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
