### PR TITLE
Throttle ink reporter rendering to 100ms for better performance

### DIFF
--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -701,6 +701,7 @@ export type Resolver = {|
 export type ProgressLogEvent = {|
   +type: 'log',
   +level: 'progress',
+  +phase?: string,
   +message: string
 |};
 

--- a/packages/core/utils/src/debounce.js
+++ b/packages/core/utils/src/debounce.js
@@ -1,0 +1,19 @@
+// @flow strict-local
+
+export default function debounce<TArgs: Array<mixed>>(
+  fn: (...args: TArgs) => mixed,
+  delay: number
+): (...args: TArgs) => void {
+  let timeout;
+
+  return function(...args: TArgs) {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+
+    timeout = setTimeout(() => {
+      timeout = null;
+      fn(...args);
+    }, delay);
+  };
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -23,6 +23,8 @@ export {default as TapStream} from './TapStream';
 export {default as urlJoin} from './urlJoin';
 export {default as loadSourceMapUrl} from './loadSourceMapUrl';
 export {default as relativeUrl} from './relativeUrl';
+export {default as debounce} from './debounce';
+export {default as throttle} from './throttle';
 
 export * from './blob';
 export * from './collection';

--- a/packages/core/utils/src/throttle.js
+++ b/packages/core/utils/src/throttle.js
@@ -1,0 +1,19 @@
+// @flow strict-local
+
+export default function throttle<TArgs: Iterable<mixed>>(
+  fn: (...args: TArgs) => mixed,
+  delay: number
+): (...args: TArgs) => void {
+  let timeout;
+
+  return function(...args: TArgs) {
+    if (timeout) {
+      return;
+    }
+
+    timeout = setTimeout(() => {
+      timeout = null;
+      fn(...args);
+    }, delay);
+  };
+}


### PR DESCRIPTION
# ↪️ Pull Request

We found during profiling that a significant amount of time is spent in the cli reporter's `dispatch` action from `useReducer`. Throttling this dispatch improved performance for the stress test by about 16% on my machine, reducing it by about 5.7s. Not reporting transformation progress events at all would improve performance by about double these amounts, but then there is no user feedback that Parcel is progressing. Throttling at 100ms seems to be a pretty good sweet spot, going any higher starts to look less responsive.
