### PR TITLE
removal of test-ci scripts

### DIFF
--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -14,10 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "test": "echo this package has no tests yet",
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@parcel/utils": "^2.0.0-alpha.1.1",
     "@parcel/workers": "^2.0.0-alpha.1.1",

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -14,9 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@parcel/events": "^2.0.0-alpha.1.1"
   }

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -22,8 +22,5 @@
     "nullthrows": "^1.1.1",
     "resolve": "^1.4.0",
     "ws": "^5.1.1"
-  },
-  "scripts": {
-    "test-ci": "yarn test"
   }
 }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -14,9 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@iarna/toml": "^2.2.0",
     "@parcel/logger": "^2.0.0-alpha.1.1",

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -14,9 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@parcel/logger": "^2.0.0-alpha.1.1",
     "@parcel/utils": "^2.0.0-alpha.1.1",

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -6,9 +6,6 @@
     "node": ">= 8.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
-  "scripts": {
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@parcel/events": "^2.0.0-alpha.1.1",
     "@parcel/logger": "^2.0.0-alpha.1.1",

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -6,9 +6,6 @@
     "node": ">= 8.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
-  "scripts": {
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@parcel/logger": "^2.0.0-alpha.1.1",
     "@parcel/plugin": "^2.0.0-alpha.1.1",

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -11,9 +11,6 @@
   "engines": {
     "node": ">= 8.0.0"
   },
-  "scripts": {
-    "test-ci": "yarn test"
-  },
   "dependencies": {
     "@babel/generator": "^7.3.3",
     "@babel/parser": "^7.0.0",

--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -9,8 +9,5 @@
   "main": "src/index.js",
   "engines": {
     "node": ">= 8.0.0"
-  },
-  "scripts": {
-    "test-ci": "yarn test"
   }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Removed unnecessary test-ci scripts that were left behind after unifying the test suites.

## 💻 Examples

packages/utils/events/package.json:13-15

`  "scripts": {
    "test-ci": "yarn test"
  }
`
<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
