### PR TITLE
Ignore: `url(#...)` (`behavior` property)

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -241,7 +241,7 @@ describe('css', () => {
     );
   });
 
-  it.only('should ignore url() with IE behavior specifiers', async function() {
+  it('should ignore url() with IE behavior specifiers', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/css-url-behavior/index.css')
     );

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -241,6 +241,23 @@ describe('css', () => {
     );
   });
 
+  it.only('should ignore url() with IE behavior specifiers', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/css-url-behavior/index.css')
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.css',
+        assets: ['index.css']
+      }
+    ]);
+
+    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
+
+    assert(css.includes('url(#default#VML)'));
+  });
+
   it('should minify CSS when minify is set', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/cssnano/index.js'),

--- a/packages/core/integration-tests/test/integration/css-url-behavior/index.css
+++ b/packages/core/integration-tests/test/integration/css-url-behavior/index.css
@@ -1,0 +1,3 @@
+.index {
+  behavior: url(#default#VML);
+}

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -111,7 +111,8 @@ export default new Transformer({
           if (
             node.type === 'function' &&
             node.value === 'url' &&
-            node.nodes.length
+            node.nodes.length > 0 &&
+            !node.nodes[0].value.startsWith('#') // IE's `behavior: url(#default#VML)`
           ) {
             node.nodes[0].value = asset.addURLDependency(node.nodes[0].value, {
               loc: createDependencyLocation(


### PR DESCRIPTION
# ↪️ Pull Request

Some libraries still include these statements in their stylesheets (see issue).

Closes #3873

**Should `url(#foo)` only be allowed in a `behavior` statement or everywhere?**

## 💻 Examples

`behavior` is non standard (IE)

```css
.lvml {
	behavior: url(#default#VML);
	display: inline-block;
	position: absolute;
}
```
