### PR TITLE
Upgrade deasync to support Node v13. Fix #2245 again.

### DIFF
--- a/packages/core/parcel-bundler/package.json
+++ b/packages/core/parcel-bundler/package.json
@@ -44,7 +44,7 @@
     "cross-spawn": "^6.0.4",
     "css-modules-loader-core": "^1.1.0",
     "cssnano": "^4.0.0",
-    "deasync": "^0.1.14",
+    "deasync": "^0.1.16",
     "dotenv": "^7.0.0",
     "dotenv-expand": "^5.1.0",
     "envinfo": "^7.3.1",


### PR DESCRIPTION
See #2245. Ran into the same "Could not locate the bindings file" error with Node v13.3.0.