### PR TITLE
[T-359] Ensure that parent bundles are invalidated when inline bundles change

### DIFF
--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -64,7 +64,11 @@ export default async function dumpGraphToGraphViz(
         path.basename(node.value.filePath) +
         ` (${getEnvDescription(node.value.env)})`;
     } else if (node.type === 'bundle') {
-      label += node.id;
+      let parts = [];
+      if (node.value.isEntry) parts.push('entry');
+      if (node.value.isInline) parts.push('inline');
+      if (parts.length) label += ' (' + parts.join(', ') + ')';
+      if (node.value.env) label += ` (${getEnvDescription(node.value.env)})`;
     } else if (node.type === 'request') {
       label = node.value.type + ':' + node.id;
     }

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1,19 +1,31 @@
 import assert from 'assert';
 import {
   bundle,
+  bundler,
   assertBundles,
   assertBundleTree,
   removeDistDirectory,
   distDir,
+  getNextBuild,
   run,
   inputFS,
   outputFS,
+  overlayFS,
+  ncp,
 } from '@parcel/test-utils';
 import path from 'path';
 
 describe('html', function() {
   beforeEach(async () => {
     await removeDistDirectory();
+  });
+
+  let subscription;
+  afterEach(async () => {
+    if (subscription) {
+      await subscription.unsubscribe();
+      subscription = null;
+    }
   });
 
   it('should support bundling HTML', async () => {
@@ -890,12 +902,43 @@ describe('html', function() {
 
     // Both HTML files should point to the sibling CSS file
     let html = await outputFS.readFile(path.join(distDir, 'a.html'), 'utf8');
-    assert(html.includes('<link rel="stylesheet" href="/a.css">'));
+    assert(/<link rel="stylesheet" href="\/a\.[a-z0-9]+\.css">/.test(html));
 
     html = await outputFS.readFile(path.join(distDir, 'b.html'), 'utf8');
-    assert(html.includes('<link rel="stylesheet" href="/a.css">'));
+    assert(/<link rel="stylesheet" href="\/a\.[a-z0-9]+\.css">/.test(html));
 
     html = await outputFS.readFile(path.join(distDir, 'c.html'), 'utf8');
-    assert(html.includes('<link rel="stylesheet" href="/a.css">'));
+    assert(/<link rel="stylesheet" href="\/a\.[a-z0-9]+\.css">/.test(html));
+  });
+
+  it('should invalidate parent bundle when inline bundles change', async function() {
+    // copy into memory fs
+    await ncp(
+      path.join(__dirname, '/integration/html-inline-js-require'),
+      path.join(__dirname, '/html-inline-js-require'),
+    );
+
+    let b = await bundler(
+      path.join(__dirname, '/html-inline-js-require/index.html'),
+      {
+        inputFS: overlayFS,
+        disableCache: false,
+      },
+    );
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let html = await outputFS.readFile('/dist/index.html', 'utf8');
+    assert(html.includes("console.log('test')"));
+
+    await overlayFS.writeFile(
+      path.join(__dirname, '/html-inline-js-require/test.js'),
+      'console.log("foo")',
+    );
+    await getNextBuild(b);
+
+    html = await outputFS.readFile('/dist/index.html', 'utf8');
+    assert(html.includes('console.log("foo")'));
   });
 });

--- a/packages/transformers/html/src/inline.js
+++ b/packages/transformers/html/src/inline.js
@@ -86,6 +86,10 @@ export default function extractInlineAssets(
         // insert parcelId to allow us to retrieve node during packaging
         node.attrs['data-parcel-key'] = parcelKey;
 
+        asset.addDependency({
+          moduleSpecifier: parcelKey,
+        });
+
         parts.push({
           type,
           code: value,
@@ -103,6 +107,10 @@ export default function extractInlineAssets(
 
     // Process inline style attributes.
     if (node.attrs && node.attrs.style) {
+      asset.addDependency({
+        moduleSpecifier: parcelKey,
+      });
+
       parts.push({
         type: 'css',
         code: node.attrs.style,


### PR DESCRIPTION
Currently, if a dependency of an inline asset is updated, the inline bundle is recompiled but the parent is not invalidated. For example, if `test.js` is updated in the following example, the parent HTML file is not changed.

```html
<script>
require('./test.js');
</script>
```

This is because inline bundles are in the same asset group as their parent, making them siblings rather than children. Only the hashes of child bundles are included in the parent, not siblings.

![BundleGraph](https://user-images.githubusercontent.com/19409/74112206-7a9f9600-4b4f-11ea-8793-4a5204c3bc22.png)

This is fixed by adding a dependency between the parent HTML bundle and the inline assets using the `uniqueKey` as the module specifier (recently added in #4010). This results in separate bundle groups being created for the inline bundles just like normal (non-inline) dependencies. Because of this, the inline bundles are children and thus included in the hash of the parent, resolving the caching issue.

![BundleGraph](https://user-images.githubusercontent.com/19409/74112245-cbaf8a00-4b4f-11ea-8796-f10b8e9576a4.png)

It could be argued that the API for this is a bit strange. Maybe we should not return multiple assets from a transformer and instead return the inline assets as part of the dependencies, or otherwise separately from the main asset. Perhaps a topic for future discussion.