### PR TITLE
Update Stale Action to run only twice a day

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale issues'
 on:
   schedule:
-    - cron: '0 */1 * * *'
+    - cron: '0 */12 * * *'
   issue_comment:
     types: [created]
 


### PR DESCRIPTION
This PR changes the stale action's schedule to only run twice a day, as all stale issues have already been flagged (due to the vast amount of issues we had to run it more frequent so we'd get through all of them in a day). We shouldn't send api calls to github for no reason.