### PR TITLE
Remove support for exporting reassigned CommonJS exports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/commonjs-exports-reassign/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/commonjs-exports-reassign/a.js
@@ -1,0 +1,3 @@
+const b = require('./b')
+
+output = [b.fn(), b];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/commonjs-exports-reassign/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/commonjs-exports-reassign/b.js
@@ -1,0 +1,2 @@
+exports.fn = () => 'foobar';
+exports = 42;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/a.js
@@ -1,4 +1,4 @@
 import foo from './wrapped'
-import bar from './exports'
+import bar from './notwrapped'
 
 output = foo() + bar()

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/exports.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/exports.js
@@ -1,1 +1,0 @@
-exports = () => 'bar'

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/notwrapped.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/notwrapped.js
@@ -1,0 +1,1 @@
+module.exports = () => 'bar'

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -334,6 +334,19 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'foobar');
     });
 
+    it('does not export reassigned CommonJS exports references', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/commonjs-exports-reassign/a.js',
+        ),
+      );
+
+      let [foo, bExports] = await run(b);
+      assert.equal(foo, 'foobar');
+      assert.equal(typeof bExports, 'object');
+    });
+
     it('supports import default CommonJS interop with dynamic imports', async function() {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
This removes support in scope hoisting for interpreting an assignment to the `exports` variable itself as an export.

In Node (and I assume CommonJS in general), `exports` is a binding local to the module, and reassigning it does not affect the module's exports. In other words, requiring a module with the contents `exports = 3` results in an empty exports object, not `3`.

Test Plan: 
* Removed support.
* Verified that test assuming this behavior is broken.
* Adjusted the test to test unwrapped `module.exports` instead, as the test doesn't reflect Node's behavior.