### PR TITLE
Use `main` over `module` for development builds for performance

### DIFF
--- a/packages/core/integration-tests/test/integration/require-async/async.js
+++ b/packages/core/integration-tests/test/integration/require-async/async.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/packages/core/integration-tests/test/integration/require-async/parcel.js
+++ b/packages/core/integration-tests/test/integration/require-async/parcel.js
@@ -1,0 +1,1 @@
+module.exports = Promise.resolve(require('./async'));

--- a/packages/core/integration-tests/test/integration/require-async/rollup.js
+++ b/packages/core/integration-tests/test/integration/require-async/rollup.js
@@ -1,0 +1,1 @@
+module.exports = new Promise(function (resolve) { resolve(require('./async')); });

--- a/packages/core/integration-tests/test/integration/require-async/ts.js
+++ b/packages/core/integration-tests/test/integration/require-async/ts.js
@@ -1,0 +1,1 @@
+module.exports = Promise.resolve().then(function () { return require('./async'); });

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1803,4 +1803,58 @@ describe('javascript', function() {
 
     assert((await run(b)).default.startsWith('data:image/webp;base64,UklGR'));
   });
+
+  it('should detect typescript style async requires in commonjs', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/require-async/ts.js')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'ts.js',
+        assets: ['ts.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js']
+      },
+      {
+        assets: ['async.js']
+      }
+    ]);
+
+    assert.equal(await run(b), 2);
+  });
+
+  it('should detect rollup style async requires in commonjs', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/require-async/rollup.js')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'rollup.js',
+        assets: ['rollup.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js']
+      },
+      {
+        assets: ['async.js']
+      }
+    ]);
+
+    assert.equal(await run(b), 2);
+  });
+
+  it('should detect parcel style async requires in commonjs', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/require-async/parcel.js')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'parcel.js',
+        assets: ['parcel.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js']
+      },
+      {
+        assets: ['async.js']
+      }
+    ]);
+
+    assert.equal(await run(b), 2);
+  });
 });

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -448,10 +448,20 @@ class NodeResolver {
       }
     }
 
+    let mainFields = [pkg.source, browser];
+
+    // If scope hoisting is enabled, we can get smaller builds using esmodule input, so choose `module` over `main`.
+    // Otherwise, we'd be wasting time transforming esmodules to commonjs, so choose `main` over `module`.
+    if (this.options.scopeHoist) {
+      mainFields.push(pkg.module, pkg.main);
+    } else {
+      mainFields.push(pkg.main, pkg.module);
+    }
+
     // libraries like d3.js specifies node.js specific files in the "main" which breaks the build
     // we use the "browser" or "module" field to get the full dependency tree if available.
     // If this is a linked module with a `source` field, use that as the entry point.
-    return [pkg.source, browser, pkg.module, pkg.main]
+    return mainFields
       .filter(entry => typeof entry === 'string')
       .map(main => {
         // Default to index file if no main field find


### PR DESCRIPTION
This optimizes performance for development builds by using the `main` entry in package.json over `module`. `module` is important when using scope hoisting to get smaller builds, but results in needing to compile ES modules down to CommonJS with babel in development builds which can be slow. By using `main` over `module`, we can avoid this cost by using pre-compiled CommonJS modules instead.

On a stress test, this improved performance by ~30%, taking ~10s off the total build time.

Some extra logic is added here to detect common patterns using by compilers when building code with async `import()` to CommonJS. In particular, we handle patterns generated by TypeScript, Rollup, and Parcel itself. This way we can still get code splitting even with precompiled modules.