### PR TITLE
Use `contains` edges to reflect bundle membership, not reference edges

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -128,7 +128,6 @@ export default new Bundler({
 
           for (let asset of assets) {
             if (bundleGraph.isAssetInAncestorBundles(bundle, asset)) {
-              bundleGraph.createAssetReference(dependency, asset);
               bundleGraph.removeAssetGraphFromBundle(asset, bundle);
             }
           }
@@ -237,12 +236,6 @@ export default new Bundler({
         bundleGraph.addAssetGraphToBundle(asset, sharedBundle);
         for (let bundle of sourceBundles) {
           bundleGraph.removeAssetGraphFromBundle(asset, bundle);
-          for (let dependency of bundleGraph.getDependenciesInBundle(
-            bundle,
-            asset
-          )) {
-            bundleGraph.createAssetReference(dependency, asset);
-          }
         }
       }
 

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -238,7 +238,8 @@ export default class BundleGraph {
 
   traverseBundle<TContext>(
     bundle: Bundle,
-    visit: GraphVisitor<AssetNode | DependencyNode, TContext>
+    visit: GraphVisitor<AssetNode | DependencyNode, TContext>,
+    includeAll: boolean = false
   ): ?TContext {
     return this._graph.filteredTraverse(
       (node, actions) => {
@@ -247,7 +248,12 @@ export default class BundleGraph {
         }
 
         if (node.type === 'dependency' || node.type === 'asset') {
-          return node;
+          if (
+            includeAll ||
+            this._graph.hasEdge(bundle.id, node.id, 'contains')
+          ) {
+            return node;
+          }
         }
 
         actions.skipChildren();

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -176,12 +176,25 @@ export default class BundleGraph {
   }
 
   isAssetReferencedByAssetType(asset: Asset, type: string): boolean {
+    let referringBundles = new Set(
+      this._graph.getNodesConnectedTo(
+        nullthrows(this._graph.getNode(asset.id)),
+        'contains'
+      )
+    );
+
     // is `asset` referenced by a dependency from an asset of `type`
     return this._graph
-      .getNodesConnectedTo(
-        nullthrows(this._graph.getNode(asset.id)),
-        'references'
-      )
+      .getNodesConnectedTo(nullthrows(this._graph.getNode(asset.id)))
+      .filter(node => {
+        // Does this dependency belong to a bundle that does not include the
+        // asset it resolves to? If so, this asset is needed by a bundle but
+        // does not belong to it.
+        return this._graph
+          .getNodesConnectedTo(node, 'contains')
+          .filter(node => node.type === 'bundle')
+          .some(b => !referringBundles.has(b));
+      })
       .map(node => {
         invariant(node.type === 'dependency');
         return this._graph.getNodesConnectedTo(node, null);

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -152,21 +152,6 @@ export default class BundleGraph {
     });
   }
 
-  getDependenciesInBundle(bundle: Bundle, asset: Asset): Array<Dependency> {
-    let assetNode = this._graph.getNode(asset.id);
-    if (!assetNode) {
-      throw new Error('Asset not found');
-    }
-
-    return this._graph
-      .getNodesConnectedTo(assetNode)
-      .filter(node => this._graph.hasEdge(bundle.id, node.id, 'contains'))
-      .map(node => {
-        invariant(node.type === 'dependency');
-        return node.value;
-      });
-  }
-
   removeAssetFromBundle(asset: Asset, bundle: Bundle): void {
     this._graph.removeEdge(bundle.id, asset.id, 'contains');
   }

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -226,7 +226,7 @@ export default class BundlerRunner {
 
         for (let asset of assets) {
           if (bundleGraph.isAssetInAncestorBundles(bundle, asset)) {
-            duplicated.push([asset, dependency]);
+            duplicated.push(asset);
             actions.skipChildren();
           }
         }
@@ -239,8 +239,7 @@ export default class BundlerRunner {
       summarizeBundle(bundle, bundleGraph);
 
       let entryIsReference = false;
-      for (let [asset, dependency] of duplicated) {
-        bundleGraph.createAssetReference(dependency, asset);
+      for (let asset of duplicated) {
         bundleGraph.removeAssetGraphFromBundle(asset, bundle);
 
         if (entry.id === asset.id) {

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -236,7 +236,11 @@ export default class BundlerRunner {
       // the node to it.
       // $FlowFixMe
       bundleGraph._graph.merge(subBundleGraph._graph);
-      summarizeBundle(bundle, bundleGraph);
+      subBundleGraph._graph.traverse(node => {
+        if (node.type === 'asset' || node.type === 'dependency') {
+          bundleGraph._graph.addEdge(bundle.id, node.id, 'contains');
+        }
+      });
 
       let entryIsReference = false;
       for (let asset of duplicated) {
@@ -305,14 +309,18 @@ function summarizeBundle(
   bundleGraph: InternalBundleGraph
 ): void {
   let size = 0;
-  bundleGraph.traverseBundle(bundle, node => {
-    if (node.type === 'dependency' || node.type === 'asset') {
-      bundleGraph._graph.addEdge(bundle.id, node.id, 'contains');
-    }
-    if (node.type === 'asset') {
-      size += node.value.stats.size;
-    }
-  });
+  bundleGraph.traverseBundle(
+    bundle,
+    node => {
+      if (node.type === 'dependency' || node.type === 'asset') {
+        bundleGraph._graph.addEdge(bundle.id, node.id, 'contains');
+      }
+      if (node.type === 'asset') {
+        size += node.value.stats.size;
+      }
+    },
+    true
+  );
 
   bundle.stats.size = size;
 }

--- a/packages/core/core/src/public/BundlerBundleGraph.js
+++ b/packages/core/core/src/public/BundlerBundleGraph.js
@@ -210,15 +210,6 @@ export class BundlerOptimizeBundleGraph extends BundlerBundleGraph
       .map(bundle => new Bundle(bundle, this.#graph, this.#options));
   }
 
-  getDependenciesInBundle(bundle: IBundle, asset: IAsset): Array<IDependency> {
-    return this.#graph
-      .getDependenciesInBundle(
-        bundleToInternalBundle(bundle),
-        assetToInternalAsset(asset).value
-      )
-      .map(dep => new Dependency(dep));
-  }
-
   getTotalSize(asset: IAsset): number {
     return this.#graph.getTotalSize(assetToInternalAsset(asset).value);
   }

--- a/packages/core/integration-tests/test/integration/dynamic-hoist-deep/1.js
+++ b/packages/core/integration-tests/test/integration/dynamic-hoist-deep/1.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/core/integration-tests/test/integration/dynamic-hoist-deep/a.js
+++ b/packages/core/integration-tests/test/integration/dynamic-hoist-deep/a.js
@@ -1,1 +1,1 @@
-import './c';
+export {default} from './c';

--- a/packages/core/integration-tests/test/integration/dynamic-hoist-deep/b.js
+++ b/packages/core/integration-tests/test/integration/dynamic-hoist-deep/b.js
@@ -1,1 +1,1 @@
-import './c';
+export {default} from './c';

--- a/packages/core/integration-tests/test/integration/dynamic-hoist-deep/c.js
+++ b/packages/core/integration-tests/test/integration/dynamic-hoist-deep/c.js
@@ -1,1 +1,1 @@
-import('./1');
+export default import('./1');

--- a/packages/core/integration-tests/test/integration/dynamic-hoist-deep/index.js
+++ b/packages/core/integration-tests/test/integration/dynamic-hoist-deep/index.js
@@ -1,6 +1,8 @@
-import('./a');
-import('./b');
-
-export default {
-  asdf: 1,
-};
+export default Promise.all([
+  import('./a'),
+  import('./b')
+]).then(([a, b]) => {
+  return Promise.all([a.default, b.default])
+}).then(([v1, v2]) => {
+  return v1.default === v2.default;
+});

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -619,15 +619,15 @@ describe('javascript', function() {
         assets: ['a.js', 'c.js', 'JSRuntime.js']
       },
       {
-        assets: ['b.js', 'c.js', 'JSRuntime.js']
+        assets: ['b.js', 'c.js']
       },
       {
         assets: ['1.js']
       }
     ]);
 
-    let output = await run(b);
-    assert.deepEqual(output, {default: {asdf: 1}});
+    let {default: promise} = await run(b);
+    assert.ok(await promise);
   });
 
   it('should support requiring JSON files', async function() {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -515,7 +515,6 @@ export interface BundlerOptimizeBundleGraph extends BundlerBundleGraph {
   findBundlesWithAsset(Asset): Array<Bundle>;
   getBundleGroupsContainingBundle(Bundle): Array<BundleGroup>;
   getBundlesInBundleGroup(BundleGroup): Array<Bundle>;
-  getDependenciesInBundle(Bundle, Asset): Array<Dependency>;
   getTotalSize(Asset): number;
   isAssetInAncestorBundles(Bundle, Asset): boolean;
   removeAssetFromBundle(Asset, Bundle): void;


### PR DESCRIPTION
Use `contains` edges to reflect bundle membership, not reference edges

Since replacing an untyped edge with a reference edge prevents it from being traversed by all bundles, adjust bundling to only remove assets from bundles -- which only removes the `contains` edge signaling membership from a bundle to an asset, and only traverse a bundle's contents further if a dependency or asset belongs to the bundle.

Notes:
* `isAssetReferencedByAssetType` relied on reference edges to determine if an asset was used by another bundle. Its logic has been adjusted to see if the asset belongs to a dependency present in a bundle that it is not a part of. Maybe this needs a new name as "referenced" has a different meaning in core. cc @mischnic
* The `dynamic-hoist-deep` test has been adjusted to assert that the extracted module is actually shared by asserting object equality of the export of the shared module in each case.
* `traverseBundle` has an `includeAll` option which will disregard `contains` membership, as `contains` membership is first applied using `traverseBundle` as a part of `summarizeBundle`. Ideally `summarizeBundle` should be removed as it only exists so we can defer adding asset membership until after the bundle phase for performance reasons. `includeAll` can be removed once bundling is refactored to remove `summarizeBundle`.

Test Plan: Tests updated accordingly.