### PR TITLE
Ensure that shared sibling bundles are added to all relevant bundle groups

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -24,6 +24,7 @@ export default new Bundler({
 
   bundle({bundleGraph}) {
     let bundleRoots: Map<Bundle, Array<Asset>> = new Map();
+    let bundlesByAsset: Map<string, Array<Bundle>> = new Map();
 
     // Step 1: create bundles for each of the explicit code split points.
     bundleGraph.traverse({
@@ -33,6 +34,7 @@ export default new Bundler({
             ...context,
             bundleGroup: context?.bundleGroup,
             bundleByType: context?.bundleByType,
+            siblingBundles: context?.siblingBundles,
             bundleGroupDependency: context?.bundleGroupDependency,
             parentNode: node,
           };
@@ -53,6 +55,7 @@ export default new Bundler({
             nullthrows(dependency.target ?? context?.bundleGroup?.target),
           );
           let bundleByType: Map<string, Bundle> = new Map();
+          let siblingBundles = [];
 
           for (let asset of assets) {
             let bundle = bundleGraph.createBundle({
@@ -63,12 +66,14 @@ export default new Bundler({
             });
             bundleByType.set(bundle.type, bundle);
             bundleRoots.set(bundle, [asset]);
+            bundlesByAsset.set(asset.id, siblingBundles);
             bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
           }
 
           return {
             bundleGroup,
             bundleByType,
+            siblingBundles,
             bundleGroupDependency: dependency,
             parentNode: node,
           };
@@ -79,8 +84,25 @@ export default new Bundler({
         let bundleGroup = nullthrows(context.bundleGroup);
         let bundleGroupDependency = nullthrows(context.bundleGroupDependency);
         let bundleByType = nullthrows(context.bundleByType);
+        let siblingBundles = nullthrows(context.siblingBundles);
 
         for (let asset of assets) {
+          // If any sibling bundles were created for this asset or it's subtree previously,
+          // add them all to the current bundle group as well. This fixes cases where two entries
+          // depend on a shared asset which has siblings. Due to DFS, the subtree of the shared
+          // asset is only processed once, meaning any sibling bundles created due to type changes
+          // would only be connected to the first bundle group. To work around this, we store a list
+          // of sibling bundles for each asset in the graph, and when we re-visit a shared asset, we
+          // connect them all to the current bundle group as well.
+          let siblings = bundlesByAsset.get(asset.id);
+          if (siblings) {
+            for (let bundle of siblings) {
+              bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
+            }
+          }
+
+          bundlesByAsset.set(asset.id, siblingBundles);
+
           let parentAsset = context.parentNode.value;
           if (parentAsset.type === asset.type) {
             continue;
@@ -100,6 +122,7 @@ export default new Bundler({
               isInline: asset.isInline,
             });
             bundleByType.set(bundle.type, bundle);
+            siblingBundles.push(bundle);
             bundleRoots.set(bundle, [asset]);
             bundleGraph.createAssetReference(dependency, asset);
             bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -883,7 +883,7 @@ describe('html', function() {
   });
 
   it('should support multiple entries with shared sibling bundles', async function() {
-    let b = await bundle(
+    await bundle(
       path.join(__dirname, '/integration/shared-sibling-entries/*.html'),
       {production: true, scopeHoist: true},
     );

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -881,4 +881,18 @@ describe('html', function() {
     assert(html.includes('.add(1, 2)'));
     assert(html.includes('.add(2, 3)'));
   });
+
+  it('should support multiple entries with shared sibling bundles', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/shared-sibling-entries/*.html'),
+      {production: true, scopeHoist: true},
+    );
+
+    // Both HTML files should point to the sibling CSS file
+    let html = await outputFS.readFile(path.join(distDir, 'a.html'), 'utf8');
+    assert(html.includes('<link rel="stylesheet" href="/a.css">'));
+
+    html = await outputFS.readFile(path.join(distDir, 'b.html'), 'utf8');
+    assert(html.includes('<link rel="stylesheet" href="/a.css">'));
+  });
 });

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/a.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/a.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>a.html</h1>
+    <script type="module">
+      import './shared';
+    </script>
+  </body>
+</html>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/b.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/b.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>b.html</h1>
+    <script type="module">
+      import './shared';
+    </script>
+  </body>
+</html>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/shared.css
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/shared.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/shared.js
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/shared.js
@@ -1,0 +1,3 @@
+import './shared.css';
+
+export default 'shared';


### PR DESCRIPTION
This fixes cases where two entries depend on a shared asset which has siblings (e.g. a shared JS bundle with a sibling CSS bundle). Due to DFS, the subtree of the shared asset is only processed once, meaning any sibling bundles created due to type changes would only be connected to the first bundle group. To work around this, we store a list of sibling bundles for each asset in the graph, and when we re-visit a shared asset, we connect them all to the current bundle group as well.