### PR TITLE
Fix shared inline bundles with more than 2 references

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -99,9 +99,9 @@ export default new Bundler({
             for (let bundle of siblings) {
               bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
             }
+          } else {
+            siblingBundlesByAsset.set(asset.id, siblingBundles);
           }
-
-          siblingBundlesByAsset.set(asset.id, siblingBundles);
 
           let parentAsset = context.parentNode.value;
           if (parentAsset.type === asset.type) {

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -894,5 +894,8 @@ describe('html', function() {
 
     html = await outputFS.readFile(path.join(distDir, 'b.html'), 'utf8');
     assert(html.includes('<link rel="stylesheet" href="/a.css">'));
+
+    html = await outputFS.readFile(path.join(distDir, 'c.html'), 'utf8');
+    assert(html.includes('<link rel="stylesheet" href="/a.css">'));
   });
 });

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/c.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/c.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>c.html</h1>
+    <script type="module">
+      import './shared';
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Small bug fix for #4067. With more than two pages pointing to the same shared bundle, styles were not applied. This was because the sibling bundle mapping was overwritten during the second traversal.