### PR TITLE
Update `localRequire` to `options.packageManager.require` in ESlint Validator

### DIFF
--- a/packages/validators/eslint/src/EslintValidator.js
+++ b/packages/validators/eslint/src/EslintValidator.js
@@ -7,8 +7,8 @@ type CodeFrameError = Error & {codeFrame?: string, ...};
 let cliEngine = null;
 
 export default new Validator({
-  async validate({asset, options, localRequire}) {
-    let eslint = await localRequire('eslint', asset.filePath);
+  async validate({asset, options}) {
+    let eslint = await options.packageManager.require('eslint', asset.filePath);
     if (!cliEngine) {
       cliEngine = new eslint.CLIEngine({});
     }


### PR DESCRIPTION
In #3471, `localRequire` was abstracted away into `options.packageManager.require`.

The `EslintValidator` PR was created prior to that and was merged using the `localRequire` code. 