### PR TITLE
Don't mistake every `export {process}` as the process global

### DIFF
--- a/packages/core/integration-tests/test/integration/globals-module-specifier/a.js
+++ b/packages/core/integration-tests/test/integration/globals-module-specifier/a.js
@@ -1,0 +1,3 @@
+import { process } from "./b.js";
+
+module.exports = process;

--- a/packages/core/integration-tests/test/integration/globals-module-specifier/b.js
+++ b/packages/core/integration-tests/test/integration/globals-module-specifier/b.js
@@ -1,0 +1,2 @@
+export { process } from "./c.js";
+export default "DEFAULT";

--- a/packages/core/integration-tests/test/integration/globals-module-specifier/c.js
+++ b/packages/core/integration-tests/test/integration/globals-module-specifier/c.js
@@ -1,0 +1,2 @@
+var process_ = 1234;
+export { process_ as process };

--- a/packages/core/integration-tests/test/integration/globals-module-specifier/package.json
+++ b/packages/core/integration-tests/test/integration/globals-module-specifier/package.json
@@ -1,0 +1,3 @@
+{
+	"browserslist": "Chrome 75"
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -974,6 +974,21 @@ describe('javascript', function() {
     });
   });
 
+  it('should not insert global variables when used in a module specifier', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/globals-module-specifier/a.js'),
+    );
+
+    assertBundles(b, [
+      {
+        assets: ['a.js', 'b.js', 'c.js'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.deepEqual(output, 1234);
+  });
+
   it('should handle re-declaration of the global constant', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/global-redeclare/index.js'),

--- a/packages/transformers/js/src/visitors/globals.js
+++ b/packages/transformers/js/src/visitors/globals.js
@@ -41,6 +41,7 @@ export default {
       VARS.hasOwnProperty(node.name) &&
       !nullthrows(asset.meta.globals).has(node.name) &&
       types.isReferenced(node, parent) &&
+      !types.isModuleSpecifier(parent) &&
       !hasBinding(ancestors, node.name)
     ) {
       nullthrows(asset.meta.globals).set(node.name, VARS[node.name](asset));


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Previously, the `process` global was inserted because the identifier in `export { process } from "./c.js";` was recognized as a ReferencedIdentifer (which it isn't).

I've now added a check that the identifier isn't used in a module specifier.

Closes https://github.com/parcel-bundler/parcel/issues/4003