### PR TITLE
strip debug info from generated wasm if minify is true

### DIFF
--- a/packages/core/parcel-bundler/src/assets/RustAsset.js
+++ b/packages/core/parcel-bundler/src/assets/RustAsset.js
@@ -157,8 +157,9 @@ class RustAsset extends Asset {
       '-o',
       this.wasmPath
     ];
+    const minifyArgs = this.options.minify ? ['-Clink-arg=-s'] : [];
 
-    await exec('rustc', args);
+    await exec('rustc', [...args, ...minifyArgs]);
 
     // Run again to collect dependencies
     this.depsPath = path.join(this.options.cacheDir, name + '.d');


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Disclaimer : I am not a wasm or rust expert.

I tinkered with parceljs, and managed to reduce the generated wasm file from 1.6MB to 116B for the usuall `add` example.

After trying to compile rust code with parcel, I noticed that the wasm file was really big ( #3235 shows the problem). More than 1.5MB 😨. Using [twiggy](https://github.com/rustwasm/twiggy) shows that it is essentially bloat from debugs symbols.

I tried to figure out how wasm-pack optimize wasm and then tried different solutions to shrink the size on the simple `add.rs` file : 
 - `-Copt-level=s` (should optimize for size): no visible effect, but it makes sense for such a simple function
 - `-Clto=thin`: it reduced the size to 44kB A big win but still a lot for a simple add function. It seems some debug symbol are still there
 - `-Cdebuginfo=0` (should remove debug info): no visible effect, so I may have misunderstood this option.
 - `-Clink-arg=-s` (option passed to the linker to strip the binary): it reduced the size to 116B. 

As a result I kept the last one (`-Clto=thin` did not show any difference once `-Clink-arg=-s` is added) . It is difficult to know if the others are useful for a more complicated case. I tried this on a mac.

I think wasm-pack actually uses wasm-opt to do this, so this might be another way to do it.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

For reference, the rust code used.
`add.rs` :  
```
#[no_mangle]
pub fn add(a: i32, b: i32) -> i32 {
  return a + b
}
```

building with parcel version 1.12.4 : 
```
✨  Built in 669ms.

dist/add.wasm    ⚠️  1.65 MB    615ms 
```

building with `--no-cache` with the modified version  :
```
✨  Built in 502ms.

dist/add.wasm    116 B    448ms
```


## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

I did not add unit tests for this (this is not really a bug). A good way to test this would be to compile the rust function mentionned above by calling parcel (or repo mentionned in #3235).

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
