### PR TITLE
Various scope hoisting fixes

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/esm-commonjs/a.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-commonjs/a.js
@@ -1,3 +1,4 @@
 import {foo} from './b';
 
 export const bar = foo + 3;
+export default 4;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-default/a.js
@@ -1,4 +1,8 @@
 import foo from './wrapped'
 import bar from './notwrapped'
 
-output = foo() + bar()
+function calc() {
+  return foo() + bar();
+}
+
+output = calc() + ':' + foo() + ':' + bar();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/a.js
@@ -1,0 +1,3 @@
+import * as bar from 'bar';
+
+output = bar.foo(4);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/node_modules/bar/foo.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/node_modules/bar/foo.js
@@ -1,0 +1,7 @@
+export function foo(a) {
+  return a * a;
+}
+
+export function bar(b) {
+  return b + b;
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/node_modules/bar/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+export * from './foo';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/node_modules/bar/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-all/node_modules/bar/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bar",
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -342,6 +342,9 @@ describe('scope hoisting', function() {
         ),
       );
 
+      let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(/var \$[a-z0-9]+\$cjs_exports/.test(dist));
+
       let [foo, bExports] = await run(b);
       assert.equal(foo, 'foobar');
       assert.equal(typeof bExports, 'object');

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -422,6 +422,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 123);
     });
 
+    it('should handle sideEffects: false with namespace imports and re-exports correctly', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/side-effects-re-exports-all/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 16);
+    });
+
     it('correctly updates deferred assets that are reexported', async function() {
       let testDir = path.join(
         __dirname,

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -330,8 +330,14 @@ describe('scope hoisting', function() {
         ),
       );
 
+      let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert.equal(
+        dist.match(/var \$[a-z0-9]+\$\$interop\$default =/g).length,
+        2,
+      );
+
       let output = await run(b);
-      assert.deepEqual(output, 'foobar');
+      assert.deepEqual(output, 'foobar:foo:bar');
     });
 
     it('does not export reassigned CommonJS exports references', async function() {

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -164,8 +164,12 @@ function getUsedExports(
         }
 
         if (symbol === '*') {
-          for (let symbol of resolvedAsset.symbols.keys()) {
-            markUsed(resolvedAsset, symbol);
+          for (let {asset, symbol} of bundleGraph.getExportedSymbols(
+            resolvedAsset,
+          )) {
+            if (symbol) {
+              markUsed(asset, symbol);
+            }
           }
         }
 

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -9,7 +9,7 @@ import {relativeBundlePath} from '@parcel/utils';
 import rename from '../renamer';
 
 const REQUIRE_TEMPLATE = template('require(BUNDLE)');
-const EXPORT_TEMPLATE = template('exports.IDENTIFIER = IDENTIFIER');
+const EXPORT_TEMPLATE = template('exports.NAME = IDENTIFIER');
 const MODULE_EXPORTS_TEMPLATE = template('module.exports = IDENTIFIER');
 const INTEROP_TEMPLATE = template('$parcel$interopDefault(MODULE)');
 const ASSIGN_TEMPLATE = template('var SPECIFIERS = MODULE');
@@ -241,6 +241,7 @@ export function generateExports(
 
     statements.push(
       EXPORT_TEMPLATE({
+        NAME: t.identifier(exportsId),
         IDENTIFIER: t.identifier(exportsId),
       }),
     );
@@ -294,11 +295,16 @@ export function generateExports(
         }
 
         let binding = path.scope.getBinding(symbol);
-        rename(path.scope, symbol, exportSymbol);
+        let id =
+          exportSymbol === 'default'
+            ? path.scope.generateUid(exportSymbol)
+            : exportSymbol;
+        rename(path.scope, symbol, id);
 
         binding.path.getStatementParent().insertAfter(
           EXPORT_TEMPLATE({
-            IDENTIFIER: t.identifier(exportSymbol),
+            NAME: t.identifier(exportSymbol),
+            IDENTIFIER: t.identifier(id),
           }),
         );
 
@@ -308,7 +314,8 @@ export function generateExports(
           for (let path of binding.constantViolations) {
             path.insertAfter(
               EXPORT_TEMPLATE({
-                IDENTIFIER: t.identifier(exportSymbol),
+                NAME: t.identifier(exportSymbol),
+                IDENTIFIER: t.identifier(id),
               }),
             );
           }

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -295,10 +295,9 @@ export function generateExports(
         }
 
         let binding = path.scope.getBinding(symbol);
-        let id =
-          !t.isValidIdentifier(exportSymbol)
-            ? path.scope.generateUid(exportSymbol)
-            : exportSymbol;
+        let id = !t.isValidIdentifier(exportSymbol)
+          ? path.scope.generateUid(exportSymbol)
+          : exportSymbol;
         rename(path.scope, symbol, id);
 
         binding.path.getStatementParent().insertAfter(

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -296,7 +296,7 @@ export function generateExports(
 
         let binding = path.scope.getBinding(symbol);
         let id =
-          exportSymbol === 'default'
+          !t.isValidIdentifier(exportSymbol)
             ? path.scope.generateUid(exportSymbol)
             : exportSymbol;
         rename(path.scope, symbol, id);

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -682,7 +682,7 @@ function getCJSExportsIdentifier(asset: MutableAsset, scope) {
   } else if (scope.getProgramParent().getData('cjsExportsReassigned')) {
     let id = getIdentifier(asset, 'cjs_exports');
     if (!scope.hasBinding(id.name)) {
-      scope.getProgramParent().addGlobal(id);
+      scope.getProgramParent().push({id});
     }
 
     return id;

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -176,7 +176,7 @@ export function link({
         let parent;
         if (binding) {
           parent = path.findParent(
-            p => p.scope === binding.scope && p.isStatement(),
+            p => getScopeBefore(p) === binding.scope && p.isStatement(),
           );
         }
 
@@ -195,7 +195,7 @@ export function link({
           binding.reference(decl.get('declarations.0.init'));
         }
 
-        parent.scope.registerDeclaration(decl);
+        getScopeBefore(parent).registerDeclaration(decl);
       }
 
       return t.identifier(name);
@@ -207,6 +207,10 @@ export function link({
     }
 
     return node;
+  }
+
+  function getScopeBefore(path) {
+    return path.isScope() ? path.parentPath.scope : path.scope;
   }
 
   function isUnusedValue(path) {


### PR DESCRIPTION
See individual commits.

1. Default exports using CommonJS output format caused a syntax error by attempting to declare a variable named `default` which is a reserved word. We now find a valid identifier to use instead.
2. The `cjs_exports` variable introduced in #3905 was never declared which threw an error in strict mode. In sloppy mode it became a global variable. We now ensure it is declared at the top of the program if needed.
3. `sideEffects` false with a namespace import pointing to a module with re-exports was broken because we only marked symbols in the immediate import as used rather than all of the re-exports as well.
4. Default interop variables were sometimes duplicated unnecessarily when referenced from within another scope. This sometimes made terser confused resulting in non-working bundles. This was due to `path.scope` referring to the inner scope rather than the outer scope when `path` is itself a scope (e.g. function). We now check the outer scope instead since we are planning on inserting before that path.