### PR TITLE
Bugfix: Update post process to recive final assets rather than initial ones

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -179,7 +179,7 @@ export default class Transformation {
 
     invariant(pipeline.postProcess != null);
     let processedFinalAssets: Array<InternalAsset> =
-      processedCacheEntry ?? (await pipeline.postProcess(assets)) ?? [];
+      processedCacheEntry ?? (await pipeline.postProcess(finalAssets)) ?? [];
 
     if (!processedCacheEntry) {
       await this.writeToCache(


### PR DESCRIPTION
# ↪️ Pull Request

This PR fixes an issue where postProcess functions in transforms where receiving the initial assets instead of the final assets. This corrects the issue allowing transforms to work on the final assets as expected.

I'm assuming this is what was intended with postProcess, as otherwise there is no way to interact with the final assets in a transform. This is also in line with the behaviour from v1 of Parcel.

I ran into this issue working on my vue transform.
