### PR TITLE
Upgrade to Flow 0.112

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,4 +35,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.110.1
+0.112.0

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "doctoc": "^1.4.0",
     "eslint": "^5.16.0",
-    "flow-bin": "0.110.1",
+    "flow-bin": "0.112.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",

--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -31,6 +31,9 @@ export default new Bundler({
         if (node.type !== 'dependency') {
           return {
             ...context,
+            bundleGroup: context?.bundleGroup,
+            bundleByType: context?.bundleByType,
+            bundleGroupDependency: context?.bundleGroupDependency,
             parentNode: node
           };
         }
@@ -72,14 +75,18 @@ export default new Bundler({
         }
 
         invariant(context != null);
+        invariant(context.parentNode.type === 'asset');
+        let bundleGroup = nullthrows(context.bundleGroup);
+        let bundleGroupDependency = nullthrows(context.bundleGroupDependency);
+        let bundleByType = nullthrows(context.bundleByType);
+
         for (let asset of assets) {
-          invariant(context.parentNode.type === 'asset');
           let parentAsset = context.parentNode.value;
           if (parentAsset.type === asset.type) {
             continue;
           }
 
-          let existingBundle = context.bundleByType.get(asset.type);
+          let existingBundle = bundleByType.get(asset.type);
           if (existingBundle) {
             // If a bundle of this type has already been created in this group,
             // merge this subgraph into it.
@@ -88,14 +95,14 @@ export default new Bundler({
           } else {
             let bundle = bundleGraph.createBundle({
               entryAsset: asset,
-              target: context.bundleGroup.target,
-              isEntry: context.bundleGroupDependency.isEntry,
+              target: bundleGroup.target,
+              isEntry: bundleGroupDependency.isEntry,
               isInline: asset.isInline
             });
-            context.bundleByType.set(bundle.type, bundle);
+            bundleByType.set(bundle.type, bundle);
             bundleRoots.set(bundle, [asset]);
             bundleGraph.createAssetReference(dependency, asset);
-            bundleGraph.addBundleToBundleGroup(bundle, context.bundleGroup);
+            bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
           }
         }
 

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -41,6 +41,10 @@ export function createDependency(opts: DependencyOpts): Dependency {
   return {
     ...opts,
     id,
+    isAsync: opts.isAsync ?? false,
+    isEntry: opts.isEntry ?? false,
+    isOptional: opts.isOptional ?? false,
+    isURL: opts.isURL ?? false,
     meta: opts.meta || {},
     symbols: opts.symbols || new Map()
   };

--- a/packages/core/core/src/InternalAsset.js
+++ b/packages/core/core/src/InternalAsset.js
@@ -288,7 +288,11 @@ export default class InternalAsset {
             ? new Map(this.value.dependencies)
             : new Map(),
         includedFiles: new Map(this.value.includedFiles),
-        meta: {...this.value.meta, ...result.meta},
+        meta: {
+          ...this.value.meta,
+          // $FlowFixMe
+          ...result.meta
+        },
         pipeline:
           result.pipeline ??
           (this.value.type === result.type ? this.value.pipeline : null),

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -79,7 +79,7 @@ export async function readAndProcess(
 }
 
 export async function processConfig(
-  configFile: ParcelConfigFile,
+  configFile: ParcelConfigFile | ResolvedParcelConfigFile,
   filePath: FilePath,
   options: ParcelOptions
 ) {
@@ -126,7 +126,7 @@ export async function resolveExtends(
 }
 
 export function validateConfigFile(
-  config: ParcelConfigFile,
+  config: ParcelConfigFile | ResolvedParcelConfigFile,
   relativePath: FilePath
 ) {
   validateNotEmpty(config, relativePath);
@@ -173,7 +173,7 @@ export function validateConfigFile(
 }
 
 export function validateNotEmpty(
-  config: ParcelConfigFile,
+  config: ParcelConfigFile | ResolvedParcelConfigFile,
   relativePath: FilePath
 ) {
   assert.notDeepStrictEqual(config, {}, `${relativePath} can't be empty`);

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -33,7 +33,7 @@ export type ModuleSpecifier = string;
 
 export type GlobMap<T> = {[Glob]: T, ...};
 
-export type ParcelConfigFile = {
+export type ParcelConfigFile = {|
   extends?: PackageName | FilePath | Array<PackageName | FilePath>,
   resolvers?: Array<PackageName>,
   transforms?: {[Glob]: Array<PackageName>, ...},
@@ -43,15 +43,14 @@ export type ParcelConfigFile = {
   packagers?: {[Glob]: PackageName, ...},
   optimizers?: {[Glob]: Array<PackageName>, ...},
   reporters?: Array<PackageName>,
-  validators?: {[Glob]: Array<PackageName>, ...},
-  ...
-};
+  validators?: {[Glob]: Array<PackageName>, ...}
+|};
 
-export type ResolvedParcelConfigFile = {
+export type ResolvedParcelConfigFile = {|
   ...ParcelConfigFile,
   filePath: FilePath,
-  ...
-};
+  resolveFrom?: FilePath
+|};
 
 export type Engines = {
   browsers?: string | Array<string>,

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -156,7 +156,11 @@ function evaluateExpression(node) {
   return res;
 }
 
-function addDependency(asset, node, opts = {}) {
+function addDependency(
+  asset,
+  node,
+  opts: ?{|isAsync?: boolean, isOptional?: boolean|}
+) {
   // If this came from an inline <script> tag, throw an error.
   // TODO: run JSPackager on inline script tags.
   // let inlineHTML =
@@ -172,7 +176,8 @@ function addDependency(asset, node, opts = {}) {
   asset.addDependency({
     moduleSpecifier: node.value,
     loc: node.loc && node.loc.start,
-    ...opts
+    isAsync: opts ? opts.isAsync : false,
+    isOptional: opts ? opts.isOptional : false
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5677,10 +5677,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@0.110.1:
-  version "0.110.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.110.1.tgz#24ac70bf0871a5d6bc181ba99801ded4d5e3b442"
-  integrity sha512-6FhvNKNvPQ523mx7sqNxTQvI/HgAWa/pbIsQuCst53qRqs387EFfYqgm4I3Zae5HLaVFacBwgWKmjKd92vf19w==
+flow-bin@0.112.0:
+  version "0.112.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.112.0.tgz#6a21c31937c4a2f23a750056a364c598a95ea216"
+  integrity sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This updates to Flow 0.112. Upgrading introduced new flow errors, some of which come from Flow 0.111 [0]:

* In the bundler, Flow understands the different states `context` can be in during traversal and errored on unexpected keys as well as values missing during phases of traversal. Since we expect traversal to happen in a particular order, such as expecting bundle groups to already be present when processing non-entry, non-async dependencies, use runtime assertions instead.
* `Dependency` and other struct-like objects expect keys to always be present. In some cases, we were spreading an object which was not guaranteed to have keys like `isAsync`, `isEntry`, etc. This makes them explicit.
* Made `ParcelConfig` and `ResolvedParcelConfig` exact object types to remove ambiguity when spreading.
* Ignored an issue when spreading Meta, as the flow error suggested removing the string indexer (which I believe we need).

Test Plan: `yarn flow && yarn test`

[0] https://medium.com/flow-type/spreads-common-errors-fixes-9701012e9d58