### PR TITLE
Account for buffered data when determining whether a readable has been read

### DIFF
--- a/packages/core/core/src/InternalAsset.js
+++ b/packages/core/core/src/InternalAsset.js
@@ -127,7 +127,9 @@ export default class InternalAsset {
     if (
       // $FlowFixMe
       typeof contentStream.bytesRead === 'number' &&
-      contentStream.bytesRead > 0
+      // If the amount of data read from this stream so far isn't exactly the amount
+      // of data that is available to be read, then it has been read from.
+      contentStream.bytesRead !== contentStream.readableLength
     ) {
       throw new Error(
         'Stream has already been read. This may happen if a plugin reads from a stream and does not replace it.'


### PR DESCRIPTION
Read streams appear to eagerly buffer some data even before they're read from, surfacing the size of this buffer in `readableLength`. Account for this when determining whether a readable stream has been read from.

If someone has insight into how to do this better, I'm definitely open.

Test Plan: 
* Added an integration test for large raw assets
* Prior to this patch, import a large static asset and verify this error: `🚨 Error: Stream has already been read. This may happen if a plugin reads from a stream and does not replace it.`
* Apply the patch, and verify bundles are produced alongside the static asset copied to the dist directory.

cc @bvaughn