### PR TITLE
Fix process hanging when using hmr reporter

### DIFF
--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -152,30 +152,6 @@ describe.only('hmr', function() {
     assert(!!message.diagnostics, 'Should contain a diagnostics key');
     assert(!!message.diagnostics.html, 'Should contain a html diagnostic');
     assert(!!message.diagnostics.ansi, 'Should contain an ansi diagnostic');
-
-    assert.deepEqual(message.diagnostics.html, [
-      {
-        message:
-          '<span style="font-weight:bold;">@parcel/transformer-babel</span>: Unexpected token, expected &quot;,&quot; (1:12)',
-        stack:
-          'SyntaxError: Unexpected token, expected &quot;,&quot; (1:12)\n    at Object.raise (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:6930:17)\n    at Object.unexpected (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:8323:16)\n    at Object.expect (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:8309:28)\n    at Object.parseCallExpressionArguments (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9342:14)\n    at Object.parseSubscript (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9270:29)\n    at Object.parseSubscript (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:2852:18)\n    at Object.parseSubscripts (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9186:19)\n    at Object.parseSubscripts (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:2814:18)\n    at Object.parseExprSubscripts (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9175:17)\n    at Object.parseMaybeUnary (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9145:21)',
-        codeframe:
-          '<u>/Users/jasperdemoor/Documents/open-source/parcel/packages/core/integration-tests/test/input/local.js:1:12</u>\n<u></u><span style="color:#ff0000;">&gt;</span> 1 | <span style="color:#ff0000;">require</span>(<span style="color:#00ffee;">&quot;fs&quot;</span>; exports.a = <span style="color:#00ffee;">5</span>; exports.b = <span style="color:#00ffee;">5</span>;\n<span style="color:#ff0000;">&gt;</span>   |            <span style="color:#ff0000;">^</span>',
-        hints: [],
-      },
-    ]);
-
-    assert.deepEqual(message.diagnostics.ansi, [
-      {
-        message:
-          '\u001b[1m@parcel/transformer-babel\u001b[22m: Unexpected token, expected "," (1:12)',
-        stack:
-          'SyntaxError: Unexpected token, expected "," (1:12)\n    at Object.raise (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:6930:17)\n    at Object.unexpected (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:8323:16)\n    at Object.expect (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:8309:28)\n    at Object.parseCallExpressionArguments (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9342:14)\n    at Object.parseSubscript (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9270:29)\n    at Object.parseSubscript (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:2852:18)\n    at Object.parseSubscripts (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9186:19)\n    at Object.parseSubscripts (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:2814:18)\n    at Object.parseExprSubscripts (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9175:17)\n    at Object.parseMaybeUnary (/Users/jasperdemoor/Documents/open-source/parcel/node_modules/@babel/parser/lib/index.js:9145:21)',
-        codeframe:
-          '\u001b[4m/Users/jasperdemoor/Documents/open-source/parcel/packages/core/integration-tests/test/input/local.js:1:12\u001b[24m\n\u001b[4m\u001b[24m\u001b[31m>\u001b[39m 1 | \u001b[31mrequire\u001b[39m(\u001b[36m"fs"\u001b[39m; exports.a = \u001b[36m5\u001b[39m; exports.b = \u001b[36m5\u001b[39m;\n\u001b[31m>\u001b[39m   |            \u001b[31m^\u001b[39m',
-        hints: [],
-      },
-    ]);
   });
 
   it('should emit an HMR error to new connections after a bundle failure', async function() {

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -9,7 +9,6 @@ import {
   outputFS,
   ncp,
 } from '@parcel/test-utils';
-// import {sleep} from '@parcel/test-utils';
 import WebSocket from 'ws';
 import json5 from 'json5';
 import getPort from 'get-port';
@@ -19,7 +18,27 @@ const config = {
   reporters: ['@parcel/reporter-hmr-server'],
 };
 
-describe.only('hmr', function() {
+async function closeSocket(ws: WebSocket) {
+  ws.close();
+  await new Promise(resolve => (ws.onclose = resolve));
+}
+
+async function openSocket(uri: string, opts: any) {
+  let ws = new WebSocket(uri, opts);
+
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+
+  return ws;
+}
+
+async function nextWSMessage(ws: WebSocket) {
+  return json5.parse(await new Promise(resolve => ws.once('message', resolve)));
+}
+
+describe('hmr', function() {
   let subscription;
   let ws;
 
@@ -39,630 +58,597 @@ describe.only('hmr', function() {
     await closeSocket(ws);
   });
 
-  async function nextWSMessage(ws: WebSocket) {
-    return json5.parse(
-      await new Promise(resolve => ws.once('message', resolve)),
-    );
-  }
+  describe('hmr server', () => {
+    it('should emit an HMR update for the file that changed', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
 
-  async function closeSocket(ws: WebSocket) {
-    ws.close();
-    await new Promise(resolve => (ws.onclose = resolve));
-  }
+      subscription = await b.watch();
+      await getNextBuild(b);
 
-  async function openSocket(uri: string) {
-    let ws = new WebSocket(uri);
+      ws = await openSocket('ws://localhost:' + port);
 
-    await new Promise((resolve, reject) => {
-      ws.once('open', resolve);
-      ws.once('error', reject);
+      outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'exports.a = 5;\nexports.b = 5;',
+      );
+
+      let message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'update');
+
+      // Figure out why output doesn't change...
+      let localAsset = message.assets.find(
+        asset => asset.output === 'exports.a = 5;\nexports.b = 5;',
+      );
+      assert(!!localAsset);
     });
 
-    return ws;
-  }
+    it('should emit an HMR update for all new dependencies along with the changed file', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
 
-  it('should emit an HMR update for the file that changed', async function() {
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      inputFS: overlayFS,
-      config,
+      subscription = await b.watch();
+      await getNextBuild(b);
+
+      ws = await openSocket('ws://localhost:' + port);
+
+      outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"); exports.a = 5; exports.b = 5;',
+      );
+
+      let message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'update');
+
+      assert.equal(message.assets.length, 2);
     });
 
-    subscription = await b.watch();
-    await getNextBuild(b);
+    it('should emit an HMR error on bundle failure', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
 
-    ws = await openSocket('ws://localhost:' + port);
+      subscription = await b.watch();
+      await getNextBuild(b);
 
-    outputFS.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'exports.a = 5;\nexports.b = 5;',
-    );
+      ws = await openSocket('ws://localhost:' + port);
 
-    let message = await nextWSMessage(ws);
+      outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"; exports.a = 5; exports.b = 5;',
+      );
 
-    assert.equal(message.type, 'update');
+      let message = await nextWSMessage(ws);
 
-    // Figure out why output doesn't change...
-    let localAsset = message.assets.find(
-      asset => asset.output === 'exports.a = 5;\nexports.b = 5;',
-    );
-    assert(!!localAsset);
+      assert.equal(message.type, 'error');
+
+      assert(!!message.diagnostics, 'Should contain a diagnostics key');
+      assert(!!message.diagnostics.html, 'Should contain a html diagnostic');
+      assert(!!message.diagnostics.ansi, 'Should contain an ansi diagnostic');
+    });
+
+    it('should emit an HMR error to new connections after a bundle failure', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
+
+      subscription = await b.watch();
+      await getNextBuild(b);
+
+      await outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"; exports.a = 5; exports.b = 5;',
+      );
+
+      ws = await openSocket('ws://localhost:' + port);
+      let message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'error');
+    });
+
+    it('should emit an HMR update after error has been resolved', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
+
+      subscription = await b.watch();
+      await getNextBuild(b);
+
+      ws = await openSocket('ws://localhost:' + port);
+
+      await outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"; exports.a = 5; exports.b = 5;',
+      );
+
+      let message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'error');
+
+      await outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"); exports.a = 5; exports.b = 5;',
+      );
+
+      message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'update');
+    });
+
+    it('should make a secure connection', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: true,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
+
+      subscription = await b.watch();
+      await getNextBuild(b);
+
+      ws = await openSocket('wss://localhost:' + port, {
+        rejectUnauthorized: false,
+      });
+
+      await outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'exports.a = 5;\nexports.b = 5;',
+      );
+
+      let message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'update');
+    });
+
+    it('should make a secure connection with custom certificate', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: {
+            key: path.join(__dirname, '/integration/https/private.pem'),
+            cert: path.join(__dirname, '/integration/https/primary.crt'),
+          },
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
+
+      subscription = await b.watch();
+      await getNextBuild(b);
+
+      ws = await openSocket('wss://localhost:' + port, {
+        rejectUnauthorized: false,
+      });
+
+      outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'exports.a = 5;\nexports.b = 5;',
+      );
+
+      let message = await nextWSMessage(ws);
+
+      assert.equal(message.type, 'update');
+    });
   });
 
