### PR TITLE
debounce concurrent builds of the same parcel

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -12,7 +12,7 @@ const {
 } = require('@parcel/test-utils');
 const {makeDeferredWithPromise} = require('@parcel/utils');
 
-describe.only('javascript', function() {
+describe('javascript', function() {
   beforeEach(async () => {
     await removeDistDirectory();
   });
@@ -1444,7 +1444,7 @@ describe.only('javascript', function() {
       }
     ]);
   });
-  it.only('should prevent multiple concurrent builds of the same Parcel', async () => {
+  it('should prevent multiple concurrent builds of the same Parcel', async () => {
     let bu = await bundler(
       path.join(__dirname, '/integration/commonjs/index.js')
     );

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -12,7 +12,7 @@ const {
 } = require('@parcel/test-utils');
 const {makeDeferredWithPromise} = require('@parcel/utils');
 
-describe('javascript', function() {
+describe.only('javascript', function() {
   beforeEach(async () => {
     await removeDistDirectory();
   });
@@ -26,6 +26,7 @@ describe('javascript', function() {
     // assert.equal(b.childBundles.size, 1);
 
     let output = await run(b);
+
     assert.equal(typeof output, 'function');
     assert.equal(output(), 3);
   });
@@ -1442,5 +1443,20 @@ describe('javascript', function() {
         assets: ['b.js', 'lodash.js']
       }
     ]);
+  });
+  it.only('should prevent multiple concurrent builds of the same Parcel', async () => {
+    let bu = await bundler(
+      path.join(__dirname, '/integration/commonjs/index.js')
+    );
+    await bu.init();
+
+    let a = bu.build();
+    let b = await bu.build();
+    let f = await bu.build();
+
+    let resolvedA = await a;
+
+    assert.equal(resolvedA.buildTime, b.buildTime);
+    assert.notEqual(resolvedA.buildTime, f.buildTime);
   });
 });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Was working on task P2B-3 "Prevent multiple concurrent builds of the same Parcel" with @wbinnssmith and @padmaia - this is an initial implementation to see if this is the right direction for this. 😁

NB: The goal was to 'prevent multiple concurrent builds'. I've implemented this with a debouncing of the builds, which will stop downstream tasks failing, but instead working of the same data as the current active build.

Alternatives could be to have a queue of requested builds to ensure each gets its own results, or outright erroring/returning an error event if someone tries to trigger a second build while one is in progress.

Finally, testing. I *think* the test I wrote is clever and will always Be Fine, since build A and build B will always be requested as a single pass of the js lifecycle, but relying on this feels too clever, and I would love better tests here, though I don't know how to write them. The using build time is also potentially flakey - return the `startTime` as part of the event would solve this but wasn't sure if it was good to add that just for testing.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
