### PR TITLE
Use relative urls to compute urls for loaders at runtime

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -72,6 +72,7 @@ describe('css', () => {
       {
         name: 'index.js',
         assets: [
+          'bundle-url.js',
           'cacheLoader.js',
           'css-loader.js',
           'index.js',

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -274,7 +274,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['local.js'],
@@ -640,7 +646,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['local.js', 'test.txt.js'],
@@ -663,7 +675,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['local.js'],
@@ -691,6 +709,7 @@ describe('javascript', function() {
         name: 'index.js',
         assets: [
           'index.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',
@@ -720,6 +739,7 @@ describe('javascript', function() {
         name: 'index.js',
         assets: [
           'index.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',
@@ -747,6 +767,7 @@ describe('javascript', function() {
         assets: [
           'index.js',
           'common.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',
@@ -774,12 +795,19 @@ describe('javascript', function() {
       },
       {
         name: 'b.js',
-        assets: ['b.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'b.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         name: 'a.js',
         assets: [
           'a.js',
+          'bundle-url.js',
           'common.js',
           'cacheLoader.js',
           'js-loader.js',
@@ -799,6 +827,7 @@ describe('javascript', function() {
         name: 'index.js',
         assets: [
           'index.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',
@@ -1726,6 +1755,7 @@ describe('javascript', function() {
           'index.js',
           'JSRuntime.js',
           'JSRuntime.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -1821,7 +1851,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'ts.js',
-        assets: ['ts.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'ts.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['async.js'],
@@ -1841,6 +1877,7 @@ describe('javascript', function() {
         name: 'ts-interop.js',
         assets: [
           'ts-interop.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',
@@ -1868,6 +1905,7 @@ describe('javascript', function() {
         name: 'ts-interop-arrow.js',
         assets: [
           'ts-interop-arrow.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',
@@ -1893,7 +1931,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'rollup.js',
-        assets: ['rollup.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'rollup.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['async.js'],
@@ -1911,7 +1955,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'parcel.js',
-        assets: ['parcel.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'parcel.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['async.js'],

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -590,7 +590,7 @@ describe('output formats', function() {
         'utf8',
       );
       assert(entry.includes('function importModule'));
-      assert(entry.includes("('/async"));
+      assert(/'async.[0-9a-f]*.js'\)/.test(entry));
 
       let async = await outputFS.readFile(
         b.getBundles().find(b => b.name.startsWith('async')).filePath,
@@ -620,7 +620,7 @@ describe('output formats', function() {
         'utf8',
       );
       assert(entry.includes('Promise.all'));
-      assert(/\('\/async\..+?\.css'\)/.test(entry));
+      assert(/'async.[0-9a-f]*.css'\)/.test(entry));
       assert(/import\('' \+ '\.\/async\..+?\.js'\)/.test(entry));
 
       let async = await outputFS.readFile(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1518,7 +1518,13 @@ describe('scope hoisting', function() {
       },
       {
         type: 'js',
-        assets: ['cacheLoader.js', 'index.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'bundle-url.js',
+          'cacheLoader.js',
+          'index.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {
         type: 'js',

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -413,7 +413,13 @@ describe('watcher', function() {
     assertBundles(bundleGraph, [
       {
         name: 'index.js',
-        assets: ['index.js', 'cacheLoader.js', 'js-loader.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+        ],
       },
       {assets: ['local.js']},
     ]);
@@ -431,6 +437,7 @@ describe('watcher', function() {
         name: 'index.js',
         assets: [
           'index.js',
+          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'JSRuntime.js',

--- a/packages/core/utils/src/relativeBundlePath.js
+++ b/packages/core/utils/src/relativeBundlePath.js
@@ -1,13 +1,19 @@
-// @flow
+// @flow strict-local
+
 import type {Bundle} from '@parcel/types';
+
 import path from 'path';
 import nullthrows from 'nullthrows';
 
-export function relativeBundlePath(from: Bundle, to: Bundle) {
+export function relativeBundlePath(
+  from: Bundle,
+  to: Bundle,
+  opts: {|leadingDotSlash: boolean|} = {leadingDotSlash: true},
+) {
   let p = path
     .relative(path.dirname(nullthrows(from.filePath)), nullthrows(to.filePath))
     .replace(/\\/g, '/');
-  if (p[0] !== '.') {
+  if (opts.leadingDotSlash && p[0] !== '.') {
     p = './' + p;
   }
 

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -123,9 +123,10 @@ export default new Runtime({
             )}'))`;
           }
 
-          let url = urlJoin(nullthrows(b.target.publicUrl), nullthrows(b.name));
-
-          return `require(${JSON.stringify(loader)})('${url}')`;
+          let url = relativeBundlePath(bundle, b, {leadingDotSlash: false});
+          return `require(${JSON.stringify(
+            loader,
+          )})(require('./bundle-url').getBundleURL() + '${url}')`;
         })
         .filter(Boolean);
 


### PR DESCRIPTION
This makes it so that only relative urls are written into bundles for loading code, and that absolute urls are computed at runtime using `bundle-url`. This makes bundles more portable as `publicUrl` may be absolute.

Test Plan: Adjusted integration tests. Additionally, temporarily added async bundle loading back to the kitchen sink test and verified async js and css was properly loaded.