### PR TITLE
Improve CommonJS and ESM interop for library builds

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -519,11 +519,10 @@ export default class BundleGraph {
   }
 
   resolveSymbol(asset: Asset, symbol: Symbol) {
-    if (symbol === '*') {
-      return {asset, exportSymbol: '*', symbol: '*'};
-    }
-
     let identifier = asset.symbols.get(symbol);
+    if (symbol === '*') {
+      return {asset, exportSymbol: '*', symbol: identifier};
+    }
 
     let deps = this.getDependencies(asset).reverse();
     for (let dep of deps) {

--- a/packages/core/integration-tests/test/integration/formats/commonjs-esm/index.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-esm/index.js
@@ -1,0 +1,5 @@
+const _ = require('lodash');
+
+module.exports = function (a, b) {
+  return _.add(a, b);
+};

--- a/packages/core/integration-tests/test/integration/formats/commonjs-esm/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-esm/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "commonjs-esm",
+  "private": true,
+  "module": "dist/index.js"
+}

--- a/packages/core/integration-tests/test/integration/formats/commonjs-esm/re-assign.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-esm/re-assign.js
@@ -1,0 +1,5 @@
+for (let v of ["a", "b", "c"]) {
+	module.exports[v] = v;
+}
+
+module.exports = "xyz";

--- a/packages/core/integration-tests/test/integration/formats/commonjs-require/index.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-require/index.js
@@ -1,0 +1,5 @@
+const _ = require('lodash');
+
+module.exports = function (a, b) {
+  return _.add(a, b);
+};

--- a/packages/core/integration-tests/test/integration/formats/commonjs-require/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-require/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "commonjs-require",
+  "private": true,
+  "main": "dist/index.js"
+}

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -701,5 +701,22 @@ describe('output formats', function() {
       assert(dist.includes('import _lodash from "lodash"'));
       assert(dist.includes('export default'));
     });
+
+    it('should support re-assigning to module.exports', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/commonjs-esm/re-assign.js')
+      );
+
+      let dist = await outputFS.readFile(
+        b.getBundles().find(b => b.type === 'js').filePath,
+        'utf8'
+      );
+      assert(
+        dist
+          .split('\n')
+          .pop()
+          .startsWith('export default')
+      );
+    });
   });
 });

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -319,6 +319,18 @@ describe('output formats', function() {
       );
       assert(dist.includes('Object.assign(exports'));
     });
+
+    it('should support commonjs requires without interop', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/commonjs-require/index.js')
+      );
+
+      let dist = await outputFS.readFile(
+        b.getBundles().find(b => b.type === 'js').filePath,
+        'utf8'
+      );
+      assert(dist.includes('= require("lodash")'));
+    });
   });
 
   describe('esmodule', function() {
@@ -675,6 +687,19 @@ describe('output formats', function() {
       assert(
         new RegExp(`import { .+ } from "\\.\\/${sharedName}"`).test(async2)
       );
+    });
+
+    it('should generating ESM from CommonJS', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/commonjs-esm/index.js')
+      );
+
+      let dist = await outputFS.readFile(
+        b.getBundles().find(b => b.type === 'js').filePath,
+        'utf8'
+      );
+      assert(dist.includes('import _lodash from "lodash"'));
+      assert(dist.includes('export default'));
     });
   });
 });

--- a/packages/shared/scope-hoisting/src/formats/esmodule.js
+++ b/packages/shared/scope-hoisting/src/formats/esmodule.js
@@ -150,7 +150,14 @@ export function generateExports(
         // Otherwise, add export statements after for each identifier.
       } else {
         if (defaultExport) {
-          path.insertAfter(
+          let binding = path.scope.getBinding(defaultExport);
+          let insertPath = path;
+          if (binding && !binding.constant) {
+            insertPath =
+              binding.constantViolations[binding.constantViolations.length - 1];
+          }
+
+          insertPath.insertAfter(
             t.exportDefaultDeclaration(t.identifier(defaultExport))
           );
         }

--- a/packages/shared/scope-hoisting/src/types.js
+++ b/packages/shared/scope-hoisting/src/types.js
@@ -1,0 +1,13 @@
+// @flow
+import type {ModuleSpecifier, Symbol, Bundle, Asset} from '@parcel/types';
+
+export type ExternalModule = {|
+  source: ModuleSpecifier,
+  specifiers: Map<Symbol, Symbol>,
+  isCommonJS: ?boolean
+|};
+
+export type ExternalBundle = {|
+  bundle: Bundle,
+  assets: Set<Asset>
+|};


### PR DESCRIPTION
This improves support for CommonJS library builds to both ESM and CJS targets

* `require` remains a plain `require` for CJS builds (no ESM namespace import interop wrapper)
* `require` maps to a default `import` for ESM builds (assuming a future tool will perform the CJS interop if needed)
* `module.exports` maps back to `module.exports` for CJS builds
* `module.exports` maps to `export default` for ESM builds

Also improves the output a bit by getting rid of the extra empty objects for the CJS exports object where possible by assigning directly to it when `module.exports` is assigned.