### PR TITLE
TypeScript types transformer: configure compiler default JSX

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/externals/other.tsx
+++ b/packages/core/integration-tests/test/integration/ts-types/externals/other.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {ReactNode} from 'react';
 
 interface OtherProps {

--- a/packages/core/integration-tests/test/integration/ts-types/externals/other.tsx
+++ b/packages/core/integration-tests/test/integration/ts-types/externals/other.tsx
@@ -5,6 +5,6 @@ interface OtherProps {
   children: ReactNode
 }
 
-export function OtherComponent(props: Props) {
+export function OtherComponent(props: OtherProps) {
   return <div>{props.children}</div>;
 }

--- a/packages/transformers/typescript-tsc/src/TSCTransformer.js
+++ b/packages/transformers/typescript-tsc/src/TSCTransformer.js
@@ -1,21 +1,10 @@
 // @flow strict-local
 
+import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
+import type {TranspileOptions} from 'typescript';
+
 import {Transformer} from '@parcel/plugin';
 import {loadTSConfig} from '@parcel/ts-utils';
-
-type TypescriptCompilerOptions = {
-  module?: mixed,
-  jsx?: mixed,
-  noEmit?: boolean,
-  sourceMap?: boolean,
-  ...
-};
-
-type TypescriptTranspilerOptions = {
-  compilerOptions: TypescriptCompilerOptions,
-  fileName: string,
-  ...
-};
 
 export default new Transformer({
   async loadConfig({config, options}) {
@@ -25,7 +14,7 @@ export default new Transformer({
   async transform({asset, config, options}) {
     asset.type = 'js';
 
-    let [typescript, code] = await Promise.all([
+    let [typescript, code]: [TypeScriptModule, string] = await Promise.all([
       options.packageManager.require('typescript', asset.filePath),
       asset.getCode(),
     ]);
@@ -36,7 +25,7 @@ export default new Transformer({
         compilerOptions: {
           // React is the default. Users can override this by supplying their own tsconfig,
           // which many TypeScript users will already have for typechecking, etc.
-          jsx: 'React',
+          jsx: typescript.JsxEmit.React,
           ...config,
           // Always emit output
           noEmit: false,
@@ -45,7 +34,7 @@ export default new Transformer({
           module: typescript.ModuleKind.ESNext,
         },
         fileName: asset.filePath, // Should be relativePath?
-      }: TypescriptTranspilerOptions),
+      }: TranspileOptions),
     );
 
     return [

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -25,6 +25,9 @@ export default new Transformer({
     );
 
     let opts: CompilerOptions = {
+      // React is the default. Users can override this by supplying their own tsconfig,
+      // which many TypeScript users will already have for typechecking, etc.
+      jsx: ts.JsxEmit.React,
       ...config,
       // Always emit output
       noEmit: false,


### PR DESCRIPTION
This configures the TypeScript compiler to treat JSX as React calls by default. I'm not sure of the impact of this given the types transformer only emits types, but the compiler warned without this. This is the same default that we set in the tsc transformer.

Fixing this uncovered additional issues with the ts-types fixtures. Several were addressed, but the following remain which don't cause Parcel to fail:

externals/index.tsx:
```ts
  3 | import {OtherComponent} from './other';
> 4 | import {External} from 'external';
>   |                        ^^^^^^^^^^^ Cannot find module 'external'.
  5 | 
```

externals/index.tsx:
```ts
  10 | export const Component: React.FC<Props> = (props) => {
> 11 |   return <OtherComponent>{props.children}</OtherComponent>;
>    |           ^^^^^^^^^^^^^^^ Property 'children' is missing in type '{}' but required in type 'OtherProps'.
  12 | }
  13 | 
```

This pull request also changes the TSC transformer to use the enum form for the `emit` value as well as updates it to use the TypeScript flow types.

Test Plan: from the integration tests package, `yarn test test/typescript-tsc test/ts-types` and verify no messages about `jsx` not being set.