### PR TITLE
Scopehoisting fixes and vendoring bundler plugin

### DIFF
--- a/packages/bundlers/vendoring/package.json
+++ b/packages/bundlers/vendoring/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@parcel/bundler-vendoring",
+  "version": "2.0.0-alpha.1.1",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "src/VendoringBundler",
+  "engines": {
+    "node": ">= 8.0.0",
+    "parcel": "^2.0.0-alpha.1.1"
+  },
+  "dependencies": {
+    "@parcel/plugin": "^2.0.0-alpha.1.1",
+    "@parcel/utils": "^2.0.0-alpha.1.1",
+    "nullthrows": "^1.1.1"
+  }
+}

--- a/packages/bundlers/vendoring/src/VendoringBundler.js
+++ b/packages/bundlers/vendoring/src/VendoringBundler.js
@@ -105,9 +105,12 @@ export default new Bundler({
             bundle = existingBundle;
           } else {
             bundle = bundleGraph.createBundle({
-              entryAsset: asset,
+              entryAsset: dependency.isEntry ? asset : null,
               target: context.bundleGroup.target,
-              isEntry: context.bundleGroupDependency.isEntry
+              isEntry: context.bundleGroupDependency.isEntry,
+              type: asset.type,
+              env: asset.env,
+              id: asset.id
             });
             bundleGraph.addBundleToBundleGroup(bundle, context.bundleGroup);
             if (isVendor(asset)) {

--- a/packages/bundlers/vendoring/src/VendoringBundler.js
+++ b/packages/bundlers/vendoring/src/VendoringBundler.js
@@ -1,0 +1,259 @@
+// @flow strict-local
+
+import type {Asset, Bundle} from '@parcel/types';
+
+import invariant from 'assert';
+import {Bundler} from '@parcel/plugin';
+import {md5FromString} from '@parcel/utils';
+import nullthrows from 'nullthrows';
+
+const OPTIONS = {
+  minBundles: 1,
+  minBundleSize: 30000,
+  maxParallelRequests: 5
+};
+
+function isVendor(asset: Asset) {
+  //TODO Yarn PnP?
+  return asset != null ? asset.filePath.includes('node_modules') : false;
+}
+
+export default new Bundler({
+  // RULES:
+  // 1. If dep.isAsync or dep.isEntry, start a new bundle group.
+  // 2. If an asset is a different type than the current bundle, make a parallel bundle in the same bundle group.
+  // 3. If an asset is already in a parent bundle in the same entry point, exclude from child bundles.
+  // 4. If an asset is only in separate isolated entry points (e.g. workers, different HTML pages), duplicate it.
+  // 5. If the sub-graph from an asset is >= 30kb, and the number of parallel requests in the bundle group is < 5, create a new bundle containing the sub-graph.
+  // 6. If two assets are always seen together, put them in the same extracted bundle
+
+  bundle({bundleGraph}) {
+    // Step 1: create bundles for each of the explicit code split points.
+    bundleGraph.traverse((node, context) => {
+      if (node.type !== 'dependency') {
+        return {
+          ...context,
+          parentNode: node
+        };
+      }
+
+      let dependency = node.value;
+      let assets = bundleGraph.getDependencyAssets(dependency);
+
+      if (dependency.isEntry || dependency.isAsync) {
+        let bundleGroup = bundleGraph.createBundleGroup(
+          dependency,
+          nullthrows(dependency.target ?? context?.bundleGroup?.target)
+        );
+
+        let bundleByType = {
+          app: new Map<string, Bundle>(),
+          vendor: new Map<string, Bundle>()
+        };
+        for (let asset of assets) {
+          let bundle = bundleGraph.createBundle({
+            entryAsset: asset,
+            isEntry: asset.isIsolated ? false : Boolean(dependency.isEntry),
+            target: bundleGroup.target
+          });
+          bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
+          if (dependency.isAsync) {
+            bundleGraph.createAssetReference(dependency, asset);
+          }
+          if (isVendor(asset)) {
+            bundleByType.vendor.set(bundle.type, bundle);
+          } else {
+            bundleByType.app.set(bundle.type, bundle);
+          }
+        }
+
+        return {
+          bundleGroup,
+          bundleGroupDependency: dependency,
+          bundleByType,
+          parentNode: node
+        };
+      }
+
+      invariant(context != null);
+      for (let asset of assets) {
+        if (asset.isIsolated) {
+          let bundleGroup = bundleGraph.createBundleGroup(
+            dependency,
+            context.bundleGroup.target
+          );
+          let bundle = bundleGraph.createBundle({
+            entryAsset: asset,
+            target: context.bundleGroup.target
+          });
+          bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
+          bundleGraph.createAssetReference(dependency, asset);
+        } else {
+          invariant(context.parentNode.type === 'asset');
+          let parentAsset = context.parentNode.value;
+          if (
+            parentAsset.type === asset.type &&
+            isVendor(parentAsset) === isVendor(asset)
+          ) {
+            continue;
+          }
+
+          let existingBundle = isVendor(asset)
+            ? context.bundleByType.vendor.get(asset.type)
+            : context.bundleByType.app.get(asset.type);
+          let bundle;
+          if (existingBundle) {
+            bundle = existingBundle;
+          } else {
+            bundle = bundleGraph.createBundle({
+              entryAsset: asset,
+              target: context.bundleGroup.target,
+              isEntry: context.bundleGroupDependency.isEntry
+            });
+            bundleGraph.addBundleToBundleGroup(bundle, context.bundleGroup);
+            if (isVendor(asset)) {
+              context.bundleByType.vendor.set(bundle.type, bundle);
+            } else {
+              context.bundleByType.app.set(bundle.type, bundle);
+            }
+          }
+          bundleGraph.addAssetToBundle(asset, bundle);
+          bundleGraph.createAssetReference(dependency, asset);
+        }
+      }
+
+      return {
+        ...context,
+        parentNode: node
+      };
+    });
+  },
+
+  optimize({bundleGraph}) {
+    // // Step 2: remove assets that are duplicated in a parent bundle
+    // bundleGraph.traverseBundles({
+    //   exit(bundle) {
+    //     if (bundle.env.isIsolated()) {
+    //       // If a bundle's environment is isolated, it can't access assets present
+    //       // in any ancestor bundles. Don't deduplicate any assets.
+    //       return;
+    //     }
+    //     bundle.traverse(node => {
+    //       if (node.type !== 'dependency') {
+    //         return;
+    //       }
+    //       let dependency = node.value;
+    //       let assets = bundleGraph.getDependencyAssets(dependency);
+    //       for (let asset of assets) {
+    //         if (bundleGraph.isAssetInAncestorBundles(bundle, asset)) {
+    //           bundleGraph.createAssetReference(dependency, asset);
+    //           bundleGraph.removeAssetGraphFromBundle(asset, bundle);
+    //         }
+    //       }
+    //     });
+    //   }
+    // });
+    // // Step 3: Find duplicated assets in different bundle groups, and separate them into their own parallel bundles.
+    // // If multiple assets are always seen together in the same bundles, combine them together.
+    // let candidateBundles: Map<
+    //   string,
+    //   {|
+    //     assets: Array<Asset>,
+    //     sourceBundles: Set<Bundle>,
+    //     size: number
+    //   |}
+    // > = new Map();
+    // bundleGraph.traverseContents((node, ctx, actions) => {
+    //   if (node.type !== 'asset') {
+    //     return;
+    //   }
+    //   let asset = node.value;
+    //   if (asset.env.isIsolated()) {
+    //     // If an asset's environment is isolated, it can't load shared bundles.
+    //     // Don't add this asset to a shared bundle.
+    //     return;
+    //   }
+    //   let containingBundles = bundleGraph
+    //     .findBundlesWithAsset(asset)
+    //     // Don't create shared bundles from entry bundles, as that would require
+    //     // another entry bundle depending on these conditions, making it difficult
+    //     // to predict and reference.
+    //     .filter(b => !b.isEntry);
+    //   if (containingBundles.length > OPTIONS.minBundles) {
+    //     let id = containingBundles
+    //       .map(b => b.id)
+    //       .sort()
+    //       .join(':');
+    //     let candidate = candidateBundles.get(id);
+    //     if (candidate) {
+    //       candidate.assets.push(asset);
+    //       for (let bundle of containingBundles) {
+    //         candidate.sourceBundles.add(bundle);
+    //       }
+    //       candidate.size += bundleGraph.getTotalSize(asset);
+    //     } else {
+    //       candidateBundles.set(id, {
+    //         assets: [asset],
+    //         sourceBundles: new Set(containingBundles),
+    //         size: bundleGraph.getTotalSize(asset)
+    //       });
+    //     }
+    //     // Skip children from consideration since we added a parent already.
+    //     actions.skipChildren();
+    //   }
+    // });
+    // // Sort candidates by size (consider larger bundles first), and ensure they meet the size threshold
+    // let sortedCandidates: Array<{|
+    //   assets: Array<Asset>,
+    //   sourceBundles: Set<Bundle>,
+    //   size: number
+    // |}> = Array.from(candidateBundles.values())
+    //   .filter(bundle => bundle.size >= OPTIONS.minBundleSize)
+    //   .sort((a, b) => b.size - a.size);
+    // for (let {assets, sourceBundles} of sortedCandidates) {
+    //   // Find all bundle groups connected to the original bundles
+    //   let bundleGroups = new Set();
+    //   for (let bundle of sourceBundles) {
+    //     for (let bundleGroup of bundleGraph.getBundleGroupsContainingBundle(
+    //       bundle
+    //     )) {
+    //       bundleGroups.add(bundleGroup);
+    //     }
+    //   }
+    //   // Check that all the bundle groups are inside the parallel request limit.
+    //   if (
+    //     Array.from(bundleGroups).some(
+    //       group =>
+    //         bundleGraph.getBundlesInBundleGroup(group).length >=
+    //         OPTIONS.maxParallelRequests
+    //     )
+    //   ) {
+    //     continue;
+    //   }
+    //   let [firstBundle] = [...sourceBundles];
+    //   let sharedBundle = bundleGraph.createBundle({
+    //     id: md5FromString([...sourceBundles].map(b => b.id).join(':')),
+    //     env: firstBundle.env,
+    //     target: firstBundle.target,
+    //     type: firstBundle.type
+    //   });
+    //   // Remove all of the root assets from each of the original bundles
+    //   for (let asset of assets) {
+    //     bundleGraph.addAssetGraphToBundle(asset, sharedBundle);
+    //     for (let bundle of sourceBundles) {
+    //       bundleGraph.removeAssetGraphFromBundle(asset, bundle);
+    //       for (let dependency of bundleGraph.getDependenciesInBundle(
+    //         bundle,
+    //         asset
+    //       )) {
+    //         bundleGraph.createAssetReference(dependency, asset);
+    //       }
+    //     }
+    //   }
+    //   // Create new bundle node and connect it to all of the original bundle groups
+    //   for (let bundleGroup of bundleGroups) {
+    //     bundleGraph.addBundleToBundleGroup(sharedBundle, bundleGroup);
+    //   }
+    // }
+  }
+});

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -498,7 +498,7 @@ export type CreateBundleOpts =
   // be provided.
   | {|
       id: string,
-      entryAsset?: Asset,
+      entryAsset?: ?Asset,
       target: Target,
       isEntry?: ?boolean,
       isInline?: ?boolean,

--- a/packages/shared/scope-hoisting/src/prelude.js
+++ b/packages/shared/scope-hoisting/src/prelude.js
@@ -36,7 +36,5 @@ globalObject.parcelRequire = function(name) {
 
 globalObject.parcelRequire.register = function register(id, exports, init) {
   $parcel$modules[id] = exports;
-  if (init) {
-    $parcel$modules$init[id] = init;
-  }
+  $parcel$modules$init[id] = init;
 };

--- a/packages/shared/scope-hoisting/src/prelude.js
+++ b/packages/shared/scope-hoisting/src/prelude.js
@@ -1,4 +1,5 @@
 var $parcel$modules = {};
+var $parcel$modules$init = {};
 
 var globalObject =
   typeof globalThis !== 'undefined'
@@ -11,8 +12,14 @@ var globalObject =
     ? global
     : {};
 
+globalObject.$parcel$modules = $parcel$modules;
+globalObject.$parcel$modules$init = $parcel$modules$init;
+
 globalObject.parcelRequire = function(name) {
   if (name in $parcel$modules) {
+    if ($parcel$modules$init[name]) {
+      $parcel$modules$init[name]();
+    }
     return $parcel$modules[name];
   }
 
@@ -27,6 +34,9 @@ globalObject.parcelRequire = function(name) {
   throw err;
 };
 
-globalObject.parcelRequire.register = function register(id, exports) {
+globalObject.parcelRequire.register = function register(id, exports, init) {
   $parcel$modules[id] = exports;
+  if (init) {
+    $parcel$modules$init[id] = init;
+  }
 };


### PR DESCRIPTION
# ↪️ Pull Request

Might be solving #3418

- Fixes a bug in scopehoisted bundles where a wrapper module is imported from a different bundle:
```js
var $f93cd3e0ab0b286715664b4f669a1c8$exports,
    $f93cd3e0ab0b286715664b4f669a1c8$export$default,
    $f93cd3e0ab0b286715664b4f669a1c8$executed = false;

function $f93cd3e0ab0b286715664b4f669a1c8$init() {
  if ($f93cd3e0ab0b286715664b4f669a1c8$executed) return;
  $f93cd3e0ab0b286715664b4f669a1c8$executed = true;
  $f93cd3e0ab0b286715664b4f669a1c8$exports = {};
  console.log("load async.js");
  $f93cd3e0ab0b286715664b4f669a1c8$export$default = 123;
  $f93cd3e0ab0b286715664b4f669a1c8$exports.default = $f93cd3e0ab0b286715664b4f669a1c8$export$default;
}

$f93cd3e0ab0b286715664b4f669a1c8$exports.__esModule = true;
parcelRequire.register("8f93cd3e0ab0b286715664b4f669a1c8", $f93cd3e0ab0b286715664b4f669a1c8$exports);
```
**Problems**
1. `__esModule` can't be set on undefined (`...$exports` isn't defined yet)
2. `parcelRequire.register` doesn't really work because `...$exports` is reassigned in `...$init`, so any `parcelRequire(...)` will return undefined, even after the asset was `init`ed
3. `...$init` can't be called from a different bundle

**Solution**
```js
var $f93cd3e0ab0b286715664b4f669a1c8$exports,
    $f93cd3e0ab0b286715664b4f669a1c8$export$default,
    $f93cd3e0ab0b286715664b4f669a1c8$executed = false;

function $f93cd3e0ab0b286715664b4f669a1c8$init() {
  if ($f93cd3e0ab0b286715664b4f669a1c8$executed) return;
  $f93cd3e0ab0b286715664b4f669a1c8$executed = true;
  $f93cd3e0ab0b286715664b4f669a1c8$exports = {};
  console.log("load async.js");
  $f93cd3e0ab0b286715664b4f669a1c8$export$default = 123;
  $f93cd3e0ab0b286715664b4f669a1c8$exports.default = $f93cd3e0ab0b286715664b4f669a1c8$export$default;

  // 1. set __esModule only after initializing exports
  $f93cd3e0ab0b286715664b4f669a1c8$exports.__esModule = true;
  // 2. the exports object might have been reassigned, so register it here. The third argument is missing and
  // therefore undefined, so `$parcel$modules$init[id]` will not be set and not be called anymore
  parcelRequire.register("8f93cd3e0ab0b286715664b4f669a1c8", $f93cd3e0ab0b286715664b4f669a1c8$exports);
}

// 3. here, the third parameter sets the init method
parcelRequire.register("8f93cd3e0ab0b286715664b4f669a1c8", undefined, $f93cd3e0ab0b286715664b4f669a1c8$init);
```

```js
globalObject.parcelRequire.register = function register(id, exports, init) {
  $parcel$modules[id] = exports;
  $parcel$modules$init[id] = init;
};
```

inside `parcelRequire`:
```js
    if ($parcel$modules$init[name]) {
      $parcel$modules$init[name]();
    }

    return $parcel$modules[name];
```

- Adds `@parcel/bundler-vendoring` (open for naming suggestions) that splits "app" and `node_modules` assets into separate bundles (logic is otherwise identical to the default bundler)

One downside of the plugin architecture of Parcel 2: `@parcel/bundler-vendoring` only has differs by a few lines from `@parcel/bundler-default`, but it isn't really possible to reuse the logic.

**TODO**
- [x] doesn't work with `--no-scope-hoist`: the last module in every bundle is always executed
- [ ] tests (the scope hoisting bugs are now reproducible using the vendoring bundler)
- [ ] `a` and `b` are in the same bundle group, `a` imports `b` conditionally but somehow asset.meta isn't being set properly (in [concat.js](https://github.com/parcel-bundler/parcel/blob/8835afdff1feacb25b16771f47cfdbaa7f62b0f4/packages/shared/scope-hoisting/src/concat.js))
```js
  bundle.traverse((node, shouldWrap) => {
    switch (node.type) {
      case 'dependency':
        // Mark assets that should be wrapped, based on metadata in the incoming dependency tree
        if (shouldWrap || node.value.meta.shouldWrap) {
          let resolved = bundleGraph.getDependencyResolution(node.value);
          if (resolved) {
            resolved.meta.shouldWrap = true;
            console.log("dep", resolved.filePath, resolved.meta);
          }
          return true;
        }
        break;
      case 'asset':
        console.log("ass", node.value.filePath, node.value.meta);
        queue.add(() => processAsset(bundle, node.value));
    }
  });
```

```
ass index.js 460359ea1b34573175c6db2c6a1806b5 {}
dep node_modules/async/index.js 8f93cd3e0ab0b286715664b4f669a1c8 { isES6Module: true, shouldWrap: true }
ass node_modules/async/index.js 8f93cd3e0ab0b286715664b4f669a1c8 { isES6Module: true } // shouldWrap missing?
```

Strangely enough, it works correctly with `PARCEL_WORKERS=0`. So something is overwriting the asset in the graph?