-  it('should emit an HMR update for all new dependencies along with the changed file', async function() {
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      inputFS: overlayFS,
-      config,
-    });
+  // TODO: Update these...
+  describe('hmr runtime', () => {
+    /*it('should work with circular dependencies', async function() {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        inputFS: overlayFS,
+        config,
+      });
 
-    subscription = await b.watch();
-    await getNextBuild(b);
+      let bundle = await b.run();
+      subscription = await b.watch();
+      await getNextBuild(b);
 
-    ws = await openSocket('ws://localhost:' + port);
+      ws = await openSocket('ws://localhost:' + port);
+      let outputs = [];
 
-    outputFS.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"); exports.a = 5; exports.b = 5;',
-    );
-
-    let message = await nextWSMessage(ws);
-
-    assert.equal(message.type, 'update');
-
-    assert.equal(message.assets.length, 2);
-  });
-
-  it('should emit an HMR error on bundle failure', async function() {
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      inputFS: overlayFS,
-      config,
-    });
-
-    subscription = await b.watch();
-    await getNextBuild(b);
-
-    ws = await openSocket('ws://localhost:' + port);
-
-    outputFS.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"; exports.a = 5; exports.b = 5;',
-    );
-
-    let message = await nextWSMessage(ws);
-
-    assert.equal(message.type, 'error');
-
-    assert(!!message.diagnostics, 'Should contain a diagnostics key');
-    assert(!!message.diagnostics.html, 'Should contain a html diagnostic');
-    assert(!!message.diagnostics.ansi, 'Should contain an ansi diagnostic');
-  });
-
-  it('should emit an HMR error to new connections after a bundle failure', async function() {
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      inputFS: overlayFS,
-      config,
-    });
-
-    subscription = await b.watch();
-    await getNextBuild(b);
-
-    await outputFS.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"; exports.a = 5; exports.b = 5;',
-    );
-
-    ws = await openSocket('ws://localhost:' + port);
-    let message = await nextWSMessage(ws);
-
-    assert.equal(message.type, 'error');
-  });
-
-  it('should emit an HMR update after error has been resolved', async function() {
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      inputFS: overlayFS,
-      config,
-    });
-
-    subscription = await b.watch();
-    await getNextBuild(b);
-
-    ws = await openSocket('ws://localhost:' + port);
-
-    await outputFS.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"; exports.a = 5; exports.b = 5;',
-    );
-
-    let message = await nextWSMessage(ws);
-
-    assert.equal(message.type, 'error');
-
-    await outputFS.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"); exports.a = 5; exports.b = 5;',
-    );
-
-    message = await nextWSMessage(ws);
-
-    assert.equal(message.type, 'update');
-  });
-
-  /*it.skip('should work with circular dependencies', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/hmr-circular'),
-      path.join(__dirname, '/input'),
-    );
-
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      watch: true,
-      hmr: true,
-    });
-    let bundle = await b.bundle();
-    let outputs = [];
-
-    await run(bundle, {
-      output(o) {
-        outputs.push(o);
-      },
-    });
-
-    assert.deepEqual(outputs, [3]);
-
-    await sleep(100);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      "var other = require('./index.js'); exports.a = 5; exports.b = 5;",
-    );
-
-    // await nextEvent(b, 'bundled');
-    assert.deepEqual(outputs, [3, 10]);
-  });
-
-  it.skip('should accept HMR updates in the runtime after an initial error', async function() {
-    await fs.mkdirp(path.join(__dirname, '/input'));
-    fs.writeFile(
-      path.join(__dirname, '/input/index.js'),
-      'module.hot.accept();throw new Error("Something");\noutput(123);',
-    );
-
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      watch: true,
-      hmr: true,
-    });
-    let bundle = await b.bundle();
-
-    let outputs = [];
-    let errors = [];
-
-    var ctx = prepareBrowserContext(bundle, {
-      output(o) {
-        outputs.push(o);
-      },
-      error(e) {
-        errors.push(e);
-      },
-    });
-    vm.createContext(ctx);
-    vm.runInContext(
-      `try {
-        ${(await fs.readFile(bundle.name)).toString()}
-      } catch(e) {
-        error(e);
-      }`,
-      ctx,
-    );
-
-    assert.deepEqual(outputs, []);
-    assert.equal(errors.length, 1);
-    assert.equal(errors[0].message, 'Something');
-
-    await sleep(100);
-    fs.writeFile(path.join(__dirname, '/input/index.js'), 'output(123);');
-
-    // await nextEvent(b, 'bundled');
-    assert.deepEqual(outputs, [123]);
-    assert.equal(errors.length, 1);
-  });
-
-  it.skip('should call dispose and accept callbacks', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/hmr-callbacks'),
-      path.join(__dirname, '/input'),
-    );
-
-    let port = await getPort();
-    let b = await bundle(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      env: {
-        HMR_HOSTNAME: 'localhost',
-        HMR_PORT: port,
-      },
-      watch: true,
-    });
-
-    let outputs = [];
-    let moduleId = '';
-
-    await run(b, {
-      reportModuleId(id) {
-        moduleId = id;
-      },
-      output(o) {
-        outputs.push(o);
-      },
-    });
-
-    assert.deepEqual(outputs, [3]);
-
-    let ws = new WebSocket('ws://localhost:' + port);
-
-    await sleep(50);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'exports.a = 5; exports.b = 5;',
-    );
-
-    await nextWSMessage(ws);
-    await sleep(50);
-
-    assert.notEqual(moduleId, undefined);
-    assert.deepEqual(outputs, [
-      3,
-      'dispose-' + moduleId,
-      10,
-      'accept-' + moduleId,
-    ]);
-  });
-
-  it.skip('should work across bundles', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/hmr-dynamic'),
-      path.join(__dirname, '/input'),
-    );
-
-    let port = await getPort();
-    let b = await bundle(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      env: {
-        HMR_HOSTNAME: 'localhost',
-        HMR_PORT: port,
-      },
-      watch: true,
-    });
-
-    let outputs = [];
-
-    await run(b, {
-      output(o) {
-        outputs.push(o);
-      },
-    });
-
-    await sleep(50);
-    assert.deepEqual(outputs, [3]);
-
-    let ws = new WebSocket('ws://localhost:' + port);
-
-    await sleep(50);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'exports.a = 5; exports.b = 5;',
-    );
-
-    await nextWSMessage(ws);
-    await sleep(50);
-
-    assert.deepEqual(outputs, [3, 10]);
-  });
-
-  it.skip('should bubble up HMR events to a page reload', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/hmr-reload'),
-      path.join(__dirname, '/input'),
-    );
-
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      watch: true,
-      hmr: true,
-    });
-    let bundle = await b.bundle();
-
-    let outputs = [];
-    let ctx = await run(
-      bundle,
-      {
+      await run(bundle, {
         output(o) {
           outputs.push(o);
         },
-      },
-      {require: false},
-    );
-    let spy = sinon.spy(ctx.location, 'reload');
+      });
 
-    await sleep(50);
-    assert.deepEqual(outputs, [3]);
-    assert(spy.notCalled);
+      assert.deepEqual(outputs, [3]);
 
-    await sleep(100);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'exports.a = 5; exports.b = 5;',
-    );
+      outputFS.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        "var other = require('./index.js'); exports.a = 5; exports.b = 5;",
+      );
 
-    // await nextEvent(b, 'bundled');
-    assert.deepEqual(outputs, [3]);
-    assert(spy.calledOnce);
-  });
-
-  it.skip('should trigger a page reload when a new bundle is created', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/hmr-new-bundle'),
-      path.join(__dirname, '/input'),
-    );
-
-    let b = bundler(path.join(__dirname, '/input/index.html'), {
-      watch: true,
-      hmr: true,
-    });
-    let bundle = await b.bundle();
-
-    let ctx = await run([...bundle.childBundles][0], {}, {require: false});
-    let spy = sinon.spy(ctx.location, 'reload');
-
-    await sleep(50);
-    assert(spy.notCalled);
-
-    await sleep(100);
-    fs.writeFile(
-      path.join(__dirname, '/input/index.js'),
-      'import "./index.css"',
-    );
-
-    // await nextEvent(b, 'bundled');
-    assert(spy.calledOnce);
-
-    let contents = await fs.readFile(
-      path.join(__dirname, '/dist/index.html'),
-      'utf8',
-    );
-    assert(contents.includes('.css'));
-  });
-
-  it.skip('should log emitted errors and show an error overlay', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/commonjs'),
-      path.join(__dirname, '/input'),
-    );
-
-    let port = await getPort();
-    let b = await bundle(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      env: {
-        HMR_HOSTNAME: 'localhost',
-        HMR_PORT: port,
-      },
-      watch: true,
+      assert.deepEqual(outputs, [3, 10]);
     });
 
-    let logs = [];
-    let ctx = await run(
-      b,
-      {
-        console: {
-          error(msg) {
-            logs.push(msg);
-          },
-          log() {},
-          clear() {},
+    it.skip('should accept HMR updates in the runtime after an initial error', async function() {
+      await fs.mkdirp(path.join(__dirname, '/input'));
+      fs.writeFile(
+        path.join(__dirname, '/input/index.js'),
+        'module.hot.accept();throw new Error("Something");\noutput(123);',
+      );
+
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        watch: true,
+        hmr: true,
+      });
+      let bundle = await b.bundle();
+
+      let outputs = [];
+      let errors = [];
+
+      var ctx = prepareBrowserContext(bundle, {
+        output(o) {
+          outputs.push(o);
         },
-      },
-      {require: false},
-    );
-
-    let spy = sinon.spy(ctx.document.body, 'appendChild');
-    let ws = new WebSocket('ws://localhost:' + port);
-
-    await sleep(50);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"; exports.a = 5; exports.b = 5;',
-    );
-
-    await nextWSMessage(ws);
-    await sleep(50);
-
-    assert.equal(logs.length, 1);
-    assert(logs[0].trim().startsWith('[parcel] 🚨'));
-    assert(spy.calledOnce);
-  });
-
-  it.skip('should log when errors resolve', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/commonjs'),
-      path.join(__dirname, '/input'),
-    );
-
-    let port = await getPort();
-    let b = await bundle(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: false,
-        port,
-        host: 'localhost',
-      },
-      env: {
-        HMR_HOSTNAME: 'localhost',
-        HMR_PORT: port,
-      },
-      watch: true,
-    });
-
-    let logs = [];
-    let ctx = await run(
-      b,
-      {
-        console: {
-          error(msg) {
-            logs.push(msg);
-          },
-          log(msg) {
-            logs.push(msg);
-          },
-          clear() {},
+        error(e) {
+          errors.push(e);
         },
-        location: {hostname: 'localhost', reload: function() {}},
-      },
-      {require: false},
-    );
+      });
+      vm.createContext(ctx);
+      vm.runInContext(
+        `try {
+          ${(await fs.readFile(bundle.name)).toString()}
+        } catch(e) {
+          error(e);
+        }`,
+        ctx,
+      );
 
-    let appendSpy = sinon.spy(ctx.document.body, 'appendChild');
-    let removeSpy = sinon.spy(ctx.document.getElementById('tmp'), 'remove');
-    let ws = new WebSocket('ws://localhost:' + port);
+      assert.deepEqual(outputs, []);
+      assert.equal(errors.length, 1);
+      assert.equal(errors[0].message, 'Something');
 
-    await sleep(50);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"; exports.a = 5; exports.b = 5;',
-    );
+      await sleep(100);
+      fs.writeFile(path.join(__dirname, '/input/index.js'), 'output(123);');
 
-    await nextWSMessage(ws);
-    await sleep(50);
-
-    assert(appendSpy.called);
-
-    await sleep(50);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'require("fs"); exports.a = 5; exports.b = 5;',
-    );
-    await nextWSMessage(ws);
-    await sleep(50);
-
-    assert(removeSpy.called);
-
-    // assert.equal(logs.length, 2);
-    assert(logs[0].trim().startsWith('[parcel] 🚨'));
-    assert(logs[1].trim().startsWith('[parcel] ✨'));
-  });
-
-  it.skip('should make a secure connection', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/commonjs'),
-      path.join(__dirname, '/input'),
-    );
-
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: true,
-        port,
-        host: 'localhost',
-      },
-      watch: true,
+      // await nextEvent(b, 'bundled');
+      assert.deepEqual(outputs, [123]);
+      assert.equal(errors.length, 1);
     });
 
-    await b.run();
+    it.skip('should call dispose and accept callbacks', async function() {
+      await ncp(
+        path.join(__dirname, '/integration/hmr-callbacks'),
+        path.join(__dirname, '/input'),
+      );
 
-    let ws = new WebSocket('wss://localhost:' + port, {
-      rejectUnauthorized: false,
-    });
-
-    await sleep(100);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'exports.a = 5;\nexports.b = 5;',
-    );
-
-    let message = await nextWSMessage(ws);
-
-    assert.equal(message.type, 'update');
-
-    assert.equal(message.assets.length, 1);
-    assert.equal(message.assets[0].generated.js, 'exports.a = 5;\nexports.b = 5;');
-    assert.deepEqual(message.assets[0].deps, {});
-
-    await closeSocket(ws);
-  });
-
-  it.skip('should make a secure connection with custom certificate', async function() {
-    await ncp(
-      path.join(__dirname, '/integration/commonjs'),
-      path.join(__dirname, '/input'),
-    );
-
-    let port = await getPort();
-    let b = bundler(path.join(__dirname, '/input/index.js'), {
-      hot: {
-        https: {
-          key: path.join(__dirname, '/integration/https/private.pem'),
-          cert: path.join(__dirname, '/integration/https/primary.crt'),
+      let port = await getPort();
+      let b = await bundle(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
         },
-        port,
-        host: 'localhost',
-      },
-      watch: true,
+        env: {
+          HMR_HOSTNAME: 'localhost',
+          HMR_PORT: port,
+        },
+        watch: true,
+      });
+
+      let outputs = [];
+      let moduleId = '';
+
+      await run(b, {
+        reportModuleId(id) {
+          moduleId = id;
+        },
+        output(o) {
+          outputs.push(o);
+        },
+      });
+
+      assert.deepEqual(outputs, [3]);
+
+      let ws = new WebSocket('ws://localhost:' + port);
+
+      await sleep(50);
+      fs.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'exports.a = 5; exports.b = 5;',
+      );
+
+      await nextWSMessage(ws);
+      await sleep(50);
+
+      assert.notEqual(moduleId, undefined);
+      assert.deepEqual(outputs, [
+        3,
+        'dispose-' + moduleId,
+        10,
+        'accept-' + moduleId,
+      ]);
     });
 
-    await b.run();
+    it.skip('should work across bundles', async function() {
+      await ncp(
+        path.join(__dirname, '/integration/hmr-dynamic'),
+        path.join(__dirname, '/input'),
+      );
 
-    let ws = new WebSocket('wss://localhost:' + port, {
-      rejectUnauthorized: false,
+      let port = await getPort();
+      let b = await bundle(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        env: {
+          HMR_HOSTNAME: 'localhost',
+          HMR_PORT: port,
+        },
+        watch: true,
+      });
+
+      let outputs = [];
+
+      await run(b, {
+        output(o) {
+          outputs.push(o);
+        },
+      });
+
+      await sleep(50);
+      assert.deepEqual(outputs, [3]);
+
+      let ws = new WebSocket('ws://localhost:' + port);
+
+      await sleep(50);
+      fs.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'exports.a = 5; exports.b = 5;',
+      );
+
+      await nextWSMessage(ws);
+      await sleep(50);
+
+      assert.deepEqual(outputs, [3, 10]);
     });
 
-    await sleep(100);
-    fs.writeFile(
-      path.join(__dirname, '/input/local.js'),
-      'exports.a = 5;\nexports.b = 5;',
-    );
+    it.skip('should bubble up HMR events to a page reload', async function() {
+      await ncp(
+        path.join(__dirname, '/integration/hmr-reload'),
+        path.join(__dirname, '/input'),
+      );
 
-    let message = await nextWSMessage(ws);
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        watch: true,
+        hmr: true,
+      });
+      let bundle = await b.bundle();
 
-    assert.equal(message.type, 'update');
+      let outputs = [];
+      let ctx = await run(
+        bundle,
+        {
+          output(o) {
+            outputs.push(o);
+          },
+        },
+        {require: false},
+      );
+      let spy = sinon.spy(ctx.location, 'reload');
 
-    assert.equal(message.assets.length, 1);
-    assert.equal(message.assets[0].generated.js, 'exports.a = 5;\nexports.b = 5;');
-    assert.deepEqual(message.assets[0].deps, {});
+      await sleep(50);
+      assert.deepEqual(outputs, [3]);
+      assert(spy.notCalled);
 
-    await closeSocket(ws);
-  });*/
+      await sleep(100);
+      fs.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'exports.a = 5; exports.b = 5;',
+      );
+
+      // await nextEvent(b, 'bundled');
+      assert.deepEqual(outputs, [3]);
+      assert(spy.calledOnce);
+    });
+
+    it.skip('should trigger a page reload when a new bundle is created', async function() {
+      await ncp(
+        path.join(__dirname, '/integration/hmr-new-bundle'),
+        path.join(__dirname, '/input'),
+      );
+
+      let b = bundler(path.join(__dirname, '/input/index.html'), {
+        watch: true,
+        hmr: true,
+      });
+      let bundle = await b.bundle();
+
+      let ctx = await run([...bundle.childBundles][0], {}, {require: false});
+      let spy = sinon.spy(ctx.location, 'reload');
+
+      await sleep(50);
+      assert(spy.notCalled);
+
+      await sleep(100);
+      fs.writeFile(
+        path.join(__dirname, '/input/index.js'),
+        'import "./index.css"',
+      );
+
+      // await nextEvent(b, 'bundled');
+      assert(spy.calledOnce);
+
+      let contents = await fs.readFile(
+        path.join(__dirname, '/dist/index.html'),
+        'utf8',
+      );
+      assert(contents.includes('.css'));
+    });
+
+    it.skip('should log emitted errors and show an error overlay', async function() {
+      await ncp(
+        path.join(__dirname, '/integration/commonjs'),
+        path.join(__dirname, '/input'),
+      );
+
+      let port = await getPort();
+      let b = await bundle(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        env: {
+          HMR_HOSTNAME: 'localhost',
+          HMR_PORT: port,
+        },
+        watch: true,
+      });
+
+      let logs = [];
+      let ctx = await run(
+        b,
+        {
+          console: {
+            error(msg) {
+              logs.push(msg);
+            },
+            log() {},
+            clear() {},
+          },
+        },
+        {require: false},
+      );
+
+      let spy = sinon.spy(ctx.document.body, 'appendChild');
+      let ws = new WebSocket('ws://localhost:' + port);
+
+      await sleep(50);
+      fs.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"; exports.a = 5; exports.b = 5;',
+      );
+
+      await nextWSMessage(ws);
+      await sleep(50);
+
+      assert.equal(logs.length, 1);
+      assert(logs[0].trim().startsWith('[parcel] 🚨'));
+      assert(spy.calledOnce);
+    });
+
+    it.skip('should log when errors resolve', async function() {
+      await ncp(
+        path.join(__dirname, '/integration/commonjs'),
+        path.join(__dirname, '/input'),
+      );
+
+      let port = await getPort();
+      let b = await bundle(path.join(__dirname, '/input/index.js'), {
+        hot: {
+          https: false,
+          port,
+          host: 'localhost',
+        },
+        env: {
+          HMR_HOSTNAME: 'localhost',
+          HMR_PORT: port,
+        },
+        watch: true,
+      });
+
+      let logs = [];
+      let ctx = await run(
+        b,
+        {
+          console: {
+            error(msg) {
+              logs.push(msg);
+            },
+            log(msg) {
+              logs.push(msg);
+            },
+            clear() {},
+          },
+          location: {hostname: 'localhost', reload: function() {}},
+        },
+        {require: false},
+      );
+
+      let appendSpy = sinon.spy(ctx.document.body, 'appendChild');
+      let removeSpy = sinon.spy(ctx.document.getElementById('tmp'), 'remove');
+      let ws = new WebSocket('ws://localhost:' + port);
+
+      await sleep(50);
+      fs.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"; exports.a = 5; exports.b = 5;',
+      );
+
+      await nextWSMessage(ws);
+      await sleep(50);
+
+      assert(appendSpy.called);
+
+      await sleep(50);
+      fs.writeFile(
+        path.join(__dirname, '/input/local.js'),
+        'require("fs"); exports.a = 5; exports.b = 5;',
+      );
+      await nextWSMessage(ws);
+      await sleep(50);
+
+      assert(removeSpy.called);
+
+      // assert.equal(logs.length, 2);
+      assert(logs[0].trim().startsWith('[parcel] 🚨'));
+      assert(logs[1].trim().startsWith('[parcel] ✨'));
+    });*/
+  });
 });

