### PR TITLE
[T-234] Fix sideEffects: false with CommonJS output format

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/commonjs-dynamic/index.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-dynamic/index.js
@@ -1,0 +1,1 @@
+Object.assign(exports, require('./other'));

--- a/packages/core/integration-tests/test/integration/formats/commonjs-dynamic/other.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-dynamic/other.js
@@ -1,0 +1,5 @@
+function test() {
+  return 2;
+}
+
+exports.test = test;

--- a/packages/core/integration-tests/test/integration/formats/commonjs-dynamic/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-dynamic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "commonjs-sideeffects",
+  "name": "commonjs-dynamic",
   "private": true,
   "main": "dist/index.js",
   "sideEffects": false

--- a/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/index.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/index.js
@@ -1,0 +1,1 @@
+export * from './other';

--- a/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/index.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/index.js
@@ -1,1 +1,1 @@
-export * from './other';
+export * from './middle';

--- a/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/middle.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/middle.js
@@ -1,0 +1,1 @@
+export * from './other';

--- a/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/other.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/other.js
@@ -1,0 +1,3 @@
+export function test() {
+  return 2;
+}

--- a/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-sideeffects/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "commonjs",
+  "private": true,
+  "main": "dist/index.js",
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -304,8 +304,20 @@ describe('output formats', function() {
         b.getBundles().find(b => b.type === 'js').filePath,
         'utf8'
       );
-      assert(dist.includes('return 2'));
-      assert(dist.includes('$parcel$exportWildcard(exports'));
+      assert(dist.includes('function test'));
+      assert(dist.includes('exports.test = test;'));
+    });
+
+    it('should support commonjs input', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/commonjs-dynamic/index.js')
+      );
+
+      let dist = await outputFS.readFile(
+        b.getBundles().find(b => b.type === 'js').filePath,
+        'utf8'
+      );
+      assert(dist.includes('Object.assign(exports'));
     });
   });
 

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -291,6 +291,22 @@ describe('output formats', function() {
         ).test(async2)
       );
     });
