### PR TITLE
Patch no readme on npm.js

### DIFF
--- a/packages/core/parcel-bundler/.gitignore
+++ b/packages/core/parcel-bundler/.gitignore
@@ -8,3 +8,4 @@ test/integration/**/Cargo.lock
 test/**/yarn.lock
 test/**/package-lock.json
 test/integration/babel-plugin-autoinstall/package.json
+README.md

--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -12,7 +12,8 @@
     "bin/",
     "lib/",
     "src/",
-    "index.js"
+    "index.js",
+    "README.md"
   ],
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
@@ -130,7 +131,7 @@
     "test-ci": "yarn test-coverage && yarn report-coverage",
     "format": "prettier --write \"./{src,bin,test}/**/*.{js,json,md}\"",
     "build": "yarn minify && babel src -d lib && ncp src/builtins lib/builtins",
-    "prepublish": "yarn build",
+    "prepublish": "yarn build && cp ../../../README.md .",
     "minify": "terser -c -m -o src/builtins/prelude.min.js src/builtins/prelude.js && terser -c -m -o src/builtins/prelude2.min.js src/builtins/prelude2.js",
     "precommit": "lint-staged",
     "lint": "eslint . && prettier \"./{src,bin,test}/**/*.{js,json,md}\" --list-different",


### PR DESCRIPTION
# ↪️ Pull Request

Fix #3619 by scripting the copy of the `README.md` file to the `parcel-bundler` folder.

Maybe a bit rough as a solution but it should work as there doesn't seem to have any kind of relative URLs in the main README.