### PR TITLE
Abstract filesystem in watcher, localResolve, and dev server

### DIFF
--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -30,13 +30,13 @@
     "@parcel/transformer-html": "^2.0.0-alpha.1.1",
     "@parcel/transformer-js": "^2.0.0-alpha.1.1",
     "@parcel/transformer-json": "^2.0.0-alpha.1.1",
-    "@parcel/transformer-toml": "^2.0.0-alpha.1.1",
     "@parcel/transformer-less": "^2.0.0-alpha.1.1",
     "@parcel/transformer-postcss": "^2.0.0-alpha.1.1",
     "@parcel/transformer-posthtml": "^2.0.0-alpha.1.1",
     "@parcel/transformer-raw": "^2.0.0-alpha.1.1",
-    "@parcel/transformer-stylus": "^2.0.0-alpha.1.1",
     "@parcel/transformer-sass": "^2.0.0-alpha.1.1",
-    "@parcel/transformer-sugarss": "^2.0.0-alpha.1.1"
+    "@parcel/transformer-stylus": "^2.0.0-alpha.1.1",
+    "@parcel/transformer-sugarss": "^2.0.0-alpha.1.1",
+    "@parcel/transformer-toml": "^2.0.0-alpha.1.1"
   }
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -21,7 +21,6 @@
     "@parcel/source-map": "^2.0.0-alpha.1.1",
     "@parcel/types": "^2.0.0-alpha.1.1",
     "@parcel/utils": "^2.0.0-alpha.1.1",
-    "@parcel/watcher": "^2.0.0-alpha.3",
     "@parcel/workers": "^2.0.0-alpha.1.1",
     "abortcontroller-polyfill": "^1.1.9",
     "browserslist": "^4.1.0",

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -1,11 +1,11 @@
 // @flow strict-local
 
 import type WorkerFarm from '@parcel/workers';
-import type {ParcelOptions, Target} from './types';
+import type {ParcelOptions, Target} from '@parcel/types';
 
 import EventEmitter from 'events';
 import {md5FromObject, md5FromString} from '@parcel/utils';
-import watcher, {type Event} from '@parcel/watcher';
+import type {Event} from '@parcel/watcher';
 
 import type {Asset} from './types';
 import AssetGraph from './AssetGraph';
