### PR TITLE
Rebuild correctly after failed transformations

### DIFF
--- a/packages/core/core/src/requests.js
+++ b/packages/core/core/src/requests.js
@@ -153,7 +153,8 @@ export class AssetRequestRunner extends RequestRunner<
     this.assetGraph = opts.assetGraph;
   }
 
-  async run(request: AssetRequestDesc) {
+  async run(request: AssetRequestDesc, api: RequestRunnerAPI) {
+    api.invalidateOnFileUpdate(request.filePath);
     let start = Date.now();
     let {assets, configRequests} = await this.runTransform({
       request: request,
@@ -175,8 +176,6 @@ export class AssetRequestRunner extends RequestRunner<
     this.assetGraph.resolveAssetGroup(request, result.assets);
 
     let {assets, configRequests} = result;
-
-    api.invalidateOnFileUpdate(request.filePath);
 
     for (let asset of assets) {
       for (let filePath of asset.includedFiles.keys()) {


### PR DESCRIPTION
#3428 ↪️ Pull Request

Accidentally added a regression in my `RequestGraph` refactor where rebuilds were not triggering when updating a file that failed to transform 😬 I've added a test so this should be caught in the future. I also updated and unskipped a test for rebuilding after successful transformations.

Close T-225

## 🚨 Test instructions

`yarn test:integration`
