### PR TITLE
Reflect child bundle contents in own bundle hash

### DIFF
--- a/packages/core/integration-tests/test/contentHashing.js
+++ b/packages/core/integration-tests/test/contentHashing.js
@@ -1,23 +1,23 @@
 import assert from 'assert';
 import path from 'path';
-import {bundle as _bundle, distDir, inputFS as fs} from '@parcel/test-utils';
+import {bundle as _bundle, outputFS, ncp} from '@parcel/test-utils';
 
 function bundle(path) {
   return _bundle(path, {
-    disableCache: false,
-    inputFS: fs,
-    // These tests must use the real fs as they rely on the watcher
-    outputFS: fs
+    inputFS: outputFS,
+    disableCache: false
   });
 }
 
+const distDir = '/dist';
+
 describe('content hashing', function() {
-  beforeEach(async function() {
-    await fs.rimraf(path.join(__dirname, '/input'));
+  beforeEach(async () => {
+    await outputFS.rimraf(path.join(__dirname, '/input'));
   });
 
   it('should update content hash when content changes', async function() {
-    await fs.ncp(
+    await ncp(
       path.join(__dirname, '/integration/html-css'),
       path.join(__dirname, '/input')
     );
@@ -25,29 +25,32 @@ describe('content hashing', function() {
     let bundleHtml = () => bundle(path.join(__dirname, '/input/index.html'));
     await bundleHtml();
 
-    let html = await fs.readFile(path.join(distDir, 'index.html'), 'utf8');
+    let html = await outputFS.readFile(
+      path.join(distDir, 'index.html'),
+      'utf8'
+    );
     let filename = html.match(
       /<link rel="stylesheet" href="[/\\]{1}(input\.[a-f0-9]+\.css)">/
     )[1];
-    assert(await fs.exists(path.join(distDir, filename)));
+    assert(await outputFS.exists(path.join(distDir, filename)));
 
-    await fs.writeFile(
+    await outputFS.writeFile(
       path.join(__dirname, '/input/index.css'),
       'body { background: green }'
     );
     await bundleHtml();
 
-    html = await fs.readFile(path.join(distDir, 'index.html'), 'utf8');
+    html = await outputFS.readFile(path.join(distDir, 'index.html'), 'utf8');
     let newFilename = html.match(
       /<link rel="stylesheet" href="[/\\]{1}(input\.[a-f0-9]+\.css)">/
     )[1];
-    assert(await fs.exists(path.join(distDir, newFilename)));
+    assert(await outputFS.exists(path.join(distDir, newFilename)));
 
     assert.notEqual(filename, newFilename);
   });
 
   it('should update content hash when raw asset changes', async function() {
-    await fs.ncp(
+    await ncp(
       path.join(__dirname, '/integration/import-raw'),
       path.join(__dirname, '/input')
     );
@@ -55,16 +58,19 @@ describe('content hashing', function() {
     let bundleJs = () => bundle(path.join(__dirname, '/input/index.js'));
     await bundleJs();
 
-    let js = await fs.readFile(path.join(distDir, 'index.js'), 'utf8');
+    let js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
     let filename = js.match(/\/(test\.[0-9a-f]+\.txt)/)[1];
-    assert(await fs.exists(path.join(distDir, filename)));
+    assert(await outputFS.exists(path.join(distDir, filename)));
 
-    await fs.writeFile(path.join(__dirname, '/input/test.txt'), 'hello world');
+    await outputFS.writeFile(
+      path.join(__dirname, '/input/test.txt'),
+      'hello world'
+    );
     await bundleJs();
 
-    js = await fs.readFile(path.join(distDir, 'index.js'), 'utf8');
+    js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
     let newFilename = js.match(/\/(test\.[0-9a-f]+\.txt)/)[1];
-    assert(await fs.exists(path.join(distDir, newFilename)));
+    assert(await outputFS.exists(path.join(distDir, newFilename)));
 
     assert.notEqual(filename, newFilename);
   });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -42,7 +42,6 @@ export async function ncp(source: FilePath, destination: FilePath) {
           .on('error', reject);
       });
     } else if (stats.isDirectory()) {
-      outputFS.mkdirp(destPath);
       await ncp(sourcePath, destPath);
     }
   }


### PR DESCRIPTION
Resolves #3393 and Resolves #3409

Since we include a bundle's hash in filenames, anything that could possibly alter the content must be factored into what a bundle's hash is, including that a bundle can reference another bundle with a changing digest.

This extracts the current hashing strategy into `_getContentHash`, which returns a hash of the bundles own content. In `getHash`, recursively retrieve child bundle's content hashes and reflect them in the current bundle's hash. Using `traverseBundles`, which now has the option to start at a given bundle, will prevent cyclic bundle dependencies from being considered.

Test Plan: 
* Enabled the `contentHashing` integration test. 
* Temporarily removed `--no-cache` from the react-hmr example and demonstrate #3393 before applying this patch. Apply the patch and verify #3393 is no longer reproducible.