### PR TITLE
[T-190] Scope hoisting replaces local variable with a different variable of the same name

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/keep-local-function-var/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/keep-local-function-var/a.js
@@ -1,0 +1,8 @@
+const foo = require("./b");
+
+let render = function() {
+	let root = "foo";
+	output = root;
+};
+
+render();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/keep-local-function-var/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/keep-local-function-var/b.js
@@ -1,0 +1,4 @@
+var root = require('./c');
+
+var freeModule = typeof module == 'object' && module && !module.nodeType && module;
+module.exports = freeModule ? null : root;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/keep-local-function-var/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/keep-local-function-var/c.js
@@ -1,0 +1,2 @@
+var root = "something else";
+module.exports = root;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1050,6 +1050,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, {foo: 2});
     });
 
+    it('should not rename function local variables according to global replacements', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/keep-local-function-var/a.js'
+        )
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'foo');
+    });
+
     it('supports assigning to this as exports object', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -416,6 +416,8 @@ export function link({
           return;
         }
 
+        let isGlobal = path.scope == path.scope.getProgramParent();
+
         // Replace patterns like `var {x} = require('y')` with e.g. `$id$export$x`.
         if (t.isObjectPattern(id)) {
           for (let p of path.get('id.properties')) {
@@ -427,6 +429,9 @@ export function link({
             let {identifier} = resolveSymbol(module, key.name);
             if (identifier) {
               replace(value.name, identifier, p);
+              if (isGlobal) {
+                replacements.set(value.name, identifier);
+              }
             }
           }
 
@@ -435,6 +440,9 @@ export function link({
           }
         } else if (t.isIdentifier(id)) {
           replace(id.name, init.name, path);
+          if (isGlobal) {
+            replacements.set(id.name, init.name);
+          }
         }
 
         function replace(id, init, path) {
@@ -447,7 +455,6 @@ export function link({
             ref.replaceWith(t.identifier(init));
           }
 
-          replacements.set(id, init);
           path.remove();
         }
       }


### PR DESCRIPTION
# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/3752

### Problem

The is the AST state between the concat and link stage.
```js
var $parcel$global = typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : {};
// ASSET: /Users/niklas/Desktop/shake-root/b.js
var $a8f3803a63b472439b25431e6fe715e$exports = {};
var $a8f3803a63b472439b25431e6fe715e$var$root = "something else";
$a8f3803a63b472439b25431e6fe715e$exports = $a8f3803a63b472439b25431e6fe715e$var$root;

// ASSET: /Users/niklas/Desktop/shake-root/a.js
var $efa628d0f351ce8b6bbf271d4b67214a$exports = function () {
  var exports = this;
  var module = {
    exports: this
  };
  var root = $parcel$require("efa628d0f351ce8b6bbf271d4b67214a", "./b");
  // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  var freeModule = typeof module == 'object' && module && !module.nodeType && module;
  module.exports = freeModule ? null : root;
  return module.exports;
}.call({});

// ASSET: /Users/niklas/Desktop/shake-root/index.js
const $f39783c07ef39639b1ad548fdaca8e$var$foo = $parcel$require("27f39783c07ef39639b1ad548fdaca8e", "./a");

let $f39783c07ef39639b1ad548fdaca8e$var$render = function () {
  let root = "hello!";
  console.log(root);
};

$f39783c07ef39639b1ad548fdaca8e$var$render();
```

When the marked line is processed, all references of `root` will be replaced with `$a8f3803a63b472439b25431e6fe715e$exports`, including the local variable in the render function (more details here: https://github.com/parcel-bundler/parcel/issues/3752#issuecomment-551285417).

### Solution

I'm not quite sure if my fix (only set the replacement if it's a toplevel statement (= in the program's scope)) will cover all cases now, is it enough that only toplevle (renamed by the hoister) variables are replaced globally? Could there still be a collision?