### PR TITLE
Resolve .parcelrc from realpath, and use root .parcelrc in node_modules

### DIFF
--- a/packages/core/core/src/ConfigLoader.js
+++ b/packages/core/core/src/ConfigLoader.js
@@ -7,6 +7,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {md5FromString, PromiseQueue} from '@parcel/utils';
 import {PluginLogger} from '@parcel/logger';
+import path from 'path';
 
 import {createConfig} from './InternalConfig';
 import Config from './public/Config';
@@ -39,15 +40,17 @@ export default class ConfigLoader {
 
   async loadParcelConfig(configRequest: ConfigRequestDesc) {
     let {filePath, isSource, env, pipeline} = configRequest;
+    let dir = isSource ? path.dirname(filePath) : this.options.projectRoot;
+    let searchPath = path.join(dir, 'index');
     let config = createConfig({
       isSource,
-      searchPath: filePath,
+      searchPath,
       env,
     });
     let publicConfig = new Config(config, this.options);
 
     let {config: parcelConfig, extendedFiles} = nullthrows(
-      await loadParcelConfig(filePath, this.options),
+      await loadParcelConfig(searchPath, this.options),
     );
 
     publicConfig.setResolvedPath(parcelConfig.filePath);

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -28,7 +28,7 @@ export async function resolveConfig(
   opts: ?ConfigOptions,
   root: FilePath = path.parse(filepath).root,
 ): Promise<FilePath | null> {
-  filepath = path.dirname(filepath);
+  filepath = await fs.realpath(path.dirname(filepath));
 
   // Don't traverse above the module root
   if (filepath === root || path.basename(filepath) === 'node_modules') {
@@ -51,7 +51,6 @@ export async function loadConfig(
   filenames: Array<FilePath>,
   opts: ?ConfigOptions,
 ): Promise<ConfigOutput | null> {
-  filepath = await fs.realpath(filepath);
   let configFile = await resolveConfig(fs, filepath, filenames, opts);
   if (configFile) {
     try {


### PR DESCRIPTION
This changes the way `.parcelrc` is resolved inside `node_modules`. Now, rather than looking for a `.parcelrc` in `node_modules`, we always resolve the `.parcelrc` in the project root. Packages in `node_modules` should never depend on a particular Parcel config in order to be built.

In addition, in monorepos, node_modules are likely to be symlinked. In this case, we want to search for a `.parcelrc` from the realpath rather than the node_modules path.