### PR TITLE
Add support for Workers with type: 'module'

### DIFF
--- a/packages/core/integration-tests/test/integration/workers-module/dedicated-worker.js
+++ b/packages/core/integration-tests/test/integration/workers-module/dedicated-worker.js
@@ -1,0 +1,3 @@
+import foo from "foo";
+
+console.log("DedicatedWorker", foo);

--- a/packages/core/integration-tests/test/integration/workers-module/index.js
+++ b/packages/core/integration-tests/test/integration/workers-module/index.js
@@ -1,0 +1,2 @@
+new Worker("dedicated-worker.js", {type: 'module'});
+new SharedWorker("shared-worker.js", {type: 'module'});

--- a/packages/core/integration-tests/test/integration/workers-module/node_modules/foo/index.js
+++ b/packages/core/integration-tests/test/integration/workers-module/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+export default "foo";

--- a/packages/core/integration-tests/test/integration/workers-module/package.json
+++ b/packages/core/integration-tests/test/integration/workers-module/package.json
@@ -1,0 +1,7 @@
+{
+    "targets": {
+        "default": {
+            "includeNodeModules": false
+        }
+    }
+}

--- a/packages/core/integration-tests/test/integration/workers-module/shared-worker.js
+++ b/packages/core/integration-tests/test/integration/workers-module/shared-worker.js
@@ -1,0 +1,3 @@
+import foo from "foo";
+
+console.log("SharedWorker", foo);

