### PR TITLE
Automatic cross-origin loading of web workers

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -362,6 +362,7 @@ describe('javascript', function() {
           'common.js',
           'worker-client.js',
           'feature.js',
+          'get-worker-url.js',
           'bundle-url.js',
           'JSRuntime.js',
           'JSRuntime.js',
@@ -392,7 +393,13 @@ describe('javascript', function() {
       },
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: ['shared-worker.js'],
@@ -434,6 +441,7 @@ describe('javascript', function() {
           'worker-client.js',
           'feature.js',
           'bundle-url.js',
+          'get-worker-url.js',
           'JSRuntime.js',
           'JSRuntime.js',
           'JSRuntime.js',
@@ -471,7 +479,11 @@ describe('javascript', function() {
         },
         {
           name: `index-${workerType}.js`,
-          assets: [`index-${workerType}.js`, 'bundle-url.js', 'JSRuntime.js'],
+          assets: [
+            `index-${workerType}.js`,
+            'bundle-url.js',
+            'JSRuntime.js',
+          ].concat(workerType === 'webworker' ? ['get-worker-url.js'] : []),
         },
         {
           assets: ['imported.js'],
@@ -516,7 +528,12 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index-external.js',
-        assets: ['index-external.js', 'bundle-url.js', 'JSRuntime.js'],
+        assets: [
+          'index-external.js',
+          'bundle-url.js',
+          'get-worker-url.js',
+          'JSRuntime.js',
+        ],
       },
       {assets: ['external.js', 'JSRuntime.js']},
     ]);
@@ -577,7 +594,12 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: ['worker.js', 'worker-dep.js'],
@@ -628,10 +650,21 @@ describe('javascript', function() {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'lodash.js', 'bundle-url.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'lodash.js',
+          'bundle-url.js',
+          'get-worker-url.js',
+          'JSRuntime.js',
+        ],
       },
       {
-        assets: ['worker-a.js', 'bundle-url.js', 'JSRuntime.js'],
+        assets: [
+          'worker-a.js',
+          'JSRuntime.js',
+          'bundle-url.js',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: ['worker-b.js'],
@@ -661,7 +694,12 @@ describe('javascript', function() {
         assets: ['index.html'],
       },
       {
-        assets: ['index.js', 'bundle-url.js', 'JSRuntime.js'],
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'JSRuntime.js',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: ['worker.js'],

--- a/packages/examples/kitchen-sink/src/index.js
+++ b/packages/examples/kitchen-sink/src/index.js
@@ -1,5 +1,5 @@
 import styles from './styles.css';
-import parcel from './parcel.webp';
+import parcel from 'url:./parcel.webp';
 import {message} from './message';
 
 // import('./async');

--- a/packages/examples/kitchen-sink/src/worker.js
+++ b/packages/examples/kitchen-sink/src/worker.js
@@ -1,1 +1,2 @@
-console.log('logged from worker.js');
+const textUrl = require('url:./test.txt');
+console.log('logged from worker.js', textUrl);

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -185,12 +185,24 @@ function getURLRuntime(
   bundle: Bundle,
   externalBundle: Bundle,
 ): RuntimeAsset {
+  let relativePath = relativeBundlePath(bundle, externalBundle, {
+    leadingDotSlash: false,
+  });
+
+  if (dependency.meta.webworker === true) {
+    return {
+      filePath: __filename,
+      code: `module.exports = require('./get-worker-url')(${JSON.stringify(
+        relativePath,
+      )});`,
+      dependency,
+    };
+  }
+
   return {
     filePath: __filename,
     code: `module.exports = require('./bundle-url').getBundleURL() + ${JSON.stringify(
-      relativeBundlePath(bundle, externalBundle, {
-        leadingDotSlash: false,
-      }),
+      relativePath,
     )}`,
     dependency,
   };

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -27,5 +27,15 @@ function getBaseURL(url) {
   );
 }
 
+// TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
+function getOrigin(url) {
+  let matches = ('' + url).match(/(https?|file|ftp):\/\/[^/]+/);
+  if (!matches) {
+    throw new Error('Origin not found');
+  }
+  return matches[0];
+}
+
 exports.getBundleURL = getBundleURLCached;
 exports.getBaseURL = getBaseURL;
+exports.getOrigin = getOrigin;

--- a/packages/runtimes/js/src/get-worker-url.js
+++ b/packages/runtimes/js/src/get-worker-url.js
@@ -1,0 +1,17 @@
+/* global self, Blob */
+
+var bundleUrl = require('./bundle-url');
+
+module.exports = function loadWorker(relativePath) {
+  var workerUrl = bundleUrl.getBundleURL() + relativePath;
+  if (bundleUrl.getOrigin(workerUrl) === self.location.origin) {
+    // If the worker bundle's url is on the same origin as the document,
+    // use the worker bundle's own url.
+    return workerUrl;
+  } else {
+    // Otherwise, create a blob URL which loads the worker bundle with `importScripts`.
+    return URL.createObjectURL(
+      new Blob(['importScripts(' + JSON.stringify(workerUrl) + ');']),
+    );
+  }
+};

--- a/packages/transformers/js/src/visitors/dependencies.js
+++ b/packages/transformers/js/src/visitors/dependencies.js
@@ -1,6 +1,10 @@
 // @flow
 
-import type {MutableAsset, PluginOptions} from '@parcel/types';
+import type {
+  DependencyOptions,
+  MutableAsset,
+  PluginOptions,
+} from '@parcel/types';
 
 import * as types from '@babel/types';
 import traverse from '@babel/traverse';
@@ -145,6 +149,9 @@ export default ({
             context: 'web-worker',
             outputFormat:
               isModule && options.scopeHoist ? 'esmodule' : undefined,
+          },
+          meta: {
+            webworker: true,
           },
         });
         return;
@@ -306,12 +313,17 @@ function addDependency(
   });
 }
 
-function addURLDependency(asset, node, opts = {}) {
+function addURLDependency(
+  asset: MutableAsset,
+  node,
+  opts: $Shape<DependencyOptions> = {},
+) {
   let url = node.value;
   asset.addURLDependency(url, {
     loc: node.loc && createDependencyLocation(node.loc.start, node.value, 0, 1),
     ...opts,
   });
+
   morph(
     node,
     types.callExpression(types.identifier('require'), [


### PR DESCRIPTION
Depends on #4033.

This implements automatic cross-origin loading of worker bundles. Workers (both web workers and service workers) are constrained to the same origin as the document. 

This implements a small runtime to determine whether the currently executing script exists on the same origin as the document. If so, the worker bundle's url is ultimately used by the `Worker` constructor. If not, and the worker is a web worker (not a service worker), a blob url is constructed at runtime to `importScripts` the main worker bundle.

Notes:
* All testing was manual. Our integration tests don't run bundles in a real browser environment and I haven't yet explored mocking the necessary environment to test this in an automated way.
* Some CSP policies may restrict using blob urls to construct workers, as well as restrict the origins that `importScripts` can reference.
    * As a solution, we should consider allowing the user to set the base url for workers, both for web workers and service workers. Currently worker bundle urls are resolved relative to the bundle constructing them, but we may need to resolve all workers from a single base url to support this. This should be done at runtime to avoid embedding an absolute url in bundles, which should be as portable as possible. This should avoid the CSP concerns above.

Test Plan: Manual test with the kitchen sink example:
* Serve the kitchen sink demo using an absolute public url, which makes the html document use absolute urls when referring to scripts.
* Host the contents of `.parcel-cache/dist` with a basic http server on a port different from the devserver's.
* Verify `‌logged from worker.js http://localhost:1234/test.5f6c14a1.txt` is logged from the page hosted by the devserver.
* Verify `logged from worker.js http://localhost:1234/test.5f6c14a1.txt` is also logged from the page hosted by the http server on port 4321.
* Verify with devtools that a blob worker is used on the server on port 4321, with the contents of a `importScripts` call pointed at the server on port 1234.