### PR TITLE
Fix mismatching ids in request and asset graph

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -109,7 +109,7 @@ export default class AssetGraphBuilder extends EventEmitter {
         this.requestGraph.addDepPathRequest(node.value);
         break;
       case 'asset_group':
-        this.requestGraph.addAssetRequest(node.value);
+        this.requestGraph.addAssetRequest(node.id, node.value);
         break;
       case 'asset': {
         let asset = node.value;

--- a/packages/core/core/src/RequestGraph.js
+++ b/packages/core/core/src/RequestGraph.js
@@ -52,20 +52,10 @@ type SerializedRequestGraph = {|
   depVersionRequestNodeIds: Set<NodeId>
 |};
 
-const hashObject = obj => {
-  return md5FromString(JSON.stringify(obj));
-};
-
 const nodeFromDepPathRequest = (dep: Dependency) => ({
   id: dep.id,
   type: 'dep_path_request',
   value: dep
-});
-
-const nodeFromAssetRequest = (assetRequest: AssetRequest) => ({
-  id: hashObject(assetRequest),
-  type: 'asset_request',
-  value: assetRequest
 });
 
 const nodeFromConfigRequest = (configRequest: ConfigRequest) => ({
@@ -208,8 +198,8 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
     }
   }
 
-  addAssetRequest(request: AssetRequest) {
-    let requestNode = nodeFromAssetRequest(request);
+  addAssetRequest(id: NodeId, request: AssetRequest) {
+    let requestNode = {id, type: 'asset_request', value: request};
     if (!this.hasNode(requestNode.id)) {
       this.addNode(requestNode);
     }


### PR DESCRIPTION
This PR fixes an issue where updating a file by removing a dependency would screw things up because when the `asset_group` node of the dependency was being removed from the `AssetGraph`, it was attempting to remove the corresponding `asset_request` node in the `RequestGraph`, but the ids were mismatching so it was trying to remove a node from the graph that didn't exist. 
