### PR TITLE
Allow --no-scope-hoist as a cli option for builds

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -95,6 +95,7 @@ let build = program
   .command('build [input...]')
   .description('bundles for production')
   .option('--no-minify', 'disable minification')
+  .option('--no-scope-hoist', 'disable scope-hoisting')
   .action(run);
 
 applyOptions(build, commonOptions);
@@ -238,11 +239,12 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     cacheDir: command.cacheDir,
     mode,
     minify: command.minify != null ? command.minify : mode === 'production',
-    sourceMaps: command.sourceMaps != false,
+    sourceMaps: command.sourceMaps ?? true,
+    scopeHoist: command.scopeHoist ?? true,
     hot: hmr,
     serve,
     targets: command.target.length > 0 ? command.target : null,
-    autoinstall: command.autoinstall !== false,
+    autoinstall: command.autoinstall ?? true,
     logLevel: command.logLevel,
     profile: command.profile
   };


### PR DESCRIPTION
This adds `--no-scope-hoist` as a cli option for disabling scope hoisting during builds.

Test Plan:

In the react-hmr example:
* run `parcel build`. Verify:
    * Sourcemaps present
    * Minified output
    * Scope-hoisted output (presence of `parcelRequire.register`)
* run `parcel build` with `--no-scope-hoist`, `--no-minify`, and `--no-source-maps` and verify none of those features is present in the bundles written to `dist`.