### PR TITLE
Add support for excluding specific node_modules

### DIFF
--- a/packages/core/core/src/TargetDescriptor.schema.js
+++ b/packages/core/core/src/TargetDescriptor.schema.js
@@ -49,6 +49,13 @@ export default ({
             __type: 'a wildcard or filepath',
           },
         },
+        {
+          type: 'object',
+          properties: {},
+          additionalProperties: {
+            type: 'boolean',
+          },
+        },
       ],
     },
     outputFormat: {

--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -83,7 +83,10 @@ export default class Environment implements IEnvironment {
     return this.#environment.engines;
   }
 
-  get includeNodeModules(): boolean | Array<PackageName> {
+  get includeNodeModules():
+    | boolean
+    | Array<PackageName>
+    | {[PackageName]: boolean, ...} {
     return this.#environment.includeNodeModules;
   }
 

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -34,7 +34,10 @@ import type {PackageManager} from '@parcel/package-manager';
 export type Environment = {|
   context: EnvironmentContext,
   engines: Engines,
-  includeNodeModules: boolean | Array<PackageName>,
+  includeNodeModules:
+    | boolean
+    | Array<PackageName>
+    | {[PackageName]: boolean, ...},
   outputFormat: OutputFormat,
   isLibrary: boolean,
 |};

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -89,7 +89,10 @@ export type OutputFormat = 'esmodule' | 'commonjs' | 'global';
 export type PackageTargetDescriptor = {|
   context?: EnvironmentContext,
   engines?: Engines,
-  includeNodeModules?: boolean | Array<PackageName>,
+  includeNodeModules?:
+    | boolean
+    | Array<PackageName>
+    | {[PackageName]: boolean, ...},
   outputFormat?: OutputFormat,
   publicUrl?: string,
   distDir?: FilePath,
@@ -105,7 +108,10 @@ export type TargetDescriptor = {|
 export type EnvironmentOpts = {|
   context?: EnvironmentContext,
   engines?: Engines,
-  includeNodeModules?: boolean | Array<PackageName>,
+  includeNodeModules?:
+    | boolean
+    | Array<PackageName>
+    | {[PackageName]: boolean, ...},
   outputFormat?: OutputFormat,
   isLibrary?: boolean,
 |};
@@ -118,7 +124,10 @@ export type VersionMap = {
 export interface Environment {
   +context: EnvironmentContext;
   +engines: Engines;
-  +includeNodeModules: boolean | Array<PackageName>;
+  +includeNodeModules:
+    | boolean
+    | Array<PackageName>
+    | {[PackageName]: boolean, ...};
   +outputFormat: OutputFormat;
   +isLibrary: boolean;
 

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -22,7 +22,9 @@ export default new Resolver({
   async resolve({dependency, options, filePath}) {
     if (WEBPACK_IMPORT_REGEX.test(dependency.moduleSpecifier)) {
       throw new Error(
-        `The import path: ${dependency.moduleSpecifier} is using webpack specific loader import syntax, which isn't supported by Parcel.`,
+        `The import path: ${
+          dependency.moduleSpecifier
+        } is using webpack specific loader import syntax, which isn't supported by Parcel.`,
       );
     }
 
@@ -224,6 +226,14 @@ class NodeResolver {
     if (Array.isArray(includeNodeModules)) {
       let parts = this.getModuleParts(name);
       return includeNodeModules.includes(parts[0]);
+    }
+
+    if (includeNodeModules && typeof includeNodeModules === 'object') {
+      let parts = this.getModuleParts(name);
+      let include = includeNodeModules[parts[0]];
+      if (include != null) {
+        return !!include;
+      }
     }
 
     return true;

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -22,9 +22,7 @@ export default new Resolver({
   async resolve({dependency, options, filePath}) {
     if (WEBPACK_IMPORT_REGEX.test(dependency.moduleSpecifier)) {
       throw new Error(
-        `The import path: ${
-          dependency.moduleSpecifier
-        } is using webpack specific loader import syntax, which isn't supported by Parcel.`,
+        `The import path: ${dependency.moduleSpecifier} is using webpack specific loader import syntax, which isn't supported by Parcel.`,
       );
     }
 


### PR DESCRIPTION
Related: #144, #3305, #3753.

This adds support for excluding specific node_modules from a bundle. The inverse was already possible via `includeNodeModules` using the array syntax, but now it's possible to use object syntax to exclude specific node_modules in a certain target.

```json
{
  "targets": {
    "library": {
      "includeNodeModules": {
        "react": false
      }
    }
  }
}
```

#3753 proposed doing this via `peerDependencies`, but that doesn't allow specifying node modules to include/exclude per target. We may want to support it as a shortcut for `includeNodeModules` across all targets, however.