### PR TITLE
Use stable ids in names of inline bundles

### DIFF
--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -91,7 +91,8 @@ export default new Namer({
     //      `index.css`.
     let name = nameFromContent(mainBundle, options.rootDir);
     if (!bundle.isEntry) {
-      name += '.' + bundle.hashReference;
+      let hash = bundle.isInline ? bundle.id.slice(-8) : bundle.hashReference;
+      name += '.' + hash;
     }
     return name + '.' + bundle.type;
   },


### PR DESCRIPTION
# ↪️ Pull Request
Fixes #4145

The issue was caused by a bundle that contained a hash reference to an inline parent bundle, which is something I didn't anticipate, but is apparently needed for scope hoisting. @devongovett @mischnic Is this expected?

See below for a visual of the bundle graph. In this case the blue bundle is referencing the pink bundle.

![bundle_graph](https://user-images.githubusercontent.com/2865858/74892468-8dc81800-533e-11ea-9046-101322d1a2f9.png)

To fix this, I changed the default namer to not use content hash references in inline bundle names. It still uses some characters of the bundle id to ensure uniqueness. This seems like a safe option since inline bundles are not served by themselves so their names do not need to be long term cacheable.

## 🚨 Test instructions
Reproduced the failure in the linked issue and tested that the changes were able to build the code successfully. We should probably add some integration tests, but I wanted to make sure that this scenario is expected.

## ✔️ PR Todo

- [ ] Probably add some integration tests
