### PR TITLE
Drop Node 8 Support

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -4,8 +4,6 @@ jobs:
       vmImage: ${{ parameters.vmImage }}
     strategy:
       matrix:
-        node_8_x:
-          node_version: 8.x
         node_10_x:
           node_version: 10.x
         node_12_x:


### PR DESCRIPTION
This stops Node 8 from running in CI.

Node 8 is nearing its end of life in the coming months [0], coinciding with the end of life of its version of OpenSSL. It also does not support worker threads in any form, which are a significant advantage to Parcel.

Test Plan (dependent on PR): Verify that agent list in CI does not include Node 8 on any supported platform.

[0] https://github.com/nodejs/Release#release-schedule