### PR TITLE
Use a lastCalled time instead of timeouts for throttle

### DIFF
--- a/packages/core/utils/src/throttle.js
+++ b/packages/core/utils/src/throttle.js
@@ -4,16 +4,12 @@ export default function throttle<TArgs: Iterable<mixed>>(
   fn: (...args: TArgs) => mixed,
   delay: number,
 ): (...args: TArgs) => void {
-  let timeout;
+  let lastCalled: ?number;
 
-  return function(...args: TArgs) {
-    if (timeout) {
-      return;
+  return function throttled(...args: TArgs) {
+    if (lastCalled == null || lastCalled + delay <= Date.now()) {
+      fn.call(this, ...args);
+      lastCalled = Date.now();
     }
-
-    timeout = setTimeout(() => {
-      timeout = null;
-      fn(...args);
-    }, delay);
   };
 }

--- a/packages/core/utils/test/throttle.test.js
+++ b/packages/core/utils/test/throttle.test.js
@@ -1,0 +1,45 @@
+// @flow strict-local
+
+import assert from 'assert';
+// $FlowFixMe
+import sinon from 'sinon';
+import throttle from '../src/throttle';
+
+describe('throttle', () => {
+  it("doesn't invoke a function more than once in a given interval", () => {
+    let spy = sinon.spy();
+    let throttled = throttle(spy, 100);
+
+    throttled(1);
+    throttled(2);
+    throttled(3);
+
+    assert(spy.calledOnceWithExactly(1));
+  });
+
+  it('calls the underlying function again once the interval has passed', () => {
+    let time = sinon.useFakeTimers();
+    let spy = sinon.spy();
+    let throttled = throttle(spy, 100);
+
+    throttled(1);
+    throttled(2);
+    throttled(3);
+
+    time.tick(100);
+    throttled(4);
+    assert.deepEqual(spy.args, [[1], [4]]);
+
+    time.restore();
+  });
+
+  it('preserves the `this` when throttled functions are invoked', () => {
+    let result;
+    let throttled = throttle(function() {
+      result = this.bar;
+    }, 100);
+
+    throttled.call({bar: 'baz'});
+    assert(result === 'baz');
+  });
+});

--- a/packages/reporters/cli/src/UI.js
+++ b/packages/reporters/cli/src/UI.js
@@ -50,11 +50,6 @@ export default function UI({events, options}: Props) {
         event.phase === state.progress?.phase
       ) {
         throttledDispatch(event);
-      } else if (
-        event.type === 'buildSuccess' ||
-        event.type === 'buildFailure'
-      ) {
-        setTimeout(() => dispatch(event), THROTTLE_DELAY);
       } else {
         dispatch(event);
       }


### PR DESCRIPTION
Rather than deferring the execution of the decorated function and ignoring calls until then, invoke it synchronously and ignore calls for the next `delay` seconds. I believe this should address the same intent as #3964 and removes these timers entirely.

This also adds a name to throttled functions and preserves the `this` value when the throttled function is invoked.

Test Plan: Added unit tests. Checked with react-hmr and simple example demo that there is no progress message printed after the build success message.