### PR TITLE
Fix dev server 404 with package.json#source

### DIFF
--- a/packages/core/integration-tests/test/integration/html-pkg-source/index.html
+++ b/packages/core/integration-tests/test/integration/html-pkg-source/index.html
@@ -1,0 +1,3 @@
+<body>
+  <h1>Hello world</h1>
+</body>

--- a/packages/core/integration-tests/test/integration/html-pkg-source/package.json
+++ b/packages/core/integration-tests/test/integration/html-pkg-source/package.json
@@ -1,0 +1,7 @@
+{
+    "source": "index.html",
+    "app": "dist/index.html",
+    "targets": {
+        "app": {}
+    }
+}

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -128,6 +128,34 @@ describe('server', function() {
     assert.equal(data, outputFile);
   });
 
+  it('should serve a default page if the main bundle is an HTML asset with package.json#source', async function() {
+    let port = await getPort();
+    let inputPath = path.join(__dirname, '/integration/html-pkg-source/');
+    let b = bundler(inputPath, {
+      config,
+      serve: {
+        https: false,
+        port: port,
+        host: 'localhost',
+      },
+    });
+
+    subscription = await b.watch();
+    let event = await getNextBuild(b);
+    assert.equal(event.type, 'buildSuccess');
+
+    let outputFile = await outputFS.readFile(
+      event.bundleGraph.getBundles()[0].filePath,
+      'utf8',
+    );
+
+    let data = await get('/', port);
+    assert.equal(data, outputFile);
+
+    data = await get('/foo/bar', port);
+    assert.equal(data, outputFile);
+  });
+
   it('should serve a 404 if the file does not exist', async function() {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -23,6 +23,7 @@
     "ejs": "^2.6.1",
     "http-proxy-middleware": "^0.19.1",
     "mime": "^2.4.4",
+    "nullthrows": "^1.1.1",
     "ws": "^6.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
# ↪️ Pull Request

Under certain circumstances, the main html bundle could be written to `.parcel-cache/dist/project-name/index.html`, while the default index is served from `.parcel-cache/dist/index.html`, causing a 404.

Now, we don't blindly take the main bundle's filename but instead the relative path to the dist dir.

@kwelch I think you experienced this recently.

## 💻 Examples

`parcel .` with
```json
{
	"source": "index.html",
	"app": "dist/index.html",
	"targets": {
		"app": {}
	}
}
```