### PR TITLE
Have NODE_ENV reflect Parcel's environment, not what it's building

### DIFF
--- a/packages/core/core/src/loadDotEnv.js
+++ b/packages/core/core/src/loadDotEnv.js
@@ -1,24 +1,27 @@
 // @flow strict-local
 
+import type {FileSystem} from '@parcel/fs';
+import type {EnvMap} from '@parcel/types';
+
 import {resolveConfig} from '@parcel/utils';
 import dotenv from 'dotenv';
 import variableExpansion from 'dotenv-expand';
-import type {FileSystem} from '@parcel/fs';
 
 export default async function loadEnv(
+  env: EnvMap,
   fs: FileSystem,
   filePath: string,
-): Promise<{[string]: string, ...}> {
-  const NODE_ENV = process.env.NODE_ENV ?? 'development';
+): Promise<EnvMap> {
+  const NODE_ENV = env.NODE_ENV ?? 'development';
 
   const dotenvFiles = [
-    `.env.${NODE_ENV}.local`,
-    `.env.${NODE_ENV}`,
+    '.env',
     // Don't include `.env.local` for `test` environment
     // since normally you expect tests to produce the same
     // results for everyone
     NODE_ENV === 'test' ? null : '.env.local',
-    '.env',
+    `.env.${NODE_ENV}`,
+    `.env.${NODE_ENV}.local`,
   ].filter(Boolean);
 
   let envs = await Promise.all(
@@ -43,5 +46,6 @@ export default async function loadEnv(
     }),
   );
 
