### PR TITLE
Improve diagnostics for target/namer related issues

### DIFF
--- a/flow-libs/ink.js.flow
+++ b/flow-libs/ink.js.flow
@@ -26,7 +26,16 @@ declare module 'ink' {
     cyan?: boolean,
     magenta?: boolean,
     reset?: boolean,
-    yellow?: boolean
+    yellow?: boolean,
+    blue?: boolean,
+    blackBright?: boolean,
+    redBright?: boolean,
+    greenBright?: boolean,
+    yellowBright?: boolean,
+    blueBright?: boolean,
+    magentaBright?: boolean,
+    cyanBright?: boolean,
+    whiteBright?: boolean,
   |};
   declare export var Color: React$ComponentType<ColorProps>;
   // https://github.com/vadimdemedes/ink#static

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -33,6 +33,7 @@
     "dotenv": "^7.0.0",
     "dotenv-expand": "^5.1.0",
     "json5": "^1.0.1",
+    "json-source-map": "^0.6.1",
     "micromatch": "^4.0.2",
     "nullthrows": "^1.1.1",
     "pirates": "^4.0.0",

--- a/packages/core/core/src/public/Target.js
+++ b/packages/core/core/src/public/Target.js
@@ -45,4 +45,8 @@ export default class Target implements ITarget {
   get publicUrl(): ?string {
     return this.#target.publicUrl;
   }
+
+  get loc() {
+    return this.#target.loc;
+  }
 }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -44,7 +44,8 @@ export type Target = {|
   env: Environment,
   sourceMap?: TargetSourceMapOptions,
   name: string,
-  publicUrl: ?string
+  publicUrl: ?string,
+  loc?: ?SourceLocation
 |};
 
 export type Dependency = {|

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -680,8 +680,9 @@ describe('TargetResolver', () => {
     await assert.rejects(() => targetResolver.resolve(fixture), {
       diagnostics: [
         {
-          message:
-            'Multiple targets have the same destination path "dist/index.js"',
+          message: `Multiple targets have the same destination path "${path.normalize(
+            'dist/index.js'
+          )}"`,
           origin: '@parcel/core',
           filePath: path.join(fixture, 'package.json'),
           language: 'json',

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -126,7 +126,18 @@ describe('TargetResolver', () => {
               outputFormat: 'commonjs',
               isLibrary: true
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 11,
+                line: 2
+              },
+              end: {
+                column: 30,
+                line: 2
+              }
+            }
           },
           {
             name: 'module',
@@ -147,6 +158,17 @@ describe('TargetResolver', () => {
             },
             sourceMap: {
               inlineSources: true
+            },
+            loc: {
+              filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 13,
+                line: 3
+              },
+              end: {
+                column: 34,
+                line: 3
+              }
             }
           },
           {
@@ -166,7 +188,18 @@ describe('TargetResolver', () => {
               outputFormat: 'commonjs',
               isLibrary: true
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 14,
+                line: 4
+              },
+              end: {
+                column: 36,
+                line: 4
+              }
+            }
           }
         ]
       }
@@ -196,7 +229,18 @@ describe('TargetResolver', () => {
               outputFormat: 'commonjs',
               isLibrary: true
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 11,
+                line: 2
+              },
+              end: {
+                column: 30,
+                line: 2
+              }
+            }
           },
           {
             name: 'browserModern',
@@ -215,7 +259,18 @@ describe('TargetResolver', () => {
               outputFormat: 'global',
               isLibrary: false
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 20,
+                line: 3
+              },
+              end: {
+                column: 48,
+                line: 3
+              }
+            }
           },
           {
             name: 'browserLegacy',
@@ -234,7 +289,18 @@ describe('TargetResolver', () => {
               outputFormat: 'global',
               isLibrary: false
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 20,
+                line: 4
+              },
+              end: {
+                column: 48,
+                line: 4
+              }
+            }
           }
         ]
       }
@@ -265,7 +331,60 @@ describe('TargetResolver', () => {
             isLibrary: true,
             outputFormat: 'commonjs'
           },
-          sourceMap: undefined
+          sourceMap: undefined,
+          loc: {
+            filePath: path.join(CONTEXT_FIXTURE_PATH, 'package.json'),
+            start: {
+              column: 11,
+              line: 2
+            },
+            end: {
+              column: 30,
+              line: 2
+            }
+          }
+        }
+      ]
+    });
+  });
+
+  it('resolves main target as an application when non-js file extension is used', async () => {
+    let targetResolver = new TargetResolver(DEFAULT_OPTIONS);
+    let fixture = path.join(__dirname, 'fixtures/application-targets');
+    assert.deepEqual(await targetResolver.resolve(fixture), {
+      files: [{filePath: path.join(fixture, 'package.json')}],
+      targets: [
+        {
+          name: 'main',
+          distDir: path.join(fixture, 'dist'),
+          distEntry: 'index.html',
+          publicUrl: '/',
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: [
+                'last 1 Chrome version',
+                'last 1 Safari version',
+                'last 1 Firefox version',
+                'last 1 Edge version'
+              ]
+            },
+            includeNodeModules: true,
+            isLibrary: false,
+            outputFormat: 'global'
+          },
+          sourceMap: undefined,
+          loc: {
+            filePath: path.join(fixture, 'package.json'),
+            start: {
+              column: 11,
+              line: 2
+            },
+            end: {
+              column: 27,
+              line: 2
+            }
+          }
         }
       ]
     });
