### PR TITLE
Make global bundles evaluate to their main exports

### DIFF
--- a/packages/packagers/js/src/prelude.js
+++ b/packages/packagers/js/src/prelude.js
@@ -130,5 +130,7 @@
     } else if (globalName) {
       this[globalName] = mainExports;
     }
+
+    return mainExports;
   }
 });


### PR DESCRIPTION
This makes the global bundle output a valid expression which evaluates to the export of the main entry asset.

Test Plan: Added an integration test