### PR TITLE
Fixed JSON parsing error by updating package.json after babel has run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
 const {Transform} = require('stream');
 const babel = require('gulp-babel');
 const gulp = require('gulp');
-const merge = require('merge-stream');
 const path = require('path');
 const rimraf = require('rimraf');
 const babelConfig = require('./babel.config.js');
@@ -33,60 +32,6 @@ const paths = {
   packages: 'packages/'
 };
 
-exports.clean = function clean(cb) {
-  rimraf('packages/*/*/lib/**', cb);
-};
-
-exports.default = exports.build = function build() {
-  return merge(
-    gulp
-      .src(paths.packageSrc)
-      .pipe(babel(babelConfig))
-      .pipe(renameStream(relative => relative.replace('src', 'lib')))
-      .pipe(gulp.dest(paths.packages)),
-    gulp
-      .src(paths.packageOther)
-      .pipe(renameStream(relative => relative.replace('src', 'lib')))
-      .pipe(gulp.dest(paths.packages)),
-    gulp
-      .src(paths.packageJson)
-      .pipe(updatePackageJson())
-      .pipe(gulp.dest(paths.packages))
-  );
-};
-
-function updatePackageJson() {
-  return new TapStream(vinyl => {
-    let json = JSON.parse(vinyl.contents);
-    // Replace all references to `src` in package.json main entries to their
-    // `lib` equivalents.
-    if (typeof json.main === 'string') {
-      json.main = json.main.replace('src', 'lib');
-    }
-    // Replace all references to `src` in package.json bin entries
-    // `lib` equivalents.
-    if (typeof json.bin === 'object' && json.bin != null) {
-      for (let [binName, binPath] of Object.entries(json.bin)) {
-        json.bin[binName] = binPath.replace('src', 'lib');
-      }
-    } else if (typeof json.bin === 'string') {
-      json.bin = json.bin.replace('src', 'lib');
-    }
-
-    json.publishConfig = {
-      access: 'public'
-    };
-    vinyl.contents = Buffer.from(JSON.stringify(json, null, 2));
-  });
-}
-
-function renameStream(fn) {
-  return new TapStream(vinyl => {
-    let relative = path.relative(vinyl.base, vinyl.path);
-    vinyl.path = path.join(vinyl.base, fn(relative));
-  });
-}
-
 /*
  * "Taps" into the contents of a flowing stream, yielding chunks to the passed
  * callback. Continues to pass data chunks down the stream.
@@ -105,4 +50,66 @@ class TapStream extends Transform {
       callback(err);
     }
   }
+}
+
+exports.clean = function clean(cb) {
+  rimraf('packages/*/*/lib/**', cb);
+};
+
+exports.default = exports.build = gulp.series(
+  gulp.parallel(buildBabel, copyOthers),
+  // Babel reads from package.json so update these after babel has run
+  updatePackageJson
+);
+
+function buildBabel() {
+  return gulp
+    .src(paths.packageSrc)
+    .pipe(babel(babelConfig))
+    .pipe(renameStream(relative => relative.replace('src', 'lib')))
+    .pipe(gulp.dest(paths.packages));
+}
+
+function copyOthers() {
+  return gulp
+    .src(paths.packageOther)
+    .pipe(renameStream(relative => relative.replace('src', 'lib')))
+    .pipe(gulp.dest(paths.packages));
+}
+
+function updatePackageJson() {
+  return gulp
+    .src(paths.packageJson)
+    .pipe(
+      new TapStream(vinyl => {
+        let json = JSON.parse(vinyl.contents);
+        // Replace all references to `src` in package.json main entries to their
+        // `lib` equivalents.
+        if (typeof json.main === 'string') {
+          json.main = json.main.replace('src', 'lib');
+        }
+        // Replace all references to `src` in package.json bin entries
+        // `lib` equivalents.
+        if (typeof json.bin === 'object' && json.bin != null) {
+          for (let [binName, binPath] of Object.entries(json.bin)) {
+            json.bin[binName] = binPath.replace('src', 'lib');
+          }
+        } else if (typeof json.bin === 'string') {
+          json.bin = json.bin.replace('src', 'lib');
+        }
+
+        json.publishConfig = {
+          access: 'public'
+        };
+        vinyl.contents = Buffer.from(JSON.stringify(json, null, 2));
+      })
+    )
+    .pipe(gulp.dest(paths.packages));
+}
+
+function renameStream(fn) {
+  return new TapStream(vinyl => {
+    let relative = path.relative(vinyl.base, vinyl.path);
+    vinyl.path = path.join(vinyl.base, fn(relative));
+  });
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",
     "lint-staged": "^7.2.2",
-    "merge-stream": "^2.0.0",
     "mocha": "^6.1.3",
     "mocha-junit-reporter": "^1.21.0",
     "mocha-multi-reporters": "^1.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8204,11 +8204,6 @@ merge-source-map@^1.1.0:
   dependencies:
     source-map "^0.6.1"
 
-merge-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
-  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
-
 merge2@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"


### PR DESCRIPTION
Before:
Every once in a while, building parcel via `yarn build` would produce a JSON parsing error. This was because babel reads package.jsons which may still be writing to disk.

After:
Parcel builds consistently every time.

Test Plan:
Verified that parcel builds without errors 7 times in a row.
Verified that parcel was able to build the react-hmr example using the build results.