### PR TITLE
 Fixes #3133 by upgrading serialize-to-js from 1.1.1 to 3.0.0 

### DIFF
--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-bundler",
-  "version": "1.12.4",
+  "version": "1.12.3",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "index.js",
   "license": "MIT",

--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-bundler",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "Blazing fast, zero configuration web application bundler",
   "main": "index.js",
   "license": "MIT",
@@ -68,7 +68,7 @@
     "posthtml-render": "^1.1.3",
     "resolve": "^1.4.0",
     "semver": "^5.4.1",
-    "serialize-to-js": "^1.1.1",
+    "serialize-to-js": "^3.0.0",
     "serve-static": "^1.12.4",
     "source-map": "0.6.1",
     "terser": "^3.7.3",

--- a/packages/core/parcel-bundler/src/utils/serializeObject.js
+++ b/packages/core/parcel-bundler/src/utils/serializeObject.js
@@ -1,5 +1,5 @@
 const {minify} = require('terser');
-const {serialize} = require('serialize-to-js');
+const serialize = require('serialize-to-js');
 
 function serializeObject(obj, shouldMinify = false) {
   let code = `module.exports = ${serialize(obj)};`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9398,13 +9398,10 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-serialize-to-js@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/serialize-to-js/-/serialize-to-js-1.2.2.tgz#1a567b0c9bf557bc7d7b77b503dfae0a8218d15d"
-  integrity sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==
-  dependencies:
-    js-beautify "^1.8.9"
-    safer-eval "^1.3.0"
+serialize-to-js@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-to-js/-/serialize-to-js-3.0.0.tgz#1fd8736744819a4df29dc85e9d04a44a4984edc3"
+  integrity sha512-WdGgi0jGnWCQXph2p3vkxceDnTfvfyXfYxherQMRcZjSaJzMQdMBAW6i0nojsBKIZ3fFOztZKKVbbm05VbIdRA==
 
 serve-static@^1.12.4:
   version "1.13.2"


### PR DESCRIPTION
# ↪️ Pull Request

Fixes issue #3133 by upgrading serialize-to-js from 1.1.1 to 3.0.0

Changed import in serializeObject.js to work with 3.0.0.

## 🚨 Test instructions

Create YAML import by following [https://parceljs.org/yaml.html](https://parceljs.org/yaml.html) and run.

Create TOML import by following [https://parceljs.org/toml.html](https://parceljs.org/toml.html) and run.

## ✔️ PR Todo

- [X] Filled out test instructions
- [X] Included links to related issues/PRs
