### PR TITLE
BabelTransformer: accept @babel/core ^7.0.0 and remove reload logic

### DIFF
--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -2,8 +2,10 @@
 
 import type {MutableAsset, AST, PluginOptions} from '@parcel/types';
 
-import packageJson from '../package.json';
 import invariant from 'assert';
+
+import {BABEL_RANGE} from './constants';
+import packageJson from '../package.json';
 
 const transformerVersion: mixed = packageJson.version;
 invariant(typeof transformerVersion === 'string');
@@ -18,7 +20,9 @@ export default async function babel7(
   // otherwise require a local version from the package we're compiling.
   let babel = babelOptions.internal
     ? require('@babel/core')
-    : await options.packageManager.require('@babel/core', asset.filePath);
+    : await options.packageManager.require('@babel/core', asset.filePath, {
+        range: BABEL_RANGE,
+      });
 
   let config = {
     ...babelOptions.config,

--- a/packages/transformers/babel/src/constants.js
+++ b/packages/transformers/babel/src/constants.js
@@ -1,0 +1,3 @@
+// @flow strict-local
+
+export const BABEL_RANGE = '^7.0.0';


### PR DESCRIPTION
This restricts babel loading and autoinstallation to ^7.0.0 using the new range support in the package manager.

This also removes unnecessary reload logic.

Test Plan: 
  * Run parcel in an app without a version of @babel/core 
  * Verify it autoinstalled and created an entry in package.json for @babel/core with a range of ^7.0.0
  * Clear cache and run parcel again and verify it does not autoinstall.