### PR TITLE
Detect TypeScript esModuleInterop generated async imports and rewrite

### DIFF
--- a/packages/core/integration-tests/test/integration/require-async/ts-interop-arrow.js
+++ b/packages/core/integration-tests/test/integration/require-async/ts-interop-arrow.js
@@ -1,0 +1,9 @@
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+module.exports = Promise.resolve().then(() => __importStar(require('./async')));

--- a/packages/core/integration-tests/test/integration/require-async/ts-interop-arrow.js
+++ b/packages/core/integration-tests/test/integration/require-async/ts-interop-arrow.js
@@ -1,3 +1,4 @@
+// TypeScript's esModuleInterop flag generates code like this when compiling dynamic import()
 "use strict";
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;

--- a/packages/core/integration-tests/test/integration/require-async/ts-interop.js
+++ b/packages/core/integration-tests/test/integration/require-async/ts-interop.js
@@ -1,0 +1,9 @@
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+module.exports = Promise.resolve().then(function () { return __importStar(require('./async')); });

--- a/packages/core/integration-tests/test/integration/require-async/ts-interop.js
+++ b/packages/core/integration-tests/test/integration/require-async/ts-interop.js
@@ -1,3 +1,4 @@
+// TypeScript's esModuleInterop flag generates code like this when compiling dynamic import()
 "use strict";
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1831,6 +1831,60 @@ describe('javascript', function() {
     assert.equal(await run(b), 2);
   });
 
+  it('should detect typescript style async requires in commonjs with esModuleInterop flag', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/require-async/ts-interop.js')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'ts-interop.js',
+        assets: [
+          'ts-interop.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js'
+        ]
+      },
+      {
+        assets: ['async.js']
+      }
+    ]);
+
+    assert.deepEqual(await run(b), {default: 2});
+
+    let jsBundle = b.getBundles()[0];
+    let contents = await outputFS.readFile(jsBundle.filePath, 'utf8');
+    assert(/.then\(function \(\$parcel\$.*?\) {/.test(contents));
+  });
+
+  it('should detect typescript style async requires in commonjs with esModuleInterop flag and arrow functions', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/require-async/ts-interop-arrow.js')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'ts-interop-arrow.js',
+        assets: [
+          'ts-interop-arrow.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js'
+        ]
+      },
+      {
+        assets: ['async.js']
+      }
+    ]);
+
+    assert.deepEqual(await run(b), {default: 2});
+
+    let jsBundle = b.getBundles()[0];
+    let contents = await outputFS.readFile(jsBundle.filePath, 'utf8');
+    assert(/.then\(\$parcel\$.*? =>/.test(contents));
+  });
+
   it('should detect rollup style async requires in commonjs', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/require-async/rollup.js')

--- a/packages/transformers/js/src/visitors/env.js
+++ b/packages/transformers/js/src/visitors/env.js
@@ -1,4 +1,5 @@
 import * as types from '@babel/types';
+import {morph} from './utils';
 
 export default {
   MemberExpression(node, {asset, env}) {
@@ -19,14 +20,3 @@ export default {
     }
   }
 };
-
-// replace object properties
-function morph(object, newProperties) {
-  for (let key in object) {
-    delete object[key];
-  }
-
-  for (let key in newProperties) {
-    object[key] = newProperties[key];
-  }
-}

--- a/packages/transformers/js/src/visitors/utils.js
+++ b/packages/transformers/js/src/visitors/utils.js
@@ -26,3 +26,14 @@ export function hasBinding(node, name) {
 
   return false;
 }
+
+// replace object properties
+export function morph(object, newProperties) {
+  for (let key in object) {
+    delete object[key];
+  }
+
+  for (let key in newProperties) {
+    object[key] = newProperties[key];
+  }
+}


### PR DESCRIPTION
The TypeScript `esModuleInterop` flag generates async imports that look like this:

```js
Promise.resolve().then(function () { return __importStar(require('./foo')); });
```

Parcel correctly identifies this pattern as async, but the `__importStar` function doesn't work properly since the `require` will return a promise instead of the module synchronously. The solution is to transform this to a promise chain like this:

```js
Promise.resolve().then(function () {
  return require('./foo');
}).then(function ($parcel$f84b) {
  return __importStar($parcel$f84b);
});
```

This way the `__importStar` operates on the result of the promise returned from `require` instead of the promise itself. This is only done if the `require` is not immediately returned without a wrapper, so we should only pay a slight perf hit when needed.

The overall performance of building atlaskit editor is almost the same with this (< 1s difference), so still much faster than compiling from ES modules.