### PR TITLE
Upgrade Flow to 0.113 and remove index stubs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -35,4 +35,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.112.0
+0.113.0

--- a/.flowconfig
+++ b/.flowconfig
@@ -23,6 +23,8 @@ untyped-type-import=error
 esproposal.export_star_as=enable
 esproposal.nullish_coalescing=enable
 esproposal.optional_chaining=enable
+module.system.node.main_field=source
+module.system.node.main_field=main
 
 [strict]
 nonstrict-import

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "doctoc": "^1.4.0",
     "eslint": "^5.16.0",
-    "flow-bin": "0.112.0",
+    "flow-bin": "0.113.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",

--- a/packages/bundlers/default/index.js
+++ b/packages/bundlers/default/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/DefaultBundler.js';

--- a/packages/core/cache/index.js
+++ b/packages/core/cache/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/Cache.js';

--- a/packages/core/codeframe/index.js
+++ b/packages/core/codeframe/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/codeframe';

--- a/packages/core/core/index.js
+++ b/packages/core/core/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/core/diagnostic/index.js
+++ b/packages/core/diagnostic/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/diagnostic';

--- a/packages/core/fs/index.js
+++ b/packages/core/fs/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/core/logger/index.js
+++ b/packages/core/logger/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/Logger.js';

--- a/packages/core/markdown-ansi/index.js
+++ b/packages/core/markdown-ansi/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/markdown-ansi';

--- a/packages/core/package-manager/index.js
+++ b/packages/core/package-manager/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/core/plugin/index.js
+++ b/packages/core/plugin/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/PluginAPI.js';

--- a/packages/core/register/index.js
+++ b/packages/core/register/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/register.js';

--- a/packages/core/source-map/index.js
+++ b/packages/core/source-map/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/SourceMap.js';

--- a/packages/core/test-utils/index.js
+++ b/packages/core/test-utils/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/utils.js';

--- a/packages/core/utils/index.js
+++ b/packages/core/utils/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/core/workers/index.js
+++ b/packages/core/workers/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/namers/default/index.js
+++ b/packages/namers/default/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/DefaultNamer.js';

--- a/packages/optimizers/blob-url/index.js
+++ b/packages/optimizers/blob-url/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/BlobURLOptimizer.js';

--- a/packages/optimizers/cssnano/index.js
+++ b/packages/optimizers/cssnano/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/CSSNanoOptimizer.js';

--- a/packages/optimizers/data-url/index.js
+++ b/packages/optimizers/data-url/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/DataURLOptimizer.js';

--- a/packages/optimizers/terser/index.js
+++ b/packages/optimizers/terser/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/TerserOptimizer.js';

--- a/packages/packagers/css/index.js
+++ b/packages/packagers/css/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/CSSPackager.js';

--- a/packages/packagers/html/index.js
+++ b/packages/packagers/html/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/HTMLPackager.js';

--- a/packages/packagers/js/index.js
+++ b/packages/packagers/js/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/JSPackager.js';

--- a/packages/packagers/raw/index.js
+++ b/packages/packagers/raw/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/RawPackager.js';

--- a/packages/packagers/ts/index.js
+++ b/packages/packagers/ts/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/TSPackager.js';

--- a/packages/reporters/build-metrics/index.js
+++ b/packages/reporters/build-metrics/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/BuildMetricsReporter.js';

--- a/packages/reporters/cli/index.js
+++ b/packages/reporters/cli/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/reporters/dev-server/index.js
+++ b/packages/reporters/dev-server/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/ServerReporter.js';

--- a/packages/reporters/hmr-server/index.js
+++ b/packages/reporters/hmr-server/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/HMRReporter.js';

--- a/packages/reporters/json/index.js
+++ b/packages/reporters/json/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/JSONReporter.js';

--- a/packages/resolvers/default/index.js
+++ b/packages/resolvers/default/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/DefaultResolver.js';

--- a/packages/runtimes/hmr/index.js
+++ b/packages/runtimes/hmr/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/HMRRuntime.js';

--- a/packages/runtimes/js/index.js
+++ b/packages/runtimes/js/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/JSRuntime.js';

--- a/packages/shared/scope-hoisting/index.js
+++ b/packages/shared/scope-hoisting/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/transformers/babel/index.js
+++ b/packages/transformers/babel/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/BabelTransformer.js';

