### PR TITLE
Fix source map on CoffeeScript assets

### DIFF
--- a/packages/core/parcel-bundler/src/assets/CoffeeScriptAsset.js
+++ b/packages/core/parcel-bundler/src/assets/CoffeeScriptAsset.js
@@ -27,7 +27,7 @@ class CoffeeScriptAsset extends Asset {
       {
         type: 'js',
         value: this.options.sourceMaps ? transpiled.js : transpiled,
-        sourceMap
+        map: sourceMap
       }
     ];
   }


### PR DESCRIPTION
# ↪️ Pull Request

The current source map information of CoffeeScript files is not correct, so it fixes this


## 💻 Examples
At the following Class, https://github.com/parcel-bundler/parcel/blob/96119be782d9d551f73b77e06ab25067c7073344/packages/core/parcel-bundler/src/assets/JSAsset.js#L38 it checks for the 'map' key on rendition object, but the CoffeeScriptAsset generate function returns 'sourceMap' instead.



## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
