### PR TITLE
Parcel V2: Fix `assertBundles` util

### DIFF
--- a/packages/core/integration-tests/test/pug.js
+++ b/packages/core/integration-tests/test/pug.js
@@ -55,7 +55,7 @@ describe('pug', function() {
         type: 'html',
         name: 'index.html',
         assets: ['index.pug'],
-        connectedFiles: {
+        includedFiles: {
           'index.pug': ['package.json', 'base.pug', 'other.pug', 'nested.pug']
         }
       }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -200,7 +200,7 @@ export function assertBundles(
     name?: string | RegExp,
     type?: string,
     assets: Array<string>,
-    connectedFiles?: {
+    includedFiles?: {
       [key: string]: Array<string>,
       ...
     }
@@ -211,12 +211,12 @@ export function assertBundles(
 
   bundleGraph.traverseBundles(bundle => {
     let assets = [];
-    const connectedFiles = {};
+    const includedFiles = {};
 
     bundle.traverseAssets(asset => {
       const name = path.basename(asset.filePath);
       assets.push(name);
-      connectedFiles[name] = asset
+      includedFiles[name] = asset
         .getIncludedFiles()
         .map(({filePath}) => path.basename(filePath))
         .sort(byAlphabet);
@@ -227,7 +227,7 @@ export function assertBundles(
       name: path.basename(nullthrows(bundle.filePath)),
       type: bundle.type,
       assets,
-      connectedFiles
+      includedFiles
     });
   });
 
@@ -275,14 +275,14 @@ export function assertBundles(
       assert.deepEqual(actualBundle.assets, bundle.assets);
     }
 
-    if (bundle.connectedFiles) {
+    if (bundle.includedFiles) {
       for (let asset of actualBundle.assets) {
-        const files = bundle.connectedFiles[asset];
+        const files = bundle.includedFiles[asset];
         if (!files) {
           continue;
         }
         assert.deepEqual(
-          actualBundle.connectedFiles[asset],
+          actualBundle.includedFiles[asset],
           files.sort(byAlphabet)
         );
       }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -217,7 +217,7 @@ export function assertBundles(
       const name = path.basename(asset.filePath);
       assets.push(name);
       connectedFiles[name] = asset
-        .getConnectedFiles()
+        .getIncludedFiles()
         .map(({filePath}) => path.basename(filePath))
         .sort(byAlphabet);
     });

--- a/packages/transformers/pug/src/PugTransformer.js
+++ b/packages/transformers/pug/src/PugTransformer.js
@@ -33,7 +33,7 @@ export default new Transformer({
     });
 
     for (let filePath of render.dependencies) {
-      await asset.addConnectedFile({filePath});
+      await asset.addIncludedFile({filePath});
     }
 
     asset.type = 'html';


### PR DESCRIPTION
The pug transformer #3476 added the ability to check bundles had proper connected files, but the method `getConnectedFiles` was recently renamed to `getIncludedFiles` this resolves the method call. 