### PR TITLE
Fixup bundlereport's asset list

### DIFF
--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -32,9 +32,9 @@ export default function bundleReport(bundleGraph: BundleGraph) {
     for (let asset of bundle.largestAssets) {
       // Add a row for the asset.
       rows.push([
-        asset == bundle.largestAssets[bundle.largestAssets.length - 1]
+        (asset == bundle.largestAssets[bundle.largestAssets.length - 1]
           ? '└── '
-          : '├── ' + formatFilename(asset.filePath, chalk.reset),
+          : '├── ') + formatFilename(asset.filePath, chalk.reset),
         chalk.dim(prettifySize(asset.size)),
         chalk.dim(chalk.green(prettifyTime(asset.time))),
       ]);


### PR DESCRIPTION
Operator precedence 😉 

before:
```
✨ Built in 7.87s

dist/index.js                                                                                        1.36 KB     22ms
├── .../parcel/packages/runtimes/js/lib/bundle-url.js                   1.33 KB    130ms
├── .../parcel/packages/runtimes/js/lib/loaders/browser/js-loader.js      804 B    217ms
├── .../parcel/packages/runtimes/js/lib/cacheLoader.js                    573 B    112ms
├── .../parcel/packages/runtimes/js/lib/JSRuntime.js                      365 B    174ms
└──                                                                                                     89 B    2.17s

dist/async.529a5838.js                                                                                 160 B     15ms
└──                                                                                                     21 B     87ms
```

after:
```
✨ Built in 7.68s

dist/index.js                                                                                        1.36 KB     18ms
├── .../parcel/packages/runtimes/js/lib/bundle-url.js                   1.33 KB    130ms
├── .../parcel/packages/runtimes/js/lib/loaders/browser/js-loader.js      804 B    217ms
├── .../parcel/packages/runtimes/js/lib/cacheLoader.js                    573 B    112ms
├── .../parcel/packages/runtimes/js/lib/JSRuntime.js                      365 B    174ms
└── index.js                                                                                            89 B    2.17s

dist/async.529a5838.js                                                                                 160 B     12ms
└── async.js                                                                                            21 B     87ms
```