### PR TITLE
[T-345] Parcel 2: `loadConfig` in PostHTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.21.0",
     "mocha-multi-reporters": "^1.1.7",
+    "posthtml-attrs-sorter": "^1.1.0",
     "prettier": "1.19.1",
     "rimraf": "^2.6.3",
     "sinon": "^7.3.1"

--- a/packages/core/core/src/public/Config.js
+++ b/packages/core/core/src/public/Config.js
@@ -13,6 +13,7 @@ import type {Config, ParcelOptions} from '../types';
 import {DefaultWeakMap, loadConfig} from '@parcel/utils';
 
 import Environment from './Environment';
+import path from 'path';
 
 const internalConfigToConfig: DefaultWeakMap<
   ParcelOptions,
@@ -112,10 +113,16 @@ export default class PublicConfig implements IConfig {
     }
 
     if (!options || !options.exclude) {
+      let filePath = conf.files[0].filePath;
       if (this.#config.resolvedPath == null) {
-        this.setResolvedPath(conf.files[0].filePath);
+        this.setResolvedPath(filePath);
       } else {
-        this.addIncludedFile(conf.files[0].filePath);
+        this.addIncludedFile(filePath);
+      }
+
+      if (typeof filePath === 'string' && path.extname(filePath) === '.js') {
+        // TODO: figure out how to log from here about using a static file
+        this.shouldInvalidateOnStartup();
       }
     }
 

--- a/packages/core/integration-tests/test/integration/posthtml-config-js-with-require/.posthtmlrc.js
+++ b/packages/core/integration-tests/test/integration/posthtml-config-js-with-require/.posthtmlrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: [
+    require('posthtml-include')({
+      root: __dirname
+    })
+  ]
+};

--- a/packages/core/integration-tests/test/integration/posthtml-config-js-with-require/index.html
+++ b/packages/core/integration-tests/test/integration/posthtml-config-js-with-require/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+    <include src="other.html"></include>
+</body>
+</html>

--- a/packages/core/integration-tests/test/integration/posthtml-config-js-with-require/other.html
+++ b/packages/core/integration-tests/test/integration/posthtml-config-js-with-require/other.html
@@ -1,0 +1,1 @@
+<h1>Other page</h1>

--- a/packages/core/integration-tests/test/integration/posthtml-config-rc/.posthtmlrc
+++ b/packages/core/integration-tests/test/integration/posthtml-config-rc/.posthtmlrc
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "posthtml-attrs-sorter": {
+      "order": ["id", "class"]
+    }
+  }
+}

--- a/packages/core/integration-tests/test/integration/posthtml-config-rc/index.html
+++ b/packages/core/integration-tests/test/integration/posthtml-config-rc/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+<body>
+    <h1 class="customClass" id="mainHeader">This is a header</h1>
+</body>
+</html>

--- a/packages/core/integration-tests/test/integration/posthtml/.posthtmlrc.js
+++ b/packages/core/integration-tests/test/integration/posthtml/.posthtmlrc.js
@@ -1,7 +1,7 @@
 module.exports = {
-  plugins: [
-    require('posthtml-include')({
+  plugins: {
+    "posthtml-include": {
       root: __dirname
-    })
-  ]
+    }
+  }
 };

--- a/packages/core/integration-tests/test/posthtml.js
+++ b/packages/core/integration-tests/test/posthtml.js
@@ -25,7 +25,10 @@ describe('posthtml', function() {
       },
     ]);
 
-    let html = await outputFS.readFile(path.join(distDir, 'index.html'));
+    let html = await outputFS.readFile(
+      path.join(distDir, 'index.html'),
+      'utf-8'
+    );
     assert(html.includes('<h1>Other page</h1>'));
   });
 
@@ -44,6 +47,37 @@ describe('posthtml', function() {
         assets: ['index.js'],
       },
     ]);
