### PR TITLE
JSONReporter test: use a sinon stub instead of patching console ourselves

### DIFF
--- a/packages/core/integration-tests/test/json-reporter.js
+++ b/packages/core/integration-tests/test/json-reporter.js
@@ -3,9 +3,11 @@
 /* eslint-disable no-console */
 
 import assert from 'assert';
+import invariant from 'assert';
 import path from 'path';
 import {bundle} from '@parcel/test-utils';
 import defaultConfigContents from '@parcel/config-default';
+import sinon from 'sinon';
 
 const jsonConfig = {
   ...defaultConfigContents,
@@ -13,13 +15,32 @@ const jsonConfig = {
   filePath: require.resolve('@parcel/config-default')
 };
 
+const DIST_INDEX = 'dist' + path.sep + 'index.js';
+
 describe('json reporter', () => {
+  let consoleStub;
+  beforeEach(() => {
+    consoleStub = sinon.stub(console, 'log');
+  });
+
+  afterEach(() => {
+    consoleStub.restore();
+  });
+
   it('logs bundling a commonjs bundle to stdout as json', async () => {
-    let oldConsoleLog = console.log;
-    let i = 0;
-    // $FlowFixMe
-    console.log = function log(msg) {
-      let parsed = JSON.parse(msg);
+    await bundle(path.join(__dirname, '/integration/commonjs/index.js'), {
+      defaultConfig: jsonConfig,
+      logLevel: 'info'
+    });
+
+    let parsedCalls = consoleStub
+      .getCalls()
+      .map(call => JSON.parse(call.lastArg));
+    for (let [iStr, parsed] of Object.entries(parsedCalls)) {
+      parsed = (parsed: any);
+      invariant(typeof iStr === 'string');
+      let i = parseInt(iStr, 10);
+
       if (i === 0) {
         assert.deepEqual(parsed, {type: 'buildStart'});
       } else if (i > 0 && i < 9) {
@@ -32,37 +53,23 @@ describe('json reporter', () => {
           phase: 'bundling'
         });
       } else if (i === 10) {
-        assert.deepEqual(parsed, {
-          type: 'buildProgress',
-          phase: 'packaging',
-          bundleFilePath: 'dist/index.js'
-        });
+        assert.equal(parsed.type, 'buildProgress');
+        assert.equal(parsed.phase, 'packaging');
+        assert(parsed.bundleFilePath.endsWith(DIST_INDEX));
       } else if (i === 11) {
+        assert.equal(parsed.type, 'buildProgress');
+        assert.equal(parsed.phase, 'optimizing');
+        assert(parsed.bundleFilePath.endsWith(DIST_INDEX));
+      } else if (i === 12) {
         assert.equal(parsed.type, 'buildSuccess');
         assert(typeof parsed.buildTime === 'number');
         assert(Array.isArray(parsed.bundles));
         let bundle = parsed.bundles[0];
-        assert.equal(bundle.filePath, 'dist/index.js');
+        assert(bundle.filePath.endsWith(DIST_INDEX));
         assert(typeof bundle.size === 'number');
         assert(typeof bundle.time === 'number');
         assert(Array.isArray(bundle.largestAssets));
-      } else {
-        // $FlowFixMe
-        assert.fail(`Unexpected message ${msg} in position ${i}`);
       }
-
-      i++;
-    };
-
-    try {
-      await bundle(path.join(__dirname, '/integration/commonjs/index.js'), {
-        defaultConfig: jsonConfig
-      });
-    } catch (e) {
-      throw e;
-    } finally {
-      // $FlowFixMe
-      console.log = oldConsoleLog;
     }
   });
 });


### PR DESCRIPTION
Rather than patching and restoring `console.log` ourselves, use sinon's api for creating stubs and asserting on them.

Test Plan: `yarn test` once CI is green for other PRs