### PR TITLE
Emit JSON.parse("...") for JSON assets

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1269,17 +1269,23 @@ describe('javascript', function() {
   });
 
   it('should minify JSON files', async function() {
-    await bundle(path.join(__dirname, '/integration/uglify-json/index.json'), {
-      minify: true,
-      scopeHoist: false
-    });
+    let b = await bundle(
+      path.join(__dirname, '/integration/uglify-json/index.json'),
+      {
+        minify: true,
+        scopeHoist: false
+      }
+    );
 
     let json = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(json.includes('{test:"test"}'));
+    assert(json.includes('{"test":"test"}'));
+
+    let output = await run(b);
+    assert.deepEqual(output, {test: 'test'});
   });
 
   it('should minify JSON5 files', async function() {
-    await bundle(
+    let b = await bundle(
       path.join(__dirname, '/integration/uglify-json5/index.json5'),
       {
         minify: true,
@@ -1288,7 +1294,10 @@ describe('javascript', function() {
     );
 
     let json = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(json.includes('{test:"test"}'));
+    assert(json.includes('{"test":"test"}'));
+
+    let output = await run(b);
+    assert.deepEqual(output, {test: 'test'});
   });
 
   it.skip('should minify YAML for production', async function() {

--- a/packages/transformers/json/src/JSONTransformer.js
+++ b/packages/transformers/json/src/JSONTransformer.js
@@ -6,12 +6,13 @@ import json5 from 'json5';
 export default new Transformer({
   async transform({asset}) {
     asset.type = 'js';
+    // Use JSON.parse("...") for faster script parsing, see
+    // https://v8.dev/blog/cost-of-javascript-2019#json.
+    // Apply `JSON.stringify` twice to make it a valid string literal.
     asset.setCode(
-      `module.exports = ${JSON.stringify(
-        json5.parse(await asset.getCode()),
-        null,
-        2
-      )};`
+      `module.exports = JSON.parse(${JSON.stringify(
+        JSON.stringify(json5.parse(await asset.getCode()))
+      )});`
     );
     return [asset];
   }


### PR DESCRIPTION
# ↪️ Pull Request

In every major JS engine, parsing a JSON object is slower than parsing and executing `JSON.parse("...")`:

- https://v8.dev/blog/cost-of-javascript-2019#json
- https://github.com/GoogleChromeLabs/json-parse-benchmark
- https://github.com/webpack/webpack/pull/9349
- https://joreteg.com/blog/improving-redux-state-transfer-performance