@@ -298,7 +417,18 @@ describe('TargetResolver', () => {
               outputFormat: 'commonjs',
               isLibrary: true
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 11,
+                line: 2
+              },
+              end: {
+                column: 30,
+                line: 2
+              }
+            }
           },
           {
             name: 'browser',
@@ -317,7 +447,18 @@ describe('TargetResolver', () => {
               outputFormat: 'commonjs',
               isLibrary: true
             },
-            sourceMap: undefined
+            sourceMap: undefined,
+            loc: {
+              filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
+              start: {
+                column: 14,
+                line: 4
+              },
+              end: {
+                column: 36,
+                line: 4
+              }
+            }
           }
         ]
       }
@@ -526,5 +667,56 @@ describe('TargetResolver', () => {
         ]
       }
     );
+  });
+
+  it('rejects duplicate target paths', async () => {
+    let fixture = path.join(__dirname, 'fixtures/duplicate-targets');
+    let targetResolver = new TargetResolver(DEFAULT_OPTIONS);
+    let code = await fs.readFileSync(
+      path.join(fixture, 'package.json'),
+      'utf8'
+    );
+    // $FlowFixMe assert.rejects is Node 10+
+    await assert.rejects(() => targetResolver.resolve(fixture), {
+      diagnostics: [
+        {
+          message:
+            'Multiple targets have the same destination path "dist/index.js"',
+          origin: '@parcel/core',
+          filePath: path.join(fixture, 'package.json'),
+          language: 'json',
+          codeFrame: {
+            code,
+            codeHighlights: [
+              {
+                end: {
+                  column: 25,
+                  line: 2
+                },
+                message: undefined,
+                start: {
+                  column: 11,
+                  line: 2
+                }
+              },
+              {
+                end: {
+                  column: 27,
+                  line: 3
+                },
+                message: undefined,
+                start: {
+                  column: 13,
+                  line: 3
+                }
+              }
+            ]
+          },
+          hints: [
+            'Try removing the duplicate targets, or changing the destination paths.'
+          ]
+        }
+      ]
+    });
   });
 });

--- a/packages/core/core/test/fixtures/application-targets/package.json
+++ b/packages/core/core/test/fixtures/application-targets/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "dist/index.html"
+}

--- a/packages/core/core/test/fixtures/duplicate-targets/package.json
+++ b/packages/core/core/test/fixtures/duplicate-targets/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/index.js",
+  "module": "dist/index.js"
+}

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -30,7 +30,7 @@ export type DiagnosticCodeFrame = {|
 // The reporter's are responsible for rendering the message, codeframes, hints, ...
 export type Diagnostic = {|
   message: string,
-  origin: string, // Name of plugin or file that threw this error
+  origin?: string, // Name of plugin or file that threw this error
 
   // basic error data
   stack?: string,
@@ -171,25 +171,29 @@ export function generateJSONCodeHighlights(
   let map = jsonMap.parse(code.replace(/\t/g, ' '));
   return ids.map(({key, type, message}) => {
     let pos = nullthrows(map.pointers[key]);
-    if (!type && pos.value) {
-      // key and value
-      return {
-        start: {line: pos.key.line + 1, column: pos.key.column + 1},
-        end: {line: pos.valueEnd.line + 1, column: pos.valueEnd.column},
-        message
-      };
-    } else if (type == 'key' || !pos.value) {
-      return {
-        start: {line: pos.key.line + 1, column: pos.key.column + 1},
-        end: {line: pos.keyEnd.line + 1, column: pos.keyEnd.column},
-        message
-      };
-    } else {
-      return {
-        start: {line: pos.value.line + 1, column: pos.value.column + 1},
-        end: {line: pos.valueEnd.line + 1, column: pos.valueEnd.column},
-        message
-      };
-    }
+    return {
+      ...getJSONSourceLocation(pos, type),
+      message
+    };
   });
+}
+
+export function getJSONSourceLocation(pos: any, type?: ?'key' | 'value') {
+  if (!type && pos.value) {
+    // key and value
+    return {
+      start: {line: pos.key.line + 1, column: pos.key.column + 1},
+      end: {line: pos.valueEnd.line + 1, column: pos.valueEnd.column}
+    };
+  } else if (type == 'key' || !pos.value) {
+    return {
+      start: {line: pos.key.line + 1, column: pos.key.column + 1},
+      end: {line: pos.keyEnd.line + 1, column: pos.keyEnd.column}
+    };
+  } else {
+    return {
+      start: {line: pos.value.line + 1, column: pos.value.column + 1},
+      end: {line: pos.valueEnd.line + 1, column: pos.valueEnd.column}
+    };
+  }
 }

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -152,7 +152,7 @@ async function run(entries: Array<string>, command: any) {
         __filename
       )).resolved
     },
