### PR TITLE
Don't shake variables as computed property in member expressions

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/a.js
@@ -1,3 +1,4 @@
-import foo from "./b.js";
+import b from './b.js';
+import c from './b.js';
 
-output = [foo("abc"), foo("x")];
+output = [b('abc'), b('x'), c('abc'), c('x')];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/a.js
@@ -1,0 +1,3 @@
+import foo from "./b.js";
+
+output = [foo("abc"), foo("x")];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/b.js
@@ -1,0 +1,8 @@
+let x = "abc",
+	y = "def";
+let data = {};
+data[x] = data[y] = true;
+
+export default function(a) {
+	return data[a];
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/c.js
@@ -1,8 +1,9 @@
 let x = "abc",
   y = "def";
 let data = {};
-data[x] = data[y] = true;
+data[x] = true;
+data[y] = true;
 
 export default function(a) {
-  return data[a];
+	return data[a];
 }

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -580,7 +580,10 @@ describe('scope hoisting', function() {
       );
 
       let output = await run(b);
-      assert.deepEqual(output, [true, false]);
+      assert.strictEqual(output[0], true);
+      assert.strictEqual(typeof output[1], 'undefined');
+      assert.strictEqual(output[2], true);
+      assert.strictEqual(typeof output[3], 'undefined');
     });
 
     it('support exporting a ES6 module exported as CommonJS', async function() {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -570,6 +570,19 @@ describe('scope hoisting', function() {
       assert(!contents.includes('method'));
     });
 
+    it('keeps member expression with computed properties that are variables', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/tree-shaking-export-computed-prop/a.js'
+        ),
+        {minify: true}
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, [true, false]);
+    });
+
     it('support exporting a ES6 module exported as CommonJS', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/shake.js
+++ b/packages/shared/scope-hoisting/src/shake.js
@@ -76,8 +76,9 @@ function isPure(binding) {
 
 function isExportAssignment(path) {
   return (
-    // match "path.any = any;"
+    // match "path.foo = bar;"
     path.parentPath.isMemberExpression() &&
+    path.parentPath.node.object === path.node &&
     path.parentPath.parentPath.isAssignmentExpression() &&
     path.parentPath.parentPath.node.left === path.parentPath.node
   );


### PR DESCRIPTION
The comment in `isExportAssignment(path)` described the expected behavior, with
```js
exports.something = someOtherThing
```
, calling `isExportAssignment(/* node of exports object*/)` returns true because `exports` can safely be removed if `exports` is only assigned in this way and `something` and `someOtherThing` are pure. 

However, it was never checked that `path` is actually the `object`  of the member expression on the left. This means that with 
```js
some_local_variable[another_local_variable] = someOtherThing;
```
, `isExportAssignment(/* node of another_local_variable */)` returned true. So the variable `another_local_variable` was removed although it *was* used (often together with this assignment, while `some_local_variable` was used!). This would cause either a ReferenceError that `another_local_variable` isn't defined or `some_local_variable` would not contains different entries.


(This was triggered by `lodash/_baseIsTypedArray.js`).

Closes #3684 (this happened with is-v2-ready-yet as well).