### PR TITLE
Less strict engines validation

### DIFF
--- a/packages/core/core/src/TargetDescriptor.schema.js
+++ b/packages/core/core/src/TargetDescriptor.schema.js
@@ -1,39 +1,46 @@
 // @flow strict-local
 import type {SchemaEntity} from '@parcel/utils';
 
-export const engines: SchemaEntity = {
+const COMMON_ENGINE_PROPERITES = {
+  browsers: {
+    oneOf: [
+      {
+        type: 'array',
+        items: {
+          type: 'string'
+        }
+      },
+      {
+        type: 'string'
+      }
+    ]
+  },
+  node: {
+    oneOf: [
+      {
+        type: 'array'
+      },
+      {
+        type: 'string'
+      }
+    ]
+  },
+  electron: {
+    type: 'string'
+  }
+};
+
+export const TOPLEVEL_ENGINES_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    browsers: {
-      oneOf: [
-        {
-          type: 'array',
-          items: {
-            type: 'string'
-          }
-        },
-        {
-          type: 'string'
-        }
-      ]
-    },
-    node: {
-      oneOf: [
-        {
-          type: 'array'
-        },
-        {
-          type: 'string'
-        }
-      ]
-    },
-    electron: {
-      type: 'string'
-    },
+    ...COMMON_ENGINE_PROPERITES,
     parcel: {
       type: 'string'
     },
     npm: {
+      type: 'string'
+    },
+    yarn: {
       type: 'string'
     }
   },
@@ -102,7 +109,13 @@ export default ({
         }
       ]
     },
-    engines
+    engines: {
+      type: 'object',
+      properties: {
+        ...COMMON_ENGINE_PROPERITES
+      },
+      additionalProperties: false
+    }
   },
   additionalProperties: false
 }: SchemaEntity);

--- a/packages/core/core/src/TargetDescriptor.schema.js
+++ b/packages/core/core/src/TargetDescriptor.schema.js
@@ -1,50 +1,27 @@
 // @flow strict-local
 import type {SchemaEntity} from '@parcel/utils';
 
-const COMMON_ENGINE_PROPERITES = {
-  browsers: {
-    oneOf: [
-      {
-        type: 'array',
-        items: {
-          type: 'string'
-        }
-      },
-      {
-        type: 'string'
-      }
-    ]
-  },
-  node: {
-    oneOf: [
-      {
-        type: 'array'
-      },
-      {
-        type: 'string'
-      }
-    ]
-  },
-  electron: {
-    type: 'string'
-  }
-};
-
-export const TOPLEVEL_ENGINES_SCHEMA: SchemaEntity = {
+export const ENGINES_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    ...COMMON_ENGINE_PROPERITES,
-    parcel: {
-      type: 'string'
-    },
-    npm: {
-      type: 'string'
-    },
-    yarn: {
-      type: 'string'
+    browsers: {
+      oneOf: [
+        {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        {
+          type: 'string'
+        }
+      ]
     }
   },
-  additionalProperties: false
+  __forbiddenProperties: ['browser'],
+  additionalProperties: {
+    type: 'string'
+  }
 };
 
 export default ({
@@ -69,7 +46,7 @@ export default ({
           type: 'array',
           items: {
             type: 'string',
-            __pattern: 'a wildcard or filepath'
+            __type: 'a wildcard or filepath'
           }
         }
       ]
@@ -109,13 +86,7 @@ export default ({
         }
       ]
     },
-    engines: {
-      type: 'object',
-      properties: {
-        ...COMMON_ENGINE_PROPERITES
-      },
-      additionalProperties: false
-    }
+    engines: ENGINES_SCHEMA
   },
   additionalProperties: false
 }: SchemaEntity);

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -19,7 +19,7 @@ import {createEnvironment} from './Environment';
 import path from 'path';
 import browserslist from 'browserslist';
 import DESCRIPTOR_SCHEMA, {
-  engines as ENGINES_SCHEMA
+  TOPLEVEL_ENGINES_SCHEMA
 } from './TargetDescriptor.schema';
 
 export type TargetResolveResult = {|
@@ -408,7 +408,7 @@ function parseEngines(
     return engines;
   } else {
     validateSchema.diagnostic(
-      ENGINES_SCHEMA,
+      TOPLEVEL_ENGINES_SCHEMA,
       engines,
       pkgPath,
       pkgContents,

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -18,9 +18,7 @@ import {loadConfig, validateSchema} from '@parcel/utils';
 import {createEnvironment} from './Environment';
 import path from 'path';
 import browserslist from 'browserslist';
-import DESCRIPTOR_SCHEMA, {
-  TOPLEVEL_ENGINES_SCHEMA
-} from './TargetDescriptor.schema';
+import DESCRIPTOR_SCHEMA, {ENGINES_SCHEMA} from './TargetDescriptor.schema';
 
 export type TargetResolveResult = {|
   targets: Array<Target>,
@@ -408,7 +406,7 @@ function parseEngines(
     return engines;
   } else {
     validateSchema.diagnostic(
-      TOPLEVEL_ENGINES_SCHEMA,
+      ENGINES_SCHEMA,
       engines,
       pkgPath,
       pkgContents,

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -470,6 +470,17 @@ describe('TargetResolver', () => {
                     column: 5,
                     line: 8
                   }
+                },
+                {
+                  end: {
+                    column: 5,
+                    line: 7
+                  },
+                  message: 'Expected type string',
+                  start: {
+                    column: 13,
+                    line: 5
+                  }
                 }
               ]
             }

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -32,7 +32,7 @@ export type SchemaString = {|
 export type SchemaObject = {|
   type: 'object',
   properties: {[string]: SchemaEntity, ...},
-  additionalProperties: boolean,
+  additionalProperties?: boolean,
   __pattern?: string
 |};
 export type SchemaError = {|

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -373,7 +373,7 @@ validateSchema.diagnostic = function(
           message = 'Unexpected property';
         }
       } else if (e.type === 'missing-prop') {
-        let {prop, expectedProps, actualProps} = e;
+        let {prop, actualProps} = e;
         let likely = fuzzySearch(actualProps, prop);
         if (likely.length > 0) {
           message = `Did you mean ${likely


### PR DESCRIPTION
# ↪️ Pull Request

Now, all engines except `browser` are allowed (that one is easy to get wrong).

This could be done within the JSON Schema standard using something like:
`allOf( [ not( is {browser: any} ) , {*: string} ] )`

However, there is no way to generate an error message in this case, because you can't determine unambiguously what should be changed so that the entity inside of `not` fails to match. Therefore, I added a `__forbiddenProperties` array to the object entity.

cc @wbinnssmith 
Supersedes https://github.com/parcel-bundler/parcel/pull/3774.