### PR TITLE
Remove eslint comments from prelude

### DIFF
--- a/packages/shared/scope-hoisting/.eslintrc.json
+++ b/packages/shared/scope-hoisting/.eslintrc.json
@@ -2,5 +2,14 @@
   "extends": "@parcel/eslint-config",
   "parserOptions": {
     "sourceType": "module"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["src/helpers.js", "src/prelude.js"],
+      "rules": {
+        "no-undef": "off",
+        "no-unused-vars": "off"
+      }
+    }
+  ]
 }

--- a/packages/shared/scope-hoisting/src/helpers.js
+++ b/packages/shared/scope-hoisting/src/helpers.js
@@ -1,14 +1,11 @@
-// eslint-disable-next-line no-unused-vars
 function $parcel$interopDefault(a) {
   return a && a.__esModule ? {d: a.default} : {d: a};
 }
 
-// eslint-disable-next-line no-unused-vars
 function $parcel$defineInteropFlag(a) {
   Object.defineProperty(a, '__esModule', {value: true});
 }
 
-// eslint-disable-next-line no-unused-vars
 function $parcel$exportWildcard(dest, source) {
   Object.keys(source).forEach(function(key) {
     if (key === 'default' || key === '__esModule') {
@@ -26,12 +23,10 @@ function $parcel$exportWildcard(dest, source) {
   return dest;
 }
 
-// eslint-disable-next-line no-unused-vars
 function $parcel$missingModule(name) {
   var err = new Error("Cannot find module '" + name + "'");
   err.code = 'MODULE_NOT_FOUND';
   throw err;
 }
 
-// eslint-disable-next-line no-unused-vars
 var $parcel$global = this;

--- a/packages/shared/scope-hoisting/src/prelude.js
+++ b/packages/shared/scope-hoisting/src/prelude.js
@@ -1,6 +1,5 @@
 var $parcel$modules = {};
 
-/* eslint-disable no-undef */
 var globalObject =
   typeof globalThis !== 'undefined'
     ? globalThis
@@ -11,7 +10,6 @@ var globalObject =
     : typeof global !== 'undefined'
     ? global
     : {};
-/* eslint-enable no-undef */
 
 globalObject.parcelRequire = function(name) {
   if (name in $parcel$modules) {


### PR DESCRIPTION
# ↪️ Pull Request

Closes #3431, Fixes #3402

Using regex to replace comments in Javascript are error prone, let's remove the comments instead.