### PR TITLE
Fix lib bug in type definition transformer

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/exporting/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting/expected.d.ts
@@ -10,6 +10,6 @@ export interface Params {
     bar: number;
 }
 export var a: number, b: number;
-export function toUpperCase(foo: string): any;
+export function toUpperCase(foo: string): string;
 
 //# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/promise-or-value/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/promise-or-value/expected.d.ts
@@ -1,0 +1,3 @@
+export type Callback = () => Promise<any> | any;
+
+//# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/promise-or-value/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/promise-or-value/index.ts
@@ -1,0 +1,1 @@
+export type Callback = () => Promise<any> | any;

--- a/packages/core/integration-tests/test/integration/ts-types/promise-or-value/package.json
+++ b/packages/core/integration-tests/test/integration/ts-types/promise-or-value/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ts-promise-or-value",
+  "private": true,
+  "main": "dist/main.js",
+  "types": "dist/types.d.ts"
+}

--- a/packages/core/integration-tests/test/integration/ts-types/promise-or-value/tsconfig.json
+++ b/packages/core/integration-tests/test/integration/ts-types/promise-or-value/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "es2017"],
+  }
+}

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import path from 'path';
 import {bundle, assertBundles, outputFS, inputFS} from '@parcel/test-utils';
 
-describe.only('typescript types', function() {
+describe('typescript types', function() {
   it('should generate a typescript declaration file', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/ts-types/main/index.ts'),
@@ -146,7 +146,7 @@ describe.only('typescript types', function() {
     assert.equal(dist, expected);
   });
 
-  it.only('should not throw errors on typing of a callback which returns a promise or value', async function() {
+  it('should not throw errors on typing of a callback which returns a promise or value', async function() {
     await bundle(
       path.join(__dirname, '/integration/ts-types/promise-or-value/index.ts'),
     );
@@ -161,12 +161,13 @@ describe.only('typescript types', function() {
       )
     ).replace(/\r\n/g, '\n');
 
-    console.log(dist);
-
-    /*let expected = await inputFS.readFile(
-      path.join(__dirname, '/integration/ts-types/private/expected.d.ts'),
+    let expected = await inputFS.readFile(
+      path.join(
+        __dirname,
+        '/integration/ts-types/promise-or-value/expected.d.ts',
+      ),
       'utf8',
     );
-    assert.equal(dist, expected);*/
+    assert.equal(dist, expected);
   });
 });

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import path from 'path';
 import {bundle, assertBundles, outputFS, inputFS} from '@parcel/test-utils';
 
-describe('typescript types', function() {
+describe.only('typescript types', function() {
   it('should generate a typescript declaration file', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/ts-types/main/index.ts'),
@@ -144,5 +144,29 @@ describe('typescript types', function() {
       'utf8',
     );
     assert.equal(dist, expected);
+  });
+
+  it.only('should not throw errors on typing of a callback which returns a promise or value', async function() {
+    await bundle(
+      path.join(__dirname, '/integration/ts-types/promise-or-value/index.ts'),
+    );
+
+    let dist = (
+      await outputFS.readFile(
+        path.join(
+          __dirname,
+          '/integration/ts-types/promise-or-value/dist/types.d.ts',
+        ),
+        'utf8',
+      )
+    ).replace(/\r\n/g, '\n');
+
+    console.log(dist);
+
+    /*let expected = await inputFS.readFile(
+      path.join(__dirname, '/integration/ts-types/private/expected.d.ts'),
+      'utf8',
+    );
+    assert.equal(dist, expected);*/
   });
 });

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -46,7 +46,16 @@ describe('typescript types', function() {
         type: 'ts',
         assets: ['index.ts'],
         includedFiles: {
-          'index.ts': ['other.ts', 'file.ts', 'namespace.ts'],
+          'index.ts': [
+            'other.ts',
+            'file.ts',
+            'namespace.ts',
+            'lib.d.ts',
+            'lib.dom.d.ts',
+            'lib.es5.d.ts',
+            'lib.scripthost.d.ts',
+            'lib.webworker.importscripts.d.ts',
+          ],
         },
       },
     ]);
@@ -78,7 +87,16 @@ describe('typescript types', function() {
         type: 'ts',
         assets: ['index.ts'],
         includedFiles: {
-          'index.ts': ['message.ts', 'other.ts', 'test.ts'],
+          'index.ts': [
+            'message.ts',
+            'other.ts',
+            'test.ts',
+            'lib.d.ts',
+            'lib.dom.d.ts',
+            'lib.es5.d.ts',
+            'lib.scripthost.d.ts',
+            'lib.webworker.importscripts.d.ts',
+          ],
         },
       },
     ]);

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -124,12 +124,6 @@ export default new Transformer({
           filePath: filename,
           codeFrame: codeframe ? codeframe : undefined,
         });
-
-        console.log({
-          message: diagnosticMessage,
-          filePath: filename,
-          codeFrame: codeframe ? codeframe : undefined,
-        });
       }
     }
 

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -3,6 +3,7 @@
 import {Transformer} from '@parcel/plugin';
 import path from 'path';
 import SourceMap from '@parcel/source-map';
+import type {DiagnosticCodeFrame} from '@parcel/diagnostic';
 
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import type {CompilerOptions} from 'typescript';
@@ -17,7 +18,7 @@ export default new Transformer({
     await loadTSConfig(config, options);
   },
 
-  async transform({asset, config, options}) {
+  async transform({asset, config, options, logger}) {
     let ts: TypeScriptModule = await options.packageManager.require(
       'typescript',
       asset.filePath,
@@ -50,7 +51,7 @@ export default new Transformer({
       .slice(0, -path.extname(asset.filePath).length);
     let moduleGraph = new TSModuleGraph(ts, mainModuleName);
 
-    program.emit(undefined, undefined, undefined, true, {
+    let emitResult = program.emit(undefined, undefined, undefined, true, {
       afterDeclarations: [
         // 1. Build module graph
         context => sourceFile => {
@@ -62,6 +63,75 @@ export default new Transformer({
         },
       ],
     });
+
+    let diagnostics = ts
+      .getPreEmitDiagnostics(program)
+      .concat(emitResult.diagnostics);
+
+    if (diagnostics.length > 0) {
+      for (let diagnostic of diagnostics) {
+        let filename = asset.filePath;
+        let {file} = diagnostic;
+
+        let diagnosticMessage =
+          typeof diagnostic.messageText === 'string'
+            ? diagnostic.messageText
+            : diagnostic.messageText.messageText;
+
+        let codeframe: ?DiagnosticCodeFrame;
+        if (file != null && diagnostic.start != null) {
+          let source = file.text || diagnostic.source;
+          if (file.fileName) {
+            filename = file.fileName;
+          }
+
+          // $FlowFixMe
+          if (source) {
+            let lineChar = file.getLineAndCharacterOfPosition(diagnostic.start);
+            let start = {
+              line: lineChar.line + 1,
+              column: lineChar.character + 1,
+            };
+            let end = {
+              line: start.line,
+              column: start.column + 1,
+            };
+
+            if (typeof diagnostic.length === 'number') {
+              let endCharPosition = file.getLineAndCharacterOfPosition(
+                diagnostic.start + diagnostic.length,
+              );
+
+              end = {
+                line: endCharPosition.line + 1,
+                column: endCharPosition.character + 1,
+              };
+            }
+
+            codeframe = {
+              code: source,
+              codeHighlights: {
+                start,
+                end,
+                message: diagnosticMessage,
+              },
+            };
+          }
+        }
+
+        logger.warn({
+          message: diagnosticMessage,
+          filePath: filename,
+          codeFrame: codeframe ? codeframe : undefined,
+        });
+
+        console.log({
+          message: diagnosticMessage,
+          filePath: filename,
+          codeFrame: codeframe ? codeframe : undefined,
+        });
+      }
+    }
 
     let code = nullthrows(host.outputCode);
     code = code.substring(0, code.lastIndexOf('//# sourceMappingURL'));

--- a/packages/utils/ts-utils/src/CompilerHost.js
+++ b/packages/utils/ts-utils/src/CompilerHost.js
@@ -15,8 +15,8 @@ export class CompilerHost extends FSHost {
       : undefined;
   }
 
-  getDefaultLibFileName() {
-    return 'lib.d.ts';
+  getDefaultLibFileName(options: any) {
+    return this.ts.getDefaultLibFilePath(options);
   }
 
   writeFile(filePath: FilePath, content: string) {

--- a/packages/utils/ts-utils/src/CompilerHost.js
+++ b/packages/utils/ts-utils/src/CompilerHost.js
@@ -1,5 +1,6 @@
 // @flow
 import type {FilePath} from '@parcel/types';
+import type {CompilerOptions} from 'typescript';
 import typeof {ScriptTarget} from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import path from 'path';
 import {FSHost} from './FSHost';
@@ -15,7 +16,7 @@ export class CompilerHost extends FSHost {
       : undefined;
   }
 
-  getDefaultLibFileName(options: any) {
+  getDefaultLibFileName(options: CompilerOptions) {
     return this.ts.getDefaultLibFilePath(options);
   }
 


### PR DESCRIPTION
# ↪️ Pull Request

There is currently a bug in the types transformer when using relatively new JS/TS, due to lib definitions failing to resolve, this PR adds a test for it and fixes the bug by calling `this.ts.getDefaultLibFilePath(options);`
