### PR TITLE
Reuse public api wrappers

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -28,7 +28,7 @@ import AssetGraphBuilder from './AssetGraphBuilder';
 import {assertSignalNotAborted, BuildAbortError} from './utils';
 import PackagerRunner from './PackagerRunner';
 import loadParcelConfig from './loadParcelConfig';
-import ReporterRunner from './ReporterRunner';
+import ReporterRunner, {report} from './ReporterRunner';
 import dumpGraphToGraphViz from './dumpGraphToGraphViz';
 import resolveOptions from './resolveOptions';
 import {ValueEmitter} from '@parcel/events';
@@ -124,12 +124,14 @@ export default class Parcel {
     this.#reporterRunner = new ReporterRunner({
       config,
       options: resolvedOptions,
+      workerFarm: this.#farm,
     });
 
     this.#packagerRunner = new PackagerRunner({
       config,
-      options: resolvedOptions,
       farm: this.#farm,
+      options: resolvedOptions,
+      report,
     });
 
     this.#runPackage = this.#farm.createHandle('runPackage');

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -1,10 +1,16 @@
 // @flow strict-local
 
 import type {ReporterEvent} from '@parcel/types';
+import type {WorkerApi} from '@parcel/workers';
 import type {ParcelOptions} from './types';
 
-import {bundleToInternalBundle, NamedBundle} from './public/Bundle';
-import {bus} from '@parcel/workers';
+import invariant from 'assert';
+import {
+  bundleToInternalBundle,
+  bundleToInternalBundleGraph,
+  NamedBundle,
+} from './public/Bundle';
+import WorkerFarm, {bus} from '@parcel/workers';
 import ParcelConfig from './ParcelConfig';
 import logger, {
   patchConsole,
@@ -13,10 +19,12 @@ import logger, {
   INTERNAL_ORIGINAL_CONSOLE,
 } from '@parcel/logger';
 import PluginOptions from './public/PluginOptions';
+import BundleGraph from './BundleGraph';
 
 type Opts = {|
   config: ParcelConfig,
   options: ParcelOptions,
+  workerFarm: WorkerFarm,
 |};
 
 export default class ReporterRunner {
@@ -31,21 +39,26 @@ export default class ReporterRunner {
 
     logger.onLog(event => this.report(event));
 
-    // Convert any internal bundles back to their public equivalents as reporting
-    // is public api
     bus.on('reporterEvent', event => {
-      if (event.bundle == null) {
-        this.report(event);
-      } else {
+      if (
+        event.type === 'buildProgress' &&
+        (event.phase === 'optimizing' || event.phase === 'packaging') &&
+        !(event.bundle instanceof NamedBundle)
+      ) {
+        // Convert any internal bundles back to their public equivalents as reporting
+        // is public api
+        let bundleGraph = opts.workerFarm.workerApi.getSharedReference(
+          event.bundleGraphRef,
+        );
+        invariant(bundleGraph instanceof BundleGraph);
         this.report({
           ...event,
-          bundle: new NamedBundle(
-            event.bundle,
-            event.bundleGraph,
-            this.options,
-          ),
+          bundle: new NamedBundle(event.bundle, bundleGraph, this.options),
         });
+        return;
       }
+
+      this.report(event);
     });
 
     if (this.options.patchConsole) {
@@ -73,15 +86,26 @@ export default class ReporterRunner {
   }
 }
 
-export function report(event: ReporterEvent) {
-  if (event.bundle == null) {
-    bus.emit('reporterEvent', event);
-  } else {
+export function reportWorker(workerApi: WorkerApi, event: ReporterEvent) {
+  if (
+    event.type === 'buildProgress' &&
+    (event.phase === 'optimizing' || event.phase === 'packaging')
+  ) {
     // Convert any public api bundles to their internal equivalents for
     // easy serialization
     bus.emit('reporterEvent', {
       ...event,
       bundle: bundleToInternalBundle(event.bundle),
+      bundleGraphRef: workerApi.resolveSharedReference(
+        bundleToInternalBundleGraph(event.bundle),
+      ),
     });
+    return;
   }
+
+  bus.emit('reporterEvent', event);
+}
+
+export function report(event: ReporterEvent) {
+  bus.emit('reporterEvent', event);
 }

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -1,7 +1,12 @@
 // @flow strict-local
 
 import type {WorkerApi} from '@parcel/workers';
-import type {AssetRequestDesc, ConfigRequestDesc, ParcelOptions} from './types';
+import type {
+  AssetRequestDesc,
+  ConfigRequestDesc,
+  ParcelOptions,
+  ReportFn,
+} from './types';
 
 import path from 'path';
 import nullthrows from 'nullthrows';
@@ -10,15 +15,15 @@ import logger, {PluginLogger} from '@parcel/logger';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 import ParcelConfig from './ParcelConfig';
 import ConfigLoader from './ConfigLoader';
-import {report} from './ReporterRunner';
 import InternalAsset, {createAsset} from './InternalAsset';
 import {Asset} from './public/Asset';
 import PluginOptions from './public/PluginOptions';
 import summarizeRequest from './summarizeRequest';
 
 export type ValidationOpts = {|
-  request: AssetRequestDesc,
   options: ParcelOptions,
+  request: AssetRequestDesc,
+  report: ReportFn,
   workerApi: WorkerApi,
 |};
 
@@ -28,17 +33,19 @@ export default class Validation {
   configLoader: ConfigLoader;
   options: ParcelOptions;
   impactfulOptions: $Shape<ParcelOptions>;
+  report: ReportFn;
   workerApi: WorkerApi;
 
-  constructor({request, options, workerApi}: ValidationOpts) {
-    this.request = request;
-    this.options = options;
-    this.workerApi = workerApi;
+  constructor({request, report, options, workerApi}: ValidationOpts) {
     this.configLoader = new ConfigLoader(options);
+    this.options = options;
+    this.report = report;
+    this.request = request;
+    this.workerApi = workerApi;
   }
 
   async run(): Promise<void> {
-    report({
+    this.report({
       type: 'validation',
       filePath: this.request.filePath,
     });

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -29,6 +29,12 @@ import Dependency from './Dependency';
 import InternalAsset from '../InternalAsset';
 import {createEnvironment} from '../Environment';
 
+const internalAssetToAsset: WeakMap<InternalAsset, Asset> = new WeakMap();
+const internalAssetToMutableAsset: WeakMap<
+  InternalAsset,
+  MutableAsset,
+> = new WeakMap();
+
 const _assetToInternalAsset: WeakMap<
   IAsset | IMutableAsset | BaseAsset,
   InternalAsset,
@@ -156,8 +162,14 @@ export class Asset extends BaseAsset implements IAsset {
   #asset; // InternalAsset
 
   constructor(asset: InternalAsset) {
+    let existing = internalAssetToAsset.get(asset);
+    if (existing != null) {
+      return existing;
+    }
+
     super(asset);
     this.#asset = asset;
+    internalAssetToAsset.set(asset, this);
   }
 
   get outputHash(): string {
@@ -173,8 +185,14 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
   #asset; // InternalAsset
 
   constructor(asset: InternalAsset) {
+    let existing = internalAssetToMutableAsset.get(asset);
+    if (existing != null) {
+      return existing;
+    }
+
     super(asset);
     this.#asset = asset;
+    internalAssetToMutableAsset.set(asset, this);
   }
 
   get ast(): ?AST {

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -40,6 +40,13 @@ const _bundleToInternalBundle: WeakMap<IBundle, InternalBundle> = new WeakMap();
 export function bundleToInternalBundle(bundle: IBundle): InternalBundle {
   return nullthrows(_bundleToInternalBundle.get(bundle));
 }
+const _bundleToInternalBundleGraph: WeakMap<
+  IBundle,
+  BundleGraph,
+> = new WeakMap();
+export function bundleToInternalBundleGraph(bundle: IBundle): BundleGraph {
+  return nullthrows(_bundleToInternalBundleGraph.get(bundle));
+}
 
 export class Bundle implements IBundle {
   #bundle; // InternalBundle
@@ -62,6 +69,7 @@ export class Bundle implements IBundle {
     this.#options = options;
 
     _bundleToInternalBundle.set(this, bundle);
+    _bundleToInternalBundleGraph.set(this, bundleGraph);
     existingMap.set(bundle, this);
   }
 

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -15,12 +15,17 @@ import type InternalBundleGraph from '../BundleGraph';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
+import {DefaultWeakMap} from '@parcel/utils';
 
 import {assetFromValue, assetToInternalAsset, Asset} from './Asset';
 import {Bundle, bundleToInternalBundle} from './Bundle';
 import Dependency, {dependencyToInternalDependency} from './Dependency';
 import {mapVisitor} from '../Graph';
 
+const internalBundleGraphToBundleGraph: DefaultWeakMap<
+  ParcelOptions,
+  WeakMap<InternalBundleGraph, BundleGraph>,
+> = new DefaultWeakMap(() => new WeakMap());
 // Friendly access for other modules within this package that need access
 // to the internal bundle.
 const _bundleGraphToInternalBundleGraph: WeakMap<
@@ -38,9 +43,15 @@ export default class BundleGraph implements IBundleGraph {
   #options; // ParcelOptions
 
   constructor(graph: InternalBundleGraph, options: ParcelOptions) {
+    let existing = internalBundleGraphToBundleGraph.get(options).get(graph);
+    if (existing != null) {
+      return existing;
+    }
+
     this.#graph = graph;
     this.#options = options;
     _bundleGraphToInternalBundleGraph.set(this, graph);
+    internalBundleGraphToBundleGraph.get(options).set(graph, this);
   }
 
   getDependencyResolution(dep: IDependency): ?Asset {

--- a/packages/core/core/src/public/Config.js
+++ b/packages/core/core/src/public/Config.js
@@ -10,17 +10,28 @@ import type {
 } from '@parcel/types';
 import type {Config, ParcelOptions} from '../types';
 
-import {loadConfig} from '@parcel/utils';
+import {DefaultWeakMap, loadConfig} from '@parcel/utils';
 
 import Environment from './Environment';
+
+const internalConfigToConfig: DefaultWeakMap<
+  ParcelOptions,
+  WeakMap<Config, PublicConfig>,
+> = new DefaultWeakMap(() => new WeakMap());
 
 export default class PublicConfig implements IConfig {
   #config; // Config;
   #options; // ParcelOptions
 
   constructor(config: Config, options: ParcelOptions) {
+    let existing = internalConfigToConfig.get(options).get(config);
+    if (existing != null) {
+      return existing;
+    }
+
     this.#config = config;
     this.#options = options;
+    internalConfigToConfig.get(options).set(config, this);
   }
 
   get env() {

--- a/packages/core/core/src/public/Dependency.js
+++ b/packages/core/core/src/public/Dependency.js
@@ -11,6 +11,10 @@ import Environment from './Environment';
 import Target from './Target';
 import nullthrows from 'nullthrows';
 
+const internalDependencyToDependency: WeakMap<
+  InternalDependency,
+  Dependency,
+> = new WeakMap();
 const _dependencyToInternalDependency: WeakMap<
   IDependency,
   InternalDependency,
@@ -25,8 +29,14 @@ export default class Dependency implements IDependency {
   #dep; // InternalDependency
 
   constructor(dep: InternalDependency) {
+    let existing = internalDependencyToDependency.get(dep);
+    if (existing != null) {
+      return existing;
+    }
+
     this.#dep = dep;
     _dependencyToInternalDependency.set(this, dep);
+    internalDependencyToDependency.set(dep, this);
   }
 
   get id(): string {

--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -57,6 +57,10 @@ const ESMODULE_BROWSERS = {
   samsung: '8.2',
 };
 
+const internalEnvironmentToEnvironment: WeakMap<
+  InternalEnvironment,
+  Environment,
+> = new WeakMap();
 const _environmentToInternalEnvironment: WeakMap<
   IEnvironment,
   InternalEnvironment,
@@ -71,8 +75,14 @@ export default class Environment implements IEnvironment {
   #environment; // InternalEnvironment
 
   constructor(env: InternalEnvironment) {
+    let existing = internalEnvironmentToEnvironment.get(env);
+    if (existing != null) {
+      return existing;
+    }
+
     this.#environment = env;
     _environmentToInternalEnvironment.set(this, env);
+    internalEnvironmentToEnvironment.set(env, this);
   }
 
   get context(): EnvironmentContext {

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -11,11 +11,22 @@ import type {FileSystem} from '@parcel/fs';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ParcelOptions} from '../types';
 
+let parcelOptionsToPluginOptions: WeakMap<
+  ParcelOptions,
+  PluginOptions,
+> = new WeakMap();
+
 export default class PluginOptions implements IPluginOptions {
   #options; // ParcelOptions
 
   constructor(options: ParcelOptions) {
+    let existing = parcelOptionsToPluginOptions.get(options);
+    if (existing != null) {
+      return existing;
+    }
+
     this.#options = options;
+    parcelOptionsToPluginOptions.set(options, this);
   }
 
   get mode(): BuildMode {

--- a/packages/core/core/src/public/Target.js
+++ b/packages/core/core/src/public/Target.js
@@ -9,6 +9,7 @@ import type {Target as TargetValue} from '../types';
 import Environment from './Environment';
 import nullthrows from 'nullthrows';
 
+const internalTargetToTarget: WeakMap<TargetValue, Target> = new WeakMap();
 const _targetToInternalTarget: WeakMap<ITarget, TargetValue> = new WeakMap();
 export function targetToInternalTarget(target: ITarget): TargetValue {
   return nullthrows(_targetToInternalTarget.get(target));
@@ -18,8 +19,14 @@ export default class Target implements ITarget {
   #target; // TargetValue
 
   constructor(target: TargetValue) {
+    let existing = internalTargetToTarget.get(target);
+    if (existing != null) {
+      return existing;
+    }
+
     this.#target = target;
     _targetToInternalTarget.set(this, target);
+    internalTargetToTarget.set(target, this);
   }
 
   get distEntry(): ?FilePath {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -15,6 +15,7 @@ import type {
   ModuleSpecifier,
   PackageName,
   PackageJSON,
+  ReporterEvent,
   ResolvedParcelConfigFile,
   Semver,
   ServerOptions,
@@ -324,3 +325,5 @@ export type ValidationOpts = {|
   request: AssetRequestDesc,
   options: ParcelOptions,
 |};
+
+export type ReportFn = (event: ReporterEvent) => void;

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -5,10 +5,12 @@ import BundleGraph from './BundleGraph';
 import type {WorkerApi} from '@parcel/workers';
 
 import Transformation, {type TransformationOpts} from './Transformation';
+import {reportWorker} from './ReporterRunner';
 import PackagerRunner from './PackagerRunner';
 import Validation, {type ValidationOpts} from './Validation';
 import ParcelConfig from './ParcelConfig';
 import {registerCoreWithSerializer} from './utils';
+
 import '@parcel/cache'; // register with serializer
 import '@parcel/package-manager';
 import '@parcel/fs';
@@ -30,14 +32,22 @@ export function runTransform(
   workerApi: WorkerApi,
   opts: TransformationOptsWithoutWorkerApi,
 ) {
-  return new Transformation({workerApi, ...opts}).run();
+  return new Transformation({
+    workerApi,
+    report: reportWorker.bind(null, workerApi),
+    ...opts,
+  }).run();
 }
 
 export function runValidate(
   workerApi: WorkerApi,
   opts: ValidationOptsWithoutWorkerApi,
 ) {
-  return new Validation({workerApi, ...opts}).run();
+  return new Validation({
+    workerApi,
+    report: reportWorker.bind(null, workerApi),
+    ...opts,
+  }).run();
 }
 
 export function runPackage(
@@ -61,5 +71,6 @@ export function runPackage(
   return new PackagerRunner({
     config,
     options,
+    report: reportWorker.bind(null, workerApi),
   }).packageAndWriteBundle(bundle, bundleGraph, cacheKey);
 }

--- a/packages/core/core/test/PublicAsset.test.js
+++ b/packages/core/core/test/PublicAsset.test.js
@@ -1,0 +1,34 @@
+// @flow strict-local
+
+import assert from 'assert';
+import {Asset, MutableAsset} from '../src/public/Asset';
+import InternalAsset, {createAsset} from '../src/InternalAsset';
+import {createEnvironment} from '../src/Environment';
+import {DEFAULT_OPTIONS} from './utils';
+
+describe('Public Asset', () => {
+  let internalAsset;
+  beforeEach(() => {
+    internalAsset = new InternalAsset({
+      options: DEFAULT_OPTIONS,
+      value: createAsset({
+        filePath: '/does/not/exist',
+        type: 'js',
+        env: createEnvironment({}),
+        isSource: true,
+        stats: {size: 0, time: 0},
+      }),
+    });
+  });
+
+  it('returns the same public Asset given an internal asset', () => {
+    assert.equal(new Asset(internalAsset), new Asset(internalAsset));
+  });
+
+  it('returns the same public MutableAsset given an internal asset', () => {
+    assert.equal(
+      new MutableAsset(internalAsset),
+      new MutableAsset(internalAsset),
+    );
+  });
+});

--- a/packages/core/core/test/PublicBundle.test.js
+++ b/packages/core/core/test/PublicBundle.test.js
@@ -1,0 +1,51 @@
+// @flow strict-local
+
+import assert from 'assert';
+import {Bundle, NamedBundle} from '../src/public/Bundle';
+import BundleGraph from '../src/BundleGraph';
+import {createEnvironment} from '../src/Environment';
+import {DEFAULT_OPTIONS} from './utils';
+import Graph from '../src/Graph';
+
+describe('Public Bundle', () => {
+  let internalBundle;
+  let bundleGraph;
+  beforeEach(() => {
+    let env = createEnvironment({});
+    internalBundle = {
+      id: '123',
+      entryAssetIds: [],
+      type: 'js',
+      env,
+      filePath: null,
+      name: null,
+      pipeline: null,
+      isEntry: null,
+      isInline: null,
+      isSplittable: true,
+      target: {
+        env,
+        distDir: '',
+        name: '',
+        publicUrl: '',
+      },
+      stats: {size: 0, time: 0},
+    };
+
+    bundleGraph = new BundleGraph({graph: new Graph()});
+  });
+
+  it('returns the same public Bundle given an internal bundle', () => {
+    assert.equal(
+      new Bundle(internalBundle, bundleGraph, DEFAULT_OPTIONS),
+      new Bundle(internalBundle, bundleGraph, DEFAULT_OPTIONS),
+    );
+  });
+
+  it('returns the same public NamedBundle given an internal bundle', () => {
+    assert.equal(
+      new NamedBundle(internalBundle, bundleGraph, DEFAULT_OPTIONS),
+      new NamedBundle(internalBundle, bundleGraph, DEFAULT_OPTIONS),
+    );
+  });
+});

--- a/packages/core/core/test/PublicDependency.test.js
+++ b/packages/core/core/test/PublicDependency.test.js
@@ -1,0 +1,20 @@
+// @flow strict-local
+
+import assert from 'assert';
+import {createEnvironment} from '../src/Environment';
+import {createDependency} from '../src/Dependency';
+import Dependency from '../src/public/Dependency';
+
+describe('Public Dependency', () => {
+  it('returns the same public Dependency given an internal dependency', () => {
+    let internalDependency = createDependency({
+      moduleSpecifier: 'foo',
+      env: createEnvironment({}),
+    });
+
+    assert.equal(
+      new Dependency(internalDependency),
+      new Dependency(internalDependency),
+    );
+  });
+});

--- a/packages/core/utils/src/DefaultMap.js
+++ b/packages/core/utils/src/DefaultMap.js
@@ -1,6 +1,30 @@
 // @flow strict-local
 
-export default class DefaultMap<K, V> extends Map<K, V> {
+export class DefaultMap<K, V> extends Map<K, V> {
+  _getDefault: K => V;
+
+  constructor(getDefault: K => V, entries?: Iterable<[K, V]>) {
+    super(entries);
+    this._getDefault = getDefault;
+  }
+
+  get(key: K): V {
+    let ret;
+    if (this.has(key)) {
+      ret = super.get(key);
+    } else {
+      ret = this._getDefault(key);
+      this.set(key, ret);
+    }
+
+    // $FlowFixMe
+    return ret;
+  }
+}
+
+// Duplicated from DefaultMap implementation for Flow
+// Roughly mirrors https://github.com/facebook/flow/blob/2eb5a78d92c167117ba9caae070afd2b9f598599/lib/core.js#L617
+export class DefaultWeakMap<K: {...}, V> extends WeakMap<K, V> {
   _getDefault: K => V;
 
   constructor(getDefault: K => V, entries?: Iterable<[K, V]>) {

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -4,7 +4,6 @@ export type * from './prettyError';
 export type * from './prettyDiagnostic';
 
 export {default as countLines} from './countLines';
-export {default as DefaultMap} from './DefaultMap';
 export {default as generateBundleReport} from './generateBundleReport';
 export {default as generateCertificate} from './generateCertificate';
 export {default as getCertificate} from './getCertificate';
@@ -29,6 +28,7 @@ export {default as throttle} from './throttle';
 export * from './blob';
 export * from './collection';
 export * from './config';
+export * from './DefaultMap';
 export * from './Deferred';
 export * from './glob';
 export * from './md5';

--- a/packages/core/utils/test/DefaultMap.test.js
+++ b/packages/core/utils/test/DefaultMap.test.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 
 import assert from 'assert';
-import DefaultMap from '../src/DefaultMap';
+import {DefaultMap} from '../src/DefaultMap';
 
 describe('DefaultMap', () => {
   it('constructs with entries just like Map', () => {

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -38,6 +38,7 @@ export class Child {
   workerApi: WorkerApi;
   handles: Map<number, Handle> = new Map();
   sharedReferences: Map<number, mixed> = new Map();
+  sharedReferencesByValue: Map<mixed, number> = new Map();
 
   constructor(ChildBackend: Class<ChildImpl>) {
     this.child = new ChildBackend(
@@ -60,6 +61,8 @@ export class Child {
     createReverseHandle: (fn: (...args: Array<any>) => mixed): Handle =>
       this.createReverseHandle(fn),
     getSharedReference: (ref: number) => this.sharedReferences.get(ref),
+    resolveSharedReference: (value: mixed) =>
+      this.sharedReferencesByValue.get(value),
   };
 
   messageListener(message: WorkerMessage): void | Promise<void> {
@@ -136,7 +139,9 @@ export class Child {
         result = errorResponseFromError(e);
       }
     } else if (method === 'createSharedReference') {
-      this.sharedReferences.set(args[0], args[1]);
+      let [ref, value] = args;
+      this.sharedReferences.set(ref, value);
+      this.sharedReferencesByValue.set(value, ref);
       result = responseFromContent(null);
     } else if (method === 'deleteSharedReference') {
       this.sharedReferences.delete(args[0]);

--- a/packages/core/workers/test/integration/workerfarm/resolve-shared-reference.js
+++ b/packages/core/workers/test/integration/workerfarm/resolve-shared-reference.js
@@ -1,0 +1,5 @@
+function run(workerApi, ref) {
+  return ref === workerApi.resolveSharedReference(workerApi.getSharedReference(ref));
+}
+
+exports.run = run;

--- a/packages/core/workers/test/workerfarm.js
+++ b/packages/core/workers/test/workerfarm.js
@@ -291,6 +291,25 @@ describe('WorkerFarm', function() {
     assert.equal(result, 'Shared reference does not exist');
   });
 
+  it('should resolve shared references in workers', async () => {
+    let workerfarm = new WorkerFarm({
+      warmWorkers: true,
+      useLocalWorker: false,
+      workerPath: require.resolve(
+        './integration/workerfarm/resolve-shared-reference.js',
+      ),
+    });
+
+    let sharedValue = 'Something to be shared';
+    let {ref, dispose} = await workerfarm.createSharedReference(sharedValue);
+
+    assert.equal(workerfarm.workerApi.resolveSharedReference(sharedValue), ref);
+    assert.ok(await workerfarm.run(ref));
+
+    await dispose();
+    assert(workerfarm.workerApi.resolveSharedReference(sharedValue) == null);
+  });
+
   it('Should support shared references in local worker', async () => {
     let workerfarm = new WorkerFarm({
       warmWorkers: true,
@@ -307,6 +326,25 @@ describe('WorkerFarm', function() {
     await dispose();
     result = await workerfarm.run(ref);
     assert.equal(result, 'Shared reference does not exist');
+  });
+
+  it('should resolve shared references in local worker', async () => {
+    let workerfarm = new WorkerFarm({
+      warmWorkers: true,
+      useLocalWorker: true,
+      workerPath: require.resolve(
+        './integration/workerfarm/resolve-shared-reference.js',
+      ),
+    });
+
+    let sharedValue = 'Something to be shared';
+    let {ref, dispose} = await workerfarm.createSharedReference(sharedValue);
+
+    assert.equal(workerfarm.workerApi.resolveSharedReference(sharedValue), ref);
+    assert.ok(await workerfarm.run(ref));
+
+    await dispose();
+    assert(workerfarm.workerApi.resolveSharedReference(sharedValue) == null);
   });
 
   it('Should dispose of shared references when ending', async () => {


### PR DESCRIPTION
This caches the public api wrappers that we create from internal objects to give to plugins. Having public wrappers created whenever the public api boundary is crossed has been error prone, as plugins have assumed object reference equality when working with structures like assets, bundles, etc.


This adds `DefaultWeakMap` to make caching these wrappers based on their arguments easier.

Alternative: This implementation could be simplified significantly by effectively memoizing the class constructor. This would probably be made available as a static/exported function and direct use of the constructor would be avoided.

Test Plan: Added unit tests for the most critical public wrappers.