### PR TITLE
babel.config.json and fix semver usage

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ['@parcel/babel-preset']
-};

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "presets": ["@parcel/babel-preset"]
+}

--- a/flow-libs/semver.js.flow
+++ b/flow-libs/semver.js.flow
@@ -1,29 +1,30 @@
-// flow-typed signature: dc381ee55406f66b7272c6343db0834b
-// flow-typed version: da30fe6876/semver_v5.1.x/flow_>=v0.25.x
+// @flow
 
-declare module 'semver' {
+// based off of flow_typed/semver_v5.6.x/flow_>=v0.104.x
+
+declare module "semver" {
   declare type Release =
-    | 'major'
-    | 'premajor'
-    | 'minor'
-    | 'preminor'
-    | 'patch'
-    | 'prepatch'
-    | 'prerelease';
+    | "major"
+    | "premajor"
+    | "minor"
+    | "preminor"
+    | "patch"
+    | "prepatch"
+    | "prerelease";
 
   // The supported comparators are taken from the source here:
   // https://github.com/npm/node-semver/blob/8bd070b550db2646362c9883c8d008d32f66a234/semver.js#L623
   declare type Operator =
-    | '==='
-    | '!=='
-    | '=='
-    | '='
-    | '' // Not sure why you would want this, but whatever.
-    | '!='
-    | '>'
-    | '>='
-    | '<'
-    | '<=';
+    | "==="
+    | "!=="
+    | "=="
+    | "="
+    | "" // Not sure why you would want this, but whatever.
+    | "!="
+    | ">"
+    | ">="
+    | "<"
+    | "<=";
 
   declare class SemVer {
     build: Array<string>;
@@ -35,7 +36,7 @@ declare module 'semver' {
     raw: string;
     version: string;
 
-    constructor(version: string | SemVer, loose?: boolean): SemVer;
+    constructor(version: string | SemVer, options?: Options): SemVer;
     compare(other: string | SemVer): -1 | 0 | 1;
     compareMain(other: string | SemVer): -1 | 0 | 1;
     comparePre(other: string | SemVer): -1 | 0 | 1;
@@ -44,12 +45,12 @@ declare module 'semver' {
   }
 
   declare class Comparator {
-    loose?: boolean;
+    options?: Options;
     operator: Operator;
     semver: SemVer;
     value: string;
 
-    constructor(comp: string | Comparator, loose?: boolean): Comparator;
+    constructor(comp: string | Comparator, options?: Options): Comparator;
     parse(comp: string): void;
     test(version: string): boolean;
   }
@@ -59,7 +60,7 @@ declare module 'semver' {
     raw: string;
     set: Array<Array<Comparator>>;
 
-    constructor(range: string | Range, loose?: boolean): Range;
+    constructor(range: string | Range, options?: Options): Range;
     format(): string;
     parseRange(range: string): Array<Comparator>;
     test(version: string): boolean;
@@ -70,13 +71,19 @@ declare module 'semver' {
   declare var re: Array<RegExp>;
   declare var src: Array<string>;
 
+  declare type Options = {
+    options?: Options,
+    includePrerelease?: boolean,
+    ...
+  } | boolean;
+
   // Functions
-  declare function valid(v: string | SemVer, loose?: boolean): string | null;
-  declare function clean(v: string | SemVer, loose?: boolean): string | null;
+  declare function valid(v: string | SemVer, options?: Options): string | null;
+  declare function clean(v: string | SemVer, options?: Options): string | null;
   declare function inc(
     v: string | SemVer,
     release: Release,
-    loose?: boolean,
+    options?: Options,
     identifier?: string
   ): string | null;
   declare function inc(
@@ -84,69 +91,68 @@ declare module 'semver' {
     release: Release,
     identifier: string
   ): string | null;
-  declare function major(v: string | SemVer, loose?: boolean): number;
-  declare function minor(v: string | SemVer, loose?: boolean): number;
-  declare function patch(v: string | SemVer, loose?: boolean): number;
+  declare function major(v: string | SemVer, options?: Options): number;
+  declare function minor(v: string | SemVer, options?: Options): number;
+  declare function patch(v: string | SemVer, options?: Options): number;
+  declare function intersects(r1: string | SemVer, r2: string | SemVer, loose?: boolean): boolean;
+  declare function minVersion(range: Range | string): ?SemVer;
 
   // Comparison
   declare function gt(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function gte(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function lt(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function lte(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function eq(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function neq(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function cmp(
     v1: string | SemVer,
     comparator: Operator,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function compare(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
+    options?: Options
   ): -1 | 0 | 1;
   declare function rcompare(
     v1: string | SemVer,
     v2: string | SemVer,
-    loose?: boolean
-  ): -1 | 0 | 1;
-  declare function compareLoose(
-    v1: string | SemVer,
-    v2: string | SemVer
+    options?: Options
   ): -1 | 0 | 1;
   declare function diff(v1: string | SemVer, v2: string | SemVer): ?Release;
+  declare function intersects(comparator: Comparator): boolean;
   declare function sort(
     list: Array<string | SemVer>,
-    loose?: boolean
+    options?: Options
   ): Array<string | SemVer>;
   declare function rsort(
     list: Array<string | SemVer>,
-    loose?: boolean
+    options?: Options
   ): Array<string | SemVer>;
   declare function compareIdentifiers(
     v1: string | SemVer,
@@ -160,39 +166,52 @@ declare module 'semver' {
   // Ranges
   declare function validRange(
     range: string | Range,
-    loose?: boolean
+    options?: Options
   ): string | null;
   declare function satisfies(
     version: string | SemVer,
     range: string | Range,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function maxSatisfying(
     versions: Array<string | SemVer>,
     range: string | Range,
-    loose?: boolean
+    options?: Options
+  ): string | SemVer | null;
+  declare function minSatisfying(
+    versions: Array<string | SemVer>,
+    range: string | Range,
+    options?: Options
   ): string | SemVer | null;
   declare function gtr(
     version: string | SemVer,
     range: string | Range,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function ltr(
     version: string | SemVer,
     range: string | Range,
-    loose?: boolean
+    options?: Options
   ): boolean;
   declare function outside(
     version: string | SemVer,
     range: string | Range,
-    hilo: '>' | '<',
-    loose?: boolean
+    hilo: ">" | "<",
+    options?: Options
+  ): boolean;
+  declare function intersects(
+    range: Range
   ): boolean;
 
+  // Coercion
+  declare function coerce(
+    version: string | SemVer
+  ): ?SemVer
+
   // Not explicitly documented, or deprecated
-  declare function parse(version: string, loose?: boolean): ?SemVer;
+  declare function parse(version: string, options?: Options): ?SemVer;
   declare function toComparators(
     range: string | Range,
-    loose?: boolean
+    options?: Options
   ): Array<Array<string>>;
 }

--- a/flow-typed/npm/semver_v6.2.x.js
+++ b/flow-typed/npm/semver_v6.2.x.js
@@ -1,6 +1,5 @@
-// @flow
-
-// based off of flow_typed/semver_v5.6.x/flow_>=v0.104.x
+// flow-typed signature: 0f3a5488505547a0a71d5b49cf5c2954
+// flow-typed version: 01cfe946d5/semver_v6.2.x/flow_>=v0.104.x
 
 declare module "semver" {
   declare type Release =
@@ -40,6 +39,7 @@ declare module "semver" {
     compare(other: string | SemVer): -1 | 0 | 1;
     compareMain(other: string | SemVer): -1 | 0 | 1;
     comparePre(other: string | SemVer): -1 | 0 | 1;
+    compareBuild(other: string | SemVer): -1 | 0 | 1;
     format(): string;
     inc(release: Release, identifier: string): this;
   }
@@ -95,7 +95,7 @@ declare module "semver" {
   declare function minor(v: string | SemVer, options?: Options): number;
   declare function patch(v: string | SemVer, options?: Options): number;
   declare function intersects(r1: string | SemVer, r2: string | SemVer, loose?: boolean): boolean;
-  declare function minVersion(range: Range | string): ?SemVer;
+  declare function minVersion(r: string | Range): Range | null;
 
   // Comparison
   declare function gt(
@@ -205,7 +205,8 @@ declare module "semver" {
 
   // Coercion
   declare function coerce(
-    version: string | SemVer
+    version: string | SemVer,
+    options?: Options
   ): ?SemVer
 
   // Not explicitly documented, or deprecated

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@ const babel = require('gulp-babel');
 const gulp = require('gulp');
 const path = require('path');
 const rimraf = require('rimraf');
-const babelConfig = require('./babel.config.js');
+const babelConfig = require('./babel.config.json');
 
 const IGNORED_PACKAGES = [
   '!packages/examples/**',
@@ -11,7 +11,7 @@ const IGNORED_PACKAGES = [
   '!packages/core/workers/test/integration/**',
   '!packages/core/is-v2-ready-yet/**',
   '!packages/core/test-utils/**',
-  '!packages/core/types/**'
+  '!packages/core/types/**',
 ];
 
 const paths = {
@@ -20,16 +20,16 @@ const paths = {
     '!packages/*/scope-hoisting/src/helpers.js',
     '!**/loaders/**',
     '!**/prelude.js',
-    ...IGNORED_PACKAGES
+    ...IGNORED_PACKAGES,
   ],
   packageOther: [
     'packages/*/scope-hoisting/src/helpers.js',
     'packages/*/*/src/**/loaders/**',
     'packages/*/*/src/**/prelude.js',
-    'packages/*/dev-server/src/templates/**'
+    'packages/*/dev-server/src/templates/**',
   ],
   packageJson: 'packages/core/parcel/package.json',
-  packages: 'packages/'
+  packages: 'packages/',
 };
 
 /*
@@ -59,7 +59,7 @@ exports.clean = function clean(cb) {
 exports.default = exports.build = gulp.series(
   gulp.parallel(buildBabel, copyOthers),
   // Babel reads from package.json so update these after babel has run
-  () => updatePackageJson(paths.packageJson)
+  () => updatePackageJson(paths.packageJson),
 );
 
 function buildBabel() {
@@ -94,7 +94,7 @@ function updatePackageJson(file) {
         }
 
         vinyl.contents = Buffer.from(JSON.stringify(json, null, 2));
-      })
+      }),
     )
     .pipe(gulp.dest(path.dirname(file)));
 }

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -15,6 +15,6 @@
     "read-pkg-up": "^4.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.1.2"
+    "@babel/core": "^7.7.0"
   }
 }

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -30,7 +30,7 @@
     "browserslist": "^4.6.6",
     "core-js": "^3.2.1",
     "nullthrows": "^1.1.1",
-    "semver": "^5.4.1"
+    "semver": "^5.7.0"
   },
   "devDependencies": {
     "@parcel/types": "^2.0.0-alpha.3.1"

--- a/packages/transformers/babel/src/getBabelTargets.js
+++ b/packages/transformers/babel/src/getBabelTargets.js
@@ -37,7 +37,7 @@ export default async function getBabelTargets(
     // Use package.engines.node by default if we are compiling for node.
     if (typeof nodeVersion === 'string') {
       try {
-        targets.node = getMinSemver(nodeVersion);
+        targets.node = semver.minVersion(nodeVersion).version;
       } catch (e) {
         throw new Error("Expected 'node' engine to be a valid Semver Range");
       }
@@ -93,12 +93,4 @@ async function loadBrowserslist(config): Promise<?BrowserslistConfig> {
   if (browserslistConfig) {
     return browserslist.parseConfig(browserslistConfig);
   }
-}
-
-// TODO: Replace with `minVersion` (https://github.com/npm/node-semver#ranges-1)
-//       once semver has been upgraded across Parcel.
-function getMinSemver(version) {
-  let range = new semver.Range(version);
-  let sorted = range.set.sort((a, b) => a[0].semver.compare(b[0].semver));
-  return sorted[0][0].semver.version;
 }

--- a/packages/transformers/babel/src/getBabelTargets.js
+++ b/packages/transformers/babel/src/getBabelTargets.js
@@ -37,6 +37,7 @@ export default async function getBabelTargets(
     // Use package.engines.node by default if we are compiling for node.
     if (typeof nodeVersion === 'string') {
       try {
+        //$FlowFixMe catch error when minVersion() returned null
         targets.node = semver.minVersion(nodeVersion).version;
       } catch (e) {
         throw new Error("Expected 'node' engine to be a valid Semver Range");

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.2", "@babel/core@^7.2.0", "@babel/core@^7.2.2", "@babel/core@^7.4.4":
+"@babel/core@^7.0.0", "@babel/core@^7.2.0", "@babel/core@^7.2.2", "@babel/core@^7.4.4":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.2.tgz#ea5b99693bcfc058116f42fa1dd54da412b29d91"
   integrity sha512-eeD7VEZKfhK1KUXGiyPFettgF3m513f8FoBSWiQ1xTvl1RAopLs42Wp9+Ze911I6H0N9lNqJMDgoZT7gHsipeQ==
@@ -45,12 +45,42 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.7.0":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.7.5.tgz#ae1323cd035b5160293307f50647e83f8ba62f7e"
+  integrity sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helpers" "^7.7.4"
+    "@babel/parser" "^7.7.5"
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.3.3", "@babel/generator@^7.4.4", "@babel/generator@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.2.tgz#2f4852d04131a5e17ea4f6645488b5da66ebf3af"
   integrity sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==
   dependencies:
     "@babel/types" "^7.7.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.4.tgz#db651e2840ca9aa66f327dcec1dc5f5fa9611369"
+  integrity sha512-m5qo2WgdOJeyYngKImbkyQrnUN1mPceaG5BV+G0E3gWsa4l/jCSryWJdM2x8OuGAOyh+3d5pVYfZWCiNFtynxg==
+  dependencies:
+    "@babel/types" "^7.7.4"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -133,12 +163,28 @@
     "@babel/template" "^7.7.0"
     "@babel/types" "^7.7.0"
 
+"@babel/helper-function-name@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz#ab6e041e7135d436d8f0a3eca15de5b67a341a2e"
+  integrity sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.7.4"
+    "@babel/template" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-get-function-arity@^7.0.0", "@babel/helper-get-function-arity@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.0.tgz#c604886bc97287a1d1398092bc666bc3d7d7aa2d"
   integrity sha512-tLdojOTz4vWcEnHWHCuPN5P85JLZWbm5Fx5ZsMEMPhF3Uoe3O7awrbM2nQ04bDOUToH/2tH/ezKEOR8zEYzqyw==
   dependencies:
     "@babel/types" "^7.7.0"
+
+"@babel/helper-get-function-arity@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz#cb46348d2f8808e632f0ab048172130e636005f0"
+  integrity sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==
+  dependencies:
+    "@babel/types" "^7.7.4"
 
 "@babel/helper-hoist-variables@^7.7.0":
   version "7.7.0"
@@ -228,6 +274,13 @@
   dependencies:
     "@babel/types" "^7.7.0"
 
+"@babel/helper-split-export-declaration@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz#57292af60443c4a3622cf74040ddc28e68336fd8"
+  integrity sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==
+  dependencies:
+    "@babel/types" "^7.7.4"
+
 "@babel/helper-wrap-function@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.7.0.tgz#15af3d3e98f8417a60554acbb6c14e75e0b33b74"
@@ -247,6 +300,15 @@
     "@babel/traverse" "^7.7.0"
     "@babel/types" "^7.7.0"
 
+"@babel/helpers@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.7.4.tgz#62c215b9e6c712dadc15a9a0dcab76c92a940302"
+  integrity sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==
+  dependencies:
+    "@babel/template" "^7.7.4"
+    "@babel/traverse" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
@@ -260,6 +322,11 @@
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
   integrity sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==
+
+"@babel/parser@^7.7.4", "@babel/parser@^7.7.5":
+  version "7.7.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.5.tgz#cbf45321619ac12d83363fcf9c94bb67fa646d71"
+  integrity sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
 
 "@babel/plugin-proposal-async-generator-functions@^7.7.0":
   version "7.7.0"
@@ -831,6 +898,15 @@
     "@babel/parser" "^7.7.0"
     "@babel/types" "^7.7.0"
 
+"@babel/template@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.7.4.tgz#428a7d9eecffe27deac0a98e23bf8e3675d2a77b"
+  integrity sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.2.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.2.tgz#ef0a65e07a2f3c550967366b3d9b62a2dcbeae09"
@@ -846,10 +922,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.7.4.tgz#9c1e7c60fb679fe4fcfaa42500833333c2058558"
+  integrity sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.7.4"
+    "@babel/helper-function-name" "^7.7.4"
+    "@babel/helper-split-export-declaration" "^7.7.4"
+    "@babel/parser" "^7.7.4"
+    "@babel/types" "^7.7.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.7.1", "@babel/types@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.2.tgz#550b82e5571dcd174af576e23f0adba7ffc683f7"
   integrity sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.7.4":
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.4.tgz#516570d539e44ddf308c07569c258ff94fde9193"
+  integrity sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"


### PR DESCRIPTION
# ↪️ Pull Request

- Use babel.config.json in the monorepo
- Update semver to make use of new `semver.minVersion` (because the old approach was broken for `*` and returned undefined as the min version in that case)