### PR TITLE
Check package cache in main process

### DIFF
--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -64,7 +64,7 @@ export default class BundlerRunner {
 
     let bundleGraph = removeAssetGroups(graph);
     // $FlowFixMe
-    let internalBundleGraph = new InternalBundleGraph(bundleGraph);
+    let internalBundleGraph = new InternalBundleGraph({graph: bundleGraph});
     await dumpGraphToGraphViz(bundleGraph, 'before_bundle');
     let mutableBundleGraph = new MutableBundleGraph(
       internalBundleGraph,
@@ -169,6 +169,7 @@ export default class BundlerRunner {
           options: this.pluginOptions
         });
         if (applied) {
+          internalBundleGraph._bundleContentHashes.delete(bundle.id);
           await this.addRuntimesToBundle(
             bundle,
             internalBundleGraph,
@@ -201,12 +202,12 @@ export default class BundlerRunner {
       let {assetGraph} = await builder.build();
 
       let entry = assetGraph.getEntryAssets()[0];
-      let subBundleGraph = new InternalBundleGraph(
+      let subBundleGraph = new InternalBundleGraph({
         // $FlowFixMe
-        removeAssetGroups(
+        graph: removeAssetGroups(
           assetGraph.getSubGraph(nullthrows(assetGraph.getNode(entry.id)))
         )
-      );
+      });
 
       // Exclude modules that are already included in an ancestor bundle
       let duplicated = [];

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -46,11 +46,13 @@ export function runPackage(
     bundle,
     bundleGraph,
     config,
+    cacheKey,
     options
   }: {
     bundle: Bundle,
     bundleGraph: BundleGraph,
     config: ParcelConfig,
+    cacheKey: string,
     options: ParcelOptions,
     ...
   }
@@ -58,5 +60,5 @@ export function runPackage(
   return new PackagerRunner({
     config,
     options
-  }).writeBundle(bundle, bundleGraph);
+  }).packageAndWriteBundle(bundle, bundleGraph, cacheKey);
 }

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1298,7 +1298,7 @@ describe('scope hoisting', function() {
     });
 
     it('should support wrapping array destructuring declarations', async function() {
-      this.timeout(70000);
+      this.timeout(90000);
       let b = await bundle(
         path.join(
           __dirname,


### PR DESCRIPTION
# ↪️ Pull Request
This PR moves the checking of that package cache to the main process so that we avoid serializing the `BundleGraph` and sending it across IPC if we don't have to.

## 🚨 Test instructions

All existing integration tests pass. Manually tested against a stress test project that saw a warm build time go from ~20s to ~1s. 
