### PR TITLE
Cache runtimes graph in memory and on disk

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -1,16 +1,22 @@
 // @flow strict-local
 
+import type {GraphVisitor} from '@parcel/types';
+import type {
+  Asset,
+  AssetGraphNode,
+  AssetGroup,
+  AssetGroupNode,
+  Dependency,
+  DependencyNode,
+  Target
+} from './types';
+
+import {md5FromObject} from '@parcel/utils';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
-
-import type {GraphVisitor} from '@parcel/types';
-import type {Target} from './types';
-import {md5FromObject} from '@parcel/utils';
-
-import type {Asset, Dependency} from './types';
-import Graph, {type GraphOpts} from './Graph';
-import type {AssetGraphNode, AssetGroup, DependencyNode} from './types';
 import crypto from 'crypto';
+
+import Graph, {type GraphOpts} from './Graph';
 import {createDependency} from './Dependency';
 
 type AssetGraphOpts = {|
@@ -200,6 +206,17 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
       visit,
       startNode
     );
+  }
+
+  getEntryAssetGroupNodes(): Array<AssetGroupNode> {
+    let entryNodes = [];
+    this.traverse((node, _, actions) => {
+      if (node.type === 'asset_group') {
+        entryNodes.push(node);
+        actions.skipChildren();
+      }
+    });
+    return entryNodes;
   }
 
   getEntryAssets(): Array<Asset> {

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -25,6 +25,7 @@ import path from 'path';
 type Opts = {|
   options: ParcelOptions,
   config: ParcelConfig,
+  name: string,
   entries?: Array<string>,
   targets?: Array<Target>,
   assetRequests?: Array<AssetRequest>,
@@ -38,10 +39,10 @@ export default class AssetGraphBuilder extends EventEmitter {
   changedAssets: Map<string, Asset> = new Map();
   options: ParcelOptions;
   cacheKey: string;
-  initialized: boolean = false;
 
   async init({
     config,
+    name,
     options,
     entries,
     targets,
@@ -51,6 +52,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     this.options = options;
     let {minify, hot, scopeHoist} = options;
     this.cacheKey = md5FromObject({
+      name,
       options: {minify, hot, scopeHoist},
       entries,
       targets
@@ -85,8 +87,6 @@ export default class AssetGraphBuilder extends EventEmitter {
         assetGroups: assetRequests
       });
     }
-
-    this.initialized = true;
   }
 
   async build(): Promise<{|

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -38,6 +38,7 @@ export default class AssetGraphBuilder extends EventEmitter {
   changedAssets: Map<string, Asset> = new Map();
   options: ParcelOptions;
   cacheKey: string;
+  initialized: boolean = false;
 
   async init({
     config,
@@ -84,6 +85,8 @@ export default class AssetGraphBuilder extends EventEmitter {
         assetGroups: assetRequests
       });
     }
+
+    this.initialized = true;
   }
 
   async build(): Promise<{|

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -1,39 +1,25 @@
 // @flow strict-local
 
-import type {Dependency, Namer} from '@parcel/types';
-import type {
-  AssetNode,
-  AssetRequest,
-  Bundle as InternalBundle,
-  DependencyNode,
-  ParcelOptions,
-  NodeId,
-  RootNode
-} from './types';
+import type {Namer} from '@parcel/types';
+import type {Bundle as InternalBundle, ParcelOptions} from './types';
 import type ParcelConfig from './ParcelConfig';
 import type WorkerFarm from '@parcel/workers';
-import type RequestGraph from './RequestGraph';
 
 import assert from 'assert';
 import invariant from 'assert';
 import path from 'path';
 import nullthrows from 'nullthrows';
-import AssetGraph, {nodeFromAssetGroup} from './AssetGraph';
+import AssetGraph from './AssetGraph';
 import BundleGraph from './public/BundleGraph';
-import InternalBundleGraph from './BundleGraph';
-import Graph from './Graph';
+import InternalBundleGraph, {removeAssetGroups} from './BundleGraph';
 import MutableBundleGraph from './public/MutableBundleGraph';
-import {Bundle, NamedBundle} from './public/Bundle';
+import {Bundle} from './public/Bundle';
 import AssetGraphBuilder from './AssetGraphBuilder';
 import {report} from './ReporterRunner';
 import dumpGraphToGraphViz from './dumpGraphToGraphViz';
-import {
-  normalizeSeparators,
-  setDifference,
-  unique,
-  md5FromObject
-} from '@parcel/utils';
+import {normalizeSeparators, unique, md5FromObject} from '@parcel/utils';
 import PluginOptions from './public/PluginOptions';
+import applyRuntimes from './applyRuntimes';
 
 type Opts = {|
   options: ParcelOptions,
@@ -46,10 +32,8 @@ export default class BundlerRunner {
   config: ParcelConfig;
   pluginOptions: PluginOptions;
   farm: WorkerFarm;
-  priorRuntimeGraphs: ?{|
-    assetGraph: AssetGraph,
-    requestGraph: RequestGraph
-  |};
+  runtimesBuilder: AssetGraphBuilder = new AssetGraphBuilder();
+  isBundling: boolean = false;
 
   constructor(opts: Opts) {
     this.options = opts.options;
@@ -59,6 +43,8 @@ export default class BundlerRunner {
   }
 
   async bundle(graph: AssetGraph): Promise<InternalBundleGraph> {
+    invariant(!this.isBundling);
+    this.isBundling = true;
     report({
       type: 'buildProgress',
       phase: 'bundling'
@@ -94,15 +80,29 @@ export default class BundlerRunner {
     });
     await dumpGraphToGraphViz(bundleGraph, 'after_optimize');
     await this.nameBundles(internalBundleGraph);
-    this.priorRuntimeGraphs = await this.applyRuntimes(
-      internalBundleGraph,
-      this.priorRuntimeGraphs
-    );
+
+    if (!this.runtimesBuilder.initialized) {
+      await this.runtimesBuilder.init({
+        options: this.options,
+        config: this.config,
+        workerFarm: this.farm
+      });
+    }
+
+    await applyRuntimes({
+      bundleGraph: internalBundleGraph,
+      runtimesBuilder: this.runtimesBuilder,
+      config: this.config,
+      options: this.options,
+      pluginOptions: this.pluginOptions
+    });
     await dumpGraphToGraphViz(bundleGraph, 'after_runtimes');
 
     if (cacheKey != null) {
       await this.options.cache.set(cacheKey, internalBundleGraph);
     }
+
+    this.isBundling = false;
 
     return internalBundleGraph;
   }
@@ -174,196 +174,4 @@ export default class BundlerRunner {
 
     throw new Error('Unable to name bundle');
   }
-
-  async applyRuntimes(
-    bundleGraph: InternalBundleGraph,
-    priorGraphs: ?{|
-      assetGraph: AssetGraph,
-      requestGraph: RequestGraph
-    |}
-  ): Promise<{|assetGraph: AssetGraph, requestGraph: RequestGraph|}> {
-    let tuples: Array<{|
-      bundle: InternalBundle,
-      assetRequest: AssetRequest,
-      dependency: ?Dependency,
-      isEntry: ?boolean
-    |}> = [];
-
-    for (let bundle of bundleGraph.getBundles()) {
-      let runtimes = await this.config.getRuntimes(bundle.env.context);
-      for (let runtime of runtimes) {
-        let applied = await runtime.apply({
-          bundle: new NamedBundle(bundle, bundleGraph, this.options),
-          bundleGraph: new BundleGraph(bundleGraph, this.options),
-          options: this.pluginOptions
-        });
-
-        if (applied) {
-          let runtimeAssets = Array.isArray(applied) ? applied : [applied];
-          for (let {code, dependency, filePath, isEntry} of runtimeAssets) {
-            let assetRequest = {
-              code,
-              filePath,
-              env: bundle.env
-            };
-            tuples.push({
-              bundle,
-              assetRequest,
-              dependency: dependency,
-              isEntry
-            });
-          }
-        }
-      }
-    }
-
-    let assetGraph, requestGraph;
-    if (priorGraphs && priorGraphs.assetGraph == null) {
-      let builder = new AssetGraphBuilder();
-      await builder.init({
-        options: this.options,
-        config: this.config,
-        assetRequests: tuples.map(t => t.assetRequest),
-        workerFarm: this.farm
-      });
-
-      // build a graph of all of the runtime assets
-      assetGraph = (await builder.build()).assetGraph;
-      requestGraph = builder.requestGraph;
-    } else {
-      invariant(priorGraphs != null);
-      invariant(priorGraphs.requestGraph != null);
-      assetGraph = priorGraphs.assetGraph;
-      requestGraph = priorGraphs.requestGraph;
-
-      let assetRequestsById = new Map(
-        tuples
-          .map(t => t.assetRequest)
-          .map(request => [nodeFromAssetGroup(request).id, request])
-      );
-      let newRequestIds = new Set(assetRequestsById.keys());
-      let oldRequestIds = new Set(
-        assetGraph.getEntryAssets().map(asset => {
-          let inboundNodes = assetGraph.getNodesConnectedTo(
-            nullthrows(assetGraph.getNode(asset.id))
-          );
-          invariant(
-            inboundNodes.length === 1 && inboundNodes[0].type === 'asset_group'
-          );
-          return inboundNodes[0].id;
-        })
-      );
-
-      let toAdd = setDifference(newRequestIds, oldRequestIds);
-      let toRemove = setDifference(oldRequestIds, newRequestIds);
-
-      for (let requestId of toAdd) {
-        requestGraph.addAssetRequest(
-          requestId,
-          nullthrows(assetRequestsById.get(requestId))
-        );
-      }
-      for (let requestId of toRemove) {
-        assetGraph.removeById(requestId);
-      }
-    }
-
-    let runtimesGraph = removeAssetGroups(assetGraph);
-
-    // merge the transformed asset into the bundle's graph, and connect
-    // the node to it.
-    // $FlowFixMe
-    bundleGraph._graph.merge(runtimesGraph);
-
-    for (let {bundle, assetRequest, dependency, isEntry} of tuples) {
-      let assetGroupNode = nodeFromAssetGroup(assetRequest);
-      let assetGroupAssets = assetGraph.getNodesConnectedFrom(assetGroupNode);
-      invariant(assetGroupAssets.length === 1);
-      let runtimeNode = assetGroupAssets[0];
-      invariant(runtimeNode.type === 'asset');
-
-      let duplicatedAssetIds: Set<NodeId> = new Set();
-      runtimesGraph.traverse((node, _, actions) => {
-        if (node.type !== 'dependency') {
-          return;
-        }
-
-        let assets = runtimesGraph
-          .getNodesConnectedFrom(node)
-          .map(assetNode => {
-            invariant(assetNode.type === 'asset');
-            return assetNode.value;
-          });
-
-        for (let asset of assets) {
-          if (bundleGraph.isAssetInAncestorBundles(bundle, asset)) {
-            duplicatedAssetIds.add(asset.id);
-            actions.skipChildren();
-          }
-        }
-      }, runtimeNode);
-
-      runtimesGraph.traverse((node, _, actions) => {
-        if (node.type === 'asset' || node.type === 'dependency') {
-          if (duplicatedAssetIds.has(node.id)) {
-            actions.skipChildren();
-            return;
-          }
-
-          bundleGraph._graph.addEdge(bundle.id, node.id, 'contains');
-        }
-      }, runtimeNode);
-
-      bundleGraph._graph.addEdge(
-        dependency
-          ? dependency.id
-          : nullthrows(bundleGraph._graph.getNode(bundle.id)).id,
-        runtimeNode.id
-      );
-
-      if (isEntry) {
-        bundle.entryAssetIds.unshift(runtimeNode.id);
-      }
-    }
-
-    return {assetGraph, requestGraph};
-  }
-}
-
-function removeAssetGroups(
-  assetGraph: AssetGraph
-): Graph<AssetNode | DependencyNode | RootNode> {
-  let graph = new Graph<AssetNode | DependencyNode | RootNode>();
-  // $FlowFixMe
-  graph.setRootNode(nullthrows(assetGraph.getRootNode()));
-  let assetGroupIds = new Set();
-
-  assetGraph.traverse(node => {
-    if (node.type === 'asset_group') {
-      assetGroupIds.add(node.id);
-    } else {
-      graph.addNode(node);
-    }
-  });
-
-  for (let edge of assetGraph.getAllEdges()) {
-    let fromIds;
-    if (assetGroupIds.has(edge.from)) {
-      fromIds = [...assetGraph.inboundEdges.get(edge.from).get(null)];
-    } else {
-      fromIds = [edge.from];
-    }
-
-    for (let from of fromIds) {
-      if (assetGroupIds.has(edge.to)) {
-        for (let to of assetGraph.outboundEdges.get(edge.to).get(null)) {
-          graph.addEdge(from, to);
-        }
-      } else {
-        graph.addEdge(from, edge.to);
-      }
-    }
-  }
-
-  return graph;
 }

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -3,7 +3,6 @@
 import type {Namer} from '@parcel/types';
 import type WorkerFarm from '@parcel/workers';
 import type AssetGraphBuilder from './AssetGraphBuilder';
-import type ParcelConfig from './ParcelConfig';
 
 import assert from 'assert';
 import path from 'path';

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -2,7 +2,6 @@
 
 import type {Namer} from '@parcel/types';
 import type WorkerFarm from '@parcel/workers';
-import type {Bundle as InternalBundle, ParcelOptions} from './types';
 import type AssetGraphBuilder from './AssetGraphBuilder';
 import type ParcelConfig from './ParcelConfig';
 

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -1,6 +1,8 @@
 // @flow strict-local
 
 import type {Namer} from '@parcel/types';
+import type {Bundle as InternalBundle, ParcelOptions} from './types';
+import type ParcelConfig from './ParcelConfig';
 import type WorkerFarm from '@parcel/workers';
 import type AssetGraphBuilder from './AssetGraphBuilder';
 

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -22,6 +22,7 @@ import WorkerFarm from '@parcel/workers';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import AssetGraphBuilder, {BuildAbortError} from './AssetGraphBuilder';
+import PackagerRunner from './PackagerRunner';
 import loadParcelConfig from './loadParcelConfig';
 import ReporterRunner from './ReporterRunner';
 import dumpGraphToGraphViz from './dumpGraphToGraphViz';
@@ -118,6 +119,12 @@ export default class Parcel {
     this.#reporterRunner = new ReporterRunner({
       config,
       options: resolvedOptions
+    });
+
+    this.#packagerRunner = new PackagerRunner({
+      config,
+      options: resolvedOptions,
+      farm: this.#farm
     });
 
     this.#runPackage = this.#farm.createHandle('runPackage');

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -22,7 +22,6 @@ import WorkerFarm from '@parcel/workers';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import AssetGraphBuilder, {BuildAbortError} from './AssetGraphBuilder';
-import PackagerRunner from './PackagerRunner';
 import loadParcelConfig from './loadParcelConfig';
 import ReporterRunner from './ReporterRunner';
 import dumpGraphToGraphViz from './dumpGraphToGraphViz';

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -38,6 +38,7 @@ export const INTERNAL_RESOLVE = Symbol('internal_resolve');
 
 export default class Parcel {
   #assetGraphBuilder; // AssetGraphBuilder
+  #runtimesAssetGraphBuilder; // AssetGraphBuilder
   #bundlerRunner; // BundlerRunner
   #packagerRunner; // PackagerRunner
   #config;
@@ -88,8 +89,29 @@ export default class Parcel {
         patchConsole: resolvedOptions.patchConsole
       });
 
+    this.#assetGraphBuilder = new AssetGraphBuilder();
+    this.#runtimesAssetGraphBuilder = new AssetGraphBuilder();
+
+    await Promise.all([
+      this.#assetGraphBuilder.init({
+        name: 'MainAssetGraph',
+        options: resolvedOptions,
+        config,
+        entries: resolvedOptions.entries,
+        targets: resolvedOptions.targets,
+        workerFarm: this.#farm
+      }),
+      this.#runtimesAssetGraphBuilder.init({
+        name: 'RuntimesAssetGraph',
+        options: resolvedOptions,
+        config,
+        workerFarm: this.#farm
+      })
+    ]);
+
     this.#bundlerRunner = new BundlerRunner({
       options: resolvedOptions,
+      runtimesBuilder: this.#runtimesAssetGraphBuilder,
       config,
       workerFarm: this.#farm
     });
