### PR TITLE
Use parentNode.removeChild instead of link.remove to support IE11

### DIFF
--- a/packages/core/parcel-bundler/src/builtins/css-loader.js
+++ b/packages/core/parcel-bundler/src/builtins/css-loader.js
@@ -3,7 +3,9 @@ var bundle = require('./bundle-url');
 function updateLink(link) {
   var newLink = link.cloneNode();
   newLink.onload = function () {
-    link.remove();
+    if (link.parentNode !== null) {
+        link.parentNode.removeChild(link);
+    }
   };
   newLink.href = link.href.split('?')[0] + '?' + Date.now();
   link.parentNode.insertBefore(newLink, link.nextSibling);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
Issue: #3291
PR related #3298 
