### PR TITLE
Added support for externals through peer dependencies

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -18,6 +18,7 @@ const PromiseQueue = require('./utils/PromiseQueue');
 const installPackage = require('./utils/installPackage');
 const bundleReport = require('./utils/bundleReport');
 const prettifyTime = require('./utils/prettifyTime');
+const getModuleParts = require('./utils/getModuleParts');
 const getRootDir = require('./utils/getRootDir');
 const {glob, isGlob} = require('./utils/glob');
 
@@ -147,6 +148,10 @@ class Bundler extends EventEmitter {
           : process.env.PARCEL_AUTOINSTALL === 'false'
           ? false
           : !isProduction,
+      peerDependencies:
+        typeof options.peerDependencies === 'boolean'
+          ? options.peerDependencies
+          : true,
       scopeHoist: scopeHoist,
       contentHash:
         typeof options.contentHash === 'boolean'
@@ -486,6 +491,17 @@ class Bundler extends EventEmitter {
       // If the dep is optional, return before we throw
       if (dep.optional) {
         return;
+      }
+
+      if (this.options.peerDependencies == false) {
+        let pkg = await asset.getPackage();
+        if (pkg && pkg.peerDependencies) {
+          let parts = getModuleParts(dep.name);
+          let peerDependencies = Object.keys(pkg.peerDependencies);
+          if (peerDependencies.includes(parts[0])) {
+            return;
+          }
+        }
       }
 
       if (err.code === 'MODULE_NOT_FOUND') {

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -181,6 +181,22 @@ class Resolver {
         dir = path.dirname(dir);
       }
 
+      // Skip package directory for dependencies in peerDependencies
+      if (this.options.peerDependencies == false) {
+        try {
+          let pkg = await this.readPackage(dir);
+          if (pkg && pkg.peerDependencies) {
+            let peerDependencies = Object.keys(pkg.peerDependencies);
+            if (peerDependencies.includes(parts[0])) {
+              dir = path.dirname(dir);
+              continue;
+            }
+          }
+        } catch (err) {
+          // ignore
+        }
+      }
+
       try {
         // First, check if the module directory exists. This prevents a lot of unnecessary checks later.
         let moduleDir = path.join(dir, 'node_modules', parts[0]);

--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -51,6 +51,7 @@ program
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
   .option('--no-autoinstall', 'disable autoinstall')
+  .option('--no-peer-dependencies', 'disable bundling of peer dependencies')
   .option(
     '-t, --target [target]',
     'set the runtime environment, either "node", "browser" or "electron". defaults to "browser"',
@@ -101,6 +102,7 @@ program
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
   .option('--no-autoinstall', 'disable autoinstall')
+  .option('--no-peer-dependencies', 'disable bundling of peer dependencies')
   .option(
     '-t, --target [target]',
     'set the runtime environment, either "node", "browser" or "electron". defaults to "browser"',
@@ -138,6 +140,7 @@ program
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
   .option('--no-autoinstall', 'disable autoinstall')
+  .option('--no-peer-dependencies', 'disable bundling of peer dependencies')
   .option('--no-content-hash', 'disable content hashing')
   .option(
     '--experimental-scope-hoisting',


### PR DESCRIPTION
Allows parcel to not bundle the peerDependencies of a project and leave them as external requires. This makes it convenient to use parcel for bundling libraries or packages linked locally.

#144 
#3305 

It works by skipping the package in the node resolve algorithm if it was specified as a peer dependency   (as if it was not there in the first place). The resolve algorithm can thus find the package higher up the tree where it was not specified as a peer dependency. In case it did not resolve (as all instances of the package in the tree are specified as a peer dependency), it will be ignored as a dependency and leave the require statement in place.

I find this useful for consuming local packages that have for example a "react" peer dependency. React should not be bundled multiple times as this makes React complain. Also useful to leave "@babel/runtime" requires in place for packages/libraries that want to depend on the babel runtime.
