### PR TITLE
Add .jss extension for the JSAsset to be registered with

### DIFF
--- a/packages/core/parcel-bundler/src/Parser.js
+++ b/packages/core/parcel-bundler/src/Parser.js
@@ -9,6 +9,7 @@ class Parser {
     this.extensions = {};
 
     this.registerExtension('js', './assets/JSAsset');
+    this.registerExtension('jss', './assets/JSAsset');
     this.registerExtension('jsx', './assets/JSAsset');
     this.registerExtension('es6', './assets/JSAsset');
     this.registerExtension('jsm', './assets/JSAsset');


### PR DESCRIPTION
# ↪️ Pull Request

The Material-UI community uses ".jss" as an extension for the JSS style files. Parcel has problems to resolve references to style files, without explicitly adding the extension to the filename.

## 💻 Examples
`./theme` and `./styles` are .jss files and can be read/resolved by parcel now.

```jsx
import React from 'react';                   
import {MuiThemeProvider, withStyles} from '@material-ui/core';       

import theme from './theme';                                                       
import styles from './styles';                                                     
                                                                                   
import Login from './login';                         
                                                                                   
const App = () => (                                                          
  <MuiThemeProvider theme={theme}>                                           
    <Login />                                                          
  </MuiThemeProvider>                                                        
);                                                                                 
                                                                                   
export default withStyles(styles)(App); 
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
