### PR TITLE
Update to Flow 0.115

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -37,4 +37,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.113.0
+0.115.0

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "doctoc": "^1.4.0",
     "eslint": "^6.0.0",
-    "flow-bin": "0.113.0",
+    "flow-bin": "0.115.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -345,9 +345,11 @@ export default class Server extends EventEmitter {
     server.listen(this.options.port, this.options.host);
     return new Promise((resolve, reject) => {
       server.once('error', err => {
-        this.options.logger.error({
-          message: serverErrors(err, this.options.port),
-        });
+        this.options.logger.error(
+          ({
+            message: serverErrors(err, this.options.port),
+          }: Diagnostic),
+        );
         reject(err);
       });
 

--- a/packages/reporters/dev-server/src/serverErrors.js
+++ b/packages/reporters/dev-server/src/serverErrors.js
@@ -8,7 +8,7 @@ const serverErrorList = {
   EADDRINUSE: 'There is already a process listening on port {port}.',
 };
 
-export default function serverErrors(err: ServerError, port: number) {
+export default function serverErrors(err: ServerError, port: number): string {
   let desc = `Error: ${
     err.code
   } occurred while setting up server on port ${port.toString()}.`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5844,10 +5844,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
-flow-bin@0.113.0:
-  version "0.113.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.113.0.tgz#6457d250dbc6f71ca51e75f00a96d23cde5d987a"
-  integrity sha512-76uE2LGNe50wm+Jup8Np4FBcMbyy5V2iE+K25PPIYLaEMGHrL1jnQfP9L0hTzA5oh2ZJlexRLMlaPqIYIKH9nw==
+flow-bin@0.115.0:
+  version "0.115.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.115.0.tgz#22e3ad9e5c7198967de80138ba8a9154ff387960"
+  integrity sha512-xW+U2SrBaAr0EeLvKmXAmsdnrH6x0Io17P6yRJTNgrrV42G8KXhBAD00s6oGbTTqRyHD0nP47kyuU34zljZpaQ==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This updates to flow 0.115 and addresses one violation by explicitly annotating a diagnostic.

Test Plan: `yarn flow`