### PR TITLE
RFC: Scope hoisting: support bundling browserify-built bundles

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/browserify-bundle.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/browserify-bundle.js
@@ -1,0 +1,105 @@
+/*
+ * The following is a browserify-produced umd bundle created with:
+ * `echo "module.exports = 'foo';" | browserify - -s foo | prettier --parser babel`
+ * using browserify@16.5.0
+ *
+ * Includes the prelude and umd wrapper from browserify. Browserify's MIT
+ * license is reproduced below.
+ * https://github.com/browserify/browserify/blob/b8ddf68ac3ebc80ee3b9b1cb67e013256503efe9/LICENSE
+ * https://github.com/browserify/browser-pack/blob/cd0bd31f8c110e19a80429019b64e887b1a82b2b/LICENSE
+ */
+
+/**
+ * MIT License
+ *
+ * Copyright (c) 2010 James Halliday
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+(function(f) {
+  if (typeof exports === "object" && typeof module !== "undefined") {
+    module.exports = f();
+  } else if (typeof define === "function" && define.amd) {
+    define([], f);
+  } else {
+    var g;
+    if (typeof window !== "undefined") {
+      g = window;
+    } else if (typeof global !== "undefined") {
+      g = global;
+    } else if (typeof self !== "undefined") {
+      g = self;
+    } else {
+      g = this;
+    }
+    g.foo = f();
+  }
+})(function() {
+  var define, module, exports;
+  return (function() {
+    function r(e, n, t) {
+      function o(i, f) {
+        if (!n[i]) {
+          if (!e[i]) {
+            var c = "function" == typeof require && require;
+            if (!f && c) return c(i, !0);
+            if (u) return u(i, !0);
+            var a = new Error("Cannot find module '" + i + "'");
+            throw ((a.code = "MODULE_NOT_FOUND"), a);
+          }
+          var p = (n[i] = { exports: {} });
+          e[i][0].call(
+            p.exports,
+            function(r) {
+              var n = e[i][1][r];
+              return o(n || r);
+            },
+            p,
+            p.exports,
+            r,
+            e,
+            n,
+            t
+          );
+        }
+        return n[i].exports;
+      }
+      for (
+        var u = "function" == typeof require && require, i = 0;
+        i < t.length;
+        i++
+      )
+        o(t[i]);
+      return o;
+    }
+    return r;
+  })()(
+    {
+      1: [
+        function(require, module, exports) {
+          module.exports = "foo";
+        },
+        {}
+      ]
+    },
+    {},
+    [1]
+  )(1);
+});

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/index.js
@@ -1,0 +1,1 @@
+output = require('./browserify-bundle');

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3640,6 +3640,17 @@ describe('scope hoisting', function() {
       assert.equal(output.require, 'function');
     });
 
+    it('can bundle browserify-produced umd bundles', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/browserify-compat/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), 'foo');
+    });
+
     it("doesn't support require.resolve calls for included assets", async function() {
       let message =
         "`require.resolve` calls for bundled modules or bundled assets aren't supported with scope hoisting";

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -359,6 +359,11 @@ const VISITOR: Visitor<MutableAsset> = {
     if (path.node.name === 'global' && !path.scope.hasBinding('global')) {
       path.replaceWith(t.identifier('$parcel$global'));
     }
+
+    if (path.node.name === 'require' && !path.scope.hasBinding('require')) {
+      // All require() calls that have any chance on working with scope-hoisting were already replaced.
+      path.replaceWith(t.identifier('undefined'));
+    }
   },
 
   ThisExpression(path, asset) {


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/4634

This adds support for bundling bundles that have already been built using browserify. 

The browserify prelude tests for an existing global `require` using `typeof require === 'function'`, ~~which we previously statically rewrote to `'function' === 'function'`,~~ leading it to attempt to invoke a require that does not exist. Should we find a way of conditionally rewriting these, maybe only if `require` is only used as a function in a statically analyzable way?

Test Plan: Added a test using a browserify bundle as a fixture.