### PR TITLE
CSSTransformer: check for no dependencies during transform

### DIFF
--- a/packages/core/integration-tests/test/integration/less-postcss/index.module.less
+++ b/packages/core/integration-tests/test/integration/less-postcss/index.module.less
@@ -2,4 +2,5 @@
 
 .index {
   color: @base;
+  background-image: url('img.svg');
 }

--- a/packages/core/integration-tests/test/less.js
+++ b/packages/core/integration-tests/test/less.js
@@ -160,6 +160,9 @@ describe('less', function() {
       {
         name: 'index.css',
         assets: ['index.module.less']
+      },
+      {
+        assets: ['img.svg']
       }
     ]);
 

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -48,7 +48,10 @@ export default new Transformer({
 
   transform({asset}) {
     let ast = asset.ast;
-    if (!ast) {
+    // Check for `hasDependencies` being false here as well, as it's possible
+    // another transformer (such as PostCSSTransformer) has already parsed an
+    // ast and CSSTransformer's parse was never called.
+    if (!ast || asset.meta.hasDependencies === false) {
       return [asset];
     }
 


### PR DESCRIPTION
In addition to checking during `parse` in the CSSTransformer (to avoid parsing all together), check for `hasDependencies` being false during transformation, which actually adds the dependencies.

In this case, PostCSS had parsed the css and produced an AST, meaning that the CSSTransformer would trace dependencies when it shouldn't have been.

Test Plan: Added a url dependency to the less+postcss integration test. Verify it fails without the additional condition in `transform`.