+  });
+
+  it('should support compiling with static .posthtmlrc config', async function() {
+    await bundle(
+      path.join(__dirname, '/integration/posthtml-config-rc/index.html')
+    );
+
+    let html = await outputFS.readFile(
+      path.join(distDir, 'index.html'),
+      'utf-8'
+    );
+    assert(
+      html.includes(
+        '<h1 id="mainHeader" class="customClass">This is a header</h1>'
+      )
+    );
+  });
+
+  it('should support compiling using a .posthtmlrc.js with require config', async function() {
+    await bundle(
+      path.join(
+        __dirname,
+        '/integration/posthtml-config-js-with-require/index.html'
+      )
+    );
+
+    let html = await outputFS.readFile(
+      path.join(distDir, 'index.html'),
+      'utf-8'
+    );
+    assert(html.includes('<h1>Other page</h1>'));
   });
 
   it.skip('should add dependencies referenced by posthtml-include', async () => {

--- a/packages/core/integration-tests/test/pug.js
+++ b/packages/core/integration-tests/test/pug.js
@@ -51,7 +51,7 @@ describe('pug', function() {
         name: 'index.html',
         assets: ['index.pug'],
         includedFiles: {
-          'index.pug': ['package.json', 'base.pug', 'other.pug', 'nested.pug'],
+          'index.pug': ['base.pug', 'other.pug', 'nested.pug'],
         },
       },
     ]);

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -9,6 +9,20 @@ import nullthrows from 'nullthrows';
 import semver from 'semver';
 import loadPlugins from './loadPlugins';
 
+const canSerializeConfig = config => {
+  if (!config || !config.plugins) {
+    return true;
+  }
+  if (Array.isArray(config.plugins)) {
+    return config.plugins.every(plugin => typeof plugin === 'string');
+  } else if (typeof config.plugins === 'object') {
+    return Object.keys(config.plugins).every(
+      plugin => typeof plugin === 'string'
+    );
+  }
+  return true;
+};
+
 export default new Transformer({
   async loadConfig({config, options}) {
     let configResult = await config.getConfig(
@@ -19,19 +33,25 @@ export default new Transformer({
     configResult = configResult || {};
     configResult.skipParse = true;
 
-    // if (canSerializeConfig(config)) {
-    //   config.shouldReload();
-    //   config.setResult({
-    //     internal: false
-    //   });
-    //   config.setResultHash(JSON.stringify(Date.now()));
-    // }
+    // isReload case
+    if (config.result != null) {
+      configResult.plugins = await loadPlugins(
+        configResult.plugins,
+        config.searchPath,
+        options
+      );
+      config.setResult(configResult);
+    } else if (!canSerializeConfig(configResult)) {
+      config.shouldReload();
+      config.setResult({isReload: true});
+      config.setResultHash(JSON.stringify(Date.now()));
+    } else {
+      if (configResult.plugins) {
+        config.shouldRehydrate();
+      }
 
-    if (configResult.plugins) {
-      config.shouldRehydrate();
+      config.setResult(configResult);
     }
-
-    config.setResult(configResult);
   },
 
   async rehydrateConfig({config, options}) {

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -102,7 +102,7 @@ export default new Transformer({
 
     const ast = nullthrows(asset.ast);
 
-    let res = await posthtml(config.plugins).process(
+    let res = await posthtml(config.fullyLoaded.plugins).process(
       ast.program,
       config.fullyLoaded,
     );

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -10,22 +10,39 @@ import semver from 'semver';
 import loadPlugins from './loadPlugins';
 
 export default new Transformer({
-  async getConfig({asset, options}) {
-    let config = await asset.getConfig(
+  async loadConfig({config, options}) {
+    let configResult = await config.getConfig(
       ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
-      {
-        packageKey: 'posthtml',
-      },
+      options,
     );
 
-    config = config || {};
+    configResult = configResult || {};
+    configResult.skipParse = true;
 
-    // load plugins
-    config.plugins = await loadPlugins(config.plugins, asset.filePath, options);
+    // if (canSerializeConfig(config)) {
+    //   config.shouldReload();
+    //   config.setResult({
+    //     internal: false
+    //   });
+    //   config.setResultHash(JSON.stringify(Date.now()));
+    // }
 
-    // tells posthtml that we have already called parse
-    config.skipParse = true;
-    return config;
+    if (configResult.plugins) {
+      config.shouldRehydrate();
+    }
+
+    config.setResult(configResult);
+  },
+
+  async rehydrateConfig({config, options}) {
+    let configResult = config.result;
+
+    // convert plugins from config to functions
+    configResult.plugins = await loadPlugins(
+      configResult.plugins,
+      config.searchPath,
+      options,
+    );
   },
 
   canReuseAST({ast}) {

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -25,45 +25,55 @@ const canSerializeConfig = config => {
 
 export default new Transformer({
   async loadConfig({config, options}) {
-    let configResult = await config.getConfig([
+    let loaded = await config.getConfig([
       '.posthtmlrc',
       '.posthtmlrc.js',
       'posthtml.config.js',
     ]);
 
-    configResult = configResult || {};
-    configResult.skipParse = true;
+    loaded = loaded || {};
+    loaded.skipParse = true;
 
-    // isReload case
-    if (config.result != null) {
-      configResult.plugins = await loadPlugins(
-        configResult.plugins,
-        config.searchPath,
-        options,
-      );
-      config.setResult(configResult);
-    } else if (!canSerializeConfig(configResult)) {
-      config.shouldReload();
-      config.setResult({isReload: true});
+    if (!canSerializeConfig(loaded)) {
+      config.setResult({fullyLoaded: loaded});
+      config.shouldInvalidateOnStartup();
       config.setResultHash(JSON.stringify(Date.now()));
     } else {
-      if (configResult.plugins) {
-        config.shouldRehydrate();
-      }
-
-      config.setResult(configResult);
+      let fullyLoaded = {
+        ...loaded,
+        plugins: await loadPlugins(loaded.plugins, config.searchPath, options),
+      };
+      config.setResult({
+        loaded,
+        fullyLoaded,
+      });
     }
   },
 
-  async rehydrateConfig({config, options}) {
-    let configResult = config.result;
+  preSerializeConfig({config}) {
+    // remove fullyLoaded so v8 doesn't choke on functions
+    delete config.result.fullyLoaded;
+  },
 
-    // convert plugins from config to functions
-    configResult.plugins = await loadPlugins(
-      configResult.plugins,
-      config.searchPath,
-      options,
-    );
+  async postDeserializeConfig({config, options}) {
+    let configResult = config.result;
+    let {loaded} = configResult;
+
+    if (!loaded) {
+      loaded = await config.getConfig([
+        '.posthtmlrc',
+        '.posthtmlrc.js',
+        'posthtml.config.js',
+      ]);
+      loaded = loaded || {};
+      loaded.skipParse = true;
+      config.fullyLoaded = loaded;
+    } else {
+      configResult.fullyLoaded = {
+        ...loaded,
+        plugins: await loadPlugins(loaded.plugins, config.searchPath, options),
+      };
+    }
   },
 
   canReuseAST({ast}) {
@@ -92,7 +102,10 @@ export default new Transformer({
 
     const ast = nullthrows(asset.ast);
 
-    let res = await posthtml(config.plugins).process(ast.program, config);
+    let res = await posthtml(config.plugins).process(
+      ast.program,
+      config.fullyLoaded,
+    );
 
     if (res.messages) {
       await Promise.all(

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -44,11 +44,10 @@ const canSerializeConfig = (config: ConfigResult, logger: PluginLogger) => {
 
 export default new Transformer({
   async loadConfig({config, options, logger}) {
-    let loaded = await config.getConfig([
-      '.posthtmlrc',
-      '.posthtmlrc.js',
-      'posthtml.config.js',
-    ]);
+    let loaded = await config.getConfig(
+      ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
+      {packageKey: 'posthtml'},
+    );
 
     loaded = loaded || {};
     loaded.skipParse = true;
@@ -79,11 +78,10 @@ export default new Transformer({
     let {loaded} = configResult;
 
     if (!loaded) {
-      loaded = await config.getConfig([
-        '.posthtmlrc',
-        '.posthtmlrc.js',
-        'posthtml.config.js',
-      ]);
+      loaded = await config.getConfig(
+        ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
+        {packageKey: 'posthtml'},
+      );
       loaded = loaded || {};
       loaded.skipParse = true;
       configResult.fullyLoaded = loaded;

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -17,7 +17,7 @@ const canSerializeConfig = config => {
     return config.plugins.every(plugin => typeof plugin === 'string');
   } else if (typeof config.plugins === 'object') {
     return Object.keys(config.plugins).every(
-      plugin => typeof plugin === 'string'
+      plugin => typeof plugin === 'string',
     );
   }
   return true;
@@ -25,10 +25,11 @@ const canSerializeConfig = config => {
 
 export default new Transformer({
   async loadConfig({config, options}) {
-    let configResult = await config.getConfig(
-      ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
-      options,
-    );
+    let configResult = await config.getConfig([
+      '.posthtmlrc',
+      '.posthtmlrc.js',
+      'posthtml.config.js',
+    ]);
 
     configResult = configResult || {};
     configResult.skipParse = true;
@@ -38,7 +39,7 @@ export default new Transformer({
       configResult.plugins = await loadPlugins(
         configResult.plugins,
         config.searchPath,
-        options
+        options,
       );
       config.setResult(configResult);
     } else if (!canSerializeConfig(configResult)) {

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -1,7 +1,6 @@
 // @flow
 import type {ConfigResult} from '@parcel/types';
 import type {PluginLogger} from '@parcel/logger';
-import type {PostHTMLOptions} from 'posthtml';
 
 import {Transformer} from '@parcel/plugin';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10518,6 +10518,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.1
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+posthtml-attrs-sorter@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/posthtml-attrs-sorter/-/posthtml-attrs-sorter-1.1.0.tgz#ada71e3b7f6a4ad6cfdf4ecb9e3fc14a091410e3"
+  integrity sha1-raceO39qStbP307Lnj/BSgkUEOM=
+
 posthtml-extend@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/posthtml-extend/-/posthtml-extend-0.2.1.tgz#d023ce7ce4dd6071071b50e315dfefa87da8a979"


### PR DESCRIPTION
This deprecates `getConfig` in `PostHTMLTransformer`, in favor of `loadConfig`.

- [x] Adding new config tests
- [x] Update to handle static rc files via `loadConfig`
- [x] Update to handle js config without `require` statements
- [x] Update to handle js config with `require` statements
- [x] should call `config.shouldInvalidateOnStartup()` for `js` file configs
- [x] Add perf warning in verbose mode
- [ ] watch mode integration tests
- [x] should call `setResolvedPath` to invalidate on changes