### PR TITLE
Default to ending WorkerFarm

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -76,7 +76,7 @@ export default async function resolveOptions(
     hot: initialOptions.hot ?? false,
     serve: initialOptions.serve ?? false,
     disableCache: initialOptions.disableCache ?? false,
-    killWorkers: initialOptions.killWorkers ?? false,
+    killWorkers: initialOptions.killWorkers ?? true,
     profile: initialOptions.profile ?? false,
     cacheDir,
     entries,


### PR DESCRIPTION
`killWorkers` had been defaulting to `false`, preventing the workerfarm from ending in situations like `parcel build`.

Test Plan: 
  * Verify that `parcel build` in the hmr example exits the process with a `0` exit code. 
  * Verify that `parcel build` in the hmr example exits the process with a `1` when a syntax error is introduced
  * Verify that `parcel`, which defaults to `parcel serve`, does not exit the process after its first build