### PR TITLE
V2: readme browser target fix

### DIFF
--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -444,7 +444,7 @@ This is the "browser" target's entry point for the package.
 
 ```json
 {
-  "browser": "distflinesof/browser/index.js"
+  "browser": "dist/browser/index.js"
 }
 ```
 


### PR DESCRIPTION
Minor fix to README - noticed a seemingly stray `flinesof` in the example code for a browser target entry point path.