@@ -182,7 +182,7 @@ export default class AssetGraphBuilder extends EventEmitter {
 
       let opts = this.getWatcherOptions();
       let snapshotPath = this.options.cache._getCachePath(snapshotKey, '.txt');
-      return watcher.getEventsSince(
+      return this.options.inputFS.getEventsSince(
         this.options.projectRoot,
         snapshotPath,
         opts
@@ -203,7 +203,11 @@ export default class AssetGraphBuilder extends EventEmitter {
 
     let opts = this.getWatcherOptions();
     let snapshotPath = this.options.cache._getCachePath(snapshotKey, '.txt');
-    await watcher.writeSnapshot(this.options.projectRoot, snapshotPath, opts);
+    await this.options.inputFS.writeSnapshot(
+      this.options.projectRoot,
+      snapshotPath,
+      opts
+    );
   }
 }
 

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -1,22 +1,23 @@
 // @flow strict-local
 
 import type WorkerFarm from '@parcel/workers';
-import type {ParcelOptions, Target} from '@parcel/types';
-
-import EventEmitter from 'events';
-import {md5FromObject, md5FromString} from '@parcel/utils';
 import type {Event} from '@parcel/watcher';
-
-import type {Asset} from './types';
-import AssetGraph from './AssetGraph';
-import type ParcelConfig from './ParcelConfig';
-import RequestGraph from './RequestGraph';
 import type {
+  Asset,
   AssetGraphNode,
   AssetRequest,
   AssetRequestNode,
-  DepPathRequestNode
+  DepPathRequestNode,
+  ParcelOptions,
+  Target
 } from './types';
+
+import EventEmitter from 'events';
+import {md5FromObject, md5FromString} from '@parcel/utils';
+
+import AssetGraph from './AssetGraph';
+import type ParcelConfig from './ParcelConfig';
+import RequestGraph from './RequestGraph';
 
 import dumpToGraphViz from './dumpGraphToGraphViz';
 import path from 'path';

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -22,7 +22,6 @@ import BundleGraph from './public/BundleGraph';
 import BundlerRunner from './BundlerRunner';
 import WorkerFarm from '@parcel/workers';
 import nullthrows from 'nullthrows';
-import watcher from '@parcel/watcher';
 import path from 'path';
 import AssetGraphBuilder, {BuildAbortError} from './AssetGraphBuilder';
 import loadParcelConfig from './loadParcelConfig';
@@ -287,7 +286,7 @@ export default class Parcel {
     let resolvedOptions = nullthrows(this.#resolvedOptions);
     let opts = this.#assetGraphBuilder.getWatcherOptions();
 
-    return watcher.subscribe(
+    return resolvedOptions.inputFS.watch(
       resolvedOptions.projectRoot,
       async (err, events) => {
         if (err) {

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -101,7 +101,7 @@ export async function resolveExtends(
   if (ext.startsWith('.')) {
     return path.resolve(path.dirname(configPath), ext);
   } else {
-    let [resolved] = await localResolve(ext, configPath);
+    let [resolved] = await localResolve(ext, configPath, fs);
     return fs.realpath(resolved);
   }
 }

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@parcel/utils": "^2.0.0-alpha.1.1",
+    "@parcel/watcher": "^2.0.0-alpha.3",
     "@parcel/workers": "^2.0.0-alpha.1.1",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -2,7 +2,11 @@
 
 import type {FileSystem, FileOptions} from './types';
 import type {FilePath} from '@parcel/types';
-
+import type {
+  Event,
+  Options as WatcherOptions,
+  AsyncSubscription
+} from '@parcel/watcher';
 import path from 'path';
 import {Readable, Writable} from 'stream';
 import {registerSerializableClass} from '@parcel/utils';
@@ -23,6 +27,9 @@ type SerializedMemoryFS = {|
 export class MemoryFS implements FileSystem {
   dirs: Map<FilePath, Directory>;
   files: Map<FilePath, File>;
+  symlinks: Map<FilePath, FilePath>;
+  watchers: Map<FilePath, Set<Watcher>>;
+  events: Array<Event>;
   id: number;
   handle: Handle;
   farm: WorkerFarm;
@@ -31,6 +38,9 @@ export class MemoryFS implements FileSystem {
     this.dirs = new Map([['/', new Directory()]]);
     this.farm = workerFarm;
     this.files = new Map();
+    this.symlinks = new Map();
+    this.watchers = new Map();
+    this.events = [];
     this.id = id++;
     instances.set(this.id, this);
   }
@@ -61,8 +71,29 @@ export class MemoryFS implements FileSystem {
     return '/';
   }
 
-  _normalizePath(filePath: FilePath): FilePath {
-    return path.resolve(this.cwd(), filePath);
+  _normalizePath(filePath: FilePath, realpath: boolean = true): FilePath {
+    filePath = path.resolve(this.cwd(), filePath);
+
+    // get realpath by following symlinks
+    if (realpath) {
+      let {root, dir, base} = path.parse(filePath);
+      let parts = dir
+        .slice(root.length)
+        .split(path.sep)
+        .concat(base);
+      let res = root;
+      for (let part of parts) {
+        res = path.join(res, part);
+        let symlink = this.symlinks.get(res);
+        if (symlink) {
+          res = symlink;
+        }
+      }
+
+      return res;
+    }
+
+    return filePath;
   }
 
   writeFile(
@@ -88,6 +119,11 @@ export class MemoryFS implements FileSystem {
     } else {
       this.files.set(filePath, new File(buffer, mode));
     }
+
+    this._triggerEvent({
+      type: file ? 'update' : 'create',
+      path: filePath
+    });
 
     return Promise.resolve();
   }
@@ -159,6 +195,14 @@ export class MemoryFS implements FileSystem {
     this.files.delete(filePath);
     this.dirs.delete(filePath);
 
+    this.symlinks.delete(filePath);
+    this.watchers.delete(filePath);
+
+    this._triggerEvent({
+      type: 'delete',
+      path: filePath
+    });
+
     return Promise.resolve();
   }
 
@@ -179,6 +223,12 @@ export class MemoryFS implements FileSystem {
       }
 
       this.dirs.set(dir, new Directory());
+
+      this._triggerEvent({
+        type: 'create',
+        path: dir
+      });
+
       dir = path.dirname(dir);
     }
 
@@ -193,18 +243,44 @@ export class MemoryFS implements FileSystem {
       for (let filePath of this.files.keys()) {
         if (filePath.startsWith(dir)) {
           this.files.delete(filePath);
+
+          this._triggerEvent({
+            type: 'delete',
+            path: filePath
+          });
         }
       }
 
       for (let dirPath of this.dirs.keys()) {
         if (dirPath.startsWith(dir)) {
           this.dirs.delete(dirPath);
+          this.watchers.delete(dirPath);
+
+          this._triggerEvent({
+            type: 'delete',
+            path: dirPath
+          });
         }
       }
-    }
 
-    this.dirs.delete(filePath);
-    this.files.delete(filePath);
+      for (let filePath of this.symlinks.keys()) {
+        if (filePath.startsWith(dir)) {
+          this.symlinks.delete(filePath);
+        }
+      }
+
+      this.dirs.delete(filePath);
+      this._triggerEvent({
+        type: 'delete',
+        path: filePath
+      });
+    } else if (this.files.has(filePath)) {
+      this.files.delete(filePath);
+      this._triggerEvent({
+        type: 'delete',
+        path: filePath
+      });
+    }
 
     return Promise.resolve();
   }
@@ -215,6 +291,10 @@ export class MemoryFS implements FileSystem {
     if (this.dirs.has(source)) {
       if (!this.dirs.has(destination)) {
         this.dirs.set(destination, new Directory());
+        this._triggerEvent({
+          type: 'create',
+          path: destination
+        });
       }
 
       let dir = source + path.sep;
@@ -223,6 +303,10 @@ export class MemoryFS implements FileSystem {
           let destName = path.join(destination, dirPath.slice(dir.length));
           if (!this.dirs.has(destName)) {
             this.dirs.set(destName, new Directory());
+            this._triggerEvent({
+              type: 'create',
+              path: destName
+            });
           }
         }
       }
@@ -230,7 +314,12 @@ export class MemoryFS implements FileSystem {
       for (let [filePath, buffer] of this.files) {
         if (filePath.startsWith(dir)) {
           let destName = path.join(destination, filePath.slice(dir.length));
+          let exists = this.files.has(destName);
           this.files.set(destName, buffer);
+          this._triggerEvent({
+            type: exists ? 'update' : 'create',
+            path: destName
+          });
         }
       }
     } else {
@@ -251,9 +340,103 @@ export class MemoryFS implements FileSystem {
     return Promise.resolve(filePath);
   }
 
+  async symlink(target: FilePath, path: FilePath) {
+    target = this._normalizePath(target);
+    path = this._normalizePath(path);
+    this.symlinks.set(path, target);
+  }
+
   exists(filePath: FilePath) {
     filePath = this._normalizePath(filePath);
     return Promise.resolve(this.files.has(filePath) || this.dirs.has(filePath));
+  }
+
+  _triggerEvent(event: Event) {
+    this.events.push(event);
+
+    for (let [dir, watchers] of this.watchers) {
+      if (!dir.endsWith(path.sep)) {
+        dir += path.sep;
+      }
+
+      if (event.path.startsWith(dir)) {
+        for (let watcher of watchers) {
+          watcher.trigger([event]);
+        }
+      }
+    }
+  }
+
+  async watch(
+    dir: FilePath,
+    fn: (err: ?Error, events: Array<Event>) => mixed,
+    opts: WatcherOptions
+  ): Promise<AsyncSubscription> {
+    let watcher = new Watcher(fn, opts);
+    let watchers = this.watchers.get(dir);
+    if (!watchers) {
+      watchers = new Set();
+      this.watchers.set(dir, watchers);
+    }
+
+    watchers.add(watcher);
+
+    return {
+      unsubscribe: async () => {
+        watchers = nullthrows(watchers);
+        watchers.delete(watcher);
+
+        if (watchers.size === 0) {
+          this.watchers.delete(dir);
+        }
+      }
+    };
+  }
+
+  async getEventsSince(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions
+  ): Promise<Array<Event>> {
+    let contents = await this.readFile(snapshot, 'utf8');
+    let len = Number(contents);
+    let events = this.events.slice(len);
+    let ignore = opts.ignore;
+    if (ignore) {
+      events = events.filter(
+        event => !ignore.some(i => event.path.startsWith(i + path.sep))
+      );
+    }
+
+    return events;
+  }
+
+  async writeSnapshot(dir: FilePath, snapshot: FilePath): Promise<void> {
+    await this.writeFile(snapshot, '' + this.events.length);
+  }
+}
+
+class Watcher {
+  fn: (err: ?Error, events: Array<Event>) => mixed;
+  options: WatcherOptions;
+
+  constructor(
+    fn: (err: ?Error, events: Array<Event>) => mixed,
+    options: WatcherOptions
+  ) {
+    this.fn = fn;
+    this.options = options;
+  }
+
+  trigger(events: Array<Event>) {
+    let ignore = this.options.ignore;
+    if (ignore) {
+      events = events.filter(
+        event => !ignore.some(i => event.path.startsWith(i + path.sep))
+      );
+    }
+
+    this.fn(null, events);
   }
 }
 
@@ -371,33 +554,65 @@ class Entry {
   }
 
   stat() {
-    return {
-      dev: 0,
-      ino: 0,
-      mode: this.mode,
-      nlink: 0,
-      uid: 0,
-      gid: 0,
-      rdev: 0,
-      size: this.getSize(),
-      blksize: 0,
-      blocks: 0,
-      atimeMs: this.atime,
-      mtimeMs: this.mtime,
-      ctimeMs: this.ctime,
-      birthtimeMs: this.birthtime,
-      atime: new Date(this.atime),
-      mtime: new Date(this.mtime),
-      ctime: new Date(this.ctime),
-      birthtime: new Date(this.birthtime),
-      isFile: () => Boolean(this.mode & S_IFREG),
-      isDirectory: () => Boolean(this.mode & S_IFDIR),
-      isBlockDevice: () => false,
-      isCharacterDevice: () => false,
-      isSymbolicLink: () => false,
-      isFIFO: () => false,
-      isSocket: () => false
-    };
+    return new Stat(this);
+  }
+}
+
+class Stat {
+  dev = 0;
+  ino = 0;
+  mode: number;
+  nlink = 0;
+  uid = 0;
+  gid = 0;
+  rdev = 0;
+  size: number;
+  blksize = 0;
+  blocks = 0;
+  atimeMs: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  birthtimeMs: number;
+  atime: Date;
+  mtime: Date;
+  ctime: Date;
+  birthtime: Date;
+
+  constructor(entry: Entry) {
+    this.mode = entry.mode;
+    this.size = entry.getSize();
+    this.atimeMs = entry.atime;
+    this.mtimeMs = entry.mtime;
+    this.ctimeMs = entry.ctime;
+    this.birthtimeMs = entry.birthtime;
+    this.atime = new Date(entry.atime);
+    this.mtime = new Date(entry.mtime);
+    this.ctime = new Date(entry.ctime);
+    this.birthtime = new Date(entry.birthtime);
+  }
+
+  isFile() {
+    return Boolean(this.mode & S_IFREG);
+  }
+
+  isDirectory() {
+    return Boolean(this.mode & S_IFDIR);
+  }
+
+  isBlockDevice() {
+    return false;
+  }
+  isCharacterDevice() {
+    return false;
+  }
+  isSymbolicLink() {
+    return false;
+  }
+  isFIFO() {
+    return false;
+  }
+  isSocket() {
+    return false;
   }
 }
 
@@ -516,10 +731,19 @@ class WorkerFS extends MemoryFS {
     return this.handleFn('ncp', [source, destination]);
   }
 
-  exists(filePath: FilePath) {
-    return this.handleFn('exists', [filePath]);
+  async realpath(filePath: FilePath) {
+    return this.handle('realpath', [filePath]);
+  }
+
+  async symlink(target: FilePath, path: FilePath) {
+    return this.handle('symlink', [target, path]);
+  }
+
+  async exists(filePath: FilePath) {
+    return this.handle('exists', [filePath]);
   }
 }
 
 registerSerializableClass(`${packageJSON.version}:MemoryFS`, MemoryFS);
 registerSerializableClass(`${packageJSON.version}:WorkerFS`, WorkerFS);
+registerSerializableClass(`${packageJSON.version}:Stat`, Stat);

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -379,6 +379,7 @@ export class MemoryFS implements FileSystem {
     fn: (err: ?Error, events: Array<Event>) => mixed,
     opts: WatcherOptions
   ): Promise<AsyncSubscription> {
+    dir = this._normalizePath(dir);
     let watcher = new Watcher(fn, opts);
     let watchers = this.watchers.get(dir);
     if (!watchers) {

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -1,12 +1,18 @@
 // @flow
 import type {FileSystem} from './types';
 import type {FilePath} from '@parcel/types';
+import type {
+  Event,
+  Options as WatcherOptions,
+  AsyncSubscription
+} from '@parcel/watcher';
 
 import fs from 'fs';
 import ncp from 'ncp';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 import {registerSerializableClass, promisify} from '@parcel/utils';
+import watcher from '@parcel/watcher';
 import packageJSON from '../package.json';
 
 // Most of this can go away once we only support Node 10+, which includes
@@ -42,6 +48,30 @@ export class NodeFS implements FileSystem {
     return new Promise(resolve => {
       fs.exists(filePath, resolve);
     });
+  }
+
+  async watch(
+    dir: FilePath,
+    fn: (err: ?Error, events: Array<Event>) => mixed,
+    opts: WatcherOptions
+  ): Promise<AsyncSubscription> {
+    return watcher.subscribe(dir, fn, opts);
+  }
+
+  async getEventsSince(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions
+  ): Promise<Array<Event>> {
+    return watcher.getEventsSince(dir, snapshot, opts);
+  }
+
+  async writeSnapshot(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions
+  ): Promise<void> {
+    await watcher.writeSnapshot(dir, snapshot, opts);
   }
 
   static deserialize() {

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -33,6 +33,7 @@ export class NodeFS implements FileSystem {
   createReadStream = fs.createReadStream;
   createWriteStream = fs.createWriteStream;
   cwd = process.cwd;
+  chdir = process.chdir;
 
   async realpath(originalPath: string): Promise<string> {
     try {
@@ -50,7 +51,7 @@ export class NodeFS implements FileSystem {
     });
   }
 
-  async watch(
+  watch(
     dir: FilePath,
     fn: (err: ?Error, events: Array<Event>) => mixed,
     opts: WatcherOptions
@@ -58,7 +59,7 @@ export class NodeFS implements FileSystem {
     return watcher.subscribe(dir, fn, opts);
   }
 
-  async getEventsSince(
+  getEventsSince(
     dir: FilePath,
     snapshot: FilePath,
     opts: WatcherOptions

--- a/packages/core/fs/src/types.js
+++ b/packages/core/fs/src/types.js
@@ -2,6 +2,11 @@
 import type {FilePath} from '@parcel/types';
 import type {Stats} from 'fs';
 import type {Readable, Writable} from 'stream';
+import type {
+  Event,
+  Options as WatcherOptions,
+  AsyncSubscription
+} from '@parcel/watcher';
 
 export type FileOptions = {mode?: number, ...};
 
@@ -29,4 +34,19 @@ export interface FileSystem {
   createReadStream(path: FilePath): Readable;
   createWriteStream(path: FilePath, options: ?FileOptions): Writable;
   cwd(): FilePath;
+  watch(
+    dir: FilePath,
+    fn: (err: ?Error, events: Array<Event>) => mixed,
+    opts: WatcherOptions
+  ): Promise<AsyncSubscription>;
+  getEventsSince(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions
+  ): Promise<Array<Event>>;
+  writeSnapshot(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions
+  ): Promise<void>;
 }

--- a/packages/core/fs/src/types.js
+++ b/packages/core/fs/src/types.js
@@ -34,6 +34,7 @@ export interface FileSystem {
   createReadStream(path: FilePath): Readable;
   createWriteStream(path: FilePath, options: ?FileOptions): Writable;
   cwd(): FilePath;
+  chdir(dir: FilePath): void;
   watch(
     dir: FilePath,
     fn: (err: ?Error, events: Array<Event>) => mixed,

--- a/packages/core/install-package/src/installPackage.js
+++ b/packages/core/install-package/src/installPackage.js
@@ -69,7 +69,7 @@ async function installPeerDependencies(
   options
 ) {
   let basedir = path.dirname(filepath);
-  const [resolved] = await resolve(name, {basedir});
+  const [resolved] = await resolve(fs, name, {basedir});
   const pkg = nullthrows(await loadConfig(fs, resolved, ['package.json']))
     .config;
   const peers = pkg.peerDependencies || {};

--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -9,7 +9,6 @@ const {
   outputFS,
   distDir
 } = require('@parcel/test-utils');
-const {symlinkSync} = require('fs');
 
 describe('babel', function() {
   afterEach(async () => {
@@ -220,23 +219,26 @@ describe('babel', function() {
 
   it('should compile node_modules when symlinked with a source field in package.json', async function() {
     const inputDir = path.join(__dirname, '/input');
-    await inputFS.rimraf(inputDir);
-    await inputFS.mkdirp(path.join(inputDir, 'node_modules'));
+    await outputFS.rimraf(inputDir);
+    await outputFS.mkdirp(path.join(inputDir, 'node_modules'));
     await ncp(
       path.join(path.join(__dirname, '/integration/babel-node-modules-source')),
       inputDir
     );
 
     // Create the symlink here to prevent cross platform and git issues
-    symlinkSync(
+    await outputFS.symlink(
       path.join(inputDir, 'packages/foo'),
       path.join(inputDir, 'node_modules/foo'),
       'dir'
     );
 
-    await bundle(inputDir + '/index.js', {outputFS: inputFS});
+    await bundle(inputDir + '/index.js', {inputFS: outputFS});
 
-    let file = await inputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
+    let file = await outputFS.readFile(
+      path.join(outputFS.cwd(), 'dist', 'index.js'),
+      'utf8'
+    );
     assert(file.includes('function Foo'));
     assert(file.includes('function Bar'));
   });

--- a/packages/core/integration-tests/test/postcss.js
+++ b/packages/core/integration-tests/test/postcss.js
@@ -263,7 +263,7 @@ describe('postcss', () => {
       path.join(__dirname, '/integration/postcss-autoinstall/yarn'),
       path.join(__dirname, '/input')
     );
-    await bundle(path.join(__dirname, '/input/index.css'), {outputFS: inputFS});
+    await bundle(path.join(__dirname, '/input/index.css'));
 
     // cssnext was installed
     let pkg = require('./input/package.json');

--- a/packages/core/integration-tests/test/proxy.js
+++ b/packages/core/integration-tests/test/proxy.js
@@ -3,15 +3,12 @@ const path = require('path');
 const {
   bundler,
   getNextBuild,
-  ncp,
-  sleep,
   inputFS,
   defaultConfig
 } = require('@parcel/test-utils');
 const http = require('http');
 const getPort = require('get-port');
 
-const inputDir = path.resolve(__dirname, './input');
 const config = {
   ...defaultConfig,
   reporters: ['@parcel/reporter-dev-server']
@@ -58,15 +55,12 @@ describe('proxy', function() {
   let subscription;
   let cwd;
   let server;
-  beforeEach(async function() {
-    await sleep(100);
-    await inputFS.rimraf(inputDir);
-    await sleep(100);
-    cwd = process.cwd();
+  beforeEach(function() {
+    cwd = inputFS.cwd();
   });
 
   afterEach(async () => {
-    process.chdir(cwd);
+    inputFS.chdir(cwd);
     if (subscription) {
       await subscription.unsubscribe();
     }
@@ -78,13 +72,11 @@ describe('proxy', function() {
   });
 
   it('should handle proxy table written in .proxyrc', async function() {
-    await ncp(path.join(__dirname, 'integration/proxyrc'), inputDir);
-    process.chdir(inputDir);
+    let dir = path.join(__dirname, 'integration/proxyrc');
+    inputFS.chdir(dir);
 
     let port = await getPort();
-    let b = bundler(path.join(inputDir, 'index.js'), {
-      // the server doesn't support custom file systems due to it's use of the `send` module.
-      outputFS: inputFS,
+    let b = bundler(path.join(dir, 'index.js'), {
       config,
       serve: {
         https: false,
@@ -106,13 +98,11 @@ describe('proxy', function() {
   });
 
   it('should handle proxy table written in .proxyrc.js', async function() {
-    await ncp(path.join(__dirname, 'integration/proxyrc-js'), inputDir);
-    process.chdir(inputDir);
+    let dir = path.join(__dirname, 'integration/proxyrc-js');
+    inputFS.chdir(dir);
 
     let port = await getPort();
-    let b = bundler(path.join(inputDir, 'index.js'), {
-      // the server doesn't support custom file systems due to it's use of the `send` module.
-      outputFS: inputFS,
+    let b = bundler(path.join(dir, 'index.js'), {
       config,
       serve: {
         https: false,

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -56,8 +56,6 @@ describe('server', function() {
   it('should serve files', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
-      // the server doesn't support custom file systems due to it's use of the `send` module.
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -78,11 +76,34 @@ describe('server', function() {
     assert.equal(data, distFile);
   });
 
+  it('should serve source files', async function() {
+    let port = await getPort();
+    let inputPath = path.join(__dirname, '/integration/commonjs/index.js');
+    let b = bundler(inputPath, {
+      config,
+      serve: {
+        https: false,
+        port: port,
+        host: 'localhost'
+      }
+    });
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let data = await get(
+      '/__parcel_source_root/packages/core/integration-tests/test/integration/commonjs/index.js',
+      port
+    );
+    let inputFile = await inputFS.readFile(inputPath, 'utf8');
+
+    assert.equal(data, inputFile);
+  });
+
   // TODO: Implement this once HTMLTransformer is in
   it.skip('should serve a default page if the main bundle is an HTML asset', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -110,7 +131,6 @@ describe('server', function() {
   it('should serve a 404 if the file does not exist', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -139,7 +159,6 @@ describe('server', function() {
     let entry = path.join(inputDir, 'index.js');
 
     let b = bundler(entry, {
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -172,7 +191,6 @@ describe('server', function() {
   it('should support HTTPS', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: true,
@@ -194,7 +212,6 @@ describe('server', function() {
   it('should support HTTPS via custom certificate', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: {
@@ -219,7 +236,6 @@ describe('server', function() {
   it('should support setting a public url', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -243,7 +259,6 @@ describe('server', function() {
   it.skip('should serve static assets as well as html', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -272,7 +287,6 @@ describe('server', function() {
   it.skip('should work with query parameters that contain a dot', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
-      outputFS: inputFS,
       config,
       serve: {
         https: false,
@@ -293,7 +307,6 @@ describe('server', function() {
 
   it.skip('should work with paths that contain a dot', async function() {
     let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
-      outputFS: inputFS,
       config,
       publicUrl: '/'
     });
@@ -308,7 +321,6 @@ describe('server', function() {
 
   it.skip('should not log dev server access for log level <= 3', async function() {
     let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
-      outputFS: inputFS,
       config,
       publicUrl: '/'
     });
@@ -324,7 +336,6 @@ describe('server', function() {
 
   it.skip('should log dev server access for log level > 3', async function() {
     let b = bundler(path.join(__dirname, '/integration/html/index.html'), {
-      outputFS: inputFS,
       config,
       publicUrl: '/'
     });

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -22,9 +22,7 @@ const distDir = path.join(inputDir, 'dist');
 describe('watcher', function() {
   let subscription;
   beforeEach(async function() {
-    await sleep(100);
     await outputFS.rimraf(inputDir);
-    await sleep(100);
   });
 
   afterEach(async () => {
@@ -91,7 +89,7 @@ describe('watcher', function() {
     await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
 
     let b = bundler(path.join(inputDir, 'index.js'), {
-      outputFS: fs,
+      inputFS: outputFS,
       targets: {
         main: {
           engines: {
@@ -104,14 +102,17 @@ describe('watcher', function() {
 
     subscription = await b.watch();
     await getNextBuild(b);
-    let distFile = await fs.readFile(path.join(distDir, 'index.js'), 'utf8');
+    let distFile = await outputFS.readFile(
+      path.join(distDir, 'index.js'),
+      'utf8'
+    );
     assert(distFile.includes('Foo'));
-    await fs.writeFile(
+    await outputFS.writeFile(
       path.join(inputDir, 'index.js'),
       'console.log("no more dependencies")'
     );
     await getNextBuild(b);
-    distFile = await fs.readFile(path.join(distDir, 'index.js'), 'utf8');
+    distFile = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
     assert(!distFile.includes('Foo'));
   });
 

--- a/packages/core/local-require/package.json
+++ b/packages/core/local-require/package.json
@@ -15,6 +15,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@parcel/fs": "^2.0.0-alpha.1.1",
     "@parcel/install-package": "^2.0.0-alpha.1.1",
     "@parcel/utils": "^2.0.0-alpha.1.1"
   }

--- a/packages/core/local-require/src/localRequire.js
+++ b/packages/core/local-require/src/localRequire.js
@@ -7,10 +7,11 @@ import installPackage, {
   installPackageFromWorker
 } from '@parcel/install-package';
 import {dirname} from 'path';
-
 import {resolve} from '@parcel/utils';
+import {NodeFS} from '@parcel/fs';
 
 const cache: Map<string, [string, ?PackageJSON]> = new Map();
+const nodeFS = new NodeFS();
 
 export async function localRequireFromWorker(
   workerApi: WorkerApi,
@@ -40,7 +41,10 @@ async function localResolveBase(
   let resolved = cache.get(key);
   if (!resolved) {
     try {
-      resolved = await resolve(name, {basedir, extensions: ['.js', '.json']});
+      resolved = await resolve(nodeFS, name, {
+        basedir,
+        extensions: ['.js', '.json']
+      });
     } catch (e) {
       if (e.code === 'MODULE_NOT_FOUND' && !triedInstall) {
         await install([name], path);

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -17,15 +17,36 @@ import path from 'path';
 import WebSocket from 'ws';
 import nullthrows from 'nullthrows';
 
-import {promisify, syncPromise} from '@parcel/utils';
-import _ncp from 'ncp';
+import {syncPromise} from '@parcel/utils';
 import _chalk from 'chalk';
 import resolve from 'resolve';
 
 const workerFarm = createWorkerFarm();
 export const inputFS = new NodeFS();
 export const outputFS = new MemoryFS(workerFarm);
-export const ncp = promisify(_ncp);
+
+// Recursively copies a directory from the inputFS to the outputFS
+export async function ncp(source: FilePath, destination: FilePath) {
+  await outputFS.mkdirp(destination);
+  let files = await inputFS.readdir(source);
+  for (let file of files) {
+    let sourcePath = path.join(source, file);
+    let destPath = path.join(destination, file);
+    let stats = await inputFS.stat(sourcePath);
+    if (stats.isFile()) {
+      await new Promise((resolve, reject) => {
+        inputFS
+          .createReadStream(sourcePath)
+          .pipe(outputFS.createWriteStream(destPath))
+          .on('finish', () => resolve())
+          .on('error', reject);
+      });
+    } else if (stats.isDirectory()) {
+      outputFS.mkdirp(destPath);
+      await ncp(sourcePath, destPath);
+    }
+  }
+}
 
 // Mocha is currently run with exit: true because of this issue preventing us
 // from properly ending the workerfarm after the test run:

--- a/packages/core/utils/src/resolve.js
+++ b/packages/core/utils/src/resolve.js
@@ -2,13 +2,43 @@
 
 import type {PackageJSON} from '@parcel/types';
 import type {ResolveOptions} from 'resolve';
+import type {FileSystem} from '@parcel/fs';
 
 // $FlowFixMe TODO: Type promisify
 import promisify from './promisify';
 
-const resolve: (
+const _resolve = promisify(require('resolve'));
+
+export default function resolve(
+  fs: FileSystem,
   id: string,
   opts?: ResolveOptions
-) => Promise<[string, ?PackageJSON]> = promisify(require('resolve'));
-
-export default resolve;
+): Promise<[string, ?PackageJSON]> {
+  return _resolve(id, {
+    ...opts,
+    async readFile(filename, callback) {
+      try {
+        let res = await fs.readFile(filename);
+        callback(null, res);
+      } catch (err) {
+        callback(err);
+      }
+    },
+    async isFile(file, callback) {
+      try {
+        let stat = await fs.stat(file);
+        callback(null, stat.isFile());
+      } catch (err) {
+        callback(null, false);
+      }
+    },
+    async isDirectory(file, callback) {
+      try {
+        let stat = await fs.stat(file);
+        callback(null, stat.isDirectory());
+      } catch (err) {
+        callback(null, false);
+      }
+    }
+  });
+}

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -20,8 +20,7 @@
     "ansi-html": "^0.0.7",
     "connect": "^3.7.0",
     "ejs": "^2.6.1",
-    "http-proxy-middleware": "^0.19.1",
-    "serve-static": "^1.13.2"
+    "http-proxy-middleware": "^0.19.1"
   },
   "devDependencies": {
     "@parcel/babel-preset": "^2.0.0-alpha.1.1",

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@parcel/logger": "^2.0.0-alpha.1.1",
     "@parcel/plugin": "^2.0.0-alpha.1.1",
-    "@parcel/reporter-cli": "^2.0.0-alpha.1.1",
     "@parcel/utils": "^2.0.0-alpha.1.1",
     "ansi-html": "^0.0.7",
     "connect": "^3.7.0",

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -136,7 +136,7 @@ export default class Server extends EventEmitter {
     }
   }
 
-  async serveDist(req: Request, res: Response, next: NextFunction) {
+  serveDist(req: Request, res: Response, next: NextFunction) {
     return this.serve(
       this.options.outputFS,
       this.options.distDir,

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -1,16 +1,16 @@
 // @flow
 import type {Request, Response, DevServerOptions} from './types.js.flow';
-import type {BundleGraph} from '@parcel/types';
+import type {BundleGraph, FilePath} from '@parcel/types';
 import type {PrintableError} from '@parcel/utils';
 import type {Server as HTTPServer} from 'http';
 import type {Server as HTTPSServer} from 'https';
+import type {FileSystem} from '@parcel/fs';
 
 import EventEmitter from 'events';
 import path from 'path';
 import http from 'http';
 import https from 'https';
 import url from 'url';
-import serveStatic from 'serve-static';
 import ansiHtml from 'ansi-html';
 import logger from '@parcel/logger';
 import {prettyError} from '@parcel/utils';
@@ -44,17 +44,11 @@ const TEMPLATE_500 = fs.readFileSync(
   'utf8'
 );
 
-type ServeFunction = (
-  req: Request,
-  res: Response,
-  next?: (req: Request, res: Response, next?: (any) => any) => any
-) => any;
+type NextFunction = (req: Request, res: Response, next?: (any) => any) => any;
 
 export default class Server extends EventEmitter {
   pending: boolean;
   options: DevServerOptions;
-  serve: ServeFunction;
-  serveSources: ServeFunction;
   bundleGraph: BundleGraph | null;
   error: PrintableError | null;
   server: HTTPServer | HTTPSServer;
@@ -66,20 +60,6 @@ export default class Server extends EventEmitter {
     this.pending = true;
     this.bundleGraph = null;
     this.error = null;
-
-    this.serve = serveStatic(this.options.distDir, {
-      index: false,
-      redirect: false,
-      setHeaders: setHeaders,
-      dotfiles: 'allow'
-    });
-
-    this.serveSources = serveStatic(this.options.projectRoot, {
-      index: false,
-      redirect: false,
-      setHeaders: setHeaders,
-      dotfiles: 'allow'
-    });
   }
 
   buildSuccess(bundleGraph: BundleGraph) {
@@ -109,11 +89,17 @@ export default class Server extends EventEmitter {
       return this.sendIndex(req, res);
     } else if (pathname.startsWith(SOURCES_ENDPOINT)) {
       req.url = pathname.slice(SOURCES_ENDPOINT.length);
-      return this.serveSources(req, res, () => this.sendIndex(req, res));
+      return this.serve(
+        this.options.inputFS,
+        this.options.projectRoot,
+        req,
+        res,
+        () => this.send404(req, res)
+      );
     } else {
       // Otherwise, serve the file from the dist folder
       req.url = pathname.slice(this.options.publicUrl.length);
-      return this.serve(req, res, () => this.sendIndex(req, res));
+      return this.serveDist(req, res, () => this.sendIndex(req, res));
     }
   }
 
@@ -141,13 +127,94 @@ export default class Server extends EventEmitter {
       if (htmlBundle) {
         req.url = `/${path.basename(htmlBundle.filePath)}`;
 
-        this.serve(req, res, () => this.send404(req, res));
+        this.serveDist(req, res, () => this.send404(req, res));
       } else {
         this.send404(req, res);
       }
     } else {
       this.send404(req, res);
     }
+  }
+
+  async serveDist(req: Request, res: Response, next: NextFunction) {
+    return this.serve(
+      this.options.outputFS,
+      this.options.distDir,
+      req,
+      res,
+      next
+    );
+  }
+
+  async serve(
+    fs: FileSystem,
+    root: FilePath,
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      // method not allowed
+      res.statusCode = 405;
+      res.setHeader('Allow', 'GET, HEAD');
+      res.setHeader('Content-Length', '0');
+      res.end();
+      return;
+    }
+
+    try {
+      var filePath = url.parse(req.url).pathname || '';
+      filePath = decodeURIComponent(filePath);
+    } catch (err) {
+      return this.sendError(res, 400);
+    }
+
+    if (filePath) {
+      filePath = path.normalize('.' + path.sep + filePath);
+    }
+
+    // malicious path
+    if (filePath.includes(path.sep + '..' + path.sep)) {
+      return this.sendError(res, 403);
+    }
+
+    // join / normalize from the root dir
+    filePath = path.normalize(path.join(root, filePath));
+
+    try {
+      var stat = await fs.stat(filePath);
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return next(req, res);
+      }
+
+      return this.sendError(res, 500);
+    }
+
+    // Fall back to next handler if not a file
+    if (!stat || !stat.isFile()) {
+      return next(req, res);
+    }
+
+    setHeaders(res);
+    res.setHeader('Content-Length', '' + stat.size);
+    if (req.method === 'HEAD') {
+      res.end();
+      return;
+    }
+
+    return new Promise((resolve, reject) => {
+      fs.createReadStream(filePath)
+        .pipe(res)
+        .on('finish', resolve)
+        .on('error', reject);
+    });
+  }
+
+  sendError(res: Response, statusCode: number) {
+    res.statusCode = statusCode;
+    setHeaders(res);
+    res.end();
   }
 
   send404(req: Request, res: Response) {

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -12,6 +12,7 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
+    "@parcel/fs": "^2.0.0-alpha.1.1",
     "@parcel/logger": "^2.0.0-alpha.1.1",
     "@parcel/plugin": "^2.0.0-alpha.1.1",
     "@parcel/utils": "^2.0.0-alpha.1.1"

--- a/packages/transformers/sass/src/SassTransformer.js
+++ b/packages/transformers/sass/src/SassTransformer.js
@@ -4,16 +4,19 @@ import {Transformer} from '@parcel/plugin';
 import {promisify, resolve} from '@parcel/utils';
 import logger from '@parcel/logger';
 import {dirname} from 'path';
+import {NodeFS} from '@parcel/fs';
 
 // E.g: ~library/file.sass
 const WEBPACK_ALIAS_RE = /^~[^/]/;
+const fs = new NodeFS();
 
 let didWarnAboutNodeSass = false;
 
 async function warnAboutNodeSassBeingUnsupported(filePath) {
   if (!didWarnAboutNodeSass) {
     try {
-      await resolve('node-sass', {basedir: dirname(filePath)});
+      // TODO: replace this with the actual filesystem later
+      await resolve(fs, 'node-sass', {basedir: dirname(filePath)});
       logger.warn(
         '`node-sass` is unsupported in Parcel 2, it will use Dart Sass a.k.a. `sass`'
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -11142,7 +11142,7 @@ serialize-to-js@^1.1.1:
     js-beautify "^1.8.9"
     safer-eval "^1.3.0"
 
-serve-static@^1.12.4, serve-static@^1.13.2:
+serve-static@^1.12.4:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.14.1.tgz#666e636dc4f010f7ef29970a88a674320898b2f9"
   integrity sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5517,6 +5517,13 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 finalhandler@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -5529,13 +5536,6 @@ finalhandler@1.1.2:
     parseurl "~1.3.3"
     statuses "~1.5.0"
     unpipe "~1.0.0"
-
-fill-range@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
-  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
-  dependencies:
-    to-regex-range "^5.0.1"
 
 find-cache-dir@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
This abstracts the filesystem access in several additional places from what we currently have. This is used in the tests to avoid writing to the real filesystem, which can cause flakiness.

* The watcher is now part of the `FileSystem` interface. `@parcel/watcher` is used by the `NodeFS` implementation, and an implementation is added for `MemoryFS`. Currently, the watchers can only be subscribed to in the main thread, not inside workers, but events created by all threads will trigger the watchers.
* The dev server now serves files using the specified filesystem implementations. This required removing the `serve-static` module and replacing it with a custom implementation that uses our fs rather than the default node fs.
* `localResolve` and `resolve` now use our filesystem as well, which is needed when resolving parcel configs and other things.

This leaves only a couple tests that write to the filesystem, mostly related to auto install. I will be replacing the auto install system with a new abstract package manager implementation in a separate PR.