### PR TITLE
Connect bundle groups to incoming bundles

### DIFF
--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -13,6 +13,7 @@ import type {
 } from '@parcel/types';
 import type {ParcelOptions} from '../types';
 
+import invariant from 'assert';
 import nullthrows from 'nullthrows';
 
 import InternalBundleGraph from '../BundleGraph';
@@ -76,6 +77,19 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
         bundleGroupNode.id,
         'bundle'
       );
+    } else {
+      let inboundBundleNodes = this.#graph._graph.getNodesConnectedTo(
+        dependencyNode,
+        'contains'
+      );
+      for (let inboundBundleNode of inboundBundleNodes) {
+        invariant(inboundBundleNode.type === 'bundle');
+        this.#graph._graph.addEdge(
+          inboundBundleNode.id,
+          bundleGroupNode.id,
+          'bundle'
+        );
+      }
     }
 
     return bundleGroup;


### PR DESCRIPTION
This corrects an issue where if bundle groups are added to the graph after incoming bundles up the tree are, connections are still made.