### PR TITLE
Allow merging of global defined data for sass

### DIFF
--- a/packages/core/integration-tests/test/integration/scss-global-data/.sassrc.js
+++ b/packages/core/integration-tests/test/integration/scss-global-data/.sassrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  data: "$color: red;"
+}

--- a/packages/core/integration-tests/test/integration/scss-global-data/index.scss
+++ b/packages/core/integration-tests/test/integration/scss-global-data/index.scss
@@ -1,0 +1,3 @@
+.a {
+  color: $color;
+}

--- a/packages/core/integration-tests/test/integration/scss-global-data/package.json
+++ b/packages/core/integration-tests/test/integration/scss-global-data/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/packages/core/integration-tests/test/sass.js
+++ b/packages/core/integration-tests/test/sass.js
@@ -204,6 +204,24 @@ describe('sass', function() {
     assert(css.includes('.b'));
   });
 
+  it('should merge global data property from .sassrc.js', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/scss-global-data/index.scss'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.css',
+        assets: ['index.scss'],
+      },
+    ]);
+
+    let css = (
+      await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8')
+    ).replace(/\s+/g, ' ');
+    assert(css.includes('.a { color: red;'));
+  });
+
   it('should throw an exception when using webpack syntax', async function() {
     let didThrow = false;
     try {

--- a/packages/transformers/sass/src/SassTransformer.js
+++ b/packages/transformers/sass/src/SassTransformer.js
@@ -4,6 +4,7 @@ import type {PluginLogger} from '@parcel/logger';
 import {Transformer} from '@parcel/plugin';
 import {promisify, resolve} from '@parcel/utils';
 import {dirname} from 'path';
+import {EOL} from 'os';
 import {NodeFS} from '@parcel/fs';
 
 // E.g: ~library/file.sass
@@ -45,11 +46,9 @@ export default new Transformer({
       config = {};
     }
 
-    if (asset.isInline) {
-      config.data = await asset.getCode();
-    } else {
-      config.file = asset.filePath;
-    }
+    const code = await asset.getCode();
+    config.data = config.data ? config.data + EOL + code : code;
+    config.file = asset.filePath;
 
     if (config.importer === undefined) {
       config.importer = [];


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #3689 

Currently, when defining a `data` in the `.sassrc.js` config, all SASS/ SCSS files will be overridden by that content. This is confusing in the first place as it is not expected behavior and doesn't fulfill any use case (as far as I can imagine).

In my case, I just got an empty CSS file without any error message (as data only consists of variables).

This PR allows defining code that is imported into all files, which e.g. allows creating global variables or mixings. This makes Parcel v2 compatible with the behavior of Parcel v1.