### PR TITLE
Fix release scripts to use exact on alpha's

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration-ci": "yarn workspace @parcel/integration-tests test-ci",
     "test": "yarn test:unit && yarn test:integration",
     "update-readme-toc": "doctoc README.md",
-    "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --force-publish=*"
+    "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=*"
   },
   "devDependencies": {
     "doctoc": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test:integration-ci": "yarn workspace @parcel/integration-tests test-ci",
     "test": "yarn test:unit && yarn test:integration",
     "update-readme-toc": "doctoc README.md",
-    "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=*"
+    "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=*",
+    "alpha:release": "lerna publish --preid alpha --dist-tag=next --exact --force-publish=*"
   },
   "devDependencies": {
     "doctoc": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "yarn test:unit && yarn test:integration",
     "update-readme-toc": "doctoc README.md",
     "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=*",
-    "alpha:release": "lerna publish --preid alpha --dist-tag=next --exact --force-publish=*"
+    "alpha:release": "lerna publish --dist-tag=next --exact --force-publish=*"
   },
   "devDependencies": {
     "doctoc": "^1.4.0",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR updates the alpha and nightly release scripts to use exact versioning as apparently that's required to work properly when installing.

To release an alpha use: `yarn alpha:release <version>` for example `yarn alpha:release 2.0.0-alpha.4`

To release a nightly use: `yarn nightly:release` (this is called by the action and should never really be called manually)

Closes #4065 
