### PR TITLE
Update to Flow 0.109

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,4 +35,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.107.0
+0.109.0

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "doctoc": "^1.4.0",
     "eslint": "^5.16.0",
-    "flow-bin": "0.107.0",
+    "flow-bin": "0.109.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",

--- a/packages/core/source-map/src/SourceMap.js
+++ b/packages/core/source-map/src/SourceMap.js
@@ -97,7 +97,10 @@ export default class SourceMap {
 
     let sourcemap: RawSourceMap =
       typeof map === 'string' ? JSON.parse(map) : map;
-    if (sourcemap.sourceRoot != null) delete sourcemap.sourceRoot;
+    if (sourcemap.sourceRoot != null) {
+      // $FlowFixMe
+      delete sourcemap.sourceRoot;
+    }
     return new SourceMapConsumer(sourcemap);
   }
 

--- a/packages/transformers/postcss/src/PostCSSTransformer.js
+++ b/packages/transformers/postcss/src/PostCSSTransformer.js
@@ -65,6 +65,7 @@ export default new Transformer({
       configFilePlugins['postcss-modules'] != null
     ) {
       originalModulesConfig = configFilePlugins['postcss-modules'];
+      // $FlowFixMe
       delete configFilePlugins['postcss-modules'];
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5611,10 +5611,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@0.107.0:
-  version "0.107.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.107.0.tgz#b37bfcce51204d35d58f8eb93b3a76b52291e4cc"
-  integrity sha512-hsmwO5Q0+XUXaO2kIKLpleUNNBSFcsGEQGBOTEC/KR/4Ez695I1fweX/ioSjbU4RWhPZhkIqnpbF9opVAauCHg==
+flow-bin@0.109.0:
+  version "0.109.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.109.0.tgz#dcdcb7402dd85b58200392d8716ccf14e5a8c24c"
+  integrity sha512-tpcMTpAGIRivYhFV3KJq+zHI2HzcXo8MoGe9pXS4G/UZuey2Faq/e8/gdph2WF0erRlML5hmwfwiq7v9c25c7w==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This updates to Flow 0.109. This update enforces that read-only object types cannot have properties deleted from them.

For now, these are ignored, but we should consider alternatives before landing this. Both of these cases can be solved by creating new objects that don't contain the key that is currently deleted. Cc @DeMoorJasper on the source map case.

Test Plan: `yarn flow`