### PR TITLE
Set terser's toplevel flag with commonjs as well

### DIFF
--- a/packages/optimizers/terser/src/TerserOptimizer.js
+++ b/packages/optimizers/terser/src/TerserOptimizer.js
@@ -28,6 +28,12 @@ export default new Optimizer({
     let config = {
       warnings: true,
       ...userConfig?.config,
+      compress: {
+        ...userConfig?.config?.compress,
+        toplevel:
+          bundle.env.outputFormat === 'esmodule' ||
+          bundle.env.outputFormat === 'commonjs',
+      },
       sourceMap: {
         filename: path.relative(options.projectRoot, bundle.filePath),
       },


### PR DESCRIPTION
# ↪️ Pull Request

Remove unused toplevel variable{s, declarations} when using the commonjs output format (by setting Terser options correctly).

Closes https://github.com/parcel-bundler/parcel/issues/4046