### PR TITLE
Load external url bundles from relative paths

### DIFF
--- a/packages/core/integration-tests/test/contentHashing.js
+++ b/packages/core/integration-tests/test/contentHashing.js
@@ -59,7 +59,7 @@ describe('content hashing', function() {
     await bundleJs();
 
     let js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    let filename = js.match(/\/(test\.[0-9a-f]+\.txt)/)[1];
+    let filename = js.match(/(test\.[0-9a-f]+\.txt)/)[1];
     assert(await outputFS.exists(path.join(distDir, filename)));
 
     await outputFS.writeFile(
@@ -69,7 +69,7 @@ describe('content hashing', function() {
     await bundleJs();
 
     js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    let newFilename = js.match(/\/(test\.[0-9a-f]+\.txt)/)[1];
+    let newFilename = js.match(/(test\.[0-9a-f]+\.txt)/)[1];
     assert(await outputFS.exists(path.join(distDir, newFilename)));
 
     assert.notEqual(filename, newFilename);

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -655,7 +655,7 @@ describe('javascript', function() {
         ],
       },
       {
-        assets: ['local.js', 'test.txt.js'],
+        assets: ['local.js', 'JSRuntime.js'],
       },
       {
         assets: ['test.txt'],
@@ -888,7 +888,7 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'test.txt.js'],
+        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js'],
       },
       {
         type: 'txt',
@@ -922,7 +922,7 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'test.txt.js'],
+        assets: ['index.js', 'JSRuntime.js', 'bundle-url.js'],
       },
       {
         type: 'txt',

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -590,7 +590,7 @@ describe('output formats', function() {
         'utf8',
       );
       assert(entry.includes('function importModule'));
-      assert(/'async.[0-9a-f]*.js'\)/.test(entry));
+      assert(/"async.[0-9a-f]*.js"\)/.test(entry));
 
       let async = await outputFS.readFile(
         b.getBundles().find(b => b.name.startsWith('async')).filePath,
@@ -620,7 +620,7 @@ describe('output formats', function() {
         'utf8',
       );
       assert(entry.includes('Promise.all'));
-      assert(/'async.[0-9a-f]*.css'\)/.test(entry));
+      assert(/"async.[0-9a-f]*.css"\)/.test(entry));
       assert(/import\('' \+ '\.\/async\..+?\.js'\)/.test(entry));
 
       let async = await outputFS.readFile(

--- a/packages/core/integration-tests/test/typescript.js
+++ b/packages/core/integration-tests/test/typescript.js
@@ -106,7 +106,7 @@ describe('typescript', function() {
       assertBundles(b, [
         {
           name: 'index.js',
-          assets: ['index.ts', 'test.txt.js'],
+          assets: ['index.ts', 'JSRuntime.js', 'bundle-url.js'],
         },
         {
           type: 'txt',

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/utils": "^2.0.0-alpha.3.1",
-    "nullthrows": "^1.1.1"
+    "@parcel/utils": "^2.0.0-alpha.3.1"
   }
 }


### PR DESCRIPTION
Load external url bundles from relative paths

This makes it so that "raw" assets create runtimes exporting their urls export code that, at runtime, derives an absolute url given a relative path to the bundle, rather than one relative to a `publicUrl`.

Like #3904, this makes use of `bundle-url.js`. Like bundle loader runtimes, this required renaming the runtime `filePath` to the path of the actual Parcel code that generates the runtime. 

Questions: 
* Should the "raw" transformer be renamed to the "url" transformer and be made always opt-in via a named pipeline rather than implicit for any unhandled ("*" in the config) asset?
* Is there a better way of requiring `bundle-url.js` that allows us to preserve a meaningful `filePath` for the runtime? Or possibly a "virtual" path?

Test Plan:
* Adjusted integration tests
* Built the `import-raw` integration test manually and logged the computed url, and verified it moved with the entry js.