### PR TITLE
Limit bundle splitting to JS and CSS bundles only

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -173,7 +173,7 @@ export default new Bundler({
         // Don't create shared bundles from entry bundles, as that would require
         // another entry bundle depending on these conditions, making it difficult
         // to predict and reference.
-        .filter(b => !b.isEntry);
+        .filter(b => !b.isEntry && (b.type === 'js' || b.type === 'css'));
 
       if (containingBundles.length > OPTIONS.minBundles) {
         let id = containingBundles


### PR DESCRIPTION
The behavior for other bundle types was somewhat undefined since we only really handle loading for JS and CSS (via JSRuntime and HtmlPackager).