### PR TITLE
Fix some type imports

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -1,6 +1,13 @@
 // @flow
 
-import type {Blob, FilePath, BundleResult, Stats} from '@parcel/types';
+import type {
+  Blob,
+  FilePath,
+  BundleResult,
+  Bundle as BundleType,
+  BundleGraph as BundleGraphType,
+  Stats
+} from '@parcel/types';
 import type SourceMap from '@parcel/source-map';
 import type WorkerFarm from '@parcel/workers';
 import type {Bundle as InternalBundle, ParcelOptions} from './types';
@@ -21,10 +28,6 @@ import path from 'path';
 import url from 'url';
 
 import {NamedBundle, bundleToInternalBundle} from './public/Bundle';
-import {
-  Bundle as BundleType,
-  BundleGraph as BundleGraphType
-} from '@parcel/types';
 import {report} from './ReporterRunner';
 import BundleGraph, {
   bundleGraphToInternalBundleGraph

--- a/packages/transformers/babel/src/flow.js
+++ b/packages/transformers/babel/src/flow.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {Config} from '@parcel/types';
+import type {Config} from '@parcel/types';
 import type {BabelConfig} from './types';
 
 /**

--- a/packages/transformers/babel/src/typescript.js
+++ b/packages/transformers/babel/src/typescript.js
@@ -1,7 +1,7 @@
 // @flow
 import path from 'path';
 
-import {Config} from '@parcel/types';
+import type {Config} from '@parcel/types';
 import type {BabelConfig} from './types';
 
 export default function getTypescriptOptions(config: Config): BabelConfig {


### PR DESCRIPTION
# ↪️ Pull Request
Noticed when running a prod build of Parcel that there were a few places where we were importing types incorrectly. Running locally with `@babel/register` doesn't present the issue because it transpiles away the types when they are imported.

## 🚨 Test instructions
Built a project with a prod build of Parcel and made sure it ran with no errors.