### PR TITLE
Inline and DCE process.env.PARCEL_BUILD_ENV and fix Linux dev env

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,9 +6,6 @@ const path = require('path');
 const rimraf = require('rimraf');
 const babelConfig = require('./babel.config.js');
 
-const BABEL_REGISTER_INTERPRETER =
-  '#!/usr/bin/env node -r @parcel/babel-register';
-
 const IGNORED_PACKAGES = [
   '!packages/examples/**',
   '!packages/core/integration-tests/**',
@@ -45,7 +42,6 @@ exports.default = exports.build = function build() {
     gulp
       .src(paths.packageSrc)
       .pipe(babel(babelConfig))
-      .pipe(removeBabelRegisterInterpreter())
       .pipe(renameStream(relative => relative.replace('src', 'lib')))
       .pipe(gulp.dest(paths.packages)),
     gulp
@@ -81,23 +77,6 @@ function updatePackageJson() {
       access: 'public'
     };
     vinyl.contents = Buffer.from(JSON.stringify(json, null, 2));
-  });
-}
-
-function removeBabelRegisterInterpreter() {
-  return new TapStream(vinyl => {
-    if (
-      vinyl.contents
-        .toString()
-        .trim()
-        .startsWith(BABEL_REGISTER_INTERPRETER)
-    ) {
-      vinyl.contents = Buffer.from(
-        vinyl.contents
-          .toString()
-          .replace(BABEL_REGISTER_INTERPRETER, '#!/usr/bin/env node')
-      );
-    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "packages/*/*"
   ],
   "scripts": {
-    "build": "gulp",
+    "build": "NODE_ENV=production PARCEL_BUILD_ENV=production gulp",
     "clean-test": "rimraf packages/core/integration-tests/.parcel-cache && rimraf packages/core/integration-tests/dist",
     "clean": "yarn clean-test && lerna clean --yes && lerna exec -- rm -rf ./lib && yarn",
     "format": "prettier --write \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\"",

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -16,5 +16,8 @@
     "get-port": "^4.2.0",
     "react": "^16.7.0",
     "v8-compile-cache": "^2.0.0"
+  },
+  "devDependencies": {
+    "@parcel/babel-register": "^2.0.0-alpha.1.1"
   }
 }

--- a/packages/core/parcel/src/bin.js
+++ b/packages/core/parcel/src/bin.js
@@ -1,2 +1,9 @@
-#!/usr/bin/env node -r @parcel/babel-register
+#!/usr/bin/env node
+
+'use strict';
+
+if (process.env.PARCEL_BUILD_ENV !== 'production') {
+  require('@parcel/babel-register');
+}
+
 require('./cli');

--- a/packages/dev/babel-preset/index.js
+++ b/packages/dev/babel-preset/index.js
@@ -15,5 +15,18 @@ module.exports = () => ({
     require('@babel/plugin-proposal-class-properties'),
     require('@babel/plugin-proposal-nullish-coalescing-operator'),
     require('@babel/plugin-proposal-optional-chaining')
-  ]
+  ],
+  env: {
+    production: {
+      plugins: [
+        // Inline the value of PARCEL_BUILD_ENV during production builds so that
+        // it can be removed through dead code elimination below
+        [
+          'babel-plugin-transform-inline-environment-variables',
+          {include: ['PARCEL_BUILD_ENV']}
+        ],
+        'babel-plugin-minify-dead-code-elimination'
+      ]
+    }
+  }
 });

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -9,6 +9,8 @@
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
+    "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+    "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "read-pkg-up": "^4.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2447,6 +2447,11 @@ babel-helper-define-map@^6.24.1:
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
+babel-helper-evaluate-path@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz#a62fa9c4e64ff7ea5cea9353174ef023a900a67c"
+  integrity sha512-mUh0UhS607bGh5wUMAQfOpt2JX2ThXMtppHRdRU1kL7ZLRWIXxoV2UIV1r2cAeeNeU1M5SB5/RSUgUxrK8yOkA==
+
 babel-helper-explode-assignable-expression@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
@@ -2483,6 +2488,11 @@ babel-helper-hoist-variables@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-helper-mark-eval-scopes@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz#d244a3bef9844872603ffb46e22ce8acdf551562"
+  integrity sha1-0kSjvvmESHJgP/tG4izorN9VFWI=
+
 babel-helper-optimise-call-expression@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
@@ -2510,6 +2520,11 @@ babel-helper-remap-async-to-generator@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
+
+babel-helper-remove-or-void@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz#a4f03b40077a0ffe88e45d07010dee241ff5ae60"
+  integrity sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=
 
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
@@ -2551,6 +2566,16 @@ babel-plugin-dynamic-import-node@^2.3.0:
   integrity sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==
   dependencies:
     object.assign "^4.1.0"
+
+babel-plugin-minify-dead-code-elimination@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.0.tgz#d23ef5445238ad06e8addf5c1cf6aec835bcda87"
+  integrity sha512-XQteBGXlgEoAKc/BhO6oafUdT4LBa7ARi55mxoyhLHNuA+RlzRmeMAfc31pb/UqU01wBzRc36YqHQzopnkd/6Q==
+  dependencies:
+    babel-helper-evaluate-path "^0.5.0"
+    babel-helper-mark-eval-scopes "^0.4.3"
+    babel-helper-remove-or-void "^0.4.3"
+    lodash.some "^4.6.0"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -2774,6 +2799,11 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-inline-environment-variables@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-inline-environment-variables/-/babel-plugin-transform-inline-environment-variables-0.4.3.tgz#a3b09883353be8b5e2336e3ff1ef8a5d93f9c489"
+  integrity sha1-o7CYgzU76LXiM24/8e+KXZP5xIk=
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -7803,6 +7833,11 @@ lodash.set@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+
+lodash.some@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+  integrity sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Currently developing Parcel 2 on Linux is broken as the entire hashbang line is treated as a filepath [0]

To resolve this, in development we can conditionally require `@parcel/babel-register`. Instead of a brittle regex replacement like we do with the hashbang, we can inline a special environment variable value and run dead code elimination to remove it entirely during builds.

This was actually the intention behind using `process.env.PARCEL_BUILD_ENV` (which currently is never set) in `dumpGraphToGraphViz`. [1]

Now it's possible by running two babel plugins during production builds: 
* `babel-plugin-transform-inline-environment-variables` configured to only inline `PARCEL_BUILD_ENV`. This was chosen over `NODE_ENV` as that must remain a runtime check when the user invokes Parcel.
* `babel-plugin-minify-dead-code-elimination`, which actually performs the dead code elimination. Alternatively we could run everything through Terser.

Alternatives:
* We could also transform something like `__DEV__` to make this more concise and typo-proof.
* We could simply inline a static value for the expression, avoiding actually needing to set the environment variable during the build.

Test Plan: Run `yarn build` from the root.
* Examine the output of `parcel/lib/cli.js`. Verify it does not contain `require('@parcel/babel-register')`.
* Examine the output of `dumpGraphToGraphViz.js` and verify the function is now entirely empty.
* Run the `parcel` binary in development mode on Linux and verify it runs whereas before it did not.

[0] https://unix.stackexchange.com/questions/399690/multiple-arguments-in-shebang
[1] https://github.com/parcel-bundler/parcel/blob/cc69cb7ad83c8a1f09f126a7cf61cf1109401bc6/packages/core/core/src/dumpGraphToGraphViz.js#L30-L35