### PR TITLE
Watch realpath and always emit HMR updates

### DIFF
--- a/packages/core/core/src/requests.js
+++ b/packages/core/core/src/requests.js
@@ -155,7 +155,9 @@ export class AssetRequestRunner extends RequestRunner<
   }
 
   async run(request: AssetRequestDesc, api: RequestRunnerAPI) {
-    api.invalidateOnFileUpdate(request.filePath);
+    api.invalidateOnFileUpdate(
+      await this.options.inputFS.realpath(request.filePath),
+    );
     let start = Date.now();
     let {assets, configRequests} = await this.runTransform({
       request: request,

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -94,10 +94,7 @@ export default class HMRServer {
   async emitUpdate(event: BuildSuccessEvent) {
     this.unresolvedError = null;
 
-    let changedAssets = Array.from(event.changedAssets.values()).filter(
-      asset => asset.env.context === 'browser',
-    );
-
+    let changedAssets = Array.from(event.changedAssets.values());
     if (changedAssets.length === 0) return;
 
     let assets = await Promise.all(


### PR DESCRIPTION
This solves two issues I had with the watcher/HMR:

1. In a monorepo, if you change a file in another package, the watcher does not cause parcel to recompile. This is because the watcher notifies Parcel that the realpath changed, but we store the logical path in the graph. I've worked around this by always taking the realpath before adding a `file` node to the graph, which is used to invalidate the asset. The asset node itself is not changed. There's possibly a case to be made for always taking the realpath in the resolver (node's default behavior) rather than the current behavior of preserving symlinks, but we can discuss and take that on separately if needed.

2. HMR updates are only sent if there are assets that changed which have a browser environment. I'm working in a statically rendered environment that generates node bundles and then executes them at build time to render static HTML. I want the browser to reload when I make a change, even to the node files.