### PR TITLE
Scope hoisting: temporarily remove module.exports optimization

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-before-module-exports/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-before-module-exports/a.js
@@ -1,0 +1,3 @@
+'use strict';
+
+output = require('./b');

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-before-module-exports/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-before-module-exports/b.js
@@ -1,0 +1,6 @@
+// Assign to both `exports` and `module.exports` in CommonJS.
+// Some published packages do this in babel-generated output:
+// https://unpkg.com/browse/dom-helpers@3.4.0/class/hasClass.js
+
+exports.foo = 27;
+module.exports = 42;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-exports-before-exports/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-exports-before-exports/a.js
@@ -1,0 +1,3 @@
+'use strict';
+
+output = require('./b');

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-exports-before-exports/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-exports-before-exports/b.js
@@ -1,0 +1,2 @@
+module.exports = 42;
+exports.foo = 27;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -968,6 +968,30 @@ describe('scope hoisting', function() {
       assert.equal(output, 5);
     });
 
+    it('builds commonjs modules that assigns to exports before module.exports', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-before-module-exports/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 42);
+    });
+
+    it('builds commonjs modules that assigns to module.exports before exports', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/module-exports-before-exports/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 42);
+    });
+
     it("doesn't insert parcelRequire for missing non-js assets", async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -252,28 +252,31 @@ const VISITOR = {
 
     // Match module.exports = expression; assignments and replace with a variable declaration
     // if this is the first assignemnt. This avoids the extra empty object assignment in many cases.
-    if (
-      t.matchesPattern(left, 'module.exports') &&
-      !path.scope.hasBinding('module')
-    ) {
-      let exportsId = getExportsIdentifier(asset, path.scope);
-      asset.meta.isCommonJS = true;
-      asset.symbols.set('*', exportsId.name);
+    //
+    // TODO: Re-introduce this when it can handle both exports and module.exports concurrently
+    //
+    // if (
+    //   t.matchesPattern(left, 'module.exports') &&
+    //   !path.scope.hasBinding('module')
+    // ) {
+    //   let exportsId = getExportsIdentifier(asset, path.scope);
+    //   asset.meta.isCommonJS = true;
+    //   asset.symbols.set('*', exportsId.name);
 
-      if (
-        path.scope === path.scope.getProgramParent() &&
-        !path.scope.getBinding(exportsId.name) &&
-        path.parentPath.isStatement()
-      ) {
-        let [decl] = path.parentPath.replaceWith(
-          t.variableDeclaration('var', [
-            t.variableDeclarator(exportsId, right),
-          ]),
-        );
+    //   if (
+    //     path.scope === path.scope.getProgramParent() &&
+    //     !path.scope.getBinding(exportsId.name) &&
+    //     path.parentPath.isStatement()
+    //   ) {
+    //     let [decl] = path.parentPath.replaceWith(
+    //       t.variableDeclaration('var', [
+    //         t.variableDeclarator(exportsId, right),
+    //       ]),
+    //     );
 
-        path.scope.registerDeclaration(decl);
-      }
-    }
+    //     path.scope.registerDeclaration(decl);
+    //   }
+    // }
 
     if (path.scope.hasBinding('exports')) {
       return;


### PR DESCRIPTION
In CommonJS, it's possible to assign to properties on both `exports` and `module.exports` as they initially represent the same object. ~Previously in these cases, the exports object was only created for `module.exports` and `exports` usage was transformed to references to an object yet to be declared.~

This temporarily undoes the optimization introduced in #3800 to allow this. We should investigate a better path forward.

Thanks to @devongovett for guidance here :smile:

Test Plan: Added an integration test