### PR TITLE
Respect log levels in cli reporter

### DIFF
--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -31,6 +31,10 @@ export function _report(event: ReporterEvent, options: PluginOptions): void {
 
   switch (event.type) {
     case 'buildStart': {
+      if (logLevelFilter < logLevels.info) {
+        break;
+      }
+
       // Clear any previous output
       resetWindow();
 
@@ -88,6 +92,10 @@ export function _report(event: ReporterEvent, options: PluginOptions): void {
       writeDiagnostic(event.diagnostics, 'red', true);
       break;
     case 'log': {
+      if (logLevelFilter < logLevels[event.level]) {
+        break;
+      }
+
       switch (event.level) {
         case 'success':
           writeOut(chalk.green(event.message));


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

I forgot a check for log level on log events in the clireporter, this PR adds that check...

It also adds a check for the server log message that only shows when loglevel is `>= info`

Closes #4052