### PR TITLE
Improve test performance for Node 8 and 10

### DIFF
--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -1,20 +1,20 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   bundler,
   getNextBuild,
   removeDistDirectory,
   run,
-  inputFS: fs,
+  inputFS as fs,
   outputFS,
   distDir,
   sleep
-} = require('@parcel/test-utils');
-const os = require('os');
-const {spawnSync} = require('child_process');
-const {symlinkSync} = require('fs');
-const tempy = require('tempy');
+} from '@parcel/test-utils';
+import os from 'os';
+import {spawnSync} from 'child_process';
+import {symlinkSync} from 'fs';
+import tempy from 'tempy';
 
 const parcelCli = require.resolve('parcel/src/bin.js');
 const inputDir = path.join(__dirname, '/input');

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -1,12 +1,12 @@
-const assert = require('assert');
-const sinon = require('sinon');
-const path = require('path');
-const {
+import assert from 'assert';
+import sinon from 'sinon';
+import path from 'path';
+import {
   assertBundleTree,
   bundle,
   bundler,
   nextBundle
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe.skip('bundler', function() {
   it('should bundle once before exporting middleware', async function() {

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -1,13 +1,13 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   run,
   assertBundles,
   distDir,
   removeDistDirectory,
   outputFS
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe('css', () => {
   afterEach(async () => {

--- a/packages/core/integration-tests/test/elm.js
+++ b/packages/core/integration-tests/test/elm.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const {bundle, assertBundleTree, run, outputFS} = require('@parcel/test-utils');
+import assert from 'assert';
+import {bundle, assertBundleTree, run, outputFS} from '@parcel/test-utils';
 
 describe.skip('elm', function() {
   it('should produce a basic Elm bundle', async function() {

--- a/packages/core/integration-tests/test/encodedURI.js
+++ b/packages/core/integration-tests/test/encodedURI.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, assertBundleTree, outputFS} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, assertBundleTree, outputFS} from '@parcel/test-utils';
 
 describe.skip('encodedURI', function() {
   it('should support bundling files which names in encoded URI', async function() {

--- a/packages/core/integration-tests/test/fs.js
+++ b/packages/core/integration-tests/test/fs.js
@@ -1,13 +1,13 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   assertBundles,
   bundle,
   removeDistDirectory,
   run,
   outputFS,
   distDir
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe('fs', function() {
   afterEach(async () => {

--- a/packages/core/integration-tests/test/glob.js
+++ b/packages/core/integration-tests/test/glob.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, run, assertBundleTree, outputFS} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, run, assertBundleTree, outputFS} from '@parcel/test-utils';
 
 describe.skip('glob', function() {
   it('should require a glob of files', async function() {

--- a/packages/core/integration-tests/test/glsl.js
+++ b/packages/core/integration-tests/test/glsl.js
@@ -1,12 +1,12 @@
-const assert = require('assert');
-const path = require('path');
-const fs = require('fs');
-const {
+import assert from 'assert';
+import path from 'path';
+import fs from 'fs';
+import {
   bundle,
   run,
   assertBundleTree,
   normaliseNewlines
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe.skip('glsl', function() {
   it('should support requiring GLSL files via glslify', async function() {

--- a/packages/core/integration-tests/test/graphql.js
+++ b/packages/core/integration-tests/test/graphql.js
@@ -1,7 +1,7 @@
-const assert = require('assert');
-const path = require('path');
-const gql = require('graphql-tag');
-const {bundle, run, assertBundleTree} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import gql from 'graphql-tag';
+import {bundle, run, assertBundleTree} from '@parcel/test-utils';
 
 describe.skip('graphql', function() {
   it('should support requiring graphql files', async function() {

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -1,19 +1,19 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   bundler,
   run,
   ncp,
   prepareBrowserContext,
-  inputFS: fs
-} = require('@parcel/test-utils');
-const vm = require('vm');
-const {sleep} = require('@parcel/test-utils');
-const WebSocket = require('ws');
-const json5 = require('json5');
-const sinon = require('sinon');
-const getPort = require('get-port');
+  inputFS as fs
+} from '@parcel/test-utils';
+import vm from 'vm';
+import {sleep} from '@parcel/test-utils';
+import WebSocket from 'ws';
+import json5 from 'json5';
+import sinon from 'sinon';
+import getPort from 'get-port';
 
 describe('hmr', function() {
   let stub;

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const {
+import assert from 'assert';
+import {
   bundle,
   assertBundles,
   assertBundleTree,
@@ -8,8 +8,8 @@ const {
   run,
   inputFS,
   outputFS
-} = require('@parcel/test-utils');
-const path = require('path');
+} from '@parcel/test-utils';
+import path from 'path';
 
 describe('html', function() {
   beforeEach(async () => {

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   bundler,
   run,
@@ -9,8 +9,8 @@ const {
   distDir,
   outputFS,
   inputFS
-} = require('@parcel/test-utils');
-const {makeDeferredWithPromise} = require('@parcel/utils');
+} from '@parcel/test-utils';
+import {makeDeferredWithPromise} from '@parcel/utils';
 
 describe('javascript', function() {
   beforeEach(async () => {

--- a/packages/core/integration-tests/test/kotlin.js
+++ b/packages/core/integration-tests/test/kotlin.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const {bundle, assertBundleTree, run} = require('@parcel/test-utils');
-const commandExists = require('command-exists');
+import assert from 'assert';
+import {bundle, assertBundleTree, run} from '@parcel/test-utils';
+import commandExists from 'command-exists';
 
 describe.skip('kotlin', function() {
   if (!commandExists.sync('java')) {

--- a/packages/core/integration-tests/test/less.js
+++ b/packages/core/integration-tests/test/less.js
@@ -1,12 +1,12 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   run,
   assertBundles,
   distDir,
   outputFS
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe('less', function() {
   it('should support requiring less files', async function() {

--- a/packages/core/integration-tests/test/markdown.js
+++ b/packages/core/integration-tests/test/markdown.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, assertBundleTree, outputFS} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, assertBundleTree, outputFS} from '@parcel/test-utils';
 
 describe.skip('markdown', function() {
   it('should support bundling Markdown', async function() {

--- a/packages/core/integration-tests/test/parser.js
+++ b/packages/core/integration-tests/test/parser.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, assertBundleTree, inputFS: fs} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, assertBundleTree, inputFS as fs} from '@parcel/test-utils';
 
 describe.skip('parser', function() {
   it('should support case-insensitive file extension', async function() {

--- a/packages/core/integration-tests/test/postcss.js
+++ b/packages/core/integration-tests/test/postcss.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   run,
   assertBundles,
@@ -9,11 +9,11 @@ const {
   outputFS,
   overlayFS,
   ncp
-} = require('@parcel/test-utils');
-const {
+} from '@parcel/test-utils';
+import {
   NodePackageManager,
   MockPackageInstaller
-} = require('@parcel/package-manager');
+} from '@parcel/package-manager';
 
 describe('postcss', () => {
   it('should support transforming css modules with postcss', async () => {

--- a/packages/core/integration-tests/test/posthtml.js
+++ b/packages/core/integration-tests/test/posthtml.js
@@ -1,12 +1,12 @@
-const assert = require('assert');
-const {
+import assert from 'assert';
+import {
   bundle,
   assertBundles,
   removeDistDirectory,
   distDir,
   outputFS
-} = require('@parcel/test-utils');
-const path = require('path');
+} from '@parcel/test-utils';
+import path from 'path';
 
 describe('posthtml', function() {
   afterEach(async () => {

--- a/packages/core/integration-tests/test/proxy.js
+++ b/packages/core/integration-tests/test/proxy.js
@@ -1,13 +1,13 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundler,
   getNextBuild,
   inputFS,
   defaultConfig
-} = require('@parcel/test-utils');
-const http = require('http');
-const getPort = require('get-port');
+} from '@parcel/test-utils';
+import http from 'http';
+import getPort from 'get-port';
 
 const config = {
   ...defaultConfig,

--- a/packages/core/integration-tests/test/pug.js
+++ b/packages/core/integration-tests/test/pug.js
@@ -1,11 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {
-  bundle,
-  assertBundles,
-  outputFS,
-  distDir
-} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, assertBundles, outputFS, distDir} from '@parcel/test-utils';
 
 describe('pug', function() {
   it('should support bundling HTML', async function() {

--- a/packages/core/integration-tests/test/reason.js
+++ b/packages/core/integration-tests/test/reason.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, run} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, run} from '@parcel/test-utils';
 
 describe.skip('reason', function() {
   it('should produce a bundle', async function() {

--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, run} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, run} from '@parcel/test-utils';
 
 describe('resolver', function() {
   it('should support resolving tilde in monorepo packages', async function() {

--- a/packages/core/integration-tests/test/rust.js
+++ b/packages/core/integration-tests/test/rust.js
@@ -1,13 +1,13 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   bundler,
   run,
   assertBundleTree,
   outputFS
-} = require('@parcel/test-utils');
-const commandExists = require('command-exists');
+} from '@parcel/test-utils';
+import commandExists from 'command-exists';
 
 describe.skip('rust', function() {
   if (typeof WebAssembly === 'undefined' || !commandExists.sync('rustup')) {

--- a/packages/core/integration-tests/test/sass.js
+++ b/packages/core/integration-tests/test/sass.js
@@ -1,12 +1,12 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   run,
   assertBundles,
   distDir,
   outputFS
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe('sass', function() {
   it('should support requiring sass files', async function() {

--- a/packages/core/integration-tests/test/schema-jsonld.js
+++ b/packages/core/integration-tests/test/schema-jsonld.js
@@ -1,4 +1,4 @@
-const {bundle, assertBundleTree} = require('@parcel/test-utils');
+import {bundle, assertBundleTree} from '@parcel/test-utils';
 
 describe.skip('schema ld+json', function() {
   it('Should parse a LD+JSON schema and collect dependencies', async function() {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1,11 +1,11 @@
-const assert = require('assert');
-const path = require('path');
-const {
-  bundle: _bundle,
+import assert from 'assert';
+import path from 'path';
+import {
+  bundle as _bundle,
   run,
   outputFS,
   assertBundles
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 const bundle = (name, opts = {}) =>
   _bundle(name, Object.assign({scopeHoist: true}, opts));

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -1,7 +1,7 @@
-const assert = require('assert');
-const path = require('path');
-const logger = require('@parcel/logger');
-const {
+import assert from 'assert';
+import path from 'path';
+import logger from '@parcel/logger';
+import {
   bundler,
   getNextBuild,
   inputFS,
@@ -9,11 +9,11 @@ const {
   overlayFS,
   defaultConfig,
   ncp
-} = require('@parcel/test-utils');
-const http = require('http');
-const https = require('https');
-const getPort = require('get-port');
-const sinon = require('sinon');
+} from '@parcel/test-utils';
+import http from 'http';
+import https from 'https';
+import getPort from 'get-port';
+import sinon from 'sinon';
 
 const distDir = path.resolve(__dirname, '.parcel-cache/dist');
 const config = {

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -1,15 +1,15 @@
-const assert = require('assert');
-const path = require('path');
-const os = require('os');
-const SourceMap = require('parcel-bundler/src/SourceMap');
-const {
+import assert from 'assert';
+import path from 'path';
+import os from 'os';
+import SourceMap from 'parcel-bundler/src/SourceMap';
+import {
   bundle,
   run,
   assertBundleTree,
   inputFS,
   outputFS
-} = require('@parcel/test-utils');
-const {loadSourceMapUrl} = require('@parcel/utils');
+} from '@parcel/test-utils';
+import {loadSourceMapUrl} from '@parcel/utils';
 
 function indexToLineCol(str, index) {
   let beforeIndex = str.slice(0, index);

--- a/packages/core/integration-tests/test/stylus.js
+++ b/packages/core/integration-tests/test/stylus.js
@@ -1,12 +1,12 @@
-const assert = require('assert');
-const path = require('path');
-const {
+import assert from 'assert';
+import path from 'path';
+import {
   bundle,
   run,
   assertBundles,
   distDir,
   outputFS
-} = require('@parcel/test-utils');
+} from '@parcel/test-utils';
 
 describe('stylus', function() {
   it('should support requiring stylus files', async function() {

--- a/packages/core/integration-tests/test/sugarss.js
+++ b/packages/core/integration-tests/test/sugarss.js
@@ -1,11 +1,6 @@
-const assert = require('assert');
-const {
-  bundle,
-  assertBundles,
-  outputFS,
-  distDir
-} = require('@parcel/test-utils');
-const path = require('path');
+import assert from 'assert';
+import {bundle, assertBundles, outputFS, distDir} from '@parcel/test-utils';
+import path from 'path';
 
 describe('sugarss', function() {
   it('should correctly parse SugarSS asset', async function() {

--- a/packages/core/integration-tests/test/vue.js
+++ b/packages/core/integration-tests/test/vue.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, assertBundleTree, run, outputFS} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, assertBundleTree, run, outputFS} from '@parcel/test-utils';
 
 describe.skip('vue', function() {
   it('should produce a basic vue bundle', async function() {

--- a/packages/core/integration-tests/test/wasm.js
+++ b/packages/core/integration-tests/test/wasm.js
@@ -1,6 +1,6 @@
-const assert = require('assert');
-const path = require('path');
-const {bundle, run, assertBundleTree, deferred} = require('@parcel/test-utils');
+import assert from 'assert';
+import path from 'path';
+import {bundle, run, assertBundleTree, deferred} from '@parcel/test-utils';
 
 describe.skip('wasm', function() {
   if (typeof WebAssembly === 'undefined') {

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -1,20 +1,20 @@
-const assert = require('assert');
-const nodeFS = require('fs');
-const path = require('path');
-const {
+import assert from 'assert';
+import nodeFS from 'fs';
+import path from 'path';
+import {
   bundler,
   getNextBuild,
   run,
   assertBundleTree,
   nextBundle,
   ncp,
-  inputFS: fs,
+  inputFS as fs,
   sleep,
   symlinkPrivilegeWarning,
   outputFS,
   overlayFS
-} = require('@parcel/test-utils');
-const {symlinkSync} = require('fs');
+} from '@parcel/test-utils';
+import {symlinkSync} from 'fs';
 
 const inputDir = path.join(__dirname, '/input');
 const distDir = path.join(inputDir, 'dist');

--- a/packages/core/test-utils/.eslintrc.json
+++ b/packages/core/test-utils/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@parcel/eslint-config",
+  "env": {
+    "mocha": true
+  }
+}

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -24,8 +24,13 @@ import {NodePackageManager} from '@parcel/package-manager';
 
 const workerFarm = createWorkerFarm();
 export const inputFS = new NodeFS();
-export const outputFS = new MemoryFS(workerFarm);
-export const overlayFS = new OverlayFS(outputFS, inputFS);
+export let outputFS = new MemoryFS(workerFarm);
+export let overlayFS = new OverlayFS(outputFS, inputFS);
+
+beforeEach(() => {
+  outputFS = new MemoryFS(workerFarm);
+  overlayFS = new OverlayFS(outputFS, inputFS);
+});
 
 // Recursively copies a directory from the inputFS to the outputFS
 export async function ncp(source: FilePath, destination: FilePath) {


### PR DESCRIPTION
I noticed that CI was taking a very long time to run the tests in Node 8 and 10, compared to Node 12. For example, ~25 minutes vs ~3 minutes. I also noticed that the tests seemed to be getting slower over time, which sometimes even resulted in individual tests timing out.

I guessed it had something to do with worker threads vs processes. This turned out to be true, but more to do with our use of SharedArrayBuffer with worker threads in the MemoryFS. Because all of the tests ran in the same instance of the MemoryFS, we were sending it over IPC over and over again and it just kept getting bigger and bigger as we wrote more files

This PR resets the fs instances before each test in order to avoid this growth. As a result, the tests run quickly across all versions of node again (~2 minutes). 🎉 