### PR TITLE
Fix prevented shutdown by clearing active sockets

### DIFF
--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -1,0 +1,76 @@
+// @flow strict-local
+
+import type {Server as HTTPServer} from 'http';
+import type {Server as HTTPSServer} from 'https';
+import type {Socket} from 'net';
+import type {FilePath, HTTPSOptions} from '@parcel/types';
+import type {FileSystem} from '@parcel/fs';
+
+import http from 'http';
+import https from 'https';
+import nullthrows from 'nullthrows';
+import {getCertificate, generateCertificate} from '../';
+
+type CreateHTTPServerOpts = {|
+  https: ?(HTTPSOptions | boolean),
+  inputFS: FileSystem,
+  outputFS: FileSystem,
+  cacheDir: FilePath,
+  listener?: (mixed, mixed) => void
+|};
+
+// Creates either an http or https server with an awaitable dispose
+// that closes any connections
+export async function createHTTPServer(
+  options: CreateHTTPServerOpts
+): Promise<{|
+  stop: () => Promise<void>,
+  server: HTTPServer | HTTPSServer
+|}> {
+  let server;
+  if (!options.https) {
+    server = http.createServer(options.listener);
+  } else if (options.https === true) {
+    server = https.createServer(
+      await generateCertificate(options.outputFS, options.cacheDir),
+      options.listener
+    );
+  } else {
+    server = https.createServer(
+      await getCertificate(options.inputFS, options.https),
+      options.listener
+    );
+  }
+
+  // HTTPServer#close only stops accepting new connections, and does not close existing ones.
+  // Before closing, destroy any active connections through their sockets. Additionally, remove sockets when they close:
+  // https://stackoverflow.com/questions/18874689/force-close-all-connections-in-a-node-js-http-server
+  // https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately/14636625#14636625
+  let sockets: Set<Socket> = new Set();
+  server.on('connection', (socket: Socket) => {
+    nullthrows(sockets).add(socket);
+    socket.on('close', () => {
+      nullthrows(sockets).delete(socket);
+    });
+  });
+  return {
+    server,
+    stop() {
+      return new Promise((resolve, reject) => {
+        for (let socket of nullthrows(sockets)) {
+          socket.destroy();
+        }
+        sockets = new Set();
+
+        server.close(err => {
+          if (err != null) {
+            reject(err);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    }
+  };
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -31,6 +31,7 @@ export * from './Deferred';
 export * from './glob';
 export * from './md5';
 export * from './schema';
+export * from './http-server';
 export * from './path';
 export * from './replaceBundleReferences';
 export * from './serializer';

--- a/packages/reporters/hmr-server/src/types.js.flow
+++ b/packages/reporters/hmr-server/src/types.js.flow
@@ -1,13 +1,11 @@
 // @flow
 import {
   IncomingMessage as HTTPIncomingMessage,
-  ServerResponse as HTTPServerResponse,
-  Server as HTTPServer
+  ServerResponse as HTTPServerResponse
 } from 'http';
 import {
   IncomingMessage as HTTPSIncomingMessage,
-  ServerResponse as HTTPSServerResponse,
-  Server as HTTPSServer
+  ServerResponse as HTTPSServerResponse
 } from 'https';
 import type {ServerOptions} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
@@ -15,7 +13,6 @@ import type {PluginLogger} from '@parcel/logger';
 
 export type Request = HTTPIncomingMessage | HTTPSIncomingMessage;
 export type Response = HTTPServerResponse | HTTPSServerResponse;
-export type Server = HTTPServer | HTTPSServer;
 
 // TODO: Figure out if there is a node.js type that could be imported with a complete ServerError
 export type ServerError = Error & {|


### PR DESCRIPTION
This fixes an issue in Parcel where an active server prevented shutdown. This was due to `server.close` not actually closing existing connections, but instead stopping accepting new ones, and never calling its callback [0] [1].

This is accomplished by extracting common code for creating an http or https server and returning both the server and an async function for shutting it down, which includes cleaning up these active connections. These sockets need to be stored to be disposed of later, but if they end on their own, they are also removed from the set of active sockets (thanks to both [0] and [1] for pointing this out).

Test Plan:
* Before applying this patch, run the `react-hmr` example and connect to the devserver with a browser. Note that `ctrl-c` no longer properly ends Parcel.
* Apply the patch and repeat. Verify that `ctrl-c` properly ends Parcel.

[0] https://stackoverflow.com/questions/18874689/force-close-all-connections-in-a-node-js-http-server
[1] https://stackoverflow.com/questions/14626636/how-do-i-shutdown-a-node-js-https-server-immediately/14636625#14636625