### PR TITLE
Runtimes single graph

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -22,7 +22,7 @@ type AssetGraphOpts = {|
 type InitOpts = {|
   entries?: Array<string>,
   targets?: Array<Target>,
-  assetGroup?: AssetGroup
+  assetGroups?: Array<AssetGroup>
 |};
 
 type SerializedAssetGraph = {|
@@ -76,7 +76,7 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
     this.onNodeRemoved = onNodeRemoved;
   }
 
-  initialize({entries, targets, assetGroup}: InitOpts) {
+  initialize({entries, targets, assetGroups}: InitOpts) {
     let rootNode = {id: '@@root', type: 'root', value: null};
     this.setRootNode(rootNode);
 
@@ -100,9 +100,10 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
           nodes.push(node);
         }
       }
-    } else if (assetGroup) {
-      let node = nodeFromAssetGroup(assetGroup);
-      nodes.push(node);
+    } else if (assetGroups) {
+      nodes.push(
+        ...assetGroups.map(assetGroup => nodeFromAssetGroup(assetGroup))
+      );
     }
 
     this.replaceNodesConnectedTo(rootNode, nodes);

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -27,7 +27,7 @@ type Opts = {|
   config: ParcelConfig,
   entries?: Array<string>,
   targets?: Array<Target>,
-  assetRequest?: AssetRequest,
+  assetRequests?: Array<AssetRequest>,
   workerFarm: WorkerFarm
 |};
 
@@ -44,7 +44,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     options,
     entries,
     targets,
-    assetRequest,
+    assetRequests,
     workerFarm
   }: Opts) {
     this.options = options;
@@ -81,7 +81,7 @@ export default class AssetGraphBuilder extends EventEmitter {
       this.assetGraph.initialize({
         entries,
         targets,
-        assetGroup: assetRequest
+        assetGroups: assetRequests
       });
     }
   }

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -190,11 +190,13 @@ export default class BundlerRunner {
       await builder.init({
         options: this.options,
         config: this.config,
-        assetRequest: {
-          code,
-          filePath,
-          env: bundle.env
-        },
+        assetRequests: [
+          {
+            code,
+            filePath,
+            env: bundle.env
+          }
+        ],
         workerFarm: this.farm
       });
 


### PR DESCRIPTION
Instead of multiple graphs for runtimes, we now use a single graph, and stop when we encounter duplicated assets, rather than adding first and then removing them after.

This optimizes packaging.