### PR TITLE
CSS hot reloading fix for platforms with urls that lack protocol and host prefix.

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/bundle-url.js
+++ b/packages/core/parcel-bundler/src/builtins/bundle-url.js
@@ -22,7 +22,7 @@ function getBundleURL() {
 }
 
 function getBaseURL(url) {
-  return ('' + url).replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\/\/.+)\/[^/]+$/, '$1') + '/';
+  return ('' + url).replace(/^((?:https?|file|ftp|chrome-extension|moz-extension):\/\/.+)?\/[^/]+(?:\?.*)?$/, '$1') + '/';
 }
 
 exports.getBundleURL = getBundleURLCached;

--- a/packages/core/parcel-bundler/src/builtins/css-loader.js
+++ b/packages/core/parcel-bundler/src/builtins/css-loader.js
@@ -18,8 +18,7 @@ function reloadCSS() {
   cssTimeout = setTimeout(function () {
     var links = document.querySelectorAll('link[rel="stylesheet"]');
     for (var i = 0; i < links.length; i++) {
-      var bundleUrl = bundle.getBundleURL();
-      if (bundle.getBaseURL(links[i].href).slice(0, bundleUrl.length) === bundleUrl) {
+      if (bundle.getBaseURL(links[i].href) === bundle.getBundleURL()) {
         updateLink(links[i]);
       }
     }

--- a/packages/core/parcel-bundler/src/builtins/css-loader.js
+++ b/packages/core/parcel-bundler/src/builtins/css-loader.js
@@ -18,7 +18,7 @@ function reloadCSS() {
   cssTimeout = setTimeout(function () {
     var links = document.querySelectorAll('link[rel="stylesheet"]');
     for (var i = 0; i < links.length; i++) {
-      let bundleUrl = bundle.getBundleURL();
+      var bundleUrl = bundle.getBundleURL();
       if (bundle.getBaseURL(links[i].href).slice(0, bundleUrl.length) === bundleUrl) {
         updateLink(links[i]);
       }

--- a/packages/core/parcel-bundler/src/builtins/css-loader.js
+++ b/packages/core/parcel-bundler/src/builtins/css-loader.js
@@ -18,7 +18,8 @@ function reloadCSS() {
   cssTimeout = setTimeout(function () {
     var links = document.querySelectorAll('link[rel="stylesheet"]');
     for (var i = 0; i < links.length; i++) {
-      if (bundle.getBaseURL(links[i].href) === bundle.getBundleURL()) {
+      let bundleUrl = bundle.getBundleURL();
+      if (bundle.getBaseURL(links[i].href).slice(0, bundleUrl.length) === bundleUrl) {
         updateLink(links[i]);
       }
     }


### PR DESCRIPTION
Our internal runtime reports a getBundleUrl() value of "/". This breaks css reloading unless the comparison is changed to match if the link base url starts with the bundle url.

# ↪️ Pull Request

This fixes a bug that breaks an internal adobe runtime. Our runtime uses unusual URLs which fail with the current comparison.

If we change the comparison to pass if the link url starts with the bundle base URL this fixes our problem.

Since the purpose of the check is only to make sure that externally referenced css files are not reloaded, this does not break current browser behavior.

A hot reloaded local url will still not start with an external urls protocol host and port.

## 💻 Examples

A typical link url in our runtime is "/src.f69400ca.css?1571167198029/"
The bundle.getBaseURL() is "/"

## 🚨 Test instructions

Hot reloading of local css files should still work.
External css files links should not be updated on local change.

## ✔️ PR Todo

- [n/a] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [n/a] Included links to related issues/PRs
