### PR TITLE
Store serialized Parcel Configs

### DIFF
--- a/packages/core/core/src/ConfigLoader.js
+++ b/packages/core/core/src/ConfigLoader.js
@@ -40,7 +40,7 @@ export default class ConfigLoader {
     );
 
     publicConfig.setResolvedPath(parcelConfig.filePath);
-    publicConfig.setResult(parcelConfig);
+    publicConfig.setResult(parcelConfig.getConfig());
     this.parcelConfig = parcelConfig;
 
     let devDeps = [];

--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -64,22 +64,26 @@ export default class ParcelConfig {
     return new ParcelConfig(serialized.config, serialized.packageManager);
   }
 
+  getConfig() {
+    return {
+      filePath: this.filePath,
+      resolvers: this.resolvers,
+      transforms: this.transforms,
+      validators: this.validators,
+      runtimes: this.runtimes,
+      bundler: this.bundler,
+      namers: this.namers,
+      packagers: this.packagers,
+      optimizers: this.optimizers,
+      reporters: this.reporters
+    };
+  }
+
   serialize(): SerializedParcelConfig {
     return {
       $$raw: false,
       packageManager: this.packageManager,
-      config: {
-        filePath: this.filePath,
-        resolvers: this.resolvers,
-        transforms: this.transforms,
-        validators: this.validators,
-        runtimes: this.runtimes,
-        bundler: this.bundler,
-        namers: this.namers,
-        packagers: this.packagers,
-        optimizers: this.optimizers,
-        reporters: this.reporters
-      }
+      config: this.getConfig()
     };
   }
 

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -25,11 +25,11 @@ import {md5FromObject} from '@parcel/utils';
 
 import {createDependency} from './Dependency';
 import PublicConfig from './public/Config';
+import ParcelConfig from './ParcelConfig';
 import ResolverRunner from './ResolverRunner';
 import {report} from './ReporterRunner';
 import {MutableAsset, assetToInternalAsset} from './public/Asset';
 import InternalAsset, {createAsset} from './InternalAsset';
-import ParcelConfig from './ParcelConfig';
 import summarizeRequest from './summarizeRequest';
 import PluginOptions from './public/PluginOptions';
 
@@ -249,7 +249,10 @@ export default class Transformation {
 
     let config = await this.loadConfig(configRequest);
     let result = nullthrows(config.result);
-    let parcelConfig = new ParcelConfig(result, this.options.packageManager);
+    let parcelConfig = new ParcelConfig(
+      config.result,
+      this.options.packageManager
+    );
 
     configs.set('parcel', config);
 
@@ -358,8 +361,10 @@ class Pipeline {
     }));
     this.configs = configs;
     this.options = options;
-    let parcelConfig = nullthrows(this.configs.get('parcel'));
-    parcelConfig = nullthrows(parcelConfig.result);
+    let parcelConfig = new ParcelConfig(
+      nullthrows(nullthrows(this.configs.get('parcel')).result),
+      this.options.packageManager
+    );
     this.resolverRunner = new ResolverRunner({
       config: parcelConfig,
       options

--- a/packages/examples/yarn.lock
+++ b/packages/examples/yarn.lock
@@ -1,0 +1,1 @@
+# This prevents examples from finding the babel.config.js in the root of the repo


### PR DESCRIPTION
Full ParcelConfigs were mistakenly set as config results and therefore stored in the RequestGraph, whose contents must be serializable.

Instead, store serialized versions of ParcelConfig and deserialize them as necessary.

Alternatives: Manually store a subset of the Parcel Config as the result, and re-create it using the `ParcelConfig` constructor rather than using the de/serializer.

Test Plan: Log the contents of the RequestGraph right before it is serialized and verify config request nodes do not contain any ParcelConfigs.