### PR TITLE
Use runtimes to load workers and other urls

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -35,6 +35,8 @@
       "@parcel/runtime-browser-hmr",
       "@parcel/runtime-react-refresh"
     ],
+    "service-worker": ["@parcel/runtime-js"],
+    "web-worker": ["@parcel/runtime-js"],
     "node": ["@parcel/runtime-js"]
   },
   "optimizers": {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -310,6 +310,12 @@ export default class BundleGraph {
             return;
           }
 
+          // Don't deduplicate when context changes
+          if (node.value.env.context !== bundle.env.context) {
+            actions.skipChildren();
+            return;
+          }
+
           if (this._graph.hasEdge(node.value.id, asset.id, 'contains')) {
             inBundle = true;
             actions.stop();

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -12,7 +12,6 @@ import type {
   AssetNode,
   Bundle,
   BundleGraphNode,
-  BundleGroupNode,
   Dependency,
   DependencyNode,
 } from './types';
@@ -442,51 +441,6 @@ export default class BundleGraph {
     }
 
     return siblings;
-  }
-
-  getBundleGroupsReferencedByBundle(
-    bundle: Bundle,
-  ): Array<{
-    bundleGroup: BundleGroup,
-    dependency: Dependency,
-    ...
-  }> {
-    let node = nullthrows(
-      this._graph.getNode(bundle.id),
-      'Bundle graph must contain bundle',
-    );
-
-    let groupNodes: Array<BundleGroupNode> = [];
-    this._graph.traverse(
-      (node, context, actions) => {
-        if (node.type === 'bundle_group') {
-          groupNodes.push(node);
-          actions.skipChildren();
-        }
-      },
-      node,
-      'bundle',
-    );
-
-    return flatMap(groupNodes, groupNode => {
-      return this._graph
-        .getNodesConnectedTo(groupNode)
-        .filter(
-          node =>
-            node.type === 'dependency' &&
-            this._graph.hasEdge(bundle.id, node.id, 'contains'),
-        )
-        .map(dependencyNode => {
-          // TODO: Enforce non-null when bundle groups have the correct bundles
-          // pointing to them
-          invariant(dependencyNode.type === 'dependency');
-
-          return {
-            bundleGroup: groupNode.value,
-            dependency: dependencyNode.value,
-          };
-        });
-    });
   }
 
   getIncomingDependencies(asset: Asset): Array<Dependency> {

--- a/packages/core/integration-tests/test/blob-url.js
+++ b/packages/core/integration-tests/test/blob-url.js
@@ -21,9 +21,10 @@ describe('blob urls', () => {
       path.join(distDir, 'index.js'),
       'utf8',
     );
+    assert(bundleContent.includes('new Worker(require("blob-url:./worker"))'));
     assert(
       bundleContent.includes(
-        'new Worker(URL.createObjectURL(new Blob(["// modules are defined as an array\\n',
+        'module.exports = URL.createObjectURL(new Blob(["// modules are defined as an array\\n',
       ),
     );
     assert(
@@ -43,9 +44,10 @@ describe('blob urls', () => {
       path.join(distDir, 'index.js'),
       'utf8',
     );
+    assert(bundleContent.match(/new Worker\([^(]*\("blob-url:.\/worker"\)\)/));
     assert(
       bundleContent.includes(
-        "new Worker(URL.createObjectURL(new Blob(['!function(",
+        ".exports=URL.createObjectURL(new Blob(['!function(",
       ),
     );
     assert(

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -140,7 +140,7 @@ describe('css', () => {
     assert.equal(output(), 2);
 
     let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(/url\("\/test\.[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
     assert(css.includes('url("data:image/gif;base64,quotes")'));
@@ -150,7 +150,7 @@ describe('css', () => {
 
     assert(
       await outputFS.exists(
-        path.join(distDir, css.match(/url\("(\/test\.[0-9a-f]+\.woff2)"\)/)[1]),
+        path.join(distDir, css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]),
       ),
     );
   });
@@ -183,10 +183,7 @@ describe('css', () => {
     assert.equal(output(), 2);
 
     let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(
-      /url\(\/test\.[0-9a-f]+\.woff2\)/.test(css),
-      'woff ext found in css',
-    );
+    assert(/url\(test\.[0-9a-f]+\.woff2\)/.test(css), 'woff ext found in css');
     assert(css.includes('url(http://google.com)'), 'url() found');
     assert(css.includes('.index'), '.index found');
     assert(css.includes('url("data:image/gif;base64,quotes")'));
@@ -196,7 +193,7 @@ describe('css', () => {
 
     assert(
       await outputFS.exists(
-        path.join(distDir, css.match(/url\((\/test\.[0-9a-f]+\.woff2)\)/)[1]),
+        path.join(distDir, css.match(/url\((test\.[0-9a-f]+\.woff2)\)/)[1]),
       ),
     );
   });
@@ -228,16 +225,16 @@ describe('css', () => {
       },
     ]);
 
-    let css = await outputFS.readFile(
-      path.join(distDir, 'a', 'style1.css'),
-      'utf8',
-    );
+    let cssPath = path.join(distDir, 'a', 'style1.css');
+    let css = await outputFS.readFile(cssPath, 'utf8');
 
     assert(css.includes('background-image'), 'includes `background-image`');
     assert(/url\([^)]*\)/.test(css), 'includes url()');
 
     assert(
-      await outputFS.exists(path.join(distDir, css.match(/url\(([^)]*)\)/)[1])),
+      await outputFS.exists(
+        path.resolve(path.dirname(cssPath), css.match(/url\(([^)]*)\)/)[1]),
+      ),
       'path specified in url() exists',
     );
   });

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -462,11 +462,13 @@ describe('javascript', function() {
 
       assertBundles(b, [
         {
-          name: `index-${workerType}.js`,
-          assets: [`index-${workerType}.js`, 'bundle-url.js', 'JSRuntime.js'],
+          assets: ['importScripts.js', 'JSRuntime.js', 'JSRuntime.js'].concat(
+            workerType === 'serviceworker' ? ['bundle-url.js'] : [],
+          ),
         },
         {
-          assets: ['importScripts.js'],
+          name: `index-${workerType}.js`,
+          assets: [`index-${workerType}.js`, 'bundle-url.js', 'JSRuntime.js'],
         },
         {
           assets: ['imported.js'],
@@ -513,7 +515,7 @@ describe('javascript', function() {
         name: 'index-external.js',
         assets: ['index-external.js', 'bundle-url.js', 'JSRuntime.js'],
       },
-      {assets: ['external.js']},
+      {assets: ['external.js', 'JSRuntime.js']},
     ]);
 
     let workerBundleFile = path.join(
@@ -529,7 +531,12 @@ describe('javascript', function() {
 
     assert(
       workerBundleContents.includes(
-        'importScripts("https://unpkg.com/parcel");',
+        'importScripts(require("https://unpkg.com/parcel"));',
+      ),
+    );
+    assert(
+      workerBundleContents.includes(
+        'module.exports = "https://unpkg.com/parcel";',
       ),
     );
   });
@@ -618,16 +625,10 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: [
-          'index.js',
-          'lodash.js',
-          'bundle-url.js',
-          'JSRuntime.js',
-          'JSRuntime.js',
-        ],
+        assets: ['index.js', 'lodash.js', 'bundle-url.js', 'JSRuntime.js'],
       },
       {
-        assets: ['worker-a.js'],
+        assets: ['worker-a.js', 'JSRuntime.js'],
       },
       {
         assets: ['worker-b.js'],
@@ -657,7 +658,7 @@ describe('javascript', function() {
         assets: ['index.html'],
       },
       {
-        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js', 'JSRuntime.js'],
+        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js'],
       },
       {
         assets: ['worker.js'],

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -462,9 +462,12 @@ describe('javascript', function() {
 
       assertBundles(b, [
         {
-          assets: ['importScripts.js', 'JSRuntime.js', 'JSRuntime.js'].concat(
-            workerType === 'serviceworker' ? ['bundle-url.js'] : [],
-          ),
+          assets: [
+            'importScripts.js',
+            'bundle-url.js',
+            'JSRuntime.js',
+            'JSRuntime.js',
+          ],
         },
         {
           name: `index-${workerType}.js`,
@@ -628,7 +631,7 @@ describe('javascript', function() {
         assets: ['index.js', 'lodash.js', 'bundle-url.js', 'JSRuntime.js'],
       },
       {
-        assets: ['worker-a.js', 'JSRuntime.js'],
+        assets: ['worker-a.js', 'bundle-url.js', 'JSRuntime.js'],
       },
       {
         assets: ['worker-b.js'],

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -347,12 +347,26 @@ describe('javascript', function() {
   });
 
   it('should support bundling workers', async function() {
-    let b = await bundle(path.join(__dirname, '/integration/workers/index.js'));
+    let b = await bundle(
+      path.join(__dirname, '/integration/workers/index.js'),
+      {
+        outputFS: inputFS,
+      },
+    );
 
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'common.js', 'worker-client.js', 'feature.js'],
+        assets: [
+          'index.js',
+          'common.js',
+          'worker-client.js',
+          'feature.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['service-worker.js'],
@@ -378,7 +392,7 @@ describe('javascript', function() {
       },
       {
         name: 'index.js',
-        assets: ['index.js'],
+        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js', 'JSRuntime.js'],
       },
       {
         assets: ['shared-worker.js'],
@@ -419,6 +433,10 @@ describe('javascript', function() {
           'common.js',
           'worker-client.js',
           'feature.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
         ],
       },
       {
@@ -445,7 +463,7 @@ describe('javascript', function() {
       assertBundles(b, [
         {
           name: `index-${workerType}.js`,
-          assets: [`index-${workerType}.js`],
+          assets: [`index-${workerType}.js`, 'bundle-url.js', 'JSRuntime.js'],
         },
         {
           assets: ['importScripts.js'],
@@ -470,8 +488,13 @@ describe('javascript', function() {
       );
 
       assert(
-        workerBundleContents.match(
-          /importScripts\("\/imported\.[0-9a-f]*\.js"\);\nimportScripts\("\/imported\.[0-9a-f]*\.js", "\/imported2\.[0-9a-f]*\.js"\);/,
+        workerBundleContents.includes(
+          'importScripts(require("imported.js"));\n',
+        ),
+      );
+      assert(
+        workerBundleContents.includes(
+          'importScripts(require("imported.js"), require("imported2.js"));\n',
         ),
       );
     });
@@ -486,7 +509,10 @@ describe('javascript', function() {
     );
 
     assertBundles(b, [
-      {name: 'index-external.js', assets: ['index-external.js']},
+      {
+        name: 'index-external.js',
+        assets: ['index-external.js', 'bundle-url.js', 'JSRuntime.js'],
+      },
       {assets: ['external.js']},
     ]);
 
@@ -516,7 +542,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'index.js'],
+        assets: [
+          'index.js',
+          'index.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['worker-nested.js'],
@@ -535,7 +567,7 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js'],
+        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js'],
       },
       {
         assets: ['worker.js', 'worker-dep.js'],
@@ -586,7 +618,13 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'lodash.js'],
+        assets: [
+          'index.js',
+          'lodash.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+        ],
       },
       {
         assets: ['worker-a.js'],
@@ -619,7 +657,7 @@ describe('javascript', function() {
         assets: ['index.html'],
       },
       {
-        assets: ['index.js'],
+        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js', 'JSRuntime.js'],
       },
       {
         assets: ['worker.js'],

--- a/packages/core/integration-tests/test/less.js
+++ b/packages/core/integration-tests/test/less.js
@@ -136,13 +136,13 @@ describe('less', function() {
     assert.equal(output(), 2);
 
     let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(/url\("\/test\.[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
 
     assert(
       await outputFS.exists(
-        path.join(distDir, css.match(/url\("\/(test\.[0-9a-f]+\.woff2)"\)/)[1]),
+        path.join(distDir, css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]),
       ),
     );
   });

--- a/packages/core/integration-tests/test/sass.js
+++ b/packages/core/integration-tests/test/sass.js
@@ -132,13 +132,13 @@ describe('sass', function() {
     assert.equal(output(), 2);
 
     let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(/url\("\/test\.[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
 
     assert(
       await outputFS.exists(
-        path.join(distDir, css.match(/url\("(\/test\.[0-9a-f]+\.woff2)"\)/)[1]),
+        path.join(distDir, css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]),
       ),
     );
   });

--- a/packages/core/integration-tests/test/stylus.js
+++ b/packages/core/integration-tests/test/stylus.js
@@ -85,13 +85,13 @@ describe('stylus', function() {
     assert.equal(output(), 2);
 
     let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(/url\("\/test\.[0-9a-f]+\.woff2"\)/.test(css));
+    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
     assert(css.includes('url("http://google.com")'));
     assert(css.includes('.index'));
 
     assert(
       await outputFS.exists(
-        path.join(distDir, css.match(/url\("\/(test\.[0-9a-f]+\.woff2)"\)/)[1]),
+        path.join(distDir, css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]),
       ),
     );
   });

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -602,12 +602,6 @@ export interface MutableBundleGraph {
 export interface BundleGraph {
   getBundles(): Array<Bundle>;
   getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
-  getBundleGroupsReferencedByBundle(
-    bundle: Bundle,
-  ): Array<{|
-    bundleGroup: BundleGroup,
-    dependency: Dependency,
-  |}>;
   getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<Bundle>;
   getChildBundles(bundle: Bundle): Array<Bundle>;
   getSiblingBundles(bundle: Bundle): Array<Bundle>;
@@ -624,6 +618,8 @@ export interface BundleGraph {
     visit: GraphTraversalCallback<Bundle, TContext>,
   ): ?TContext;
   findBundlesWithAsset(Asset): Array<Bundle>;
+  getExternalDependencies(bundle: Bundle): Array<Dependency>;
+  resolveExternalDependency(dependency: Dependency): ?BundleGroup;
 }
 
 export type BundleResult = {|

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -623,9 +623,9 @@ export interface BundleGraph {
 }
 
 export type BundleResult = {|
-  contents: Blob,
-  ast?: AST,
-  map?: ?SourceMap,
+  +contents: Blob,
+  +ast?: AST,
+  +map?: ?SourceMap,
 |};
 
 export type ResolveResult = {|

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -1,14 +1,7 @@
 // @flow strict-local
 
 import type SourceMap from '@parcel/source-map';
-import type {
-  Async,
-  Blob,
-  Bundle,
-  BundleResult,
-  BundleGraph,
-  Dependency,
-} from '@parcel/types';
+import type {Async, Blob, Bundle, BundleGraph, Dependency} from '@parcel/types';
 
 import {Readable} from 'stream';
 import nullthrows from 'nullthrows';
@@ -21,88 +14,115 @@ type ReplacementMap = Map<
 >;
 
 /*
- * Replaces references to dependency ids with either:
- *   - in the case of an inline bundle, the packaged contents of that bundle
- *   - in the case of another bundle reference, the bundle's url from the publicUrl root
- *   - in the case of a url dependency that Parcel did not handle,
- *     the original moduleSpecifier. These are external requests.
+ * Replaces references to dependency ids for URL dependencies with:
+ *   - in the case of an unresolvable url dependency, the original moduleSpecifier.
+ *     These are external requests that Parcel did not bundle.
+ *   - in the case of a reference to another bundle, the relative url to that
+ *     bundle from the current bundle.
  */
-export async function replaceBundleReferences({
+export function replaceURLReferences({
   bundle,
   bundleGraph,
   contents,
   map,
-  replaceInline,
-  replaceUrls = true,
   relative = true,
 }: {|
   bundle: Bundle,
   bundleGraph: BundleGraph,
   contents: string,
   relative?: boolean,
-  replaceInline?: {|
-    getInlineReplacement: (
-      Dependency,
-      ?'string',
-      string,
-    ) => {|from: string, to: string|},
-    getInlineBundleContents: (
-      Bundle,
-      BundleGraph,
-    ) => Async<{|contents: Blob, map: ?(Readable | string)|}>,
-  |},
-  replaceUrls?: boolean,
   map?: ?SourceMap,
-|}): Promise<BundleResult> {
+|}): {|+contents: string, +map: ?SourceMap|} {
   let replacements = new Map();
 
   for (let dependency of bundleGraph.getExternalDependencies(bundle)) {
+    if (!dependency.isURL) {
+      continue;
+    }
+
     let bundleGroup = bundleGraph.resolveExternalDependency(dependency);
     if (bundleGroup == null) {
-      if (replaceUrls) {
-        replacements.set(dependency.id, {
-          from: dependency.id,
-          to: dependency.moduleSpecifier,
-        });
-      }
+      replacements.set(dependency.id, {
+        from: dependency.id,
+        to: dependency.moduleSpecifier,
+      });
       continue;
     }
 
     let [entryBundle] = bundleGraph.getBundlesInBundleGroup(bundleGroup);
     if (entryBundle.isInline) {
-      if (replaceInline != null) {
-        // inline bundles
-        let packagedBundle = await replaceInline.getInlineBundleContents(
-          entryBundle,
-          bundleGraph,
-        );
-        let packagedContents = (packagedBundle.contents instanceof Readable
-          ? await bufferStream(packagedBundle.contents)
-          : packagedBundle.contents
-        ).toString();
+      // If a bundle is inline, it should be replaced with inline contents,
+      // not a URL.
+      continue;
+    }
 
-        let inlineType = nullthrows(entryBundle.getMainEntry()).meta.inlineType;
-        if (inlineType == null || inlineType === 'string') {
-          replacements.set(
-            dependency.id,
-            replaceInline.getInlineReplacement(
-              dependency,
-              inlineType,
-              packagedContents,
-            ),
-          );
-        }
-      }
-    } else if (dependency.isURL && replaceUrls) {
-      // url references
+    replacements.set(
+      dependency.id,
+      getURLReplacement({
+        dependency,
+        fromBundle: bundle,
+        toBundle: entryBundle,
+        relative,
+      }),
+    );
+  }
+
+  return performReplacement(replacements, contents, map);
+}
+
+/*
+ * Replaces references to dependency ids for inline bundles with the packaged
+ * contents of that bundle.
+ */
+export async function replaceInlineReferences({
+  bundle,
+  bundleGraph,
+  contents,
+  map,
+  getInlineReplacement,
+  getInlineBundleContents,
+}: {|
+  bundle: Bundle,
+  bundleGraph: BundleGraph,
+  contents: string,
+  getInlineReplacement: (
+    Dependency,
+    ?'string',
+    string,
+  ) => {|from: string, to: string|},
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph,
+  ) => Async<{|contents: Blob, map: ?(Readable | string)|}>,
+  map?: ?SourceMap,
+|}): Promise<{|+contents: string, +map: ?SourceMap|}> {
+  let replacements = new Map();
+
+  for (let dependency of bundleGraph.getExternalDependencies(bundle)) {
+    let bundleGroup = bundleGraph.resolveExternalDependency(dependency);
+    if (bundleGroup == null) {
+      continue;
+    }
+
+    let [entryBundle] = bundleGraph.getBundlesInBundleGroup(bundleGroup);
+    if (!entryBundle.isInline) {
+      continue;
+    }
+
+    let packagedBundle = await getInlineBundleContents(
+      entryBundle,
+      bundleGraph,
+    );
+    let packagedContents = (packagedBundle.contents instanceof Readable
+      ? await bufferStream(packagedBundle.contents)
+      : packagedBundle.contents
+    ).toString();
+
+    let inlineType = nullthrows(entryBundle.getMainEntry()).meta.inlineType;
+    if (inlineType == null || inlineType === 'string') {
       replacements.set(
         dependency.id,
-        getURLReplacement({
-          dependency,
-          fromBundle: bundle,
-          toBundle: entryBundle,
-          relative,
-        }),
+        getInlineReplacement(dependency, inlineType, packagedContents),
       );
     }
   }
@@ -143,7 +163,7 @@ function performReplacement(
   replacements: ReplacementMap,
   contents: string,
   map?: ?SourceMap,
-): BundleResult {
+): {|+contents: string, +map: ?SourceMap|} {
   let finalContents = contents;
   for (let {from, to} of replacements.values()) {
     // Perform replacement

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "demo": "parcel build src/index.js"
+    "demo": "parcel src/index.html"
   },
   "devDependencies": {
     "@parcel/babel-register": "^2.0.0-alpha.3.1",

--- a/packages/examples/kitchen-sink/src/index.html
+++ b/packages/examples/kitchen-sink/src/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>Modern Simple Example</title>
-    <link rel="stylesheet" href="dist/legacy/styles.css" />
-    <script src="dist/modern/index.js"></script>
+    <link rel="stylesheet" href="styles.css" />
+    <script src="index.js"></script>
   </head>
   <body>
     <h1>I am an H1</h1>

--- a/packages/examples/kitchen-sink/src/index.js
+++ b/packages/examples/kitchen-sink/src/index.js
@@ -1,12 +1,11 @@
 import styles from './styles.css';
 import parcel from './parcel.webp';
+import {message} from './message';
 
 // import('./async');
 // import('./async2');
 
-// new Worker('./worker.js');
-
-import {message} from './message';
+new Worker('worker.js');
 
 console.log(message);
 

--- a/packages/examples/kitchen-sink/src/worker.js
+++ b/packages/examples/kitchen-sink/src/worker.js
@@ -1,1 +1,1 @@
-module.exports = 'worker';
+console.log('logged from worker.js');

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -37,11 +37,13 @@ export default new Packager({
       bundle,
       bundleGraph,
       contents: await outputs.map(output => output).join('\n'),
-      getInlineBundleContents,
-      getInlineReplacement: (dep, inlineType, contents) => ({
-        from: dep.id,
-        to: contents,
-      }),
+      replaceInline: {
+        getInlineBundleContents,
+        getInlineReplacement: (dep, inlineType, contents) => ({
+          from: dep.id,
+          to: contents,
+        }),
+      },
     });
   },
 });

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -1,7 +1,11 @@
 // @flow
 
 import {Packager} from '@parcel/plugin';
-import {PromiseQueue, replaceBundleReferences} from '@parcel/utils';
+import {
+  PromiseQueue,
+  replaceInlineReferences,
+  replaceURLReferences,
+} from '@parcel/utils';
 
 export default new Packager({
   async package({bundle, bundleGraph, getInlineBundleContents}) {
@@ -33,17 +37,20 @@ export default new Packager({
     });
 
     let outputs = await queue.run();
-    return replaceBundleReferences({
+    return replaceInlineReferences({
       bundle,
       bundleGraph,
-      contents: await outputs.map(output => output).join('\n'),
-      replaceInline: {
-        getInlineBundleContents,
-        getInlineReplacement: (dep, inlineType, contents) => ({
-          from: dep.id,
-          to: contents,
-        }),
-      },
+      // $FlowFixMe
+      contents: replaceURLReferences({
+        bundle,
+        bundleGraph,
+        contents: outputs.map(output => output).join('\n'),
+      }).contents,
+      getInlineBundleContents,
+      getInlineReplacement: (dep, inlineType, contents) => ({
+        from: dep.id,
+        to: contents,
+      }),
     });
   },
 });

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -4,7 +4,7 @@ import type {Bundle, BundleGraph} from '@parcel/types';
 import assert from 'assert';
 import {Packager} from '@parcel/plugin';
 import posthtml from 'posthtml';
-import {replaceURLReferences, urlJoin} from '@parcel/utils';
+import {replaceBundleReferences, urlJoin} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 
 // https://www.w3.org/TR/html5/dom.html#metadata-content-2
@@ -65,7 +65,7 @@ export default new Packager({
       ),
     ]).process(code);
 
-    return replaceURLReferences({
+    return replaceBundleReferences({
       bundle,
       bundleGraph,
       contents: html,

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -69,6 +69,7 @@ export default new Packager({
       bundle,
       bundleGraph,
       contents: html,
+      relative: false,
     });
   },
 });

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -4,7 +4,7 @@ import type {Bundle, BundleGraph} from '@parcel/types';
 import assert from 'assert';
 import {Packager} from '@parcel/plugin';
 import posthtml from 'posthtml';
-import {replaceBundleReferences, urlJoin} from '@parcel/utils';
+import {replaceURLReferences, urlJoin} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 
 // https://www.w3.org/TR/html5/dom.html#metadata-content-2
@@ -65,7 +65,7 @@ export default new Packager({
       ),
     ]).process(code);
 
-    return replaceBundleReferences({
+    return replaceURLReferences({
       bundle,
       bundleGraph,
       contents: html,

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -34,8 +34,11 @@ export default new Packager({
     // Insert references to sibling bundles. For example, a <script> tag in the original HTML
     // may import CSS files. This will result in a sibling bundle in the same bundle group as the
     // JS. This will be inserted as a <link> element into the HTML here.
-    let bundleGroups = bundleGraph.getBundleGroupsReferencedByBundle(bundle);
-    let bundles = bundleGroups.reduce((p, {bundleGroup}) => {
+    let bundleGroups = bundleGraph
+      .getExternalDependencies(bundle)
+      .map(dependency => bundleGraph.resolveExternalDependency(dependency))
+      .filter(Boolean);
+    let bundles = bundleGroups.reduce((p, bundleGroup) => {
       let bundles = bundleGraph
         .getBundlesInBundleGroup(bundleGroup)
         .filter(

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -31,11 +31,15 @@ export default new Packager({
         bundle,
         bundleGraph,
         contents,
-        getInlineReplacement: (dependency, inlineType, content) => ({
-          from: `"${dependency.id}"`,
-          to: inlineType === 'string' ? JSON.stringify(content) : content,
-        }),
-        getInlineBundleContents,
+        replaceInline: {
+          getInlineReplacement: (dependency, inlineType, content) => ({
+            from: `"${dependency.id}"`,
+            to: inlineType === 'string' ? JSON.stringify(content) : content,
+          }),
+          getInlineBundleContents,
+        },
+        // JSRuntime handles exporting URLs
+        replaceUrls: false,
         map,
       });
     }

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -9,7 +9,7 @@ import {
   countLines,
   PromiseQueue,
   relativeBundlePath,
-  replaceBundleReferences,
+  replaceInlineReferences,
 } from '@parcel/utils';
 import path from 'path';
 
@@ -27,19 +27,15 @@ export default new Packager({
     options,
   }) {
     function replaceReferences({contents, map}) {
-      return replaceBundleReferences({
+      return replaceInlineReferences({
         bundle,
         bundleGraph,
         contents,
-        replaceInline: {
-          getInlineReplacement: (dependency, inlineType, content) => ({
-            from: `"${dependency.id}"`,
-            to: inlineType === 'string' ? JSON.stringify(content) : content,
-          }),
-          getInlineBundleContents,
-        },
-        // JSRuntime handles exporting URLs
-        replaceUrls: false,
+        getInlineReplacement: (dependency, inlineType, content) => ({
+          from: `"${dependency.id}"`,
+          to: inlineType === 'string' ? JSON.stringify(content) : content,
+        }),
+        getInlineBundleContents,
         map,
       });
     }

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -2,6 +2,7 @@
 
 import type {Bundle, Dependency, RuntimeAsset} from '@parcel/types';
 
+import assert from 'assert';
 import {Runtime} from '@parcel/plugin';
 import {relativeBundlePath} from '@parcel/utils';
 import path from 'path';
@@ -48,11 +49,6 @@ export default new Runtime({
     // $FlowFixMe - ignore unknown properties?
     let loaders = LOADERS[bundle.env.context];
 
-    let assets = [];
-    if (!loaders) {
-      return assets;
-    }
-
     // Determine if we need to add a dynamic import() polyfill, or if all target browsers support it natively.
     let needsDynamicImportPolyfill = false;
     if (bundle.env.isBrowser() && bundle.env.outputFormat === 'esmodule') {
@@ -61,24 +57,44 @@ export default new Runtime({
       );
     }
 
-    for (let {
-      bundleGroup,
-      dependency,
-    } of bundleGraph.getBundleGroupsReferencedByBundle(bundle)) {
-      // Sort so the bundles containing the entry asset appear last
+    let assets = [];
+    for (let dependency of bundleGraph.getExternalDependencies(bundle)) {
+      let bundleGroup = bundleGraph.resolveExternalDependency(dependency);
+      if (bundleGroup == null) {
+        if (dependency.isURL) {
+          // If a URL dependency was not able to be resolved, add a runtime that
+          // exports the original moduleSpecifier.
+          assets.push({
+            filePath: __filename,
+            code: `module.exports = ${JSON.stringify(
+              dependency.moduleSpecifier,
+            )}`,
+            dependency,
+          });
+        }
+        continue;
+      }
+
       let bundlesInGroup = bundleGraph.getBundlesInBundleGroup(bundleGroup);
 
       let [firstBundle] = bundlesInGroup;
       if (firstBundle.isInline) {
         assets.push({
           filePath: path.join(__dirname, `/bundles/${firstBundle.id}.js`),
-          code: `module.exports = "${dependency.id}";`,
+          code: `module.exports = ${JSON.stringify(dependency.id)};`,
           dependency,
         });
 
         continue;
       }
 
+      // URL dependencies should always resolve to a runtime that exports a url
+      if (dependency.isURL) {
+        assets.push(getURLRuntime(dependency, bundle, firstBundle));
+        continue;
+      }
+
+      // Sort so the bundles containing the entry asset appear last
       let externalBundles = bundlesInGroup
         .filter(bundle => !bundle.isInline)
         .sort(bundle =>
@@ -98,43 +114,39 @@ export default new Runtime({
         externalBundles = externalBundles.slice(-1);
       }
 
-      // URL dependencies should always resolve to a runtime that exports a url
-      if (dependency.isURL) {
-        assets.push(...getURLRuntimes(dependency, bundle, externalBundles));
-        continue;
-      }
+      let loaderModules = loaders
+        ? externalBundles
+            .map(b => {
+              let loader = loaders[b.type];
+              if (!loader) {
+                return;
+              }
 
-      let loaderModules = externalBundles
-        .map(b => {
-          let loader = loaders[b.type];
-          if (!loader) {
-            return;
-          }
+              // Use esmodule loader if possible
+              if (b.type === 'js' && b.env.outputFormat === 'esmodule') {
+                if (!needsDynamicImportPolyfill) {
+                  return `import('' + '${relativeBundlePath(bundle, b)}')`;
+                }
 
-          // Use esmodule loader if possible
-          if (b.type === 'js' && b.env.outputFormat === 'esmodule') {
-            if (!needsDynamicImportPolyfill) {
-              return `import('' + '${relativeBundlePath(bundle, b)}')`;
-            }
+                loader = IMPORT_POLYFILL;
+              } else if (b.type === 'js' && b.env.outputFormat === 'commonjs') {
+                return `Promise.resolve(require('' + '${relativeBundlePath(
+                  bundle,
+                  b,
+                )}'))`;
+              }
 
-            loader = IMPORT_POLYFILL;
-          } else if (b.type === 'js' && b.env.outputFormat === 'commonjs') {
-            return `Promise.resolve(require('' + '${relativeBundlePath(
-              bundle,
-              b,
-            )}'))`;
-          }
-
-          let relativePath = relativeBundlePath(bundle, b, {
-            leadingDotSlash: false,
-          });
-          return `require(${JSON.stringify(
-            loader,
-          )})(require('./bundle-url').getBundleURL() + ${JSON.stringify(
-            relativePath,
-          )})`;
-        })
-        .filter(Boolean);
+              let relativePath = relativeBundlePath(bundle, b, {
+                leadingDotSlash: false,
+              });
+              return `require(${JSON.stringify(
+                loader,
+              )})(require('./bundle-url').getBundleURL() + ${JSON.stringify(
+                relativePath,
+              )})`;
+            })
+            .filter(Boolean)
+        : [];
 
       if (loaderModules.length > 0) {
         let loaders = loaderModules.join(', ');
@@ -159,7 +171,8 @@ export default new Runtime({
           dependency,
         });
       } else {
-        assets.push(...getURLRuntimes(dependency, bundle, externalBundles));
+        assert(externalBundles.length === 1);
+        assets.push(getURLRuntime(dependency, bundle, externalBundles[0]));
       }
     }
 
@@ -167,12 +180,12 @@ export default new Runtime({
   },
 });
 
-function getURLRuntimes(
+function getURLRuntime(
   dependency: Dependency,
   bundle: Bundle,
-  externalBundles: Array<Bundle>,
-): Array<RuntimeAsset> {
-  return externalBundles.map(externalBundle => ({
+  externalBundle: Bundle,
+): RuntimeAsset {
+  return {
     filePath: __filename,
     code: `module.exports = require('./bundle-url').getBundleURL() + ${JSON.stringify(
       relativeBundlePath(bundle, externalBundle, {
@@ -180,5 +193,5 @@ function getURLRuntimes(
       }),
     )}`,
     dependency,
-  }));
+  };
 }

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -8,6 +8,12 @@ import {isURL, md5FromString, createDependencyLocation} from '@parcel/utils';
 import {hasBinding, morph} from './utils';
 import invariant from 'assert';
 
+type Visitor = (
+  node: any,
+  {|asset: MutableAsset, options: PluginOptions|},
+  ancestors: Array<any>,
+) => void;
+
 const serviceWorkerPattern = ['navigator', 'serviceWorker', 'register'];
 
 export default ({
@@ -32,112 +38,121 @@ export default ({
     asset.meta.isES6Module = true;
   },
 
-  CallExpression(node, {asset}, ancestors) {
-    let {callee, arguments: args} = node;
+  CallExpression: {
+    enter(node, {asset}, ancestors) {
+      let {callee, arguments: args} = node;
 
-    let isRequire =
-      types.isIdentifier(callee) &&
-      callee.name === 'require' &&
-      args.length === 1 &&
-      types.isStringLiteral(args[0]) &&
-      !hasBinding(ancestors, 'require') &&
-      !isInFalsyBranch(ancestors);
+      let isRequire =
+        types.isIdentifier(callee) &&
+        callee.name === 'require' &&
+        args.length === 1 &&
+        types.isStringLiteral(args[0]) &&
+        !hasBinding(ancestors, 'require') &&
+        !isInFalsyBranch(ancestors);
 
-    if (isRequire) {
-      let isOptional =
-        ancestors.some(a => types.isTryStatement(a)) || undefined;
-      invariant(asset.ast);
-      let isAsync = isRequireAsync(ancestors, node, asset.ast);
-      addDependency(asset, args[0], {isOptional, isAsync});
-      return;
-    }
-
-    let isDynamicImport =
-      callee.type === 'Import' &&
-      args.length === 1 &&
-      types.isStringLiteral(args[0]);
-
-    if (isDynamicImport) {
-      // Ignore dynamic imports of fully specified urls
-      if (isURL(args[0].value)) {
+      if (isRequire) {
+        let isOptional =
+          ancestors.some(a => types.isTryStatement(a)) || undefined;
+        invariant(asset.ast);
+        let isAsync = isRequireAsync(ancestors, node, asset.ast);
+        addDependency(asset, args[0], {isOptional, isAsync});
         return;
       }
 
-      addDependency(asset, args[0], {isAsync: true});
+      let isDynamicImport =
+        callee.type === 'Import' &&
+        args.length === 1 &&
+        types.isStringLiteral(args[0]);
 
-      node.callee = types.identifier('require');
-      invariant(asset.ast);
-      asset.ast.isDirty = true;
-      return;
-    }
-
-    let isRegisterServiceWorker =
-      types.isStringLiteral(args[0]) &&
-      types.matchesPattern(callee, serviceWorkerPattern) &&
-      !hasBinding(ancestors, 'navigator') &&
-      !isInFalsyBranch(ancestors);
-
-    if (isRegisterServiceWorker) {
-      // Treat service workers as an entry point so filenames remain consistent across builds.
-      // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#avoid_changing_the_url_of_your_service_worker_script
-      addURLDependency(asset, args[0], {
-        isEntry: true,
-        env: {context: 'service-worker'},
-      });
-      return;
-    }
-
-    let isImportScripts =
-      (asset.env.context === 'web-worker' ||
-        asset.env.context === 'service-worker') &&
-      callee.name === 'importScripts';
-
-    if (isImportScripts) {
-      for (let arg of args) {
-        if (types.isStringLiteral(arg)) {
-          addURLDependency(asset, arg);
+      if (isDynamicImport) {
+        // Ignore dynamic imports of fully specified urls
+        if (isURL(args[0].value)) {
+          return;
         }
+
+        addDependency(asset, args[0], {isAsync: true});
+
+        node.callee = types.identifier('require');
+        invariant(asset.ast);
+        asset.ast.isDirty = true;
+        return;
       }
-      return;
-    }
+    },
+    exit(node, {asset}, ancestors) {
+      if (node.type !== 'CallExpression') {
+        // It's possible this node has been morphed into another type
+        return;
+      }
+
+      let {callee, arguments: args} = node;
+
+      let isRegisterServiceWorker =
+        types.isStringLiteral(args[0]) &&
+        types.matchesPattern(callee, serviceWorkerPattern) &&
+        !hasBinding(ancestors, 'navigator') &&
+        !isInFalsyBranch(ancestors);
+
+      if (isRegisterServiceWorker) {
+        // Treat service workers as an entry point so filenames remain consistent across builds.
+        // https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#avoid_changing_the_url_of_your_service_worker_script
+        addURLDependency(asset, args[0], {
+          isEntry: true,
+          env: {context: 'service-worker'},
+        });
+        return;
+      }
+
+      let isImportScripts =
+        (asset.env.context === 'web-worker' ||
+          asset.env.context === 'service-worker') &&
+        callee.name === 'importScripts';
+
+      if (isImportScripts) {
+        for (let arg of args) {
+          if (types.isStringLiteral(arg)) {
+            addURLDependency(asset, arg);
+          }
+        }
+        return;
+      }
+    },
   },
 
-  NewExpression(node, {asset, options}, ancestors) {
-    let {callee, arguments: args} = node;
+  NewExpression: {
+    exit(node, {asset, options}, ancestors) {
+      let {callee, arguments: args} = node;
 
-    let isWebWorker =
-      callee.type === 'Identifier' &&
-      (callee.name === 'Worker' || callee.name === 'SharedWorker') &&
-      !hasBinding(ancestors, callee.name) &&
-      !isInFalsyBranch(ancestors) &&
-      types.isStringLiteral(args[0]) &&
-      (args.length === 1 || args.length === 2);
+      let isWebWorker =
+        callee.type === 'Identifier' &&
+        (callee.name === 'Worker' || callee.name === 'SharedWorker') &&
+        !hasBinding(ancestors, callee.name) &&
+        !isInFalsyBranch(ancestors) &&
+        types.isStringLiteral(args[0]) &&
+        (args.length === 1 || args.length === 2);
 
-    if (isWebWorker) {
-      let isModule = false;
-      if (types.isObjectExpression(args[1])) {
-        let prop = args[1].properties.find(v =>
-          types.isIdentifier(v.key, {name: 'type'}),
-        );
-        if (prop && types.isStringLiteral(prop.value))
-          isModule = prop.value.value === 'module';
+      if (isWebWorker) {
+        let isModule = false;
+        if (types.isObjectExpression(args[1])) {
+          let prop = args[1].properties.find(v =>
+            types.isIdentifier(v.key, {name: 'type'}),
+          );
+          if (prop && types.isStringLiteral(prop.value))
+            isModule = prop.value.value === 'module';
+        }
+
+        addURLDependency(asset, args[0], {
+          env: {
+            context: 'web-worker',
+            outputFormat:
+              isModule && options.scopeHoist ? 'esmodule' : undefined,
+          },
+        });
+        return;
       }
-
-      addURLDependency(asset, args[0], {
-        env: {
-          context: 'web-worker',
-          outputFormat: isModule && options.scopeHoist ? 'esmodule' : undefined,
-        },
-      });
-      return;
-    }
+    },
   },
 }: {
-  [key: string]: (
-    node: any,
-    {|asset: MutableAsset, options: PluginOptions|},
-    ancestors: Array<any>,
-  ) => void,
+  [key: string]: Visitor | {|enter?: Visitor, exit?: Visitor|},
   ...,
 });
 
@@ -292,10 +307,17 @@ function addDependency(
 }
 
 function addURLDependency(asset, node, opts = {}) {
-  node.value = asset.addURLDependency(node.value, {
+  let url = node.value;
+  asset.addURLDependency(url, {
     loc: node.loc && createDependencyLocation(node.loc.start, node.value, 0, 1),
     ...opts,
   });
+  morph(
+    node,
+    types.callExpression(types.identifier('require'), [
+      types.stringLiteral(url),
+    ]),
+  );
   invariant(asset.ast);
   asset.ast.isDirty = true;
 }


### PR DESCRIPTION
This replaces the packaging-time text-replacement of url dependencies with the results of a runtime asset to determine worker urls and those from other url dependencies. The text replacement remains for css though, where a move to simple relative urls is more appropriate.

To do:
* [ ] The module specifier to dependency id mapping generated in the JS packager shares specifiers with url and non-url dependencies. It's possible that specifiers could clash.
* [x] `new Worker` will now be constructed with absolute urls determined at runtime based on resolving a relative path to the current script's url. It's possible this isn't the document's origin, and workers are only allowed same-origin. (Solved in #4081)
* [x] Figure out what to do with the existing blob url transformer + optimizer (stay the same)
* [x] Handle external url references. This will likely require further changes to the JSRuntime and possibly to the bundle graph for performance, as these dependencies aren't reachable through `bundleGraph.getBundleGroupsReferencedByBundle`.