### PR TITLE
Update engines to node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon": "^7.3.1"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "lint-staged": {
     "*.{js,json,md}": [

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/DefaultBundler",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/Cache",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "@parcel/logger": "^2.0.0-alpha.1.1",

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -127,7 +127,7 @@
     "parcel1": "bin/cli.js"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "lint-staged": {
     "*.{js,json,md}": [

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "main": "./src/PluginAPI.js",
   "dependencies": {

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -4,7 +4,7 @@
   "main": "./src/register.js",
   "license": "MIT",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "scripts": {
     "run-example": "node ./example/index.js",

--- a/packages/core/source-map/package.json
+++ b/packages/core/source-map/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {},
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "@parcel/utils": "^2.0.0-alpha.1.1",

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "@parcel/config-default": "^2.0.0-alpha.1.1",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/optimizers/terser/package.json
+++ b/packages/optimizers/terser/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/TerserOptimizer",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/CSSPackager",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/HTMLPackager",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/JSPackager",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/packagers/raw/package.json
+++ b/packages/packagers/raw/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/RawPackager",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/reporters/build-metrics/package.json
+++ b/packages/reporters/build-metrics/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-alpha.1.1",
   "main": "src/BuildMetricsReporter.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-alpha.1.1",
   "main": "src/index.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-alpha.1.1",
   "main": "src/JSONReporter.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/runtimes/hmr/package.json
+++ b/packages/runtimes/hmr/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/HMRRuntime",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/JSRuntime",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "@babel/generator": "^7.3.3",

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/BabelTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/coffeescript/package.json
+++ b/packages/transformers/coffeescript/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/CoffeeScriptTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/CSSTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/HTMLTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/JSTransformer",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/less/package.json
+++ b/packages/transformers/less/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/LessTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/PostCSSTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/pug/package.json
+++ b/packages/transformers/pug/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/PugTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/raw/package.json
+++ b/packages/transformers/raw/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/RawTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/SassTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/stylus/package.json
+++ b/packages/transformers/stylus/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/StylusTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/sugarss/package.json
+++ b/packages/transformers/sugarss/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/SugarssTransformer",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/typescript-tsc/package.json
+++ b/packages/transformers/typescript-tsc/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/TSCTransformer",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/transformers/yaml/package.json
+++ b/packages/transformers/yaml/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/YAMLTransformer.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/utils/babel-preset-env/package.json
+++ b/packages/utils/babel-preset-env/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/index.js",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "dependencies": {
     "semver": "^5.4.1",

--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -8,6 +8,6 @@
   },
   "main": "src/index.js",
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/validators/eslint/package.json
+++ b/packages/validators/eslint/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/EslintValidator.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {

--- a/packages/validators/typescript/package.json
+++ b/packages/validators/typescript/package.json
@@ -8,7 +8,7 @@
   },
   "main": "src/TypeScriptValidator.js",
   "engines": {
-    "node": ">= 8.0.0",
+    "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {


### PR DESCRIPTION
This updates the entry in `engines` in `package.json` files for packages across the monorepo to require at least node 10, rather than at least node 8.