### PR TITLE
Use `flow check` in CI

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -47,7 +47,7 @@ jobs:
         displayName: 'Run unit tests'
       - script: yarn test:integration-ci
         displayName: 'Run integration tests'
-      - script: yarn flow
+      - script: yarn flow check
         displayName: 'Type check with Flow'
       - script: yarn lint
         displayName: 'Lint'


### PR DESCRIPTION
This has CI run a complete `yarn flow check` which is exhaustive:

> Does a full Flow check and prints the results

(from `yarn flow --help`)

The default command for flow is `status`:

> Shows current Flow errors by asking the Flow server

(from `yarn flow --help`)

Which I believe depends on the server state and can be affected by lazy mode: 

```
~/s/parcel $ yarn flow --lazy-mode fs

~/s/parcel $ yarn flow                                                                            (wbinnssmith/flow-check-azure|✔)
yarn run v1.21.1
$ path/to/parcel/node_modules/.bin/flow
No errors!

The Flow server is currently in filesystem lazy mode and is only checking 0/4071 files.
To learn more, visit flow.org/en/docs/lang/lazy-modes
✨  Done in 0.20s.
```

Test Plan: Ran `yarn flow check` locally and verify it fails assigning a number to a variable with a type annotated as `string`. Verify this PR passes CI.