### PR TITLE
Update elm-hot dependency to 1.1.3

### DIFF
--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -93,7 +93,7 @@
     "coffeescript": "^2.0.3",
     "cross-env": "^5.1.1",
     "elm": "^0.19.0-bugfix6",
-    "elm-hot": "^1.0.1",
+    "elm-hot": "^1.1.3",
     "eslint": "^4.13.0",
     "glslify-bundle": "^5.0.0",
     "glslify-deps": "^1.3.0",


### PR DESCRIPTION
elm-hot has been updated to fix compatibility with the Elm 0.19.1 release