### PR TITLE
RFC: Support cache between versions

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -69,6 +69,8 @@ const nodeFromEntryFile = (entry: string) => ({
 });
 
 export default class AssetGraph extends Graph<AssetGraphNode> {
+  static VERSION = Graph.VERSION + ':1';
+
   onNodeAdded: ?(node: AssetGraphNode) => mixed;
   onNodeRemoved: ?(node: AssetGraphNode) => mixed;
   hash: ?string;

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -183,8 +183,12 @@ export default class AssetGraphBuilder extends EventEmitter {
   }
 
   getCacheKeys() {
-    let assetGraphKey = md5FromString(`${this.cacheKey}:assetGraph`);
-    let requestGraphKey = md5FromString(`${this.cacheKey}:requestGraph`);
+    let assetGraphKey = md5FromString(
+      `${this.cacheKey}:assetGraph:${AssetGraph.VERSION}`
+    );
+    let requestGraphKey = md5FromString(
+      `${this.cacheKey}:requestGraph:${RequestGraph.VERSION}`
+    );
     let snapshotKey = md5FromString(`${this.cacheKey}:snapshot`);
     return {assetGraphKey, requestGraphKey, snapshotKey};
   }

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -41,6 +41,8 @@ type BundleGraphEdgeTypes =
   | 'references';
 
 export default class BundleGraph {
+  static VERSION = Graph.VERSION + ':1';
+
   // TODO: These hashes are being invalidated in mutative methods, but this._graph is not a private
   // property so it is possible to reach in and mutate the graph without invalidating these hashes.
   // It needs to be exposed in BundlerRunner for now based on how applying runtimes works and the

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -103,10 +103,11 @@ export default class BundlerRunner {
       `${this.config.filePath}/index` // TODO: is this right?
     );
 
-    let version = nullthrows(pkg).version;
+    let bundlerVersion = nullthrows(pkg).version;
     return md5FromObject({
       bundler,
-      version,
+      bundlerVersion,
+      bundleGraphVersion: InternalBundleGraph.VERSION,
       hash: assetGraph.getHash()
     });
   }

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -20,6 +20,8 @@ type AdjacencyList<TEdgeType> = DefaultMap<
 export const ALL_EDGE_TYPES = '@@all_edge_types';
 
 export default class Graph<TNode: Node, TEdgeType: string | null = null> {
+  static VERSION = '1';
+
   nodes: Map<NodeId, TNode>;
   inboundEdges: AdjacencyList<TEdgeType | null> = new DefaultMap(
     () => new DefaultMap(() => new Set())

--- a/packages/core/core/src/RequestGraph.js
+++ b/packages/core/core/src/RequestGraph.js
@@ -102,6 +102,8 @@ const nodeFromTargetRequest = (entry: FilePath) => ({
 });
 
 export default class RequestGraph extends Graph<RequestGraphNode> {
+  static VERSION = Graph.VERSION + ':1';
+
   // $FlowFixMe
   inProgress: Map<NodeId, Promise<any>> = new Map();
   invalidNodeIds: Set<NodeId> = new Set();

--- a/packages/core/core/src/registerCoreWithSerializer.js
+++ b/packages/core/core/src/registerCoreWithSerializer.js
@@ -36,5 +36,10 @@ export default function registerCoreWithSerializer() {
 }
 
 function register(ctor: Class<*>): void {
-  registerSerializableClass(packageVersion + ':' + ctor.name, ctor);
+  registerSerializableClass(
+    (typeof ctor.VERSION === 'string' ? ctor.VERSION : packageVersion) +
+      ':' +
+      ctor.name,
+    ctor
+  );
 }


### PR DESCRIPTION
Resolves #3598. Thanks @banou26 for mentioning this.

**NOTE**: Right now, structures like AssetGraph, RequestGraph, and BundleGraph depend on many structures that could change subtly. I'm thinking of an alternate approach in which we always factor in e.g. up to the minor version of core and not version independent structures. This seems too error prone to do perfectly and manually, and maybe we could just reserve all breaking changes to any structure for semver minor versions.

This supports caching structures between versions of Parcel by:

* Allowing individual classes to include versions, beyond versioning in the `package.json`
* Including these versions in the cache keys of these structures

Without these changes, upgrading Parcel with a new version in `@parcel/core`'s package.json would cause Parcel to continue to look in the same location for a cache entry, only for it to fail to deserialize as the versions conflict. Instead, factor important versions into the cache keys.

Test Plan:
* Run the react-hmr example. Increment the version in `@parcel/core`'s package.json and re-run. Verify a deserializer error.
* Apply patches. Re-run the example, increment again, and run once more. Verify no deserializer errors.
* Increment `VERSION` on AssetGraph and re-run. Verify building takes place between runs.