### PR TITLE
[T-227] Coffescript sourcemap fix and Buffer deprecation warnings

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -829,7 +829,7 @@ describe('javascript', function() {
     assert.deepEqual(output(), {
       dir: path.join(__dirname, '/integration/globals'),
       file: path.join(__dirname, '/integration/globals/index.js'),
-      buf: new Buffer('browser').toString('base64'),
+      buf: Buffer.from('browser').toString('base64'),
       global: true
     });
   });

--- a/packages/core/source-map/src/SourceMap.js
+++ b/packages/core/source-map/src/SourceMap.js
@@ -34,9 +34,9 @@ type SerializedSourceMap = {
 };
 
 function generateInlineMap(map: string): string {
-  return `data:application/json;charset=utf-8;base64,${new Buffer(map).toString(
-    'base64'
-  )}`;
+  return `data:application/json;charset=utf-8;base64,${Buffer.from(
+    map
+  ).toString('base64')}`;
 }
 
 export default class SourceMap {

--- a/packages/core/source-map/src/SourceMap.js
+++ b/packages/core/source-map/src/SourceMap.js
@@ -61,7 +61,10 @@ export default class SourceMap {
   }
 
   // Static Helper functions
-  static generateEmptyMap(sourceName: string, sourceContent: string) {
+  static generateEmptyMap(
+    sourceName: string,
+    sourceContent: string
+  ): SourceMap {
     let map = new SourceMap();
     map.setSourceContentFor(sourceName, sourceContent);
 
@@ -84,7 +87,7 @@ export default class SourceMap {
     return map;
   }
 
-  static async fromRawSourceMap(input: RawMapInput) {
+  static async fromRawSourceMap(input: RawMapInput): Promise<SourceMap> {
     let map = new SourceMap();
     await map.addRawMap(input);
     return map;
@@ -108,7 +111,7 @@ export default class SourceMap {
     map: RawMapInput,
     lineOffset: number = 0,
     columnOffset: number = 0
-  ) {
+  ): Promise<SourceMap> {
     let consumer = await this.getConsumer(map);
 
     consumer.eachMapping(mapping => {
@@ -130,7 +133,11 @@ export default class SourceMap {
     return this;
   }
 
-  addMap(map: SourceMap, lineOffset: number = 0, columnOffset: number = 0) {
+  addMap(
+    map: SourceMap,
+    lineOffset: number = 0,
+    columnOffset: number = 0
+  ): SourceMap {
     if (lineOffset === 0 && columnOffset === 0) {
       this.mappings.push(...map.mappings);
     } else {
@@ -206,7 +213,7 @@ export default class SourceMap {
     this.mappings.forEach(callback);
   }
 
-  async extend(extension: SourceMap | RawMapInput) {
+  async extend(extension: SourceMap | RawMapInput): Promise<SourceMap> {
     let sourceMap =
       extension instanceof SourceMap
         ? extension
@@ -215,7 +222,7 @@ export default class SourceMap {
     return this._extend(sourceMap);
   }
 
-  _extend(extension: SourceMap) {
+  _extend(extension: SourceMap): SourceMap {
     extension.eachMapping(mapping => {
       let originalMappingIndex = null;
       if (mapping.original != null) {

--- a/packages/transformers/coffeescript/src/CoffeeScriptTransformer.js
+++ b/packages/transformers/coffeescript/src/CoffeeScriptTransformer.js
@@ -20,7 +20,7 @@ export default new Transformer({
     // return from compile is based on sourceMaps option
     if (options.sourceMaps) {
       asset.setCode(output.js);
-      asset.setMap(SourceMap.fromRawSourceMap(output.v3SourceMap));
+      asset.setMap(await SourceMap.fromRawSourceMap(output.v3SourceMap));
     } else {
       asset.setCode(output);
     }


### PR DESCRIPTION
# ↪️ Pull Request

Fixes the `Promise could not be cloned` error in the integration test. I don't know if they are related to the flakiness on Linux (that error occurred always and on every platform, but the exit code wasn't always 1). Also adds return types to SourceMap, so that this error will be caught in the future.

Also removes the last remaining `new Buffer` calls.