### PR TITLE
Fixup: Use bundled babel when asset is not source

### DIFF
--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -17,7 +17,7 @@ export default async function babel7(
   // If this is an internally generated config, use our internal @babel/core,
   // otherwise require a local version from the package we're compiling.
   let babel =
-    asset.isSource || babelOptions.internal
+    !asset.isSource || babelOptions.internal
       ? require('@babel/core')
       : await options.packageManager.require('@babel/core', asset.filePath);
 

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -288,7 +288,7 @@ async function reload(config: Config, options: PluginOptions) {
 }
 
 function loadBabelCore(config: Config, options: PluginOptions): Promise<any> {
-  return config.isSource || config.result?.internal
+  return !config.isSource || config.result?.internal
     ? bundledBabelCore
     : options.packageManager.require('@babel/core', config.searchPath);
 }


### PR DESCRIPTION
This corrects the logic by reversing it.

Test Plan:  Verify auto-install works in a situation where the user has not provided their own copy of @babel/core, but has provided a babel config.