--- a/packages/core/integration-tests/test/integration/workers/worker-client.js
+++ b/packages/core/integration-tests/test/integration/workers/worker-client.js
@@ -3,7 +3,7 @@ const commonText = require('./common').commonFunction('Index');
 navigator.serviceWorker.register('service-worker.js', { scope: './' });
 
 exports.startWorker = function() {
-  const worker = new Worker('worker.js');
+  const worker = new Worker('worker.js', {name: 'myName'});
   worker.postMessage(commonText);
 };
 

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -81,7 +81,7 @@ export default new Transformer({
 
     // Collect dependencies
     if (canHaveDependencies(code) || ast.isDirty) {
-      walk.ancestor(ast.program, collectDependencies, asset);
+      walk.ancestor(ast.program, collectDependencies, {asset, options});
     }
 
     // If there's a hashbang, remove it and store it on the asset meta.

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -1,12 +1,17 @@
+// @flow
+
+import type {MutableAsset} from '@parcel/types';
+
 import * as types from '@babel/types';
 import traverse from '@babel/traverse';
 import {isURL} from '@parcel/utils';
 import nodeBuiltins from 'node-libs-browser';
 import {hasBinding} from './utils';
+import invariant from 'assert';
 
 const serviceWorkerPattern = ['navigator', 'serviceWorker', 'register'];
 
-export default {
+export default ({
   ImportDeclaration(node, asset) {
     asset.meta.isES6Module = true;
     addDependency(asset, node.source);
@@ -60,13 +65,16 @@ export default {
       addDependency(asset, args[0], {isAsync: true});
 
       node.callee = types.identifier('require');
+      invariant(asset.ast);
       asset.ast.isDirty = true;
       return;
     }
 
     const isRegisterServiceWorker =
       types.isStringLiteral(args[0]) &&
-      types.matchesPattern(callee, serviceWorkerPattern);
+      types.matchesPattern(callee, serviceWorkerPattern) &&
+      !hasBinding(ancestors, 'navigator') &&
+      !isInFalsyBranch(ancestors);
 
     if (isRegisterServiceWorker) {
       // Treat service workers as an entry point so filenames remain consistent across builds.
@@ -79,21 +87,44 @@ export default {
     }
   },
 
-  NewExpression(node, asset) {
-    const {callee, arguments: args} = node;
+  NewExpression(node, asset, ancestors) {
+    let {callee, arguments: args} = node;
 
-    const isWebWorker =
+    let isWebWorker =
       callee.type === 'Identifier' &&
       (callee.name === 'Worker' || callee.name === 'SharedWorker') &&
-      args.length === 1 &&
-      types.isStringLiteral(args[0]);
+      !hasBinding(ancestors, callee.name) &&
+      !isInFalsyBranch(ancestors) &&
+      types.isStringLiteral(args[0]) &&
+      (args.length === 1 || args.length === 2);
 
     if (isWebWorker) {
-      addURLDependency(asset, args[0], {env: {context: 'web-worker'}});
+      let isModule = false;
+      if (types.isObjectExpression(args[1])) {
+        let prop = args[1].properties.find(v =>
+          types.isIdentifier(v.key, {name: 'type'})
+        );
+        if (prop && types.isStringLiteral(prop.value))
+          isModule = prop.value.value === 'module';
+      }
+
+      addURLDependency(asset, args[0], {
+        env: {
+          context: 'web-worker',
+          outputFormat: isModule ? 'esmodule' : undefined
+        }
+      });
       return;
     }
   }
-};
+}: {
+  [key: string]: (
+    node: any,
+    asset: MutableAsset,
+    ancestors: Array<any>
+  ) => void,
+  ...
+});
 
 function isInFalsyBranch(ancestors) {
   // Check if any ancestors are if statements
@@ -160,5 +191,6 @@ function addURLDependency(asset, node, opts = {}) {
     loc: node.loc && node.loc.start,
     ...opts
   });
+  invariant(asset.ast);
   asset.ast.isDirty = true;
 }

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {MutableAsset} from '@parcel/types';
+import type {MutableAsset, PluginOptions} from '@parcel/types';
 
 import * as types from '@babel/types';
 import traverse from '@babel/traverse';
@@ -12,28 +12,28 @@ import invariant from 'assert';
 const serviceWorkerPattern = ['navigator', 'serviceWorker', 'register'];
 
 export default ({
-  ImportDeclaration(node, asset) {
+  ImportDeclaration(node, {asset}) {
     asset.meta.isES6Module = true;
     addDependency(asset, node.source);
   },
 
-  ExportNamedDeclaration(node, asset) {
+  ExportNamedDeclaration(node, {asset}) {
     asset.meta.isES6Module = true;
     if (node.source) {
       addDependency(asset, node.source);
     }
   },
 
-  ExportAllDeclaration(node, asset) {
+  ExportAllDeclaration(node, {asset}) {
     asset.meta.isES6Module = true;
     addDependency(asset, node.source);
   },
 
-  ExportDefaultDeclaration(node, asset) {
+  ExportDefaultDeclaration(node, {asset}) {
     asset.meta.isES6Module = true;
   },
 
-  CallExpression(node, asset, ancestors) {
+  CallExpression(node, {asset}, ancestors) {
     let {callee, arguments: args} = node;
 
     let isRequire =
@@ -87,7 +87,7 @@ export default ({
     }
   },
 
-  NewExpression(node, asset, ancestors) {
+  NewExpression(node, {asset, options}, ancestors) {
     let {callee, arguments: args} = node;
 
     let isWebWorker =
@@ -111,7 +111,7 @@ export default ({
       addURLDependency(asset, args[0], {
         env: {
           context: 'web-worker',
-          outputFormat: isModule ? 'esmodule' : undefined
+          outputFormat: isModule && options.scopeHoist ? 'esmodule' : undefined
         }
       });
       return;
@@ -120,7 +120,7 @@ export default ({
 }: {
   [key: string]: (
     node: any,
-    asset: MutableAsset,
+    {|asset: MutableAsset, options: PluginOptions|},
     ancestors: Array<any>
   ) => void,
   ...

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -175,15 +175,11 @@ function addDependency(asset, node, opts = {}) {
   //   throw err;
   // }
 
-  asset.addDependency(
-    Object.assign(
-      {
-        moduleSpecifier: node.value,
-        loc: node.loc && node.loc.start
-      },
-      opts
-    )
-  );
+  asset.addDependency({
+    moduleSpecifier: node.value,
+    loc: node.loc && node.loc.start,
+    ...opts
+  });
 }
 
 function addURLDependency(asset, node, opts = {}) {


### PR DESCRIPTION
Closes #2619
Closes #2732

This adds the primitive for module workers (and enables transforming them when a second argument is specified).
I don't think there there are any practical advantages to setting `type: module` (yet).