-    patchConsole: false,
+    patchConsole: true,
     ...(await normalizeOptions(command))
   });
 

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -73,6 +73,7 @@ export interface Target {
   +sourceMap: ?TargetSourceMapOptions;
   +name: string;
   +publicUrl: ?string;
+  +loc: ?SourceLocation;
 }
 
 export type EnvironmentContext =

--- a/packages/core/utils/src/prettyDiagnostic.js
+++ b/packages/core/utils/src/prettyDiagnostic.js
@@ -35,7 +35,8 @@ export default function prettyDiagnostic(
   };
 
   result.message =
-    mdAnsi(`**${origin}**: `) + (skipFormatting ? message : mdAnsi(message));
+    mdAnsi(`**${origin ?? 'unknown'}**: `) +
+    (skipFormatting ? message : mdAnsi(message));
   result.stack = stack || '';
 
   if (codeFrame !== undefined) {

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -15,6 +15,7 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
+    "@parcel/diagnostic": "^2.0.0-alpha.3",
     "@parcel/plugin": "^2.0.0-alpha.3.1",
     "nullthrows": "^1.1.1"
   }

--- a/packages/reporters/cli/src/Log.js
+++ b/packages/reporters/cli/src/Log.js
@@ -60,8 +60,9 @@ export function Log({event}: LogProps) {
 function Hints({hints}: {hints: Array<string>, ...}) {
   return (
     <div>
+      {' ' /* spacer */}
       {hints.map((hint, i) => {
-        return <div key={i}>{`- ${hint}`}</div>;
+        return <Color blue bold key={i}>{`${Emoji.hint}  ${hint}`}</Color>;
       })}
     </div>
   );
@@ -84,8 +85,9 @@ function DiagnosticContainer({
 
         return (
           <div key={i}>
+            {i > 0 ? ' ' : '' /* spacer */}
             <Color keyword={color}>
-              <Color bold>{`${emoji}`}</Color> {message}
+              <Color bold>{`${emoji} `}</Color> {message}
             </Color>
             {!codeframe && stack && (
               <div>

--- a/packages/reporters/cli/src/emoji.js
+++ b/packages/reporters/cli/src/emoji.js
@@ -9,3 +9,4 @@ export const success = supportsEmoji ? '✨' : '√';
 export const error = supportsEmoji ? '🚨' : '×';
 export const warning = supportsEmoji ? '⚠️' : '‼';
 export const info = supportsEmoji ? 'ℹ️' : 'ℹ';
+export const hint = supportsEmoji ? '💡' : 'ℹ';


### PR DESCRIPTION
This adds improved diagnostics for a few target configuration/namer related issues that have come up frequently.

* #3500 - `Destination name index.js extension does not match bundle type "html"`. This was likely due to having a `main` in package.json for example, which pointed to a `.js` file instead of a `.html` file. However, it was not very clear without knowing about the internals of Parcel. The new error message should point directly to the configuration error:

    <img width="822" alt="image" src="https://user-images.githubusercontent.com/19409/69931848-c15d7980-1496-11ea-8ade-850d5e83bc62.png">

    This is made possible by adding a `loc` property to `Target` objects to track the package.json source location they are defined in. This can be used to construct a diagnostic in the namer. Hopefully this makes it much clearer what the problem is an how to fix it.

* #3816 - `External modules are not supported when building for browser`. This could happen when using an HTML target in the `main` or `browser` field in package.json. Those fields put you into library mode, and compile to CommonJS. This behavior is now disabled automatically if the file extension of the target is not `.js`, so putting an HTML file in those fields should now work out of the box.

* #3442 - `Bundles must have unique filePaths`. This could happen if you declared multiple targets in package.json pointing to the same dist path. The TargetResolver now checks for this case and provides a diagnostic early rather than waiting for the namer to return duplicates later.

    <img width="822" alt="image" src="https://user-images.githubusercontent.com/19409/69932885-cd4b3a80-149a-11ea-9128-8b87bf8979ec.png">

cc. @sw-yx since you seem to have come across several of these