+  // $FlowFixMe
   return Object.assign({}, ...envs);
 }

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -1,6 +1,7 @@
 // @flow
 import type {
   BuildMode,
+  EnvMap,
   FilePath,
   LogLevel,
   PluginOptions as IPluginOptions,
@@ -33,7 +34,7 @@ export default class PluginOptions implements IPluginOptions {
     return this.#options.sourceMaps;
   }
 
-  get env(): {+[string]: string, ...} {
+  get env(): EnvMap {
     return this.#options.env;
   }
 

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -70,9 +70,15 @@ export default async function resolveOptions(
     defaultConfig: initialOptions.defaultConfig,
     patchConsole:
       initialOptions.patchConsole ?? process.env.NODE_ENV !== 'test',
-    env:
-      initialOptions.env ??
-      (await loadDotEnv(inputFS, path.join(projectRoot, 'index'))),
+    env: {
+      ...initialOptions.env,
+      // $FlowFixMe
+      ...(await loadDotEnv(
+        initialOptions.env ?? {},
+        inputFS,
+        path.join(projectRoot, 'index'),
+      )),
+    },
     mode,
     minify,
     autoinstall: initialOptions.autoinstall ?? true,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -5,6 +5,7 @@ import type {
   BundleGroup,
   Engines,
   EnvironmentContext,
+  EnvMap,
   File,
   FilePath,
   Glob,
@@ -93,7 +94,7 @@ export type ParcelOptions = {|
   rootDir: FilePath,
   config?: ResolvedParcelConfigFile,
   defaultConfig?: ResolvedParcelConfigFile,
-  env: {+[string]: string, ...},
+  env: EnvMap,
   targets: ?(Array<string> | {+[string]: TargetDescriptor, ...}),
   defaultEngines?: Engines,
 

--- a/packages/core/integration-tests/test/integration/env-file/.env.production
+++ b/packages/core/integration-tests/test/integration/env-file/.env.production
@@ -1,0 +1,2 @@
+FOO=production
+BAR=test

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -994,6 +994,18 @@ describe('javascript', function() {
     assert.equal(output(), 'test:test');
   });
 
+  it("should insert the user's NODE_ENV as process.env.NODE_ENV if passed", async function() {
+    let b = await bundle(path.join(__dirname, '/integration/env/index.js'), {
+      env: {
+        NODE_ENV: 'production',
+      },
+    });
+
+    let output = await run(b);
+    assert.ok(output.toString().indexOf('process.env') === -1);
+    assert.equal(output(), 'production:production');
+  });
+
   it('should insert environment variables from a file', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/env-file/index.js'),
@@ -1004,6 +1016,16 @@ describe('javascript', function() {
 
     let output = await run(b);
     assert.equal(output, 'bartest');
+  });
+
+  it("should insert environment variables matching the user's NODE_ENV if passed", async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/env-file/index.js'),
+      {env: {NODE_ENV: 'production'}},
+    );
+
+    let output = await run(b);
+    assert.equal(output, 'productiontest');
   });
 
   it.skip('should support adding implicit dependencies', async function() {

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -35,6 +35,16 @@ const path = require('path');
 const getPort = require('get-port');
 const version = require('../package.json').version;
 
+// Capture the NODE_ENV this process was launched with, so that it can be
+// used in Parcel (such as in process.env inlining).
+const initialNodeEnv = process.env.NODE_ENV;
+// Then, override NODE_ENV to be PARCEL_BUILD_ENV (replaced with `production` in builds)
+// so that dependencies of Parcel like React (which renders the cli through `ink`)
+// run in the appropriate mode.
+if (typeof process.env.PARCEL_BUILD_ENV === 'string') {
+  process.env.NODE_ENV = process.env.PARCEL_BUILD_ENV;
+}
+
 program.version(version);
 
 // --no-cache, --cache-dir, --no-source-maps, --no-autoinstall, --global?, --public-url, --log-level
@@ -231,9 +241,9 @@ async function run(entries: Array<string>, command: any) {
 async function normalizeOptions(command): Promise<InitialParcelOptions> {
   let nodeEnv;
   if (command.name() === 'build') {
-    nodeEnv = process.env.NODE_ENV || 'production';
+    nodeEnv = initialNodeEnv || 'production';
   } else {
-    nodeEnv = process.env.NODE_ENV || 'development';
+    nodeEnv = initialNodeEnv || 'development';
   }
 
   let https = !!command.https;
@@ -294,6 +304,8 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     autoinstall: command.autoinstall ?? true,
     logLevel: command.logLevel,
     profile: command.profile,
-    nodeEnv,
+    env: {
+      NODE_ENV: nodeEnv,
+    },
   };
 }

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -229,10 +229,11 @@ async function run(entries: Array<string>, command: any) {
 }
 
 async function normalizeOptions(command): Promise<InitialParcelOptions> {
+  let nodeEnv;
   if (command.name() === 'build') {
-    process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+    nodeEnv = process.env.NODE_ENV || 'production';
   } else {
-    process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+    nodeEnv = process.env.NODE_ENV || 'development';
   }
 
   let https = !!command.https;
@@ -293,5 +294,6 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     autoinstall: command.autoinstall ?? true,
     logLevel: command.logLevel,
     profile: command.profile,
+    nodeEnv,
   };
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -12,6 +12,7 @@ import type {AST as _AST, ConfigResult as _ConfigResult} from './unsafe';
 
 export type AST = _AST;
 export type ConfigResult = _ConfigResult;
+export type EnvMap = typeof process.env;
 
 export type JSONValue =
   | null
@@ -43,13 +44,13 @@ export type ParcelConfigFile = {|
   packagers?: {[Glob]: PackageName, ...},
   optimizers?: {[Glob]: Array<PackageName>, ...},
   reporters?: Array<PackageName>,
-  validators?: {[Glob]: Array<PackageName>, ...}
+  validators?: {[Glob]: Array<PackageName>, ...},
 |};
 
 export type ResolvedParcelConfigFile = {|
   ...ParcelConfigFile,
   filePath: FilePath,
-  resolveFrom?: FilePath
+  resolveFrom?: FilePath,
 |};
 
 export type Engines = {
@@ -63,7 +64,7 @@ export type Engines = {
 export type TargetSourceMapOptions = {|
   sourceRoot?: string,
   inline?: boolean,
-  inlineSources?: boolean
+  inlineSources?: boolean,
 |};
 
 export interface Target {
@@ -93,12 +94,12 @@ export type PackageTargetDescriptor = {|
   publicUrl?: string,
   distDir?: FilePath,
   sourceMap?: TargetSourceMapOptions,
-  isLibrary?: boolean
+  isLibrary?: boolean,
 |};
 
 export type TargetDescriptor = {|
   ...PackageTargetDescriptor,
-  distDir: FilePath
+  distDir: FilePath,
 |};
 
 export type EnvironmentOpts = {|
@@ -106,12 +107,12 @@ export type EnvironmentOpts = {|
   engines?: Engines,
   includeNodeModules?: boolean | Array<PackageName>,
   outputFormat?: OutputFormat,
-  isLibrary?: boolean
+  isLibrary?: boolean,
 |};
 
 export type VersionMap = {
   [string]: string,
-  ...
+  ...,
 };
 
 export interface Environment {
@@ -130,7 +131,7 @@ export interface Environment {
 }
 
 type PackageDependencies = {|
-  [PackageName]: Semver
+  [PackageName]: Semver,
 |};
 
 export type PackageJSON = {
@@ -160,7 +161,7 @@ export type InitialParcelOptions = {|
   rootDir?: FilePath,
   config?: ResolvedParcelConfigFile,
   defaultConfig?: ResolvedParcelConfigFile,
-  env?: {[string]: string, ...},
+  env?: EnvMap,
   targets?: ?(Array<string> | {+[string]: TargetDescriptor, ...}),
 
   disableCache?: boolean,
@@ -181,7 +182,7 @@ export type InitialParcelOptions = {|
   outputFS?: FileSystem,
   workerFarm?: WorkerFarm,
   packageManager?: PackageManager,
-  defaultEngines?: Engines
+  defaultEngines?: Engines,
 
   // contentHash
   // throwErrors
@@ -194,7 +195,7 @@ export interface PluginOptions {
   +minify: boolean;
   +scopeHoist: boolean;
   +sourceMaps: boolean;
-  +env: {+[string]: string, ...};
+  +env: EnvMap;
   +hot: ServerOptions | false;
   +serve: ServerOptions | false;
   +autoinstall: boolean;
@@ -211,12 +212,12 @@ export type ServerOptions = {|
   host?: string,
   port: number,
   https?: HTTPSOptions | boolean,
-  publicUrl?: string
+  publicUrl?: string,
 |};
 
 export type HTTPSOptions = {|
   cert: FilePath,
-  key: FilePath
+  key: FilePath,
 |};
 
 // Source locations are 1-based, meaning lines and columns start at 1
@@ -224,12 +225,12 @@ export type SourceLocation = {|
   filePath: string,
   start: {|
     line: number,
-    column: number
+    column: number,
   |},
   end: {|
     line: number,
-    column: number
-  |}
+    column: number,
+  |},
 |};
 
 export type Meta = {
@@ -251,7 +252,7 @@ export type DependencyOptions = {|
   env?: EnvironmentOpts,
   meta?: Meta,
   target?: Target,
-  symbols?: Map<Symbol, Symbol>
+  symbols?: Map<Symbol, Symbol>,
 |};
 
 export interface Dependency {
@@ -274,7 +275,7 @@ export interface Dependency {
 
 export type File = {|
   filePath: FilePath,
-  hash?: string
+  hash?: string,
 |};
 
 export interface BaseAsset {
@@ -302,8 +303,8 @@ export interface BaseAsset {
     filePaths: Array<FilePath>,
     options: ?{|
       packageKey?: string,
-      parse?: boolean
-    |}
+      parse?: boolean,
+    |},
   ): Promise<ConfigResult | null>;
   getPackage(): Promise<PackageJSON | null>;
 }
@@ -348,16 +349,16 @@ export interface Config {
     options: ?{|
       packageKey?: string,
       parse?: boolean,
-      exclude?: boolean
-    |}
+      exclude?: boolean,
+    |},
   ): Promise<ConfigResult | null>;
   getConfig(
     filePaths: Array<FilePath>,
     options: ?{|
       packageKey?: string,
       parse?: boolean,
-      exclude?: boolean
-    |}
+      exclude?: boolean,
+    |},
   ): Promise<ConfigResult | null>;
   getPackage(): Promise<PackageJSON | null>;
   shouldRehydrate(): void;
@@ -367,12 +368,12 @@ export interface Config {
 
 export type Stats = {|
   time: number,
-  size: number
+  size: number,
 |};
 
 export type GenerateOutput = {|
   code: string,
-  map?: ?SourceMap
+  map?: ?SourceMap,
 |};
 
 export type Blob = string | Buffer | Readable;
@@ -401,12 +402,12 @@ export type Async<T> = T | Promise<T>;
 export type ResolveFn = (from: FilePath, to: string) => Promise<FilePath>;
 
 type ResolveConfigFn = (
-  configNames: Array<FilePath>
+  configNames: Array<FilePath>,
 ) => Promise<FilePath | null>;
 
 export type ValidateResult = {|
   warnings: Array<Diagnostic>,
-  errors: Array<Diagnostic>
+  errors: Array<Diagnostic>,
 |};
 
 export type Validator = {|
@@ -414,14 +415,14 @@ export type Validator = {|
     asset: Asset,
     config: ConfigResult | void,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}): Async<ValidateResult | void>,
   getConfig?: ({|
     asset: Asset,
     resolveConfig: ResolveConfigFn,
     options: PluginOptions,
-    logger: PluginLogger
-  |}) => Async<ConfigResult | void>
+    logger: PluginLogger,
+  |}) => Async<ConfigResult | void>,
 |};
 
 export type Transformer = {|
@@ -430,55 +431,55 @@ export type Transformer = {|
     asset: MutableAsset,
     resolve: ResolveFn,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}) => Async<ConfigResult | void>,
   loadConfig?: ({|
     config: Config,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}) => Async<void>,
   preSerializeConfig?: ({|
     config: Config,
-    options: PluginOptions
+    options: PluginOptions,
   |}) => Async<void>,
   postDeserializeConfig?: ({|
     config: Config,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}) => Async<void>,
   canReuseAST?: ({|
     ast: AST,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}) => boolean,
   parse?: ({|
     asset: MutableAsset,
     config: ?ConfigResult,
     resolve: ResolveFn,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}) => Async<?AST>,
   transform({|
     asset: MutableAsset,
     config: ?ConfigResult,
     resolve: ResolveFn,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}): Async<Array<TransformerResult | MutableAsset>>,
   generate?: ({|
     asset: MutableAsset,
     config: ?ConfigResult,
     resolve: ResolveFn,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}) => Async<GenerateOutput>,
   postProcess?: ({|
     assets: Array<MutableAsset>,
     config: ?ConfigResult,
     resolve: ResolveFn,
     options: PluginOptions,
-    logger: PluginLogger
-  |}) => Async<Array<TransformerResult>>
+    logger: PluginLogger,
+  |}) => Async<Array<TransformerResult>>,
 |};
 
 export interface TraversalActions {
@@ -490,12 +491,12 @@ export type GraphVisitor<TNode, TContext> =
   | GraphTraversalCallback<TNode, TContext>
   | {|
       enter?: GraphTraversalCallback<TNode, TContext>,
-      exit?: GraphTraversalCallback<TNode, TContext>
+      exit?: GraphTraversalCallback<TNode, TContext>,
     |};
 export type GraphTraversalCallback<TNode, TContext> = (
   node: TNode,
   context: ?TContext,
-  actions: TraversalActions
+  actions: TraversalActions,
 ) => ?TContext;
 
 export type BundleTraversable =
@@ -516,7 +517,7 @@ export type CreateBundleOpts =
       isEntry?: ?boolean,
       isInline?: ?boolean,
       type?: ?string,
-      env?: ?Environment
+      env?: ?Environment,
     |}
   // If an entryAsset is not provided, a bundle id, type, and environment must
   // be provided.
@@ -527,13 +528,13 @@ export type CreateBundleOpts =
       isEntry?: ?boolean,
       isInline?: ?boolean,
       type: string,
-      env: Environment
+      env: Environment,
     |};
 
 export type SymbolResolution = {|
   asset: Asset,
   exportSymbol: Symbol | string,
-  symbol: void | Symbol
+  symbol: void | Symbol,
 |};
 
 export interface Bundle {
@@ -552,7 +553,7 @@ export interface Bundle {
   getHash(): string;
   traverseAssets<TContext>(visit: GraphVisitor<Asset, TContext>): ?TContext;
   traverse<TContext>(
-    visit: GraphVisitor<BundleTraversable, TContext>
+    visit: GraphVisitor<BundleTraversable, TContext>,
   ): ?TContext;
 }
 
@@ -563,7 +564,7 @@ export interface NamedBundle extends Bundle {
 
 export type BundleGroup = {|
   target: Target,
-  entryAssetId: string
+  entryAssetId: string,
 |};
 
 export interface MutableBundleGraph {
@@ -581,11 +582,11 @@ export interface MutableBundleGraph {
   isAssetInAncestorBundles(Bundle, Asset): boolean;
   removeAssetGraphFromBundle(Asset, Bundle): void;
   traverse<TContext>(
-    GraphVisitor<BundlerBundleGraphTraversable, TContext>
+    GraphVisitor<BundlerBundleGraphTraversable, TContext>,
   ): ?TContext;
   traverseBundles<TContext>(GraphVisitor<Bundle, TContext>): ?TContext;
   traverseContents<TContext>(
-    GraphVisitor<BundlerBundleGraphTraversable, TContext>
+    GraphVisitor<BundlerBundleGraphTraversable, TContext>,
   ): ?TContext;
 }
 
@@ -593,10 +594,10 @@ export interface BundleGraph {
   getBundles(): Array<Bundle>;
   getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
   getBundleGroupsReferencedByBundle(
-    bundle: Bundle
+    bundle: Bundle,
   ): Array<{|
     bundleGroup: BundleGroup,
-    dependency: Dependency
+    dependency: Dependency,
   |}>;
   getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<Bundle>;
   getChildBundles(bundle: Bundle): Array<Bundle>;
@@ -611,7 +612,7 @@ export interface BundleGraph {
   resolveSymbol(asset: Asset, symbol: Symbol): SymbolResolution;
   getExportedSymbols(asset: Asset): Array<SymbolResolution>;
   traverseBundles<TContext>(
-    visit: GraphTraversalCallback<Bundle, TContext>
+    visit: GraphTraversalCallback<Bundle, TContext>,
   ): ?TContext;
   findBundlesWithAsset(Asset): Array<Bundle>;
 }
@@ -619,27 +620,27 @@ export interface BundleGraph {
 export type BundleResult = {|
   contents: Blob,
   ast?: AST,
-  map?: ?SourceMap
+  map?: ?SourceMap,
 |};
 
 export type ResolveResult = {|
   filePath?: FilePath,
   isExcluded?: boolean,
   sideEffects?: boolean,
-  code?: string
+  code?: string,
 |};
 
 export type Bundler = {|
   bundle({|
     bundleGraph: MutableBundleGraph,
     options: PluginOptions,
-    logger: PluginLogger
+    logger: PluginLogger,
   |}): Async<void>,
   optimize({|
     bundleGraph: MutableBundleGraph,
     options: PluginOptions,
-    logger: PluginLogger
-  |}): Async<void>
+    logger: PluginLogger,
+  |}): Async<void>,
 |};
 
 export type Namer = {|
@@ -647,15 +648,15 @@ export type Namer = {|
     bundle: Bundle,
     bundleGraph: BundleGraph,
     options: PluginOptions,
-    logger: PluginLogger
-  |}): Async<?FilePath>
+    logger: PluginLogger,
+  |}): Async<?FilePath>,
 |};
 
 export type RuntimeAsset = {|
   filePath: FilePath,
   code: string,
   dependency?: Dependency,
-  isEntry?: boolean
+  isEntry?: boolean,
 |};
 
 export type Runtime = {|
@@ -663,8 +664,8 @@ export type Runtime = {|
     bundle: NamedBundle,
     bundleGraph: BundleGraph,
     options: PluginOptions,
-    logger: PluginLogger
-  |}): Async<void | RuntimeAsset | Array<RuntimeAsset>>
+    logger: PluginLogger,
+  |}): Async<void | RuntimeAsset | Array<RuntimeAsset>>,
 |};
 
 export type Packager = {|
@@ -676,9 +677,9 @@ export type Packager = {|
     logger: PluginLogger,
     getInlineBundleContents: (
       Bundle,
-      BundleGraph
-    ) => Async<{|contents: Blob, map: ?(Readable | string)|}>
-  |}): Async<BundleResult>
+      BundleGraph,
+    ) => Async<{|contents: Blob, map: ?(Readable | string)|}>,
+  |}): Async<BundleResult>,
 |};
 
 export type Optimizer = {|
@@ -687,8 +688,8 @@ export type Optimizer = {|
     contents: Blob,
     map: ?SourceMap,
     options: PluginOptions,
-    logger: PluginLogger
-  |}): Async<BundleResult>
+    logger: PluginLogger,
+  |}): Async<BundleResult>,
 |};
 
 export type Resolver = {|
@@ -696,70 +697,70 @@ export type Resolver = {|
     dependency: Dependency,
     options: PluginOptions,
     logger: PluginLogger,
-    filePath: FilePath
-  |}): Async<?ResolveResult>
+    filePath: FilePath,
+  |}): Async<?ResolveResult>,
 |};
 
 export type ProgressLogEvent = {|
   +type: 'log',
   +level: 'progress',
   +phase?: string,
-  +message: string
+  +message: string,
 |};
 
 export type DiagnosticLogEvent = {|
   +type: 'log',
   +level: 'error' | 'warn' | 'info' | 'verbose',
-  +diagnostics: Array<Diagnostic>
+  +diagnostics: Array<Diagnostic>,
 |};
 
 export type TextLogEvent = {|
   +type: 'log',
   +level: 'success',
-  +message: string
+  +message: string,
 |};
 
 export type LogEvent = ProgressLogEvent | DiagnosticLogEvent | TextLogEvent;
 
 export type BuildStartEvent = {|
-  type: 'buildStart'
+  type: 'buildStart',
 |};
 
 type WatchStartEvent = {|
-  type: 'watchStart'
+  type: 'watchStart',
 |};
 
 type WatchEndEvent = {|
-  type: 'watchEnd'
+  type: 'watchEnd',
 |};
 
 type ResolvingProgressEvent = {|
   type: 'buildProgress',
   phase: 'resolving',
-  dependency: Dependency
+  dependency: Dependency,
 |};
 
 type TransformingProgressEvent = {|
   type: 'buildProgress',
   phase: 'transforming',
-  filePath: FilePath
+  filePath: FilePath,
 |};
 
 type BundlingProgressEvent = {|
   type: 'buildProgress',
-  phase: 'bundling'
+  phase: 'bundling',
 |};
 
 type PackagingProgressEvent = {|
   type: 'buildProgress',
   phase: 'packaging',
-  bundle: NamedBundle
+  bundle: NamedBundle,
 |};
 
 type OptimizingProgressEvent = {|
   type: 'buildProgress',
   phase: 'optimizing',
-  bundle: NamedBundle
+  bundle: NamedBundle,
 |};
 
 export type BuildProgressEvent =
