### PR TITLE
Fix getBundlesIncludedInHash()

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -535,7 +535,9 @@ function assignComplexNameHashes(hashRefToNameHash, bundles, bundleInfoMap) {
       continue;
     }
 
-    let includedBundles = getBundlesIncludedInHash(bundle.id, bundleInfoMap);
+    let includedBundles = [
+      ...getBundlesIncludedInHash(bundle.id, bundleInfoMap),
+    ];
 
     hashRefToNameHash.set(
       bundle.hashReference,
@@ -546,14 +548,16 @@ function assignComplexNameHashes(hashRefToNameHash, bundles, bundleInfoMap) {
   }
 }
 
-function getBundlesIncludedInHash(bundleId, bundleInfoMap, included = []) {
-  included.push(bundleId);
+function getBundlesIncludedInHash(
+  bundleId,
+  bundleInfoMap,
+  included = new Set(),
+) {
+  included.add(bundleId);
   for (let hashRef of bundleInfoMap[bundleId].hashReferences) {
     let referencedId = getIdFromHashRef(hashRef);
-    if (!included.includes(referencedId)) {
-      included.push(
-        ...getBundlesIncludedInHash(referencedId, bundleInfoMap, included),
-      );
+    if (!included.has(referencedId)) {
+      getBundlesIncludedInHash(referencedId, bundleInfoMap, included);
     }
   }
 


### PR DESCRIPTION
# ↪️ Pull Request
Fixed some bad recursion that was introduced in #4114. 

## 🚨 Test instructions
I was seeing call stack size exceeded limit errors building a large project. I made the fix and confirmed it built and was not adding already included bundles many times.

