### PR TITLE
Use the same cache key for persisting initial asset

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -132,15 +132,16 @@ export default class Transformation {
     initialAsset: InternalAsset
   ): Promise<Array<InternalAsset>> {
     let initialType = initialAsset.value.type;
-    // TODO: is this reading/writing from the cache every time we jump a pipeline? Seems possibly unnecessary...
-    let initialCacheEntry = await this.readFromCache(
+    let initialAssetCacheKey = this.getCacheKey(
       [initialAsset],
       pipeline.configs
     );
+    // TODO: is this reading/writing from the cache every time we jump a pipeline? Seems possibly unnecessary...
+    let initialCacheEntry = await this.readFromCache(initialAssetCacheKey);
 
     let assets = initialCacheEntry || (await pipeline.transform(initialAsset));
     if (!initialCacheEntry) {
-      await this.writeToCache(assets, pipeline.configs);
+      await this.writeToCache(initialAssetCacheKey, assets, pipeline.configs);
     }
 
     let finalAssets: Array<InternalAsset> = [];
@@ -167,8 +168,7 @@ export default class Transformation {
     }
 
     let processedCacheEntry = await this.readFromCache(
-      finalAssets,
-      pipeline.configs
+      this.getCacheKey(finalAssets, pipeline.configs)
     );
 
     invariant(pipeline.postProcess != null);
@@ -176,21 +176,21 @@ export default class Transformation {
       processedCacheEntry ?? (await pipeline.postProcess(assets)) ?? [];
 
     if (!processedCacheEntry) {
-      await this.writeToCache(processedFinalAssets, pipeline.configs);
+      await this.writeToCache(
+        this.getCacheKey(processedFinalAssets, pipeline.configs),
+        processedFinalAssets,
+        pipeline.configs
+      );
     }
 
     return processedFinalAssets;
   }
 
-  async readFromCache(
-    assets: Array<InternalAsset>,
-    configs: ConfigMap
-  ): Promise<null | Array<InternalAsset>> {
+  async readFromCache(cacheKey: string): Promise<null | Array<InternalAsset>> {
     if (this.options.disableCache || this.request.code != null) {
       return null;
     }
 
-    let cacheKey = this.getCacheKey(assets, configs);
     let cachedAssets = await this.options.cache.get(cacheKey);
     if (!cachedAssets) {
       return null;
@@ -206,10 +206,10 @@ export default class Transformation {
   }
 
   async writeToCache(
+    cacheKey: string,
     assets: Array<InternalAsset>,
     configs: ConfigMap
   ): Promise<void> {
-    let cacheKey = this.getCacheKey(assets, configs);
     await Promise.all(
       // TODO: account for impactfulOptions maybe being different per pipeline
       assets.map(asset =>


### PR DESCRIPTION
When reading cached content for the asset in the request, we computed a key different than the one used to persist its results. Use the same key.

Test Plan: 
* Log cache keys in transformer to verify different keys were computed before.
* Log `initialCacheEntry` and verify it never had a value after multiple builds.
* Apply the fix, log cache entries again, and verify they're present