### PR TITLE
Fix contributing alias work flow

### DIFF
--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -40,7 +40,9 @@ export default class ReporterRunner {
       }
     });
 
-    patchConsole();
+    if (this.options.patchConsole) {
+      patchConsole();
+    }
   }
 
   async report(event: ReporterEvent) {

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -8,6 +8,7 @@ import {bus} from '@parcel/workers';
 import ParcelConfig from './ParcelConfig';
 import logger from '@parcel/logger';
 import PluginOptions from './public/PluginOptions';
+import {patchConsole} from '@parcel/logger';
 
 type Opts = {|
   config: ParcelConfig,
@@ -38,6 +39,8 @@ export default class ReporterRunner {
         });
       }
     });
+
+    patchConsole();
   }
 
   async report(event: ReporterEvent) {

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -67,6 +67,7 @@ export default async function resolveOptions(
   return {
     config: initialOptions.config,
     defaultConfig: initialOptions.defaultConfig,
+    patchConsole: initialOptions.patchConsole,
     env:
       initialOptions.env ??
       (await loadDotEnv(inputFS, path.join(rootDir, 'index'))),

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -97,6 +97,7 @@ export type ParcelOptions = {|
   projectRoot: FilePath,
   lockFile: ?FilePath,
   profile: boolean,
+  patchConsole: ?boolean,
 
   inputFS: FileSystem,
   outputFS: FileSystem,

--- a/packages/core/core/test/utils.js
+++ b/packages/core/core/test/utils.js
@@ -28,5 +28,6 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
   profile: false,
   inputFS,
   outputFS,
-  cache
+  cache,
+  patchConsole: false
 };

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -2,7 +2,6 @@
 
 import type {ParcelConfigFile, InitialParcelOptions} from '@parcel/types';
 import {BuildError} from '@parcel/core';
-import {patchConsole} from '@parcel/logger';
 
 require('v8-compile-cache');
 
@@ -144,8 +143,6 @@ async function run(entries: Array<string>, command: any) {
     },
     ...(await normalizeOptions(command))
   });
-
-  patchConsole();
 
   if (command.name() === 'watch' || command.name() === 'serve') {
     let {unsubscribe} = await parcel.watch(err => {

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -141,6 +141,7 @@ async function run(entries: Array<string>, command: any) {
       ...defaultConfig,
       filePath: require.resolve('@parcel/config-default')
     },
+    patchConsole: true,
     ...(await normalizeOptions(command))
   });
 

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -156,6 +156,7 @@ export type InitialParcelOptions = {|
   autoinstall?: boolean,
   logLevel?: LogLevel,
   profile?: boolean,
+  patchConsole?: boolean,
 
   inputFS?: FileSystem,
   outputFS?: FileSystem,

--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -9,4 +9,4 @@ require('@babel/register')({
 
 // This adds the registration to the Node args, which are passed
 // to child processes by Node when we fork to create workers.
-process.execArgv.push('-r', '@parcel/babel-register');
+process.execArgv.push('-r', __filename);

--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -3,7 +3,8 @@ const path = require('path');
 
 require('@babel/register')({
   ignore: [filepath => filepath.includes(path.sep + 'node_modules' + path.sep)],
-  presets: [parcelBabelPreset]
+  presets: [parcelBabelPreset],
+  cwd: path.join(__dirname, '../../..')
 });
 
 // This adds the registration to the Node args, which are passed


### PR DESCRIPTION
# ↪️ Pull Request
Someone mentioned in the spectrum contributing channel that they were following the alias instructions in the `CONTRIBUTING.md` file and running into issues. [[Spectrum post](https://spectrum.chat/parcel/contributing/first-time-contributor-issues-with-running-local-version~966dc9fe-32ca-4498-b28e-c268b0c7689f)]

The first issue was that we are patching console before our cli reporter is set up, so nothing was getting logged when an error was being thrown during initialization. The error that was getting thrown during initialization was related to `@babel/register` trying to resolve plugins relative to the directory where parcel was called instead of the parcel repo.

## 🚨 Test instructions

Followed alias instructions in `CONTRIBUTING.md` and ran `parceldev build index.js` in a simple project outside of the parcel repo and confirmed it built as expected.
