### PR TITLE
[T-206] Validate .parcelrc using the JSON Schema validator

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -1,6 +1,6 @@
 {
   "bundler": "@parcel/bundler-default",
-  "transforms": {
+  "transformss": {
     "types:*.{ts,tsx}": ["@parcel/transformer-typescript-types"],
     "bundle-text:*": ["@parcel/transformer-inline-string", "..."],
     "data-url:*": ["@parcel/transformer-inline-string", "..."],

--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -1,6 +1,6 @@
 {
   "bundler": "@parcel/bundler-default",
-  "transformss": {
+  "transforms": {
     "types:*.{ts,tsx}": ["@parcel/transformer-typescript-types"],
     "bundle-text:*": ["@parcel/transformer-inline-string", "..."],
     "data-url:*": ["@parcel/transformer-inline-string", "..."],

--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -1,0 +1,62 @@
+// @flow strict-local
+import type {SchemaEntity} from '@parcel/utils';
+
+const PipelineSchema: SchemaEntity = {
+  type: 'array',
+  items: {
+    type: 'string'
+  }
+};
+
+const MapPipelineSchema: SchemaEntity = {
+  type: 'object',
+  properties: {},
+  additionalProperties: PipelineSchema
+};
+
+const MapStringSchema: SchemaEntity = {
+  type: 'object',
+  properties: {},
+  additionalProperties: {
+    type: 'string'
+  }
+};
+
+const ConfigBase: SchemaEntity = {
+  type: 'object',
+  properties: {
+    extends: {
+      oneOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
+      ]
+    },
+    bundler: {
+      type: 'string'
+    },
+    resolvers: PipelineSchema,
+    transforms: MapPipelineSchema,
+    validators: MapPipelineSchema,
+    namers: PipelineSchema,
+    packagers: MapStringSchema,
+    optimizers: MapPipelineSchema,
+    reporters: PipelineSchema,
+    runtimes: MapPipelineSchema,
+    filePath: {
+      type: 'string'
+    },
+    resolveFrom: {
+      type: 'string'
+    }
+  },
+  additionalProperties: false
+};
+
+export default ConfigBase;

--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -1,62 +1,117 @@
 // @flow strict-local
+import type {FilePath} from '@parcel/types';
 import type {SchemaEntity} from '@parcel/utils';
+import {validatePackageName} from './loadParcelConfig';
 
-const PipelineSchema: SchemaEntity = {
-  type: 'array',
-  items: {
-    type: 'string'
-  }
-};
+const validatePluginName = (
+  pluginType: string,
+  key: string,
+  relativePath: FilePath
+) => {
+  return (val: string) => {
+    // Skip plugin spread...
+    if (val === '...') return;
 
-const MapPipelineSchema: SchemaEntity = {
-  type: 'object',
-  properties: {},
-  additionalProperties: PipelineSchema
-};
-
-const MapStringSchema: SchemaEntity = {
-  type: 'object',
-  properties: {},
-  additionalProperties: {
-    type: 'string'
-  }
-};
-
-const ConfigBase: SchemaEntity = {
-  type: 'object',
-  properties: {
-    extends: {
-      oneOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'array',
-          items: {
-            type: 'string'
-          }
-        }
-      ]
-    },
-    bundler: {
-      type: 'string'
-    },
-    resolvers: PipelineSchema,
-    transforms: MapPipelineSchema,
-    validators: MapPipelineSchema,
-    namers: PipelineSchema,
-    packagers: MapStringSchema,
-    optimizers: MapPipelineSchema,
-    reporters: PipelineSchema,
-    runtimes: MapPipelineSchema,
-    filePath: {
-      type: 'string'
-    },
-    resolveFrom: {
-      type: 'string'
+    try {
+      validatePackageName(val, pluginType, key, relativePath);
+    } catch (e) {
+      return e.message;
     }
-  },
-  additionalProperties: false
+  };
 };
 
-export default ConfigBase;
+const validateExtends = (relativePath: FilePath) => {
+  return (val: string) => {
+    // Skip plugin spread...
+    if (val.startsWith('.')) return;
+
+    try {
+      validatePackageName(val, 'config', 'extends', relativePath);
+    } catch (e) {
+      return e.message;
+    }
+  };
+};
+
+const pipelineSchema = (
+  pluginType: string,
+  key: string,
+  relativePath: FilePath
+): SchemaEntity => {
+  return {
+    type: 'array',
+    items: {
+      type: 'string',
+      validate: validatePluginName(pluginType, key, relativePath)
+    }
+  };
+};
+
+const mapPipelineSchema = (
+  pluginType: string,
+  key: string,
+  relativePath: FilePath
+): SchemaEntity => {
+  return {
+    type: 'object',
+    properties: {},
+    additionalProperties: pipelineSchema(pluginType, key, relativePath)
+  };
+};
+
+const mapStringSchema = (
+  pluginType: string,
+  key: string,
+  relativePath: FilePath
+): SchemaEntity => {
+  return {
+    type: 'object',
+    properties: {},
+    additionalProperties: {
+      type: 'string',
+      validate: validatePluginName(pluginType, key, relativePath)
+    }
+  };
+};
+
+export default (relativePath: string): SchemaEntity => {
+  return {
+    type: 'object',
+    properties: {
+      extends: {
+        oneOf: [
+          {
+            type: 'string',
+            validate: validateExtends(relativePath)
+          },
+          {
+            type: 'array',
+            items: {
+              type: 'string',
+              validate: validateExtends(relativePath)
+            }
+          }
+        ]
+      },
+      bundler: {
+        type: 'string',
+        validate: validatePluginName('bundler', 'bundler', relativePath)
+      },
+      resolvers: pipelineSchema('resolver', 'resolvers', relativePath),
+      transforms: mapPipelineSchema('transformer', 'transforms', relativePath),
+      validators: mapPipelineSchema('validator', 'validators', relativePath),
+      namers: pipelineSchema('namer', 'namers', relativePath),
+      packagers: mapStringSchema('packager', 'packagers', relativePath),
+      optimizers: mapPipelineSchema('optimizer', 'optimizers', relativePath),
+      reporters: pipelineSchema('reporter', 'reporters', relativePath),
+      runtimes: mapPipelineSchema('runtime', 'runtimes', relativePath),
+      filePath: {
+        type: 'string'
+      },
+      resolveFrom: {
+        type: 'string'
+      }
+    },
+    additionalProperties: false
+  };
+};

--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -1,117 +1,130 @@
 // @flow strict-local
-import type {FilePath} from '@parcel/types';
+import type {PackageName} from '@parcel/types';
 import type {SchemaEntity} from '@parcel/utils';
-import {validatePackageName} from './loadParcelConfig';
+import assert from 'assert';
 
-const validatePluginName = (
+// Reasoning behind this validation:
+// https://github.com/parcel-bundler/parcel/issues/3397#issuecomment-521353931
+export function validatePackageName(
+  pkg: ?PackageName,
   pluginType: string,
-  key: string,
-  relativePath: FilePath
-) => {
+  key: string
+) {
+  // $FlowFixMe
+  if (!pkg) {
+    return;
+  }
+
+  assert(typeof pkg === 'string', `"${key}" must be a string`);
+
+  if (pkg.startsWith('@parcel')) {
+    assert(
+      pkg.replace(/^@parcel\//, '').startsWith(`${pluginType}-`),
+      `Official parcel ${pluginType} packages must be named according to "@parcel/${pluginType}-{name}"`
+    );
+  } else if (pkg.startsWith('@')) {
+    let [scope, name] = pkg.split('/');
+    assert(
+      name.startsWith(`parcel-${pluginType}-`),
+      `Scoped parcel ${pluginType} packages must be named according to "${scope}/parcel-${pluginType}-{name}"`
+    );
+  } else {
+    assert(
+      pkg.startsWith(`parcel-${pluginType}-`),
+      `Parcel ${pluginType} packages must be named according to "parcel-${pluginType}-{name}"`
+    );
+  }
+}
+
+const validatePluginName = (pluginType: string, key: string) => {
   return (val: string) => {
-    // Skip plugin spread...
+    // allow plugin spread...
     if (val === '...') return;
 
     try {
-      validatePackageName(val, pluginType, key, relativePath);
+      validatePackageName(val, pluginType, key);
     } catch (e) {
       return e.message;
     }
   };
 };
 
-const validateExtends = (relativePath: FilePath) => {
-  return (val: string) => {
-    // Skip plugin spread...
-    if (val.startsWith('.')) return;
+const validateExtends = (val: string) => {
+  // allow relative paths...
+  if (val.startsWith('.')) return;
 
-    try {
-      validatePackageName(val, 'config', 'extends', relativePath);
-    } catch (e) {
-      return e.message;
-    }
-  };
+  try {
+    validatePackageName(val, 'config', 'extends');
+  } catch (e) {
+    return e.message;
+  }
 };
 
-const pipelineSchema = (
-  pluginType: string,
-  key: string,
-  relativePath: FilePath
-): SchemaEntity => {
+const pipelineSchema = (pluginType: string, key: string): SchemaEntity => {
   return {
     type: 'array',
     items: {
       type: 'string',
-      validate: validatePluginName(pluginType, key, relativePath)
+      validate: validatePluginName(pluginType, key)
     }
   };
 };
 
-const mapPipelineSchema = (
-  pluginType: string,
-  key: string,
-  relativePath: FilePath
-): SchemaEntity => {
+const mapPipelineSchema = (pluginType: string, key: string): SchemaEntity => {
   return {
     type: 'object',
     properties: {},
-    additionalProperties: pipelineSchema(pluginType, key, relativePath)
+    additionalProperties: pipelineSchema(pluginType, key)
   };
 };
 
-const mapStringSchema = (
-  pluginType: string,
-  key: string,
-  relativePath: FilePath
-): SchemaEntity => {
+const mapStringSchema = (pluginType: string, key: string): SchemaEntity => {
   return {
     type: 'object',
     properties: {},
     additionalProperties: {
       type: 'string',
-      validate: validatePluginName(pluginType, key, relativePath)
+      validate: validatePluginName(pluginType, key)
     }
   };
 };
 
-export default (relativePath: string): SchemaEntity => {
-  return {
-    type: 'object',
-    properties: {
-      extends: {
-        oneOf: [
-          {
+export default {
+  type: 'object',
+  properties: {
+    extends: {
+      oneOf: [
+        {
+          type: 'string',
+          validate: validateExtends
+        },
+        {
+          type: 'array',
+          items: {
             type: 'string',
-            validate: validateExtends(relativePath)
-          },
-          {
-            type: 'array',
-            items: {
-              type: 'string',
-              validate: validateExtends(relativePath)
-            }
+            validate: validateExtends
           }
-        ]
-      },
-      bundler: {
-        type: 'string',
-        validate: validatePluginName('bundler', 'bundler', relativePath)
-      },
-      resolvers: pipelineSchema('resolver', 'resolvers', relativePath),
-      transforms: mapPipelineSchema('transformer', 'transforms', relativePath),
-      validators: mapPipelineSchema('validator', 'validators', relativePath),
-      namers: pipelineSchema('namer', 'namers', relativePath),
-      packagers: mapStringSchema('packager', 'packagers', relativePath),
-      optimizers: mapPipelineSchema('optimizer', 'optimizers', relativePath),
-      reporters: pipelineSchema('reporter', 'reporters', relativePath),
-      runtimes: mapPipelineSchema('runtime', 'runtimes', relativePath),
-      filePath: {
-        type: 'string'
-      },
-      resolveFrom: {
-        type: 'string'
-      }
+        }
+      ]
     },
-    additionalProperties: false
-  };
+    bundler: {
+      type: 'string',
+      validate: validatePluginName('bundler', 'bundler')
+    },
+    resolvers: pipelineSchema('resolver', 'resolvers'),
+    transforms: mapPipelineSchema('transformer', 'transforms'),
+    validators: mapPipelineSchema('validator', 'validators'),
+    namers: pipelineSchema('namer', 'namers'),
+    packagers: mapStringSchema('packager', 'packagers'),
+    optimizers: mapPipelineSchema('optimizer', 'optimizers'),
+    reporters: pipelineSchema('reporter', 'reporters'),
+    runtimes: mapPipelineSchema('runtime', 'runtimes'),
+    filePath: {
+      type: 'string'
+    },
+    resolveFrom: {
+      type: 'string'
+    }
+  },
+  additionalProperties: false
 };

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -133,7 +133,7 @@ export function validateConfigFile(
   validateNotEmpty(config, relativePath);
 
   validateSchema.diagnostic(
-    ParcelConfigSchema,
+    ParcelConfigSchema(relativePath),
     config,
     relativePath,
     JSON.stringify(config, null, '\t'),
@@ -141,47 +141,6 @@ export function validateConfigFile(
     '',
     'Invalid Parcel Config'
   );
-
-  /*validateExtends(config.extends, relativePath);
-  validatePipeline(config.resolvers, 'resolver', 'resolvers', relativePath);
-  validateMap(
-    config.transforms,
-    validatePipeline.bind(this),
-    'transformer',
-    'transforms',
-    relativePath
-  );
-  validateMap(
-    config.validators,
-    validatePipeline.bind(this),
-    'validator',
-    'validators',
-    relativePath
-  );
-  validatePackageName(config.bundler, 'bundler', 'bundler', relativePath);
-  validatePipeline(config.namers, 'namer', 'namers', relativePath);
-  validateMap(
-    config.runtimes,
-    validatePipeline.bind(this),
-    'runtime',
-    'runtimes',
-    relativePath
-  );
-  validateMap(
-    config.packagers,
-    validatePackageName.bind(this),
-    'packager',
-    'packagers',
-    relativePath
-  );
-  validateMap(
-    config.optimizers,
-    validatePipeline.bind(this),
-    'optimizer',
-    'optimizers',
-    relativePath
-  );
-  validatePipeline(config.reporters, 'reporter', 'reporters', relativePath);*/
 }
 
 export function validateNotEmpty(
@@ -189,80 +148,6 @@ export function validateNotEmpty(
   relativePath: FilePath
 ) {
   assert.notDeepStrictEqual(config, {}, `${relativePath} can't be empty`);
-}
-
-export function validateExtends(
-  exts: string | Array<string> | void,
-  relativePath: FilePath
-) {
-  if (Array.isArray(exts)) {
-    for (let ext of exts) {
-      assert(
-        typeof ext === 'string',
-        `"extends" elements must be strings in ${relativePath}`
-      );
-      validateExtendsConfig(ext, relativePath);
-    }
-  } else if (exts) {
-    assert(
-      typeof exts === 'string',
-      `"extends" must be a string or array of strings in ${relativePath}`
-    );
-    validateExtendsConfig(exts, relativePath);
-  }
-}
-
-export function validateExtendsConfig(ext: string, relativePath: FilePath) {
-  if (!ext.startsWith('.')) {
-    validatePackageName(ext, 'config', 'extends', relativePath);
-  }
-}
-
-export function validatePipeline(
-  pipeline: ?Pipeline,
-  pluginType: string,
-  key: string,
-  relativePath: FilePath
-) {
-  if (!pipeline) {
-    return;
-  }
-
-  assert(
-    Array.isArray(pipeline),
-    `"${key}" must be an array in ${relativePath}`
-  );
-  assert(
-    pipeline.every(pkg => typeof pkg === 'string'),
-    `"${key}" elements must be strings in ${relativePath}`
-  );
-  for (let pkg of pipeline) {
-    if (pkg !== '...') {
-      validatePackageName(pkg, pluginType, key, relativePath);
-    }
-  }
-}
-
-export function validateMap<K, V>(
-  globMap: ?ConfigMap<K, V>,
-  validator: (v: V, p: string, k: string, p: FilePath) => void,
-  pluginType: string,
-  configKey: string,
-  relativePath: FilePath
-) {
-  if (!globMap) {
-    return;
-  }
-
-  assert(
-    typeof globMap === 'object',
-    `"${configKey}" must be an object in ${relativePath}`
-  );
-  for (let k in globMap) {
-    // Flow doesn't correctly infer the type. See https://github.com/facebook/flow/issues/1736.
-    let key: K = (k: any);
-    validator(globMap[key], pluginType, `${configKey}["${k}"]`, relativePath);
-  }
 }
 
 // Reasoning behind this validation:

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -133,7 +133,7 @@ export function validateConfigFile(
   validateNotEmpty(config, relativePath);
 
   validateSchema.diagnostic(
-    ParcelConfigSchema(relativePath),
+    ParcelConfigSchema,
     config,
     relativePath,
     JSON.stringify(config, null, '\t'),
@@ -148,42 +148,6 @@ export function validateNotEmpty(
   relativePath: FilePath
 ) {
   assert.notDeepStrictEqual(config, {}, `${relativePath} can't be empty`);
-}
-
-// Reasoning behind this validation:
-// https://github.com/parcel-bundler/parcel/issues/3397#issuecomment-521353931
-export function validatePackageName(
-  pkg: ?PackageName,
-  pluginType: string,
-  key: string,
-  relativePath: FilePath
-) {
-  if (!pkg) {
-    return;
-  }
-
-  assert(
-    typeof pkg === 'string',
-    `"${key}" must be a string in ${relativePath}`
-  );
-
-  if (pkg.startsWith('@parcel')) {
-    assert(
-      pkg.replace(/^@parcel\//, '').startsWith(`${pluginType}-`),
-      `Official parcel ${pluginType} packages must be named according to "@parcel/${pluginType}-{name}" but got "${pkg}" in ${relativePath}.`
-    );
-  } else if (pkg.startsWith('@')) {
-    let [scope, name] = pkg.split('/');
-    assert(
-      name.startsWith(`parcel-${pluginType}-`),
-      `Scoped parcel ${pluginType} packages must be named according to "${scope}/parcel-${pluginType}-{name}" but got "${pkg}" in ${relativePath}.`
-    );
-  } else {
-    assert(
-      pkg.startsWith(`parcel-${pluginType}-`),
-      `Parcel ${pluginType} packages must be named according to "parcel-${pluginType}-{name}" but got "${pkg}" in ${relativePath}.`
-    );
-  }
 }
 
 export function mergeConfigs(

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -6,12 +6,13 @@ import type {
   PackageName
 } from '@parcel/types';
 import type {ParcelOptions} from './types';
-import {resolveConfig, resolve} from '@parcel/utils';
+import {resolveConfig, resolve, validateSchema} from '@parcel/utils';
 import {parse} from 'json5';
 import path from 'path';
 import assert from 'assert';
 
 import ParcelConfig from './ParcelConfig';
+import ParcelConfigSchema from './ParcelConfig.schema';
 
 type Pipeline = Array<PackageName>;
 type ConfigMap<K, V> = {[K]: V, ...};
@@ -130,7 +131,18 @@ export function validateConfigFile(
   relativePath: FilePath
 ) {
   validateNotEmpty(config, relativePath);
-  validateExtends(config.extends, relativePath);
+
+  validateSchema.diagnostic(
+    ParcelConfigSchema,
+    config,
+    relativePath,
+    JSON.stringify(config, null, '\t'),
+    '@parcel/core',
+    '',
+    'Invalid Parcel Config'
+  );
+
+  /*validateExtends(config.extends, relativePath);
   validatePipeline(config.resolvers, 'resolver', 'resolvers', relativePath);
   validateMap(
     config.transforms,
@@ -169,7 +181,7 @@ export function validateConfigFile(
     'optimizers',
     relativePath
   );
-  validatePipeline(config.reporters, 'reporter', 'reporters', relativePath);
+  validatePipeline(config.reporters, 'reporter', 'reporters', relativePath);*/
 }
 
 export function validateNotEmpty(

--- a/packages/core/core/test/loadParcelConfig.test.js
+++ b/packages/core/core/test/loadParcelConfig.test.js
@@ -3,7 +3,6 @@ import assert from 'assert';
 import path from 'path';
 import ParcelConfig from '../src/ParcelConfig';
 import {
-  validatePackageName,
   validateConfigFile,
   mergePipelines,
   mergeMaps,
@@ -12,80 +11,50 @@ import {
   readAndProcess,
   resolveParcelConfig
 } from '../src/loadParcelConfig';
+import {validatePackageName} from '../src/ParcelConfig.schema';
 import {DEFAULT_OPTIONS} from './utils';
 
 describe('loadParcelConfig', () => {
   describe('validatePackageName', () => {
     it('should error on an invalid official package', () => {
       assert.throws(() => {
-        validatePackageName(
-          '@parcel/foo-bar',
-          'transform',
-          'transforms',
-          '.parcelrc'
-        );
-      }, /Official parcel transform packages must be named according to "@parcel\/transform-{name}" but got "@parcel\/foo-bar" in .parcelrc./);
+        validatePackageName('@parcel/foo-bar', 'transform', 'transforms');
+      }, /Official parcel transform packages must be named according to "@parcel\/transform-{name}"/);
     });
 
     it('should succeed on a valid official package', () => {
-      validatePackageName(
-        '@parcel/transform-bar',
-        'transform',
-        'transforms',
-        '.parcelrc'
-      );
+      validatePackageName('@parcel/transform-bar', 'transform', 'transforms');
     });
 
     it('should error on an invalid community package', () => {
       assert.throws(() => {
-        validatePackageName('foo-bar', 'transform', 'transforms', '.parcelrc');
-      }, /Parcel transform packages must be named according to "parcel-transform-{name}" but got "foo-bar" in .parcelrc./);
+        validatePackageName('foo-bar', 'transform', 'transforms');
+      }, /Parcel transform packages must be named according to "parcel-transform-{name}"/);
 
       assert.throws(() => {
-        validatePackageName(
-          'parcel-foo-bar',
-          'transform',
-          'transforms',
-          '.parcelrc'
-        );
-      }, /Parcel transform packages must be named according to "parcel-transform-{name}" but got "parcel-foo-bar" in .parcelrc./);
+        validatePackageName('parcel-foo-bar', 'transform', 'transforms');
+      }, /Parcel transform packages must be named according to "parcel-transform-{name}"/);
     });
 
     it('should succeed on a valid community package', () => {
-      validatePackageName(
-        'parcel-transform-bar',
-        'transform',
-        'transforms',
-        '.parcelrc'
-      );
+      validatePackageName('parcel-transform-bar', 'transform', 'transforms');
     });
 
     it('should error on an invalid scoped package', () => {
       assert.throws(() => {
-        validatePackageName(
-          '@test/foo-bar',
-          'transform',
-          'transforms',
-          '.parcelrc'
-        );
-      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform-{name}" but got "@test\/foo-bar" in .parcelrc./);
+        validatePackageName('@test/foo-bar', 'transform', 'transforms');
+      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform-{name}"/);
 
       assert.throws(() => {
-        validatePackageName(
-          '@test/parcel-foo-bar',
-          'transform',
-          'transforms',
-          '.parcelrc'
-        );
-      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform-{name}" but got "@test\/parcel-foo-bar" in .parcelrc./);
+        validatePackageName('@test/parcel-foo-bar', 'transform', 'transforms');
+      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform-{name}"/);
     });
 
     it('should succeed on a valid scoped package', () => {
       validatePackageName(
         '@test/parcel-transform-bar',
         'transform',
-        'transforms',
-        '.parcelrc'
+        'transforms'
       );
     });
   });

--- a/packages/core/core/test/loadParcelConfig.test.js
+++ b/packages/core/core/test/loadParcelConfig.test.js
@@ -4,9 +4,6 @@ import path from 'path';
 import ParcelConfig from '../src/ParcelConfig';
 import {
   validatePackageName,
-  validatePipeline,
-  validateMap,
-  validateExtends,
   validateConfigFile,
   mergePipelines,
   mergeMaps,
@@ -90,127 +87,6 @@ describe('loadParcelConfig', () => {
         'transforms',
         '.parcelrc'
       );
-    });
-  });
-
-  describe('validatePipeline', () => {
-    it('should require pipeline to be an array', () => {
-      assert.throws(() => {
-        // $FlowFixMe
-        validatePipeline('123', 'resolver', 'resolvers', '.parcelrc');
-      }, /"resolvers" must be an array in .parcelrc/);
-    });
-
-    it('should require pipeline elements to be strings', () => {
-      assert.throws(() => {
-        validatePipeline(
-          // $FlowFixMe
-          [1, 'foo', 3],
-          'resolver',
-          'resolvers',
-          '.parcelrc'
-        );
-      }, /"resolvers" elements must be strings in .parcelrc/);
-    });
-
-    it('should require package names to be valid', () => {
-      assert.throws(() => {
-        validatePipeline(
-          ['parcel-foo-bar'],
-          'resolver',
-          'resolvers',
-          '.parcelrc'
-        );
-      }, /Parcel resolver packages must be named according to "parcel-resolver-{name}" but got "parcel-foo-bar" in .parcelrc./);
-    });
-
-    it('should succeed with an array of valid package names', () => {
-      validatePipeline(
-        ['parcel-resolver-test'],
-        'resolver',
-        'resolvers',
-        '.parcelrc'
-      );
-    });
-
-    it('should support spread elements', () => {
-      validatePipeline(
-        ['parcel-resolver-test', '...'],
-        'resolver',
-        'resolvers',
-        '.parcelrc'
-      );
-    });
-  });
-
-  describe('validateMap', () => {
-    it('should require glob map to be an object', () => {
-      assert.throws(() => {
-        validateMap(
-          // $FlowFixMe
-          'foo',
-          () => {},
-          'transform',
-          'transforms',
-          '.parcelrc'
-        );
-      }, /"transforms" must be an object in .parcelrc/);
-    });
-
-    it('should trigger the validator function for each key', () => {
-      assert.throws(() => {
-        validateMap(
-          {
-            '*.js': ['foo']
-          },
-          validatePipeline,
-          'transform',
-          'transforms',
-          '.parcelrc'
-        );
-      });
-
-      validateMap(
-        {
-          '*.js': ['parcel-transform-foo']
-        },
-        validatePipeline,
-        'transform',
-        'transforms',
-        '.parcelrc'
-      );
-    });
-  });
-
-  describe('validateExtends', () => {
-    it('should require extends to be a string or array of strings', () => {
-      assert.throws(() => {
-        // $FlowFixMe
-        validateExtends(2, '.parcelrc');
-      }, /"extends" must be a string or array of strings in .parcelrc/);
-
-      assert.throws(() => {
-        // $FlowFixMe
-        validateExtends([2, 4], '.parcelrc');
-      }, /"extends" elements must be strings in .parcelrc/);
-    });
-
-    it('should support relative paths', () => {
-      validateExtends('./foo', '.parcelrc');
-      validateExtends(['./foo', './bar'], '.parcelrc');
-    });
-
-    it('should validate package names', () => {
-      assert.throws(() => {
-        validateExtends('foo', '.parcelrc');
-      });
-
-      assert.throws(() => {
-        validateExtends(['foo', 'bar'], '.parcelrc');
-      });
-
-      validateExtends('parcel-config-foo', '.parcelrc');
-      validateExtends(['parcel-config-foo', 'parcel-config-bar'], '.parcelrc');
     });
   });
 

--- a/packages/core/core/test/loadParcelConfig.test.js
+++ b/packages/core/core/test/loadParcelConfig.test.js
@@ -106,6 +106,175 @@ describe('loadParcelConfig', () => {
       });
     });
 
+    it('should require pipeline to be an array', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            // $FlowFixMe
+            resolvers: '123'
+          },
+          '.parcelrc'
+        );
+      });
+    });
+
+    it('should require pipeline elements to be strings', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            // $FlowFixMe
+            resolvers: [1, '123', 5]
+          },
+          '.parcelrc'
+        );
+      });
+    });
+
+    it('should require package names to be valid', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            // $FlowFixMe
+            resolvers: ['parcel-foo-bar']
+          },
+          '.parcelrc'
+        );
+      });
+    });
+
+    it('should succeed with an array of valid package names', () => {
+      validateConfigFile(
+        {
+          filePath: '.parcelrc',
+          // $FlowFixMe
+          resolvers: ['parcel-resolver-test']
+        },
+        '.parcelrc'
+      );
+    });
+
+    it('should support spread elements', () => {
+      validateConfigFile(
+        {
+          filePath: '.parcelrc',
+          // $FlowFixMe
+          resolvers: ['parcel-resolver-test', '...']
+        },
+        '.parcelrc'
+      );
+    });
+
+    it('should require glob map to be an object', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            // $FlowFixMe
+            transforms: ['parcel-transformer-test', '...']
+          },
+          '.parcelrc'
+        );
+      });
+    });
+
+    it('should trigger the validator function for each key', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            transforms: {
+              'types:*.{ts,tsx}': ['@parcel/transformer-typescript-types'],
+              'bundle-text:*': ['-inline-string', '...']
+            }
+          },
+          '.parcelrc'
+        );
+      });
+    });
+
+    it('should require extends to be a string or array of strings', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            // $FlowFixMe
+            extends: 2
+          },
+          '.parcelrc'
+        );
+      });
+
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            // $FlowFixMe
+            extends: [2, 7]
+          },
+          '.parcelrc'
+        );
+      });
+    });
+
+    it('should support relative paths', () => {
+      validateConfigFile(
+        {
+          filePath: '.parcelrc',
+          extends: './foo'
+        },
+        '.parcelrc'
+      );
+
+      validateConfigFile(
+        {
+          filePath: '.parcelrc',
+          extends: ['./foo', './bar']
+        },
+        '.parcelrc'
+      );
+    });
+
+    it('should validate package names', () => {
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            extends: 'foo'
+          },
+          '.parcelrc'
+        );
+      });
+
+      assert.throws(() => {
+        validateConfigFile(
+          {
+            filePath: '.parcelrc',
+            extends: ['foo', 'bar']
+          },
+          '.parcelrc'
+        );
+      });
+
+      validateConfigFile(
+        {
+          filePath: '.parcelrc',
+          extends: 'parcel-config-foo'
+        },
+        '.parcelrc'
+      );
+
+      validateConfigFile(
+        {
+          filePath: '.parcelrc',
+          extends: ['parcel-config-foo', 'parcel-config-bar']
+        },
+        '.parcelrc'
+      );
+    });
+
     it('should succeed on valid config', () => {
       validateConfigFile(
         {

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -18,6 +18,8 @@
     "@parcel/fs": "^2.0.0-alpha.3.1",
     "@parcel/logger": "^2.0.0-alpha.3.1",
     "@parcel/package-manager": "^2.0.0-alpha.3.1",
+    "@parcel/diagnostic": "^2.0.0-alpha.3.1",
+    "@parcel/utils": "^2.0.0-alpha.3.1",
     "chalk": "^2.1.0",
     "commander": "^2.19.0",
     "get-port": "^4.2.0",

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -36,6 +36,7 @@ export type SchemaNot = {|
 export type SchemaString = {|
   type: 'string',
   enum?: Array<string>,
+  validate?: (val: string) => ?string,
   __type?: string
 |};
 export type SchemaObject = {|
@@ -147,6 +148,19 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   dataType: 'value',
                   dataPath,
                   expectedValues: schemaNode.enum,
+                  actualValue: value,
+                  ancestors: schemaAncestors
+                };
+              }
+            } else if (schemaNode.validate) {
+              let validationError = schemaNode.validate(value);
+              // $FlowFixMe
+              if (validationError) {
+                return {
+                  type: 'other',
+                  dataType: 'value',
+                  dataPath,
+                  message: validationError,
                   actualValue: value,
                   ancestors: schemaAncestors
                 };


### PR DESCRIPTION
# ↪️ Pull Request

This PR updates the parcelrc validator to use the JSON Schema validator, this results in clearer errors and codeframes.

## 💻 Examples

<img width="766" alt="Screenshot 2019-12-06 at 16 04 37" src="https://user-images.githubusercontent.com/2175521/70332690-6c2cb980-1842-11ea-926e-352418a10264.png">

![Screenshot 2019-12-08 at 16 00 51](https://user-images.githubusercontent.com/2175521/70391307-ee001c80-19d3-11ea-8426-1d98b4d43062.png)

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
