### PR TITLE
test-utils: await dynamic imports created during run()

### DIFF
--- a/packages/core/integration-tests/test/json-reporter.js
+++ b/packages/core/integration-tests/test/json-reporter.js
@@ -18,58 +18,54 @@ const jsonConfig = {
 const DIST_INDEX = 'dist' + path.sep + 'index.js';
 
 describe('json reporter', () => {
-  let consoleStub;
-  beforeEach(() => {
-    consoleStub = sinon.stub(console, 'log');
-  });
-
-  afterEach(() => {
-    consoleStub.restore();
-  });
-
   it('logs bundling a commonjs bundle to stdout as json', async () => {
-    await bundle(path.join(__dirname, '/integration/commonjs/index.js'), {
-      defaultConfig: jsonConfig,
-      logLevel: 'info'
-    });
+    let consoleStub = sinon.stub(console, 'log');
+    try {
+      await bundle(path.join(__dirname, '/integration/commonjs/index.js'), {
+        defaultConfig: jsonConfig,
+        logLevel: 'info'
+      });
 
-    let parsedCalls = consoleStub
-      .getCalls()
-      .map(call => JSON.parse(call.lastArg));
-    for (let [iStr, parsed] of Object.entries(parsedCalls)) {
-      parsed = (parsed: any);
-      invariant(typeof iStr === 'string');
-      let i = parseInt(iStr, 10);
+      let parsedCalls = consoleStub
+        .getCalls()
+        .map(call => JSON.parse(call.lastArg));
+      for (let [iStr, parsed] of Object.entries(parsedCalls)) {
+        parsed = (parsed: any);
+        invariant(typeof iStr === 'string');
+        let i = parseInt(iStr, 10);
 
-      if (i === 0) {
-        assert.deepEqual(parsed, {type: 'buildStart'});
-      } else if (i > 0 && i < 9) {
-        assert.equal(parsed.type, 'buildProgress');
-        assert.equal(parsed.phase, 'transforming');
-        assert(typeof parsed.filePath === 'string');
-      } else if (i === 9) {
-        assert.deepEqual(parsed, {
-          type: 'buildProgress',
-          phase: 'bundling'
-        });
-      } else if (i === 10) {
-        assert.equal(parsed.type, 'buildProgress');
-        assert.equal(parsed.phase, 'packaging');
-        assert(parsed.bundleFilePath.endsWith(DIST_INDEX));
-      } else if (i === 11) {
-        assert.equal(parsed.type, 'buildProgress');
-        assert.equal(parsed.phase, 'optimizing');
-        assert(parsed.bundleFilePath.endsWith(DIST_INDEX));
-      } else if (i === 12) {
-        assert.equal(parsed.type, 'buildSuccess');
-        assert(typeof parsed.buildTime === 'number');
-        assert(Array.isArray(parsed.bundles));
-        let bundle = parsed.bundles[0];
-        assert(bundle.filePath.endsWith(DIST_INDEX));
-        assert(typeof bundle.size === 'number');
-        assert(typeof bundle.time === 'number');
-        assert(Array.isArray(bundle.largestAssets));
+        if (i === 0) {
+          assert.deepEqual(parsed, {type: 'buildStart'});
+        } else if (i > 0 && i < 9) {
+          assert.equal(parsed.type, 'buildProgress');
+          assert.equal(parsed.phase, 'transforming');
+          assert(typeof parsed.filePath === 'string');
+        } else if (i === 9) {
+          assert.deepEqual(parsed, {
+            type: 'buildProgress',
+            phase: 'bundling'
+          });
+        } else if (i === 10) {
+          assert.equal(parsed.type, 'buildProgress');
+          assert.equal(parsed.phase, 'packaging');
+          assert(parsed.bundleFilePath.endsWith(DIST_INDEX));
+        } else if (i === 11) {
+          assert.equal(parsed.type, 'buildProgress');
+          assert.equal(parsed.phase, 'optimizing');
+          assert(parsed.bundleFilePath.endsWith(DIST_INDEX));
+        } else if (i === 12) {
+          assert.equal(parsed.type, 'buildSuccess');
+          assert(typeof parsed.buildTime === 'number');
+          assert(Array.isArray(parsed.bundles));
+          let bundle = parsed.bundles[0];
+          assert(bundle.filePath.endsWith(DIST_INDEX));
+          assert(typeof bundle.size === 'number');
+          assert(typeof bundle.time === 'number');
+          assert(Array.isArray(bundle.largestAssets));
+        }
       }
+    } finally {
+      consoleStub.restore();
     }
   });
 });


### PR DESCRIPTION
`run` reads and executes the js entry bundle. However, dynamic imports may have been created during the run which read their bundle contents from the filesystem at a later point in time.

Currently, awaiting `run` awaits the result of executing the bundle, but does not await the effects of dynamic imports reading in other bundles. This PR makes this so.

This also changes the json-reporter test so that it patches `console.log` within the test, not before and after it, which prevent Mocha from correctly logging the test name and its state during the run.

Test Plan: 
* Run `yarn test` a number of times without receiving an error re: missing bundle files or failure to parse json.
* Log the pending promises before they are awaited and verify that before the json-reporter test, one or more promises is present in the array.