### PR TITLE
Graph integrity: error if edge to be removed doesn't exist

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -84,7 +84,10 @@ export default class BundleGraph {
   }
 
   removeAssetGraphFromBundle(asset: Asset, bundle: Bundle) {
-    this._graph.removeEdge(bundle.id, asset.id);
+    if (this._graph.hasEdge(bundle.id, asset.id)) {
+      this._graph.removeEdge(bundle.id, asset.id);
+    }
+
     this._graph.traverse((node, context, actions) => {
       if (node.type === 'bundle_group') {
         actions.skipChildren();
@@ -123,7 +126,9 @@ export default class BundleGraph {
 
   createAssetReference(dependency: Dependency, asset: Asset): void {
     this._graph.addEdge(dependency.id, asset.id, 'references');
-    this._graph.removeEdge(dependency.id, asset.id);
+    if (this._graph.hasEdge(dependency.id, asset.id)) {
+      this._graph.removeEdge(dependency.id, asset.id);
+    }
   }
 
   findBundlesWithAsset(asset: Asset): Array<Bundle> {

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -193,10 +193,29 @@ export default class Graph<TNode: Node, TEdgeType: string | null = null> {
 
   // Removes edge and node the edge is to if the node is orphaned
   removeEdge(from: NodeId, to: NodeId, type: TEdgeType | null = null) {
+    if (
+      !this.outboundEdges
+        .get(from)
+        .get(type)
+        .has(to)
+    ) {
+      throw new Error(`Outbound edge from ${from} to ${to} not found!`);
+    }
+
+    if (
+      !this.inboundEdges
+        .get(to)
+        .get(type)
+        .has(from)
+    ) {
+      throw new Error(`Inbound edge from ${to} to ${from} not found!`);
+    }
+
     this.outboundEdges
       .get(from)
       .get(type)
       .delete(to);
+
     this.inboundEdges
       .get(to)
       .get(type)

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -111,7 +111,9 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
     this.#graph._graph.addEdge(bundleGroupId, bundle.id);
     this.#graph._graph.addEdge(bundleGroupId, bundle.id, 'bundle');
     for (let entryAsset of bundle.getEntryAssets()) {
-      this.#graph._graph.removeEdge(bundleGroupId, entryAsset.id);
+      if (this.#graph._graph.hasEdge(bundleGroupId, entryAsset.id)) {
+        this.#graph._graph.removeEdge(bundleGroupId, entryAsset.id);
+      }
     }
   }
 


### PR DESCRIPTION
We should add some safeguards to our Graph structure to maintain its integrity. This ensures that the graph can't remove an edge that doesn't exist.

Test Plan: `yarn test`