### PR TITLE
Add back --dist-dir and --public-url CLI options

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -79,11 +79,13 @@ export default class AssetGraphBuilder extends EventEmitter {
     this.options = options;
     this.assetRequests = [];
 
-    let {hot} = options;
+    // TODO: changing these should not throw away the entire graph.
+    // We just need to re-run target resolution.
+    let {hot, publicUrl, distDir, minify, scopeHoist} = options;
     this.cacheKey = md5FromObject({
       parcelVersion: PARCEL_VERSION,
       name,
-      options: {hot},
+      options: {hot, publicUrl, distDir, minify, scopeHoist},
       entries,
     });
 

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -128,7 +128,7 @@ export default class TargetResolver {
           return {
             name,
             distDir: path.resolve(this.fs.cwd(), distDir),
-            publicUrl: descriptor.publicUrl,
+            publicUrl: descriptor.publicUrl ?? this.options.publicUrl,
             env: createEnvironment({
               engines: descriptor.engines,
               context: descriptor.context,
@@ -170,7 +170,6 @@ export default class TargetResolver {
       if (this.options.serve) {
         // In serve mode, we only support a single browser target. Since the user
         // hasn't specified a target, use one targeting modern browsers for development
-        let serveOptions = this.options.serve;
         targets = [
           {
             name: 'default',
@@ -178,7 +177,7 @@ export default class TargetResolver {
             // temporary, likely in a .gitignore or similar, but still readily
             // available for introspection by the user if necessary.
             distDir: path.resolve(this.options.cacheDir, DEFAULT_DIST_DIRNAME),
-            publicUrl: serveOptions.publicUrl ?? '/',
+            publicUrl: this.options.publicUrl ?? '/',
             env: createEnvironment({
               context: 'browser',
               engines: {
@@ -303,7 +302,9 @@ export default class TargetResolver {
             ...getJSONSourceLocation(pkgMap.pointers[pointer], 'value'),
           };
         } else {
-          distDir = path.resolve(pkgDir, DEFAULT_DIST_DIRNAME, targetName);
+          distDir =
+            this.options.distDir ??
+            path.resolve(pkgDir, DEFAULT_DIST_DIRNAME, targetName);
         }
 
         let descriptor = parseCommonTargetDescriptor(
@@ -322,7 +323,7 @@ export default class TargetResolver {
           name: targetName,
           distDir,
           distEntry,
-          publicUrl: descriptor.publicUrl ?? '/',
+          publicUrl: descriptor.publicUrl ?? this.options.publicUrl,
           env: createEnvironment({
             engines: descriptor.engines ?? pkgEngines,
             context:
@@ -362,7 +363,9 @@ export default class TargetResolver {
       let distEntry;
       let loc;
       if (distPath == null) {
-        distDir = path.resolve(pkgDir, DEFAULT_DIST_DIRNAME, targetName);
+        distDir =
+          this.options.distDir ??
+          path.resolve(pkgDir, DEFAULT_DIST_DIRNAME, targetName);
       } else {
         if (typeof distPath !== 'string') {
           let contents: string =
@@ -411,7 +414,7 @@ export default class TargetResolver {
           name: targetName,
           distDir,
           distEntry,
-          publicUrl: descriptor.publicUrl ?? '/',
+          publicUrl: descriptor.publicUrl ?? this.options.publicUrl,
           env: createEnvironment({
             engines: descriptor.engines ?? pkgEngines,
             context: descriptor.context,
@@ -432,8 +435,10 @@ export default class TargetResolver {
     if (targets.size === 0) {
       targets.set('default', {
         name: 'default',
-        distDir: path.resolve(this.fs.cwd(), DEFAULT_DIST_DIRNAME),
-        publicUrl: '/',
+        distDir:
+          this.options.distDir ??
+          path.resolve(this.fs.cwd(), DEFAULT_DIST_DIRNAME),
+        publicUrl: this.options.publicUrl,
         env: createEnvironment({
           engines: pkgEngines,
           context,

--- a/packages/core/core/src/public/Target.js
+++ b/packages/core/core/src/public/Target.js
@@ -49,7 +49,7 @@ export default class Target implements ITarget {
     return this.#target.name;
   }
 
-  get publicUrl(): ?string {
+  get publicUrl(): string {
     return this.#target.publicUrl;
   }
 

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -95,6 +95,11 @@ export default async function resolveOptions(
     sourceMaps: initialOptions.sourceMaps ?? true,
     scopeHoist:
       initialOptions.scopeHoist ?? initialOptions.mode === 'production',
+    publicUrl: initialOptions.publicUrl ?? '/',
+    distDir:
+      initialOptions.distDir != null
+        ? path.resolve(initialOptions.distDir)
+        : null,
     logLevel: initialOptions.logLevel ?? 'info',
     projectRoot,
     lockFile,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -51,7 +51,7 @@ export type Target = {|
   env: Environment,
   sourceMap?: TargetSourceMapOptions,
   name: string,
-  publicUrl: ?string,
+  publicUrl: string,
   loc?: ?SourceLocation,
 |};
 
@@ -113,6 +113,8 @@ export type ParcelOptions = {|
   minify: boolean,
   scopeHoist: boolean,
   sourceMaps: boolean,
+  publicUrl: string,
+  distDir: ?FilePath,
   hot: boolean,
   serve: ServerOptions | false,
   autoinstall: boolean,

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -23,7 +23,7 @@ const TARGETS = [
     distDir: 'dist',
     distEntry: 'out.js',
     env: DEFAULT_ENV,
-    publicUrl: null,
+    publicUrl: '/',
   },
 ];
 

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -74,7 +74,7 @@ describe('TargetResolver', () => {
         targets: [
           {
             name: 'customA',
-            publicUrl: undefined,
+            publicUrl: '/',
             distDir: path.resolve('customA'),
             env: {
               context: 'browser',
@@ -91,7 +91,7 @@ describe('TargetResolver', () => {
           },
           {
             name: 'customB',
-            publicUrl: undefined,
+            publicUrl: '/',
             distDir: path.resolve('customB'),
             env: {
               context: 'node',

--- a/packages/core/core/test/utils.js
+++ b/packages/core/core/test/utils.js
@@ -23,6 +23,8 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
   mode: 'development',
   scopeHoist: false,
   minify: false,
+  publicUrl: '/',
+  distDir: process.cwd(),
   env: {},
   disableCache: false,
   sourceMaps: false,

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -92,7 +92,7 @@ let serve = program
     'set the port to serve on. defaults to 1234',
     parseInt,
   )
-  .option('--public-url <url>', 'set the path prefix to use in serve mode')
+  .option('--public-url <url>', 'the path prefix for absolute urls')
   .option(
     '--host <host>',
     'set the host to listen on, defaults to listening on all interfaces',
@@ -110,6 +110,11 @@ applyOptions(serve, commonOptions);
 let watch = program
   .command('watch [input...]')
   .description('starts the bundler in watch mode')
+  .option(
+    '--dist-dir <dir>',
+    'output directory to write to when unspecified by targets',
+  )
+  .option('--public-url <url>', 'the path prefix for absolute urls')
   .option('--watch-for-stdin', 'exit when stdin closes')
   .action(run);
 
@@ -121,6 +126,11 @@ let build = program
   .description('bundles for production')
   .option('--no-minify', 'disable minification')
   .option('--no-scope-hoist', 'disable scope-hoisting')
+  .option('--public-url <url>', 'the path prefix for absolute urls')
+  .option(
+    '--dist-dir <dir>',
+    'Output directory to write to when unspecified by targets',
+  )
   .action(run);
 
 applyOptions(build, commonOptions);
@@ -292,6 +302,8 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     minify: command.minify != null ? command.minify : mode === 'production',
     sourceMaps: command.sourceMaps ?? true,
     scopeHoist: command.scopeHoist,
+    publicUrl: command.publicUrl,
+    distDir: command.distDir,
     hot: hmr,
     serve,
     targets: command.target.length > 0 ? command.target : null,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -73,7 +73,7 @@ export interface Target {
   +env: Environment;
   +sourceMap: ?TargetSourceMapOptions;
   +name: string;
-  +publicUrl: ?string;
+  +publicUrl: string;
   +loc: ?SourceLocation;
 }
 
@@ -186,6 +186,8 @@ export type InitialParcelOptions = {|
   minify?: boolean,
   scopeHoist?: boolean,
   sourceMaps?: boolean,
+  publicUrl?: string,
+  distDir?: FilePath,
   hot?: boolean,
   serve?: ServerOptions | false,
   autoinstall?: boolean,

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -150,7 +150,7 @@ function getURLReplacement({
     to = URL.format(url);
   } else {
     url.pathname = nullthrows(toBundle.name);
-    to = urlJoin(nullthrows(toBundle.target.publicUrl), URL.format(url));
+    to = urlJoin(toBundle.target.publicUrl, URL.format(url));
   }
 
   return {

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -146,7 +146,7 @@ function insertBundleReferences(siblingBundles, tree) {
         attrs: {
           rel: 'stylesheet',
           href: urlJoin(
-            nullthrows(bundle.target).publicUrl ?? '/',
+            nullthrows(bundle.target).publicUrl,
             nullthrows(bundle.name),
           ),
         },
@@ -157,7 +157,7 @@ function insertBundleReferences(siblingBundles, tree) {
         attrs: {
           type: bundle.env.outputFormat === 'esmodule' ? 'module' : undefined,
           src: urlJoin(
-            nullthrows(bundle.target).publicUrl ?? '/',
+            nullthrows(bundle.target).publicUrl,
             nullthrows(bundle.name),
           ),
         },


### PR DESCRIPTION
Previously, we had removed the `--out-dir` and `--public-url` CLI options that existed in Parcel 1 due to multi-target support in Parcel 2. However, due to confusion, along with needs to change these dynamically rather than hard coding them in package.json, they make their triumphant return in this PR.

`publicUrl` and `distDir` are still options to targets, but the CLI options are now used by default in case these are not defined. In particular, `--dist-dir` is used when there isn't a top-level package.json field for the target's main entry, and `--public-url` is used when a `publicUrl` option isn't set in the target config in package.json.