### PR TITLE
Asset content cache keys

### DIFF
--- a/packages/core/core/src/InternalAsset.js
+++ b/packages/core/core/src/InternalAsset.js
@@ -211,7 +211,7 @@ export default class InternalAsset {
   }
 
   generateCacheKey(key: string): string {
-    return md5FromString(key + this.value.id + JSON.stringify(this.value.env));
+    return md5FromString(key + this.value.id + (this.value.hash || ''));
   }
 
   addDependency(opts: DependencyOptions) {

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -222,8 +222,7 @@ export default class Transformation {
   ): Promise<string> {
     let assetsKeyInfo = assets.map(a => ({
       filePath: a.value.filePath,
-      hash: a.value.hash,
-      type: a.value.type
+      hash: a.value.hash
     }));
 
     let configsKeyInfo = [...configs].map(([, {resultHash, devDeps}]) => ({
@@ -488,8 +487,7 @@ async function finalize(
 ): Promise<InternalAsset> {
   if (asset.ast && generate) {
     let result = await generate(new MutableAsset(asset));
-    asset.content = result.code;
-    asset.map = result.map;
+    return asset.createChildAsset({type: asset.value.type, ...result});
   }
   return asset;
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -308,7 +308,7 @@ export type Stats = {|
 
 export type GenerateOutput = {|
   code: string,
-  map?: SourceMap
+  map?: ?SourceMap
 |};
 
 export type Blob = string | Buffer | Readable;


### PR DESCRIPTION
# ↪️ Pull Request
This PR adds some information to Asset's `.commit()` cache key:

* **The input hash of the asset** - One scenario where this is necessary is when an asset jumps pipelines. For example, mdx takes a markdown asset and outputs a javascript asset and sets the type to `js`. The second pipeline also outputs an asset with type `js` while the only other things that factor into the cache key (filePath, env) don't change either so the output of the second pipeline ends up overwriting the output of the first pipeline. I also added some code to ensure that the hash gets updated when we generate at the end of a pipeline.
* **Impactful pipeline config info** - In the future we will support the same asset going through different pipelines, so we need information about the pipeline the asset was transformed with to be included in the cache key as well.

## 🚨 Test instructions
For now I have just manually tested the above scenarios. The second scenario should be tested well with integration tests once we support something like imports with query params. The first scenario should be easier to test with integration tests when we start working on garbage collection because we will need to keep track of commit cache keys used in a transformation. If we see two different ones instead of one, then it is working correctly.