@@ -773,19 +774,19 @@ export type BuildSuccessEvent = {|
   type: 'buildSuccess',
   bundleGraph: BundleGraph,
   buildTime: number,
-  changedAssets: Map<string, Asset>
+  changedAssets: Map<string, Asset>,
 |};
 
 export type BuildFailureEvent = {|
   type: 'buildFailure',
-  diagnostics: Array<Diagnostic>
+  diagnostics: Array<Diagnostic>,
 |};
 
 export type BuildEvent = BuildFailureEvent | BuildSuccessEvent;
 
 export type ValidationEvent = {|
   type: 'validation',
-  filePath: FilePath
+  filePath: FilePath,
 |};
 
 export type ReporterEvent =
@@ -802,8 +803,8 @@ export type Reporter = {|
   report({|
     event: ReporterEvent,
     options: PluginOptions,
-    logger: PluginLogger
-  |}): Async<void>
+    logger: PluginLogger,
+  |}): Async<void>,
 |};
 
 export interface ErrorWithCode extends Error {


### PR DESCRIPTION
Previously, `NODE_ENV` varied based on what Parcel was building, which prevented libraries like React, which is used through `ink` in Parcel's CLI, from behaving in production mode in Parcel itself. 

Now, we capture any original `NODE_ENV`  as a build option and pass it through in `env`, and then set Parcel's own  `NODE_ENV` to `PARCEL_BUILD_ENV` if it's set ("production" in builds). Any passed `env` is now merged with the results of loading `dotenv`.

~This required adding a top-level Parcel option for `nodeEnv` as a build option, distinct from the `env` option. `NODE_ENV` could be added to an `env` passed by the cli, but we rely on the absence of `env` to determine whether to load the environment from `dotenv`.~

This also reverses the priority of `dotenv` files, making more specific `dotenv` files override less specific ones. This grew out of the integration test for `dotenv` with this behavior. It seems more intuitive to me. cc @demoorjasper


Test Plan:

Added integration test for overriding `NODE_ENV` in cases with and without a `dotenv` file present. Additionally:
* Verify that `process.env.NODE_ENV` remains `undefined` in Node when running Parcel from source, and that it loads the development build of React
* Verify that production React in Parcel itself is loaded when using a built version of Parcel
* Verify that a development version of React is loaded when using `parcel serve` in the react-hmr example
* Verify that a development version of React is *not* loaded when using `parcel server` with `NODE_ENV` set to "production" when invoking Parcel (Note: This required clearing cache between development and production builds as environment variables don't currently seem to invalidate cache.)