### PR TITLE
Fix autoinstall not using proper package names

### DIFF
--- a/packages/core/install-package/src/installPackage.js
+++ b/packages/core/install-package/src/installPackage.js
@@ -13,6 +13,7 @@ import WorkerFarm from '@parcel/workers';
 import {loadConfig, PromiseQueue, resolve, resolveConfig} from '@parcel/utils';
 import Npm from './Npm';
 import Yarn from './Yarn';
+import validateModuleSpecifiers from './validateModuleSpecifiers';
 
 type InstallOptions = {
   installPeers?: boolean,
@@ -114,6 +115,8 @@ export function _addToInstallQueue(
   filePath: FilePath,
   options?: InstallOptions
 ): Promise<mixed> {
+  modules = validateModuleSpecifiers(modules);
+
   // Wrap PromiseQueue and track modules that are currently installing.
   // If a request comes in for a module that is currently installing, don't bother
   // enqueuing it.

--- a/packages/core/install-package/src/validateModuleSpecifiers.js
+++ b/packages/core/install-package/src/validateModuleSpecifiers.js
@@ -1,12 +1,16 @@
 // @flow
 
-const MODULE_REGEX = /((@[^/\s]+\/){0,1}([^/@\s]+)){1}(@[^/\s]+){0,1}/;
+const MODULE_REGEX = /^((@[^/\s]+\/){0,1}([^/\s.~]+[^/\s]*)){1}(@[^/\s]+){0,1}/;
 
 export default function validateModuleSpecifiers(
   modules: Array<string>
 ): Array<string> {
   return modules.map(module => {
-    // $FlowFixMe, not sure why this happens
-    return MODULE_REGEX.exec(module)[0] || '';
+    let matches = MODULE_REGEX.exec(module);
+    if (matches) {
+      return matches[0];
+    }
+
+    return '';
   });
 }

--- a/packages/core/install-package/src/validateModuleSpecifiers.js
+++ b/packages/core/install-package/src/validateModuleSpecifiers.js
@@ -1,0 +1,12 @@
+// @flow
+
+const MODULE_REGEX = /((@[^/\s]+\/){0,1}([^/@\s]+)){1}(@[^/\s]+){0,1}/;
+
+export default function validateModuleSpecifiers(
+  modules: Array<string>
+): Array<string> {
+  return modules.map(module => {
+    // $FlowFixMe, not sure why this happens
+    return MODULE_REGEX.exec(module)[0] || '';
+  });
+}

--- a/packages/core/install-package/test/validateModuleSpecifiers.test.js
+++ b/packages/core/install-package/test/validateModuleSpecifiers.test.js
@@ -9,6 +9,8 @@ describe('Validate Module Specifiers', () => {
       '@parcel/transformer-posthtml/package.json',
       '@some-org/package@v1.0.0',
       '@org/some-package@v1.0.0-alpha.1',
+      'something.js/something/index.js',
+      '@some.org/something.js/index.js',
       'lodash/something/index.js'
     ];
 
@@ -16,7 +18,15 @@ describe('Validate Module Specifiers', () => {
       '@parcel/transformer-posthtml',
       '@some-org/package@v1.0.0',
       '@org/some-package@v1.0.0-alpha.1',
+      'something.js',
+      '@some.org/something.js',
       'lodash'
     ]);
+  });
+
+  it('Return empty on invalid modules', () => {
+    let modules = ['./somewhere.js', './hello/world.js', '~/hello/world.js'];
+
+    assert.deepEqual(validateModuleSpecifiers(modules), ['', '', '']);
   });
 });

--- a/packages/core/install-package/test/validateModuleSpecifiers.test.js
+++ b/packages/core/install-package/test/validateModuleSpecifiers.test.js
@@ -1,0 +1,22 @@
+// @flow
+import assert from 'assert';
+
+import validateModuleSpecifiers from '../src/validateModuleSpecifiers';
+
+describe('Validate Module Specifiers', () => {
+  it('Validate Module Specifiers', () => {
+    let modules = [
+      '@parcel/transformer-posthtml/package.json',
+      '@some-org/package@v1.0.0',
+      '@org/some-package@v1.0.0-alpha.1',
+      'lodash/something/index.js'
+    ];
+
+    assert.deepEqual(validateModuleSpecifiers(modules), [
+      '@parcel/transformer-posthtml',
+      '@some-org/package@v1.0.0',
+      '@org/some-package@v1.0.0-alpha.1',
+      'lodash'
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,7 +944,7 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@iarna/toml@^2.2.0":
+"@iarna/toml@^2.2.0", "@iarna/toml@^2.2.3":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
   integrity sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==


### PR DESCRIPTION
# ↪️ Pull Request

This PR adds a utility in install-package that validates and fixes package names before they get installed.

See the issue this fixes for context.

Fixes #3396 

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
