### PR TITLE
Let terser eliminate transpiled classes

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-classes-babel/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-classes-babel/a.js
@@ -1,0 +1,2 @@
+import {foo} from './b';
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-classes-babel/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-classes-babel/b.js
@@ -1,0 +1,6 @@
+export const foo = 3;
+export class Bar {
+	method() {
+		console.log("bar");
+	}
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-classes-babel/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-classes-babel/package.json
@@ -1,0 +1,5 @@
+{
+  "browserslist": [
+    "IE 11"
+  ]
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4,7 +4,8 @@ import {
   bundle as _bundle,
   run,
   outputFS,
-  assertBundles
+  assertBundles,
+  distDir
 } from '@parcel/test-utils';
 
 const bundle = (name, opts = {}) =>
@@ -523,7 +524,7 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 2);
 
       let contents = await outputFS.readFile(
-        path.join(__dirname, '/../dist/a.js'),
+        path.join(distDir, 'a.js'),
         'utf8'
       );
       assert(contents.includes('foo'));
@@ -543,11 +544,30 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 9);
 
       let contents = await outputFS.readFile(
-        path.join(__dirname, '/../dist/a.js'),
+        path.join(distDir, 'a.js'),
         'utf8'
       );
       assert(/.\+./.test(contents));
       assert(!/.-./.test(contents));
+    });
+
+    it('removes unused transpiled classes using terser when minified', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/tree-shaking-classes-babel/a.js'
+        ),
+        {minify: true}
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 3);
+
+      let contents = await outputFS.readFile(
+        path.join(distDir, 'a.js'),
+        'utf8'
+      );
+      assert(!contents.includes('method'));
     });
 
     it('support exporting a ES6 module exported as CommonJS', async function() {
@@ -608,7 +628,7 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 2);
 
       let contents = await outputFS.readFile(
-        path.join(__dirname, '/../dist/a.js'),
+        path.join(distDir, 'a.js'),
         'utf8'
       );
       assert(!/bar/.test(contents));
@@ -1238,7 +1258,7 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 2);
 
       let contents = await outputFS.readFile(
-        path.join(__dirname, '/../dist/a.js'),
+        path.join(distDir, 'a.js'),
         'utf8'
       );
       assert(contents.includes('foo'));

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -12,7 +12,7 @@ export function generate(
 ) {
   let {code} = babelGenerate(ast, {
     minified: options.minify,
-    comments: !options.minify
+    comments: true // retain /*@__PURE__*/ comments for terser
   });
 
   // $FlowFixMe


### PR DESCRIPTION
# ↪️ Pull Request

A statement like this doesn't get tree shaken because it does look pure (without looking at the comment).
```js
var $fa7e8a5a8249ace53223ae89975fffbd$export$default =
/*#__PURE__*/
function () {
  function XYZ() {
    $fa7e8a5a8249ace53223ae89975fffbd$var$_classCallCheck(this, XYZ);
  }

  $fa7e8a5a8249ace53223ae89975fffbd$var$_createClass(XYZ, [{
    key: "method",
    value: function method() {
      return "abc";
    }
  }]);
  return XYZ;
}();
```

By outputting comments when generating the code after scopehoisting (and before terser), we can leverage terser to remove everything.

This also makes it possible to allow certain comments to be preserved by terser (e.g. license headers): fixes #3322

---

We could a handle these comments in `treeShake`, but I'm not sure if there is an advantage to doing that?
`+` Smaller cache size, less data to serialize (both to cache and AST->code)
`-` larger error surface, would need more tests

```diff
diff --git a/packages/shared/scope-hoisting/src/shake.js b/packages/shared/scope-hoisting/src/shake.js
index c3b3d09a..7a87f25d 100644
--- a/packages/shared/scope-hoisting/src/shake.js
+++ b/packages/shared/scope-hoisting/src/shake.js
@@ -67,7 +67,9 @@ function isPure(binding) {
       init.isPure() ||
       init.isIdentifier() ||
       init.isThisExpression() ||
-      binding.path.node.id.name === '$parcel$global'
+      binding.path.node.id.name === '$parcel$global' ||
+      (init.isCallExpression() &&
+        init.node.leadingComments.filter(v => v.value === '#__PURE__'))
     );
   }

```
(it might be more complicated than that: https://github.com/rollup/rollup/pull/2429)