### PR TITLE
Point GraphQL Transformer's "main" target to the correct file

### DIFF
--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -12,6 +12,9 @@
   "bin": "src/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
+  "engines": {
+    "node": ">= 10.0.0"
+  },
   "dependencies": {
     "@parcel/config-default": "^2.0.0-alpha.3.1",
     "@parcel/core": "^2.0.0-alpha.3.2",

--- a/packages/transformers/graphql/package.json
+++ b/packages/transformers/graphql/package.json
@@ -9,7 +9,8 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "src/GraphQLTransformer.js",
+  "main": "lib/GraphQLTransformer.js",
+  "source": "src/GraphQLTransformer.js",
   "engines": {
     "node": ">= 10.0.0",
     "parcel": "^2.0.0-alpha.1.1"


### PR DESCRIPTION
# ↪️ Pull Request

I was testing out Parcel 2 and noticed that the graphql transformer's `package.json`#main entry points to the `src/` file instead of the built one in `lib/`, causing my builds to fail with `Unexpected token` errors.

This PR switches `main` to use the `lib` dir and adds a `source` field to the `package.json`.

## 💻 Examples

N/A

## 🚨 Test instructions

As far as I can tell, any build that tries to use the GraphQL transformer would fail.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs

<!--
Love parcel? Please consider supporting our collective:
👉  https://opencollective.com/parcel/donate
-->
