### PR TITLE
Fix Firefox certificate warnings

### DIFF
--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -7,6 +7,7 @@ import logger from '@parcel/logger';
 export default async function generateCertificate(
   fs: FileSystem,
   cacheDir: string,
+  domain: ?string,
 ) {
   let certDirectory = cacheDir;
 
@@ -63,9 +64,31 @@ export default async function generateCertificate(
     },
   ];
 
+  let altNames = [
+    {
+      type: 2, // DNS
+      value: 'localhost',
+    },
+    {
+      type: 7, // IP
+      ip: '127.0.0.1',
+    },
+  ];
+
+  if (domain) {
+    altNames.push({
+      type: 2, // DNS
+      value: domain,
+    });
+  }
+
   cert.setSubject(attrs);
   cert.setIssuer(attrs);
   cert.setExtensions([
+    {
+      name: 'basicConstraints',
+      cA: false,
+    },
     {
       name: 'keyUsage',
       keyCertSign: true,
@@ -94,16 +117,7 @@ export default async function generateCertificate(
     },
     {
       name: 'subjectAltName',
-      altNames: [
-        {
-          type: 6, // URI
-          value: 'http://example.org/webid#me',
-        },
-        {
-          type: 7, // IP
-          ip: '127.0.0.1',
-        },
-      ],
+      altNames,
     },
     {
       name: 'subjectKeyIdentifier',

--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -7,7 +7,7 @@ import logger from '@parcel/logger';
 export default async function generateCertificate(
   fs: FileSystem,
   cacheDir: string,
-  domain: ?string,
+  host: ?string,
 ) {
   let certDirectory = cacheDir;
 
@@ -75,10 +75,10 @@ export default async function generateCertificate(
     },
   ];
 
-  if (domain) {
+  if (host) {
     altNames.push({
       type: 2, // DNS
-      value: domain,
+      value: host,
     });
   }
 

--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -67,10 +67,6 @@ export default async function generateCertificate(
   cert.setIssuer(attrs);
   cert.setExtensions([
     {
-      name: 'basicConstraints',
-      cA: true,
-    },
-    {
       name: 'keyUsage',
       keyCertSign: true,
       digitalSignature: true,

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -17,6 +17,7 @@ type CreateHTTPServerOpts = {|
   outputFS: FileSystem,
   cacheDir: FilePath,
   listener?: (mixed, mixed) => void,
+  host?: string,
 |};
 
 // Creates either an http or https server with an awaitable dispose
@@ -32,7 +33,11 @@ export async function createHTTPServer(
     server = http.createServer(options.listener);
   } else if (options.https === true) {
     server = https.createServer(
-      await generateCertificate(options.outputFS, options.cacheDir),
+      await generateCertificate(
+        options.outputFS,
+        options.cacheDir,
+        options.host,
+      ),
       options.listener,
     );
   } else {

--- a/packages/examples/react-hmr/package.json
+++ b/packages/examples/react-hmr/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "demo": "parcel serve src/index.html --no-cache"
+    "demo": "parcel serve src/index.html --no-cache --https"
   },
   "devDependencies": {
     "parcel": "^2.0.0-alpha.3.2"

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -338,6 +338,7 @@ export default class Server extends EventEmitter {
       inputFS: this.options.inputFS,
       listener: app,
       outputFS: this.options.outputFS,
+      host: this.options.host,
     });
     this.stopServer = stop;
 

--- a/packages/reporters/hmr-server/src/HMRServer.js
+++ b/packages/reporters/hmr-server/src/HMRServer.js
@@ -51,6 +51,7 @@ export default class HMRServer {
       inputFS: this.options.inputFS,
       outputFS: this.options.outputFS,
       cacheDir: this.options.cacheDir,
+      host: this.options.host,
     });
     this.stopServer = stop;
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

According to #3398 firefox throws errors on our self-signed certificates, this is due to a misconfiguration in the generate script we use.

This PR fixes the script by removing the feature that says our certificates are issued by a CA.

Closes #3398

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Run dev server in firefox

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