+
+    it('should support sideEffects: false', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/formats/commonjs-sideeffects/index.js'
+        )
+      );
+
+      let dist = await outputFS.readFile(
+        b.getBundles().find(b => b.type === 'js').filePath,
+        'utf8'
+      );
+      assert(dist.includes('return 2'));
+      assert(dist.includes('$parcel$exportWildcard(exports'));
+    });
   });
 
   describe('esmodule', function() {

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -53,7 +53,7 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
 
   bundle.traverseAssets<TraversalContext>({
     enter(asset, context) {
-      if (shouldExcludeAsset(asset, usedExports)) {
+      if (shouldExcludeAsset(asset, usedExports, bundle)) {
         return context;
       }
 
@@ -63,7 +63,7 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
       };
     },
     exit(asset, context) {
-      if (!context || shouldExcludeAsset(asset, usedExports)) {
+      if (!context || shouldExcludeAsset(asset, usedExports, bundle)) {
         return;
       }
 
@@ -191,10 +191,12 @@ function getUsedExports(
 
 function shouldExcludeAsset(
   asset: Asset,
-  usedExports: Map<string, Set<Symbol>>
+  usedExports: Map<string, Set<Symbol>>,
+  bundle: Bundle
 ) {
   return (
     asset.sideEffects === false &&
+    asset.id !== bundle.getMainEntry()?.id &&
     (!usedExports.has(asset.id) ||
       nullthrows(usedExports.get(asset.id)).size === 0)
   );

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -53,7 +53,7 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
 
   bundle.traverseAssets<TraversalContext>({
     enter(asset, context) {
-      if (shouldExcludeAsset(asset, usedExports, bundle)) {
+      if (shouldExcludeAsset(asset, usedExports)) {
         return context;
       }
 
@@ -63,7 +63,7 @@ export async function concat(bundle: Bundle, bundleGraph: BundleGraph) {
       };
     },
     exit(asset, context) {
-      if (!context || shouldExcludeAsset(asset, usedExports, bundle)) {
+      if (!context || shouldExcludeAsset(asset, usedExports)) {
         return;
       }
 
@@ -191,12 +191,11 @@ function getUsedExports(
 
 function shouldExcludeAsset(
   asset: Asset,
-  usedExports: Map<string, Set<Symbol>>,
-  bundle: Bundle
+  usedExports: Map<string, Set<Symbol>>
 ) {
   return (
     asset.sideEffects === false &&
-    asset.id !== bundle.getMainEntry()?.id &&
+    !asset.meta.isCommonJS &&
     (!usedExports.has(asset.id) ||
       nullthrows(usedExports.get(asset.id)).size === 0)
   );

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -11,6 +11,7 @@ import * as t from '@babel/types';
 import template from '@babel/template';
 import invariant from 'assert';
 import {relativeBundlePath} from '@parcel/utils';
+import rename from '../renamer';
 
 const REQUIRE_TEMPLATE = template('require(BUNDLE)');
 const EXPORT_TEMPLATE = template('exports.IDENTIFIER = IDENTIFIER');
@@ -221,7 +222,8 @@ export function generateExports(
   bundleGraph: BundleGraph,
   bundle: Bundle,
   referencedAssets: Set<Asset>,
-  path: any
+  path: any,
+  replacements: Map<Symbol, Symbol>
 ) {
   let exported = new Set<Symbol>();
   let statements = [];
@@ -240,27 +242,68 @@ export function generateExports(
 
   let entry = bundle.getMainEntry();
   if (entry) {
-    let exportsId = entry.meta.exportsIdentifier;
-    invariant(typeof exportsId === 'string');
+    if (entry.meta.isCommonJS) {
+      let exportsId = entry.meta.exportsIdentifier;
+      invariant(typeof exportsId === 'string');
 
-    let binding = path.scope.getBinding(exportsId);
-    if (binding) {
-      // If the exports object is constant, then we can just remove it and rename the
-      // references to the builtin CommonJS exports object. Otherwise, assign to module.exports.
-      if (binding.constant) {
-        for (let path of binding.referencePaths) {
-          path.node.name = 'exports';
+      let binding = path.scope.getBinding(exportsId);
+      if (binding) {
+        // If the exports object is constant, then we can just remove it and rename the
+        // references to the builtin CommonJS exports object. Otherwise, assign to module.exports.
+        if (binding.constant) {
+          for (let path of binding.referencePaths) {
+            path.node.name = 'exports';
+          }
+
+          binding.path.remove();
+          exported.add('exports');
+        } else {
+          exported.add(exportsId);
+          statements.push(
+            MODULE_EXPORTS_TEMPLATE({
+              IDENTIFIER: t.identifier(exportsId)
+            })
+          );
+        }
+      }
+    } else {
+      for (let {exportSymbol, symbol} of bundleGraph.getExportedSymbols(
+        entry
+      )) {
+        if (symbol) {
+          symbol = replacements.get(symbol) || symbol;
         }
 
-        binding.path.remove();
-        exported.add('exports');
-      } else {
-        exported.add(exportsId);
-        statements.push(
-          MODULE_EXPORTS_TEMPLATE({
-            IDENTIFIER: t.identifier(exportsId)
+        // If there is an existing binding with the exported name (e.g. an import),
+        // rename it so we can use the name for the export instead.
+        if (path.scope.hasBinding(exportSymbol) && exportSymbol !== symbol) {
+          rename(
+            path.scope,
+            exportSymbol,
+            path.scope.generateUid(exportSymbol)
+          );
+        }
+
+        let binding = path.scope.getBinding(symbol);
+        rename(path.scope, symbol, exportSymbol);
+
+        binding.path.getStatementParent().insertAfter(
+          EXPORT_TEMPLATE({
+            IDENTIFIER: t.identifier(exportSymbol)
           })
         );
+
+        // Exports other than the default export are live bindings. Insert an assignment
+        // after each constant violation so this remains true.
+        if (exportSymbol !== 'default') {
+          for (let path of binding.constantViolations) {
+            path.insertAfter(
+              EXPORT_TEMPLATE({
+                IDENTIFIER: t.identifier(exportSymbol)
+              })
+            );
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Built on #3791. Merge that first.

When `sideEffects: false` was set, CommonJS bundles that re-exported other modules were sometimes empty or missing exports. This happened when there were modules that only re-exported things from other modules. These modules were excluded because they don't have any exports of their own. However, we relied on them to insert `$parcel$exportWildcard` calls etc. Later on, in the shaking phase, the actual exported functions would be removed because they were unreferenced.

This PR adds assignments to `exports` for each exported symbol, similar to how the ES module output format works. This produces much nicer looking output than before. However, due to the dynamic nature of CommonJS input, we always include CommonJS assets even with `sideEffects: false`, and assign the bundle's entry exports object to `module.exports` as before.