@@ -97,20 +119,6 @@ export default class Parcel {
     this.#reporterRunner = new ReporterRunner({
       config,
       options: resolvedOptions
-    });
-
-    this.#assetGraphBuilder = new AssetGraphBuilder();
-    await this.#assetGraphBuilder.init({
-      options: resolvedOptions,
-      config,
-      entries: resolvedOptions.entries,
-      targets: resolvedOptions.targets,
-      workerFarm: this.#farm
-    });
-    this.#packagerRunner = new PackagerRunner({
-      config,
-      options: resolvedOptions,
-      farm: this.#farm
     });
 
     this.#runPackage = this.#farm.createHandle('runPackage');
@@ -124,7 +132,10 @@ export default class Parcel {
     }
 
     let result = await this.build(startTime);
-    await this.#assetGraphBuilder.writeToCache();
+    await Promise.all([
+      this.#assetGraphBuilder.writeToCache(),
+      this.#runtimesAssetGraphBuilder.writeToCache()
+    ]);
 
     if (!this.#initialOptions.workerFarm) {
       // If there wasn't a workerFarm passed in, we created it. End the farm.
@@ -181,7 +192,10 @@ export default class Parcel {
           await nullthrows(this.#watcherSubscription).unsubscribe();
           this.#watcherSubscription = null;
           await this.#reporterRunner.report({type: 'watchEnd'});
-          await this.#assetGraphBuilder.writeToCache();
+          await Promise.all([
+            this.#assetGraphBuilder.writeToCache(),
+            this.#runtimesAssetGraphBuilder.writeToCache()
+          ]);
         }
       }
     };

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -74,6 +74,7 @@ export default async function applyRuntimes({
     runtimesBuilder,
     connections
   );
+
   let runtimesGraph = removeAssetGroups(runtimesAssetGraph);
 
   // merge the transformed asset into the bundle's graph, and connect
@@ -163,18 +164,12 @@ async function reconcileNewRuntimes(
   let toAdd = setDifference(newRequestIds, oldRequestIds);
   let toRemove = setDifference(oldRequestIds, newRequestIds);
 
-  let newEntryNodes = assetGraph
-    .getNodesConnectedFrom(nullthrows(assetGraph.getRootNode()))
-    .filter(node => !toRemove.has(node.id))
-    .concat(
-      Array.from(toAdd).map(requestId =>
-        nullthrows(assetRequestNodesById.get(requestId))
-      )
-    );
-
   assetGraph.replaceNodesConnectedTo(
     nullthrows(assetGraph.getRootNode()),
-    newEntryNodes
+    [...toAdd].map(requestId =>
+      nullthrows(assetRequestNodesById.get(requestId))
+    ),
+    node => toRemove.has(node.id)
   );
 
   // rebuild the graph

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -1,0 +1,182 @@
+// @flow strict-local
+
+import type {Dependency} from '@parcel/types';
+import type {
+  AssetRequest,
+  Bundle as InternalBundle,
+  NodeId,
+  ParcelOptions
+} from './types';
+import type InternalBundleGraph from './BundleGraph';
+import type AssetGraphBuilder from './AssetGraphBuilder';
+import type ParcelConfig from './ParcelConfig';
+import type PluginOptions from './public/PluginOptions';
+
+import invariant from 'assert';
+import nullthrows from 'nullthrows';
+import AssetGraph, {nodeFromAssetGroup} from './AssetGraph';
+import BundleGraph from './public/BundleGraph';
+import {removeAssetGroups} from './BundleGraph';
+import {NamedBundle} from './public/Bundle';
+import {setDifference} from '@parcel/utils';
+
+type RuntimeConnection = {|
+  bundle: InternalBundle,
+  assetRequest: AssetRequest,
+  dependency: ?Dependency,
+  isEntry: ?boolean
+|};
+
+export default async function applyRuntimes({
+  bundleGraph,
+  config,
+  options,
+  pluginOptions,
+  runtimesBuilder
+}: {|
+  bundleGraph: InternalBundleGraph,
+  config: ParcelConfig,
+  options: ParcelOptions,
+  pluginOptions: PluginOptions,
+  runtimesBuilder: AssetGraphBuilder
+|}): Promise<void> {
+  let connections: Array<RuntimeConnection> = [];
+
+  for (let bundle of bundleGraph.getBundles()) {
+    let runtimes = await config.getRuntimes(bundle.env.context);
+    for (let runtime of runtimes) {
+      let applied = await runtime.apply({
+        bundle: new NamedBundle(bundle, bundleGraph, options),
+        bundleGraph: new BundleGraph(bundleGraph, options),
+        options: pluginOptions
+      });
+
+      if (applied) {
+        let runtimeAssets = Array.isArray(applied) ? applied : [applied];
+        for (let {code, dependency, filePath, isEntry} of runtimeAssets) {
+          let assetRequest = {
+            code,
+            filePath,
+            env: bundle.env
+          };
+          connections.push({
+            bundle,
+            assetRequest,
+            dependency: dependency,
+            isEntry
+          });
+        }
+      }
+    }
+  }
+
+  let runtimesAssetGraph = await reconcileNewRuntimes(
+    runtimesBuilder,
+    connections
+  );
+  let runtimesGraph = removeAssetGroups(runtimesAssetGraph);
+
+  // merge the transformed asset into the bundle's graph, and connect
+  // the node to it.
+  // $FlowFixMe
+  bundleGraph._graph.merge(runtimesGraph);
+
+  for (let {bundle, assetRequest, dependency, isEntry} of connections) {
+    let assetGroupNode = nodeFromAssetGroup(assetRequest);
+    let assetGroupAssets = runtimesAssetGraph.getNodesConnectedFrom(
+      assetGroupNode
+    );
+    invariant(assetGroupAssets.length === 1);
+    let runtimeNode = assetGroupAssets[0];
+    invariant(runtimeNode.type === 'asset');
+
+    let duplicatedAssetIds: Set<NodeId> = new Set();
+    runtimesGraph.traverse((node, _, actions) => {
+      if (node.type !== 'dependency') {
+        return;
+      }
+
+      let assets = runtimesGraph.getNodesConnectedFrom(node).map(assetNode => {
+        invariant(assetNode.type === 'asset');
+        return assetNode.value;
+      });
+
+      for (let asset of assets) {
+        if (bundleGraph.isAssetInAncestorBundles(bundle, asset)) {
+          duplicatedAssetIds.add(asset.id);
+          actions.skipChildren();
+        }
+      }
+    }, runtimeNode);
+
+    runtimesGraph.traverse((node, _, actions) => {
+      if (node.type === 'asset' || node.type === 'dependency') {
+        if (duplicatedAssetIds.has(node.id)) {
+          actions.skipChildren();
+          return;
+        }
+
+        bundleGraph._graph.addEdge(bundle.id, node.id, 'contains');
+      }
+    }, runtimeNode);
+
+    bundleGraph._graph.addEdge(
+      dependency
+        ? dependency.id
+        : nullthrows(bundleGraph._graph.getNode(bundle.id)).id,
+      runtimeNode.id
+    );
+
+    if (isEntry) {
+      bundle.entryAssetIds.unshift(runtimeNode.id);
+    }
+  }
+}
+
+async function reconcileNewRuntimes(
+  runtimesBuilder: AssetGraphBuilder,
+  connections: Array<RuntimeConnection>
+): Promise<AssetGraph> {
+  let {assetGraph} = runtimesBuilder;
+
+  let assetRequestNodesById = new Map(
+    connections
+      .map(t => t.assetRequest)
+      .map(request => {
+        let node = nodeFromAssetGroup(request);
+        return [node.id, node];
+      })
+  );
+  let newRequestIds = new Set(assetRequestNodesById.keys());
+  let oldRequestIds = new Set(
+    assetGraph.getEntryAssets().map(asset => {
+      let inboundNodes = assetGraph.getNodesConnectedTo(
+        nullthrows(assetGraph.getNode(asset.id))
+      );
+      invariant(
+        inboundNodes.length === 1 && inboundNodes[0].type === 'asset_group'
+      );
+      return inboundNodes[0].id;
+    })
+  );
+
+  let toAdd = setDifference(newRequestIds, oldRequestIds);
+  let toRemove = setDifference(oldRequestIds, newRequestIds);
+
+  let newEntryNodes = assetGraph
+    .getNodesConnectedFrom(nullthrows(assetGraph.getRootNode()))
+    .filter(node => !toRemove.has(node.id))
+    .concat(
+      Array.from(toAdd).map(requestId =>
+        nullthrows(assetRequestNodesById.get(requestId))
+      )
+    );
+
+  assetGraph.replaceNodesConnectedTo(
+    nullthrows(assetGraph.getRootNode()),
+    newEntryNodes
+  );
+
+  // rebuild the graph
+  return (await runtimesBuilder.build()).assetGraph;
+}

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -150,15 +150,7 @@ async function reconcileNewRuntimes(
   );
   let newRequestIds = new Set(assetRequestNodesById.keys());
   let oldRequestIds = new Set(
-    assetGraph.getEntryAssets().map(asset => {
-      let inboundNodes = assetGraph.getNodesConnectedTo(
-        nullthrows(assetGraph.getNode(asset.id))
-      );
-      invariant(
-        inboundNodes.length === 1 && inboundNodes[0].type === 'asset_group'
-      );
-      return inboundNodes[0].id;
-    })
+    assetGraph.getEntryAssetGroupNodes().map(node => node.id)
   );
 
   let toAdd = setDifference(newRequestIds, oldRequestIds);

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -43,7 +43,7 @@ export default async function dumpGraphToGraphViz(
     n.set('color', COLORS[node.type || 'default']);
     n.set('shape', 'box');
     n.set('style', 'filled');
-    let label = `${node.type || 'No Type'}: `;
+    let label = `${node.type || 'No Type'}: [${node.id}]: `;
     if (node.type === 'dependency') {
       label += node.value.moduleSpecifier;
       let parts = [];
@@ -64,7 +64,7 @@ export default async function dumpGraphToGraphViz(
       label += node.id;
     } else {
       // label += node.id;
-      label = node.type;
+      // label = node.type;
     }
     n.set('label', label);
   }

--- a/packages/core/core/test/AssetGraphBuilder.test.js
+++ b/packages/core/core/test/AssetGraphBuilder.test.js
@@ -54,6 +54,7 @@ describe('AssetGraphBuilder', function() {
 
     builder = new AssetGraphBuilder();
     await builder.init({
+      name: 'test',
       options: DEFAULT_OPTIONS,
       config,
       entries: ['./module-b'],

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import nodeFS from 'fs';
 import path from 'path';
 import {
+  assertBundles,
   bundler,
   getNextBuild,
   run,
@@ -379,5 +380,58 @@ describe('watcher', function() {
         this.skip();
       }
     }
+  });
+
+  it('should add and remove necessary runtimes to bundles', async () => {
+    await ncp(path.join(__dirname, 'integration/dynamic'), inputDir);
+
+    let indexPath = path.join(inputDir, 'index.js');
+
+    let b = bundler(indexPath, {inputFS: overlayFS});
+    let bundleGraph;
+    subscription = await b.watch((err, event) => {
+      assert(event.type === 'buildSuccess');
+      bundleGraph = event.bundleGraph;
+    });
+    await getNextBuild(b);
+    assertBundles(bundleGraph, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js']
+      },
+      {assets: ['local.js']}
+    ]);
+
+    await outputFS.writeFile(path.join(inputDir, 'other.js'), '');
+    await outputFS.writeFile(
+      indexPath,
+      (await outputFS.readFile(indexPath, 'utf8')) + "\nimport('./other.js');\n"
+    );
+
+    await getNextBuild(b);
+    assertBundles(bundleGraph, [
+      {
+        name: 'index.js',
+        assets: [
+          'index.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+          'JSRuntime.js'
+        ]
+      },
+      {assets: ['local.js']},
+      {assets: ['other.js']}
+    ]);
+
+    await outputFS.writeFile(indexPath, '');
+
+    await getNextBuild(b);
+    assertBundles(bundleGraph, [
+      {
+        name: 'index.js',
+        assets: ['index.js']
+      }
+    ]);
   });
 });

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -17,21 +17,11 @@ import {
 } from '@parcel/test-utils';
 import {symlinkSync} from 'fs';
 
-const inputDir = path.join(__dirname, '/input');
+const inputDir = path.join(__dirname, '/watcher');
 const distDir = path.join(inputDir, 'dist');
 
 describe('watcher', function() {
   let subscription;
-
-  before(async () => {
-    await fs.rimraf(inputDir);
-    await fs.mkdirp(inputDir);
-  });
-
-  beforeEach(async () => {
-    await outputFS.rimraf(inputDir);
-  });
-
   afterEach(async () => {
     if (subscription) {
       await subscription.unsubscribe();

--- a/packages/core/utils/src/collection.js
+++ b/packages/core/utils/src/collection.js
@@ -45,3 +45,13 @@ function sortEntry(entry: mixed) {
 
   return entry;
 }
+
+export function setDifference<T>(a: Set<T>, b: Set<T>): Set<T> {
+  let difference = new Set();
+  for (let e of a) {
+    if (!b.has(e)) {
+      difference.add(e);
+    }
+  }
+  return difference;
+}


### PR DESCRIPTION
This retains a copy of the runtimes graph in memory and applies necessary changes as bundle runtimes come and go. 

This also persists the runtimes asset graph on disk, and changes are applied when Parcel runs next. A `name` key was added to `AssetGraphBuilder` to differentiate it from the cache key used for the main graphs.

Test Plan: Added an integration test for runtimes being added and removed over time.