### PR TITLE
[T-115] Version in cache keys

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -19,6 +19,7 @@ import {md5FromObject, md5FromString} from '@parcel/utils';
 import AssetGraph from './AssetGraph';
 import type ParcelConfig from './ParcelConfig';
 import RequestGraph from './RequestGraph';
+import {PARCEL_VERSION} from './constants';
 
 import dumpToGraphViz from './dumpGraphToGraphViz';
 import path from 'path';
@@ -52,6 +53,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     this.options = options;
     let {minify, hot, scopeHoist} = options;
     this.cacheKey = md5FromObject({
+      parcelVersion: PARCEL_VERSION,
       name,
       options: {minify, hot, scopeHoist},
       entries

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -19,6 +19,7 @@ import dumpGraphToGraphViz from './dumpGraphToGraphViz';
 import {normalizeSeparators, unique, md5FromObject} from '@parcel/utils';
 import PluginOptions from './public/PluginOptions';
 import applyRuntimes from './applyRuntimes';
+import {PARCEL_VERSION} from './constants';
 
 type Opts = {|
   options: ParcelOptions,
@@ -105,6 +106,7 @@ export default class BundlerRunner {
 
     let version = nullthrows(pkg).version;
     return md5FromObject({
+      parcelVersion: PARCEL_VERSION,
       bundler,
       version,
       hash: assetGraph.getHash()

--- a/packages/core/core/src/InternalAsset.js
+++ b/packages/core/core/src/InternalAsset.js
@@ -27,6 +27,7 @@ import {
 } from '@parcel/utils';
 import {createDependency, mergeDependencies} from './Dependency';
 import {mergeEnvironments} from './Environment';
+import {PARCEL_VERSION} from './constants';
 
 type AssetOptions = {|
   id?: string,
@@ -138,7 +139,7 @@ export default class InternalAsset {
     // and hash while it's being written to the cache.
     let [contentKey, mapKey] = await Promise.all([
       this.options.cache.setStream(
-        this.generateCacheKey('content' + pipelineKey),
+        this.getCacheKey('content' + pipelineKey),
         contentStream.pipe(
           new TapStream(buf => {
             size += buf.length;
@@ -149,7 +150,7 @@ export default class InternalAsset {
       this.map == null
         ? Promise.resolve()
         : this.options.cache.set(
-            this.generateCacheKey('map' + pipelineKey),
+            this.getCacheKey('map' + pipelineKey),
             this.map
           )
     ]);
@@ -218,8 +219,10 @@ export default class InternalAsset {
     this.map = map;
   }
 
-  generateCacheKey(key: string): string {
-    return md5FromString(key + this.value.id + (this.value.hash || ''));
+  getCacheKey(key: string): string {
+    return md5FromString(
+      PARCEL_VERSION + key + this.value.id + (this.value.hash || '')
+    );
   }
 
   addDependency(opts: DependencyOptions) {

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -33,6 +33,7 @@ import BundleGraph, {
   bundleGraphToInternalBundleGraph
 } from './public/BundleGraph';
 import PluginOptions from './public/PluginOptions';
+import {PARCEL_VERSION} from './constants';
 
 type Opts = {|
   config: ParcelConfig,
@@ -371,6 +372,7 @@ export default class PackagerRunner {
     // TODO: add third party configs to the cache key
     let {minify, scopeHoist, sourceMaps} = this.options;
     return md5FromObject({
+      parcelVersion: PARCEL_VERSION,
       deps,
       opts: {minify, scopeHoist, sourceMaps},
       hash: bundleGraph.getHash(bundle)

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -32,6 +32,7 @@ import {MutableAsset, assetToInternalAsset} from './public/Asset';
 import InternalAsset, {createAsset} from './InternalAsset';
 import summarizeRequest from './summarizeRequest';
 import PluginOptions from './public/PluginOptions';
+import {PARCEL_VERSION} from './constants';
 
 type GenerateFunc = (input: IMutableAsset) => Promise<GenerateOutput>;
 
@@ -236,6 +237,7 @@ export default class Transformation {
     }));
 
     return md5FromObject({
+      parcelVersion: PARCEL_VERSION,
       assets: assetsKeyInfo,
       configs: getImpactfulConfigInfo(configs),
       env: this.request.env,

--- a/packages/core/core/src/constants.js
+++ b/packages/core/core/src/constants.js
@@ -1,0 +1,6 @@
+// @flow strict-local
+
+// $FlowFixMe
+import {version} from '../package.json';
+
+export const PARCEL_VERSION = version;


### PR DESCRIPTION
# ↪️ Pull Request
This adds the version of `@parcel/core` to all of the cache keys. See [this comment](https://github.com/parcel-bundler/parcel/pull/3615#issuecomment-541236933) for reasoning. 

Resolves #3598.

## 🚨 Test instructions

Run a cold build and then a cached build and confirm that the second run skips all building and goes straight to writing cached bundles. Change `@parcel/core` version and run build again, confirming that everything is rebuilt.