--- a/packages/reporters/hmr-server/src/HMRReporter.js
+++ b/packages/reporters/hmr-server/src/HMRReporter.js
@@ -2,6 +2,7 @@
 import type {HMRServerOptions} from './types.js.flow';
 
 import {Reporter} from '@parcel/plugin';
+import invariant from 'assert';
 import HMRServer from './HMRServer';
 
 let servers: Map<number, HMRServer> = new Map();
@@ -19,18 +20,28 @@ export default new Reporter({
     };
 
     let server = servers.get(hmrOptions.port);
-    if (!server) {
-      server = new HMRServer(hmrOptions);
-      servers.set(hmrOptions.port, server);
-      await server.start();
-    }
+    switch (event.type) {
+      case 'watchStart': {
+        invariant(server == null);
 
-    if (event.type === 'buildSuccess') {
-      server.emitUpdate(event);
-    }
-
-    if (event.type === 'buildFailure') {
-      server.emitError(event.diagnostics);
+        server = new HMRServer(hmrOptions);
+        servers.set(hmrOptions.port, server);
+        await server.start();
+        break;
+      }
+      case 'watchEnd':
+        invariant(server != null);
+        await server.stop();
+        servers.delete(hmrOptions.port);
+        break;
+      case 'buildSuccess':
+        invariant(server != null);
+        server.emitUpdate(event);
+        break;
+      case 'buildFailure':
+        invariant(server != null);
+        server.emitError(event.diagnostics);
+        break;
     }
   },
 });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The HMR server(s) in the hmr reporter weren't being shut down after watchEnd and started before watchStart. This PR fixes that by using these events properly as intended.
Maybe this will also allow us to re-introduce the hmr tests?

This PR also re-enables all HMR server tests with a lot of tweaks so they run reliably on the new virtual fs and properly handle websocket connections so there's no need for any kind of sleeping in the tests.

In a follow-up PR we should probably look into re-enabling all tests for the hmr runtime.

cc @padmaia 

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