--- a/packages/transformers/coffeescript/index.js
+++ b/packages/transformers/coffeescript/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/CoffeeScriptTransformer.js';

--- a/packages/transformers/css/index.js
+++ b/packages/transformers/css/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/CSSTransformer.js';

--- a/packages/transformers/html/index.js
+++ b/packages/transformers/html/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/HTMLTransformer.js';

--- a/packages/transformers/inline-string/index.js
+++ b/packages/transformers/inline-string/index.js
@@ -1,1 +1,0 @@
-export * from './src/InlineStringTransformer';

--- a/packages/transformers/inline/index.js
+++ b/packages/transformers/inline/index.js
@@ -1,1 +1,0 @@
-export * from './src/InlineTransformer';

--- a/packages/transformers/js/index.js
+++ b/packages/transformers/js/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/JSTransformer.js';

--- a/packages/transformers/json/index.js
+++ b/packages/transformers/json/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/JSONTransformer.js';

--- a/packages/transformers/less/index.js
+++ b/packages/transformers/less/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/LessTransformer.js';

--- a/packages/transformers/postcss/index.js
+++ b/packages/transformers/postcss/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/PostCSSTransformer.js';

--- a/packages/transformers/posthtml/index.js
+++ b/packages/transformers/posthtml/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/PostHTMLTransformer.js';

--- a/packages/transformers/pug/index.js
+++ b/packages/transformers/pug/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/PugTransformer.js';

--- a/packages/transformers/raw/index.js
+++ b/packages/transformers/raw/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/RawTransformer.js';

--- a/packages/transformers/sass/index.js
+++ b/packages/transformers/sass/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/SassTransformer.js';

--- a/packages/transformers/stylus/index.js
+++ b/packages/transformers/stylus/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/StylusTransformer.js';

--- a/packages/transformers/sugarss/index.js
+++ b/packages/transformers/sugarss/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/SugarssTransformer.js';

--- a/packages/transformers/toml/index.js
+++ b/packages/transformers/toml/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/TOMLTransformer.js';

--- a/packages/transformers/typescript-tsc/index.js
+++ b/packages/transformers/typescript-tsc/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/TSCTransformer.js';

--- a/packages/transformers/typescript-types/index.js
+++ b/packages/transformers/typescript-types/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/TSTypesTransformer.js';

--- a/packages/transformers/yaml/index.js
+++ b/packages/transformers/yaml/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/YAMLTransformer.js';

--- a/packages/utils/events/index.js
+++ b/packages/utils/events/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/utils/ts-utils/index.js
+++ b/packages/utils/ts-utils/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/index.js';

--- a/packages/validators/eslint/index.js
+++ b/packages/validators/eslint/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/EslintValidator.js';

--- a/packages/validators/typescript/index.js
+++ b/packages/validators/typescript/index.js
@@ -1,2 +1,0 @@
-// @flow
-export * from './src/TypeScriptValidator.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5649,10 +5649,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@0.112.0:
-  version "0.112.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.112.0.tgz#6a21c31937c4a2f23a750056a364c598a95ea216"
-  integrity sha512-vdcuKv0UU55vjv0e2EVh1ZxlU+TSNT19SkE+6gT1vYzTKtzYE6dLuAmBIiS3Rg2N9D9HOI6TKSyl53zPtqZLrA==
+flow-bin@0.113.0:
+  version "0.113.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.113.0.tgz#6457d250dbc6f71ca51e75f00a96d23cde5d987a"
+  integrity sha512-76uE2LGNe50wm+Jup8Np4FBcMbyy5V2iE+K25PPIYLaEMGHrL1jnQfP9L0hTzA5oh2ZJlexRLMlaPqIYIKH9nw==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This upgrades Flow to version 0.113, which did not introduce any breakages. It does introduce `module.system.node.main_field` (thanks @mischnic!) as a way of specifying which package.json field should be used as a module entry in Flow [0].

This PR configures Flow to use `source` as a main entry with priority over `main`, and removes the `index.js` stubs that we had in place to address this before.

Test Plan: `yarn flow`, `yarn lint`, `yarn test`

[0] https://flow.org/en/docs/config/options/#toc-module-system-node-main-field-string