### PR TITLE
Use AbortController to cancel builds

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -233,7 +233,3 @@ export default class AssetGraphBuilder extends EventEmitter {
     );
   }
 }
-
-export class BuildAbortError extends Error {
-  name = 'BuildAbortError';
-}

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -37,7 +37,6 @@ type Opts = {|
 export default class AssetGraphBuilder extends EventEmitter {
   assetGraph: AssetGraph;
   requestGraph: RequestGraph;
-  controller: AbortController;
   changedAssets: Map<string, Asset> = new Map();
   options: ParcelOptions;
   cacheKey: string;

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -586,10 +586,12 @@ export function removeAssetGroups(
   assetGraph: AssetGraph
 ): Graph<BundleGraphNode> {
   let graph = new Graph<BundleGraphNode>();
-  // $FlowFixMe
-  graph.setRootNode(nullthrows(assetGraph.getRootNode()));
-  let assetGroupIds = new Set();
 
+  let rootNode = assetGraph.getRootNode();
+  invariant(rootNode != null && rootNode.type === 'root');
+  graph.setRootNode(rootNode);
+
+  let assetGroupIds = new Set();
   assetGraph.traverse(node => {
     if (node.type === 'asset_group') {
       assetGroupIds.add(node.id);

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -5,6 +5,7 @@ import type {Bundle as InternalBundle, ParcelOptions} from './types';
 import type ParcelConfig from './ParcelConfig';
 import type WorkerFarm from '@parcel/workers';
 import type AssetGraphBuilder from './AssetGraphBuilder';
+import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 
 import assert from 'assert';
 import path from 'path';
@@ -20,6 +21,7 @@ import {normalizeSeparators, unique, md5FromObject} from '@parcel/utils';
 import PluginOptions from './public/PluginOptions';
 import applyRuntimes from './applyRuntimes';
 import {PARCEL_VERSION} from './constants';
+import {assertSignalNotAborted} from './utils';
 
 type Opts = {|
   options: ParcelOptions,
@@ -44,7 +46,10 @@ export default class BundlerRunner {
     this.farm = opts.workerFarm;
   }
 
-  async bundle(graph: AssetGraph): Promise<InternalBundleGraph> {
+  async bundle(
+    graph: AssetGraph,
+    {signal}: {|signal: ?AbortSignal|}
+  ): Promise<InternalBundleGraph> {
     report({
       type: 'buildProgress',
       phase: 'bundling'
@@ -54,12 +59,12 @@ export default class BundlerRunner {
     if (!this.options.disableCache) {
       cacheKey = await this.getCacheKey(graph);
       let cachedBundleGraph = await this.options.cache.get(cacheKey);
+      assertSignalNotAborted(signal);
+
       if (cachedBundleGraph) {
         return cachedBundleGraph;
       }
     }
-
-    let bundler = await this.config.getBundler();
 
     let bundleGraph = removeAssetGroups(graph);
     // $FlowFixMe
@@ -69,15 +74,21 @@ export default class BundlerRunner {
       internalBundleGraph,
       this.options
     );
+
+    let bundler = await this.config.getBundler();
     await bundler.bundle({
       bundleGraph: mutableBundleGraph,
       options: this.pluginOptions
     });
+    assertSignalNotAborted(signal);
+
     await dumpGraphToGraphViz(bundleGraph, 'after_bundle');
     await bundler.optimize({
       bundleGraph: mutableBundleGraph,
       options: this.pluginOptions
     });
+    assertSignalNotAborted(signal);
+
     await dumpGraphToGraphViz(bundleGraph, 'after_optimize');
     await this.nameBundles(internalBundleGraph);
 
@@ -88,11 +99,13 @@ export default class BundlerRunner {
       options: this.options,
       pluginOptions: this.pluginOptions
     });
+    assertSignalNotAborted(signal);
     await dumpGraphToGraphViz(bundleGraph, 'after_runtimes');
 
     if (cacheKey != null) {
       await this.options.cache.set(cacheKey, internalBundleGraph);
     }
+    assertSignalNotAborted(signal);
 
     return internalBundleGraph;
   }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -342,7 +342,7 @@ export default class Parcel {
         }
 
         let isInvalid = this.#assetGraphBuilder.respondToFSEvents(events);
-        if (isInvalid && this.#watchQueue._queue.length === 0) {
+        if (isInvalid && this.#watchQueue.getNumWaiting() === 0) {
           if (this.#watchAbortController) {
             this.#watchAbortController.abort();
           }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -22,7 +22,8 @@ import BundlerRunner from './BundlerRunner';
 import WorkerFarm from '@parcel/workers';
 import nullthrows from 'nullthrows';
 import path from 'path';
-import AssetGraphBuilder, {BuildAbortError} from './AssetGraphBuilder';
+import AssetGraphBuilder from './AssetGraphBuilder';
+import {assertSignalNotAborted, BuildAbortError} from './utils';
 import PackagerRunner from './PackagerRunner';
 import loadParcelConfig from './loadParcelConfig';
 import ReporterRunner from './ReporterRunner';
@@ -242,10 +243,11 @@ export default class Parcel {
       let {assetGraph, changedAssets} = await this.#assetGraphBuilder.build();
       dumpGraphToGraphViz(assetGraph, 'MainAssetGraph');
 
-      let bundleGraph = await this.#bundlerRunner.bundle(assetGraph);
+      let bundleGraph = await this.#bundlerRunner.bundle(assetGraph, {signal});
       dumpGraphToGraphViz(bundleGraph._graph, 'BundleGraph');
 
       await this.#packagerRunner.writeBundles(bundleGraph);
+      assertSignalNotAborted(signal);
 
       let event = {
         type: 'buildSuccess',

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -11,6 +11,7 @@ import type {
 } from '@parcel/types';
 import type {ParcelOptions} from './types';
 import type {FarmOptions} from '@parcel/workers';
+import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 
 import invariant from 'assert';
 import {createDependency} from './Dependency';
@@ -30,6 +31,8 @@ import resolveOptions from './resolveOptions';
 import {ValueEmitter} from '@parcel/events';
 import registerCoreWithSerializer from './registerCoreWithSerializer';
 import {createCacheDir} from '@parcel/cache';
+import {AbortController} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
+import {PromiseQueue} from '@parcel/utils';
 
 registerCoreWithSerializer();
 
@@ -48,6 +51,8 @@ export default class Parcel {
   #reporterRunner; // ReporterRunner
   #resolvedOptions = null; // ?ParcelOptions
   #runPackage; // (bundle: IBundle, bundleGraph: InternalBundleGraph) => Promise<Stats>;
+  #watchAbortController; // AbortController
+  #watchQueue = new PromiseQueue<?BuildEvent>({maxConcurrent: 1}); // PromiseQueue<?BuildEvent>
   #watchEvents = new ValueEmitter<
     | {
         +error: Error,
@@ -136,7 +141,7 @@ export default class Parcel {
       await this.init();
     }
 
-    let result = await this.build(startTime);
+    let result = await this.build({startTime});
     await Promise.all([
       this.#assetGraphBuilder.writeToCache(),
       this.#runtimesAssetGraphBuilder.writeToCache()
@@ -152,6 +157,23 @@ export default class Parcel {
     }
 
     return result.bundleGraph;
+  }
+
+  async startNextBuild() {
+    this.#watchAbortController = new AbortController();
+
+    try {
+      this.#watchEvents.emit({
+        buildEvent: await this.build({
+          signal: this.#watchAbortController.signal
+        })
+      });
+    } catch (err) {
+      // Ignore BuildAbortErrors and only emit critical errors.
+      if (!(err instanceof BuildAbortError)) {
+        throw err;
+      }
+    }
   }
 
   async watch(
@@ -174,14 +196,8 @@ export default class Parcel {
 
       // Kick off a first build, but don't await its results. Its results will
       // be provided to the callback.
-      this.build()
-        .then(buildEvent => {
-          this.#watchEvents.emit({buildEvent});
-        })
-        .catch(error => {
-          // Ignore BuildAbortErrors and only emit critical errors.
-          this.#watchEvents.emit({error});
-        });
+      this.#watchQueue.add(() => this.startNextBuild());
+      this.#watchQueue.run();
     }
 
     this.#watcherCount++;
@@ -206,7 +222,13 @@ export default class Parcel {
     };
   }
 
-  async build(startTime: number = Date.now()): Promise<BuildEvent> {
+  async build({
+    signal,
+    startTime = Date.now()
+  }: {|
+    signal?: AbortSignal,
+    startTime?: number
+  |}): Promise<BuildEvent> {
     let options = nullthrows(this.#resolvedOptions);
     try {
       if (options.profile) {
@@ -311,24 +333,22 @@ export default class Parcel {
 
     return resolvedOptions.inputFS.watch(
       resolvedOptions.projectRoot,
-      async (err, events) => {
+      (err, _events) => {
+        let events = _events.filter(e => !e.path.includes('.cache'));
+
         if (err) {
           this.#watchEvents.emit({error: err});
           return;
         }
 
         let isInvalid = this.#assetGraphBuilder.respondToFSEvents(events);
-        if (isInvalid) {
-          try {
-            this.#watchEvents.emit({
-              buildEvent: await this.build()
-            });
-          } catch (error) {
-            // Ignore BuildAbortErrors and only emit critical errors.
-            if (!(err instanceof BuildAbortError)) {
-              this.#watchEvents.emit({error});
-            }
+        if (isInvalid && this.#watchQueue._queue.length === 0) {
+          if (this.#watchAbortController) {
+            this.#watchAbortController.abort();
           }
+
+          this.#watchQueue.add(() => this.startNextBuild());
+          this.#watchQueue.run();
         }
       },
       opts

--- a/packages/core/core/src/RequestGraph.js
+++ b/packages/core/core/src/RequestGraph.js
@@ -218,6 +218,7 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
   }
 
   removeNode(node: RequestGraphNode) {
+    this.invalidNodeIds.delete(node.id);
     if (node.type === 'glob') {
       this.globNodeIds.delete(node.id);
     } else if (node.type === 'dep_version_request') {
@@ -314,17 +315,13 @@ export default class RequestGraph extends Graph<RequestGraphNode> {
     }
   }
 
-  async validate(requestNode: AssetRequestNode) {
-    try {
-      await this.runValidate({
-        request: requestNode.value,
-        loadConfig: this.loadConfigHandle,
-        parentNodeId: requestNode.id,
-        options: this.options
-      });
-    } catch (e) {
-      throw e;
-    }
+  validate(requestNode: AssetRequestNode) {
+    return this.runValidate({
+      request: requestNode.value,
+      loadConfig: this.loadConfigHandle,
+      parentNodeId: requestNode.id,
+      options: this.options
+    });
   }
 
   async transform(requestNode: AssetRequestNode) {

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -1,6 +1,18 @@
 // @flow strict-local
 
+import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import type {BundleGroup} from '@parcel/types';
 
-export const getBundleGroupId = (bundleGroup: BundleGroup) =>
-  'bundle_group:' + bundleGroup.entryAssetId;
+export function getBundleGroupId(bundleGroup: BundleGroup): string {
+  return 'bundle_group:' + bundleGroup.entryAssetId;
+}
+
+export function assertSignalNotAborted(signal: ?AbortSignal): void {
+  if (signal && signal.aborted) {
+    throw new BuildAbortError();
+  }
+}
+
+export class BuildAbortError extends Error {
+  name = 'BuildAbortError';
+}

--- a/packages/core/utils/src/PromiseQueue.js
+++ b/packages/core/utils/src/PromiseQueue.js
@@ -2,7 +2,7 @@
 
 import {makeDeferredWithPromise, type Deferred} from './Deferred';
 
-type PromiseQueueOpts = {maxConcurrent: number, ...};
+type PromiseQueueOpts = {|maxConcurrent: number|};
 
 export default class PromiseQueue<T> {
   _deferred: ?Deferred<Array<T>>;
@@ -76,7 +76,6 @@ export default class PromiseQueue<T> {
 
   async _runFn(fn: () => mixed): Promise<void> {
     this._numRunning++;
-    // console.log('RUNNING', this._numRunning, this._maxConcurrent, this._queue.length)
     try {
       await fn();
       this._numRunning--;

--- a/packages/core/utils/src/PromiseQueue.js
+++ b/packages/core/utils/src/PromiseQueue.js
@@ -21,6 +21,10 @@ export default class PromiseQueue<T> {
     this._maxConcurrent = opts.maxConcurrent;
   }
 
+  getNumWaiting(): number {
+    return this._queue.length;
+  }
+
   add(fn: () => Promise<T>): Promise<T> {
     return new Promise((resolve, reject) => {
       let i = this._count++;

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -40,10 +40,7 @@ export default function UI({events, options}: Props) {
     defaultState
   );
 
-  useEffect(() => {
-    let {dispose} = events.addListener(dispatch);
-    return dispose;
-  }, [events]);
+  useEffect(() => events.addListener(dispatch).dispose, [events]);
 
   let {logs, progress, bundleGraph} = state;
   return (


### PR DESCRIPTION
This implements a single top-level AbortController used for cancelling builds when new filesystem events occur that invalidate the RequestGraph.

A PromiseQueue was used to ensure that only one build is in process at a time. When a new filesystem event occurs, it enqueues a build, and cancels the previous build. 

Test Plan:

- Begin initial build
- When it enters bundling, make a change
- Verify that Parcel restarts build
- Ensure that only one build success message is printed