### PR TITLE
fix: replace eslint string when we used helpers.js content

### DIFF
--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -17,6 +17,8 @@ const HELPERS = fs.readFileSync(HELPERS_PATH, 'utf8');
 const PRELUDE_PATH = path.join(__dirname, 'prelude.js');
 const PRELUDE = fs.readFileSync(PRELUDE_PATH, 'utf8');
 
+const EslintNoUnusedVarsRegExp = /\/\/\seslint-disable-next-line\sno-unused-vars/g;
+
 type AssetASTMap = Map<string, Object>;
 type TraversalContext = {|
   parent: ?AssetASTMap,
@@ -44,7 +46,9 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
   });
 
   let outputs = new Map(await queue.run());
-  let result = [...parse(HELPERS, HELPERS_PATH)];
+  let result = [
+    ...parse(HELPERS.replace(EslintNoUnusedVarsRegExp, ''), HELPERS_PATH)
+  ];
 
   // If this is an entry bundle and it has child bundles, we need to add the prelude code, which allows
   // registering modules dynamically at runtime.

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -11,17 +11,17 @@ import fs from 'fs';
 import nullthrows from 'nullthrows';
 import {PromiseQueue} from '@parcel/utils';
 
-const EslintCommentsRegExp = /^\s*\/\/\s*eslint.*?$|^\s*\/\*\s*eslint.*?\s*\*\/$/gm;
+const eslintCommentsRegExp = /^\s*\/\/\s*eslint.*?$|^\s*\/\*\s*eslint.*?\s*\*\/$/gm;
 
 const HELPERS_PATH = path.join(__dirname, 'helpers.js');
 const HELPERS = fs
   .readFileSync(HELPERS_PATH, 'utf8')
-  .replace(EslintCommentsRegExp, '');
+  .replace(eslintCommentsRegExp, '');
 
 const PRELUDE_PATH = path.join(__dirname, 'prelude.js');
 const PRELUDE = fs
   .readFileSync(PRELUDE_PATH, 'utf8')
-  .replace(EslintCommentsRegExp, '');
+  .replace(eslintCommentsRegExp, '');
 
 type AssetASTMap = Map<string, Object>;
 type TraversalContext = {|

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -11,13 +11,17 @@ import fs from 'fs';
 import nullthrows from 'nullthrows';
 import {PromiseQueue} from '@parcel/utils';
 
+const EslintCommentsRegExp = /^\s*\/\/\s*eslint.*?$|^\s*\/\*\s*eslint.*?\s*\*\/$/gm;
+
 const HELPERS_PATH = path.join(__dirname, 'helpers.js');
-const HELPERS = fs.readFileSync(HELPERS_PATH, 'utf8');
+const HELPERS = fs
+  .readFileSync(HELPERS_PATH, 'utf8')
+  .replace(EslintCommentsRegExp, '');
 
 const PRELUDE_PATH = path.join(__dirname, 'prelude.js');
-const PRELUDE = fs.readFileSync(PRELUDE_PATH, 'utf8');
-
-const EslintNoUnusedVarsRegExp = /\/\/\seslint-disable-next-line\sno-unused-vars/g;
+const PRELUDE = fs
+  .readFileSync(PRELUDE_PATH, 'utf8')
+  .replace(EslintCommentsRegExp, '');
 
 type AssetASTMap = Map<string, Object>;
 type TraversalContext = {|
@@ -46,9 +50,7 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
   });
 
   let outputs = new Map(await queue.run());
-  let result = [
-    ...parse(HELPERS.replace(EslintNoUnusedVarsRegExp, ''), HELPERS_PATH)
-  ];
+  let result = [...parse(HELPERS, HELPERS_PATH)];
 
   // If this is an entry bundle and it has child bundles, we need to add the prelude code, which allows
   // registering modules dynamically at runtime.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->


# ↪️ Pull Request

Fixes #3402 

replace eslint string when we used helpers.js content

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
now 

```js
(function(){
// eslint-disable-next-line no-unused-vars
// eslint-disable-next-line no-unused-vars
// eslint-disable-next-line no-unused-vars
// eslint-disable-next-line no-unused-vars
// eslint-disable-next-line no-unused-vars
// ASSET: c:\dev\parcel\test.js
console.log('foo');
})();
```

should be 

```js
(function(){
// ASSET: c:\dev\parcel\test.js
console.log('foo');
})();
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

#3402 

should i add test case with this issue?
<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
