### PR TITLE
Fixup: Simplify bundled babel loading

### DIFF
--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -16,10 +16,9 @@ export default async function babel7(
 ): Promise<?AST> {
   // If this is an internally generated config, use our internal @babel/core,
   // otherwise require a local version from the package we're compiling.
-  let babel =
-    !asset.isSource || babelOptions.internal
-      ? require('@babel/core')
-      : await options.packageManager.require('@babel/core', asset.filePath);
+  let babel = babelOptions.internal
+    ? require('@babel/core')
+    : await options.packageManager.require('@babel/core', asset.filePath);
 
   let config = {
     ...babelOptions.config,


### PR DESCRIPTION
Checking for `!asset.isSource` isn't necessary as this condition also flags `internal` to `true` in `config.js` [0]

Test Plan:
* `yarn test`
* Verify `node_modules` content is transformed with babel in a sample app
* Verify auto-install works in a situation where the user has not provided their own copy of @babel/core, but has provided a babel config.

[0] https://github.com/parcel-bundler/parcel/blob/283af2cef13bbb6b4fad7642e4acecae4f4f7cf1/packages/transformers/babel/src/config.js#L138