### PR TITLE
Windows fix: Compare ports by parsing as an integer

### DIFF
--- a/packages/core/parcel-bundler/src/Server.js
+++ b/packages/core/parcel-bundler/src/Server.js
@@ -144,7 +144,7 @@ async function serve(bundler, port, host, useHTTPS = false) {
 
     server.once('listening', () => {
       let addon =
-        server.address().port !== port
+        server.address().port !== Number.parseInt(port)
           ? `- ${logger.chalk.yellow(
               `configured port ${port} could not be used.`
             )}`


### PR DESCRIPTION
# ↪️ Pull Request

This is the suggested fix for #3249, working well in local testing.

## 💻 Examples

On Windows, the command-line terminal outputs that the "configured port <port> could not be used" when used within another CLI, yet this is a lie - the configured port works perfectly fine.

![parcel-windows-cmd-error](https://user-images.githubusercontent.com/1004564/65925973-4fd16280-e436-11e9-8c6b-27e5a2d224a2.png)

When applying this fix, the "error" message disappears.

## 🚨 Test instructions

Note: only tested on Windows, but according to the issue it's only a problem with Windows.

Create an `index.html`, `cli.js` and `package.json`.

### package.json
```
{
  "name": "parcel-windows-port-comparison-fix",
  "version": "1.0.0",
  "dependencies": {
    "parcel-bundler": "file:C:/path/to/parcel-bundler"
  }
  "scripts": {
    "start": "node cli.js ./index.html"
  }
}
```

### cli.js
```
#!/usr/bin/env node
const context = process.cwd();
const Bundler = require('parcel-bundler');
const Path = require('path');

const [,, ... args] = process.argv;
const file= Path.join(context, './' + args);
const options = {};

(async function() {
  const bundler = new Bundler([file], options);
  const bundle = await bundler.serve('1234', false, '');
})();
```

### index.html
```
<!DOCTYPE html>
<head>
  <meta charset="utf-8">
  <title>Parcel Windows Port Fix</title>
</head>
<body>
  <main>
    <h1>Hello World</h1>
  </main>
</body>
```

