### PR TITLE
Link to reasoning behind plugin name validation

### DIFF
--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -226,6 +226,8 @@ export function validateMap<K, V>(
   }
 }
 
+// Reasoning behind this validation:
+// https://github.com/parcel-bundler/parcel/issues/3397#issuecomment-521353931
 export function validatePackageName(
   pkg: ?PackageName,
   pluginType: string,


### PR DESCRIPTION
Figured it would be good to keep this reasoning in the codebase so if someone comes back to it years from now they'll know why it was done this way.