### PR TITLE
Deduplicate shared bundles

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -236,6 +236,9 @@ export default new Bundler({
       let [firstBundle] = [...sourceBundles];
       let sharedBundle = bundleGraph.createBundle({
         id: md5FromString([...sourceBundles].map(b => b.id).join(':')),
+        // Allow this bundle to be deduplicated. It shouldn't be further split.
+        // TODO: Reconsider bundle/asset flags.
+        isSplittable: true,
         env: firstBundle.env,
         target: firstBundle.target,
         type: firstBundle.type,

--- a/packages/core/integration-tests/test/integration/dynamic-common-large/common.js
+++ b/packages/core/integration-tests/test/integration/dynamic-common-large/common.js
@@ -1,1 +1,3 @@
+require('./c');
+
 module.exports = require('lodash').add(1, 1);

--- a/packages/core/integration-tests/test/integration/dynamic-common-large/index.js
+++ b/packages/core/integration-tests/test/integration/dynamic-common-large/index.js
@@ -1,3 +1,4 @@
+var c = require('./c');
 var a = import('./a');
 var b = import('./b');
 

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -819,6 +819,7 @@ describe('javascript', function() {
         name: 'index.js',
         assets: [
           'index.js',
+          'c.js',
           'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',


### PR DESCRIPTION
This allows common shared bundles to be deduplicated (have assets in them removed if they're present in the bundle's ancestry).

`isSplittable` controls both whether a bundle is split and if it is deduplicated. We should reconsider these flags and their names @devongovett.

Test Plan: Changed the common bundle test to include an asset common to the root bundle and the shared bundle. `yarn test`.