### PR TITLE
Stop removing subgraphs at bundle boundaries

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -130,7 +130,10 @@ export default new Bundler({
           let assets = bundleGraph.getDependencyAssets(dependency);
 
           for (let asset of assets) {
-            if (bundleGraph.isAssetInAncestorBundles(bundle, asset)) {
+            if (
+              bundle.hasAsset(asset) &&
+              bundleGraph.isAssetInAncestorBundles(bundle, asset)
+            ) {
               bundleGraph.removeAssetGraphFromBundle(asset, bundle);
             }
           }

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -78,11 +78,14 @@ export default class BundleGraph {
 
   removeAssetGraphFromBundle(asset: Asset, bundle: Bundle) {
     this._graph.removeEdge(bundle.id, asset.id);
-    this._graph.traverse(node => {
-      if (node.type === 'asset' || node.type === 'dependency') {
+    this.traverseBundle(
+      bundle,
+      node => {
         this._graph.removeEdge(bundle.id, node.id, 'contains');
-      }
-    }, nullthrows(this._graph.getNode(asset.id)));
+      },
+      false,
+      nullthrows(this._graph.getNode(asset.id))
+    );
   }
 
   createAssetReference(dependency: Dependency, asset: Asset): void {
@@ -253,7 +256,8 @@ export default class BundleGraph {
   traverseBundle<TContext>(
     bundle: Bundle,
     visit: GraphVisitor<AssetNode | DependencyNode, TContext>,
-    includeAll: boolean = false
+    includeAll: boolean = false,
+    startNode?: BundleGraphNode = nullthrows(this._graph.getNode(bundle.id))
   ): ?TContext {
     return this._graph.filteredTraverse(
       (node, actions) => {
@@ -273,7 +277,7 @@ export default class BundleGraph {
         actions.skipChildren();
       },
       visit,
-      nullthrows(this._graph.getNode(bundle.id))
+      startNode
     );
   }
 


### PR DESCRIPTION
We used to rely on reference edges to stop traversing, but moved to removing contains edges to remove an asset from a bundle.

This yielded a 3x performance improvement on the optimizing phase of bundling of Atlaskit Editor.