### PR TITLE
Plugin loader fail early

### DIFF
--- a/packages/core/core/src/loadParcelPlugin.js
+++ b/packages/core/core/src/loadParcelPlugin.js
@@ -37,6 +37,14 @@ export default async function loadPlugin(
 
   let plugin = await packageManager.require(resolved, `${resolveFrom}/index`);
   plugin = plugin.default ? plugin.default : plugin;
+  if (!plugin) {
+    throw new Error(`Plugin ${pluginName} has no exports.`);
+  }
   plugin = plugin[CONFIG];
+  if (!plugin) {
+    throw new Error(
+      `Plugin ${pluginName} is not a valid Parcel plugin, should export an instance of a Parcel plugin ex. "export default new Reporter({ ... })".`
+    );
+  }
   return plugin;
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

I think it would be helpful to fail early on plugin load rather than waiting until some core Parcel function throws a `<plugin-type>.<something>` is undefined error.

This would be pretty helpful for people who will create Parcel plugins.

Reason I created this PR is I encountered this issue: #3542 and was kinda puzzled that it didn't fail on load.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
