### PR TITLE
Add jsx to resolver extensions

### DIFF
--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -29,7 +29,7 @@ export default new Resolver({
     }
 
     const resolver = new NodeResolver({
-      extensions: ['ts', 'tsx', 'js', 'json', 'css', 'styl'],
+      extensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'css', 'styl'],
       options
     });
     const resolved = await resolver.resolve({


### PR DESCRIPTION
# ↪️ Pull Request

A hotfix until we generate that list properly (T-235)

Closes #3653:

> ```
> index.html
>   index.jsx
>     useHello.js
>       hello.jsx
> ```
> 
> and ended up with the same error:
> 
> ```
>   Cannot find module './hello' from '/Users/wojciech.maj/Projekty/cfola/src'
> ```
> 
> Turns out that while `html` and `jsx` files are perfectly able to resolve `jsx` files, `js` files cannot. When I changed `hello.jsx` into `hello.js`it started building.