### PR TITLE
Increase timeouts for unit tests requiring WorkerFarm

### DIFF
--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -32,7 +32,10 @@ const TARGETS = [
   }
 ];
 
-describe('AssetGraphBuilder', () => {
+describe('AssetGraphBuilder', function() {
+  // This depends on spinning up a WorkerFarm, which can take some time.
+  this.timeout(20000);
+
   let config;
   let builder;
   let workerFarm;

--- a/packages/core/workers/test/workerfarm.js
+++ b/packages/core/workers/test/workerfarm.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 import WorkerFarm from '../';
 
 describe('WorkerFarm', function() {
-  this.timeout(10000);
+  this.timeout(20000);
 
   it('Should start up workers', async () => {
     let workerfarm = new WorkerFarm({


### PR DESCRIPTION
WorkerFarms require some time to spin up, causing tests to take longer. Looking through recent CI runs, we just barely passed the prior timeout of 10s only in certain environments, so 20s should be enough.This should address the flaky test failures in recent days.

Test Plan: Re-run CI a number of times and verify all agents pass reliably.