### PR TITLE
Incorporate child bundle ids in BundleGraph.getHash(bundle)

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -576,14 +576,15 @@ export default class BundleGraph {
 
   getHash(bundle: Bundle): string {
     let hash = crypto.createHash('md5');
-    this.traverseBundles((childBundle, ctx) => {
+    this.traverseBundles((childBundle, ctx, traversal) => {
       if (
         childBundle.id === bundle.id ||
         (ctx?.parentBundle === bundle.id && childBundle.isInline)
       ) {
         hash.update(this.getContentHash(childBundle));
-      } else if (!childBundle.isInline) {
+      } else {
         hash.update(childBundle.id);
+        traversal.skipChildren();
       }
       return {parentBundle: childBundle.id};
     }, bundle);

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -582,7 +582,7 @@ export default class BundleGraph {
         (ctx?.parentBundle === bundle.id && childBundle.isInline)
       ) {
         hash.update(this.getContentHash(childBundle));
-      } else {
+      } else if (!childBundle.isInline) {
         hash.update(childBundle.id);
       }
       return {parentBundle: childBundle.id};

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -576,12 +576,16 @@ export default class BundleGraph {
 
   getHash(bundle: Bundle): string {
     let hash = crypto.createHash('md5');
-    this.traverseBundles((childBundle, ctx, traversal) => {
-      if (childBundle.id === bundle.id || childBundle.isInline) {
+    this.traverseBundles((childBundle, ctx) => {
+      if (
+        childBundle.id === bundle.id ||
+        (ctx?.parentBundle === bundle.id && childBundle.isInline)
+      ) {
         hash.update(this.getContentHash(childBundle));
       } else {
-        traversal.skipChildren();
+        hash.update(childBundle.id);
       }
+      return {parentBundle: childBundle.id};
     }, bundle);
 
     hash.update(JSON.stringify(objectSortedEntriesDeep(bundle.env)));

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -33,7 +33,7 @@ import BundleGraph, {
   bundleGraphToInternalBundleGraph,
 } from './public/BundleGraph';
 import PluginOptions from './public/PluginOptions';
-import {PARCEL_VERSION, HASH_REF_PREFIX} from './constants';
+import {PARCEL_VERSION, HASH_REF_PREFIX, HASH_REF_REGEX} from './constants';
 
 type Opts = {|
   config: ParcelConfig,
@@ -55,7 +55,6 @@ type CacheKeyMap = {|
 |};
 
 const BOUNDARY_LENGTH = HASH_REF_PREFIX.length + 32 - 1;
-const HASH_REF_REGEX = new RegExp(`${HASH_REF_PREFIX}\\w{32}`, 'g');
 
 export default class PackagerRunner {
   config: ParcelConfig;

--- a/packages/core/core/src/constants.js
+++ b/packages/core/core/src/constants.js
@@ -5,3 +5,4 @@ import {version} from '../package.json';
 
 export const PARCEL_VERSION = version;
 export const HASH_REF_PREFIX = 'HASH_REF_';
+export const HASH_REF_REGEX = new RegExp(`${HASH_REF_PREFIX}\\w{32}`, 'g');


### PR DESCRIPTION
# ↪️ Pull Request
Before the addition of bundle content hash references (#4114), `BundleGraph.getHash(bundle)` incorporated the content of all descendant bundles (See #3414 for reasoning). With bundles maintaining stable hash references through packaging and optimizing, this was overkill, so I updated the method. Unfortunately I updated it to not consider they may end up referencing different bundles 😔.

Now all descendant bundle ids are considered in the `BundleGraph.getHash(bundle)` function. This is still a little overkill because bundles usually only reference direct child bundles, but in the future when we add mappings of stable ids to final bundle names for all bundles in entry bundles, we would need to consider every child. Maybe the runtime assets with the mappings could add dependencies to all bundles it references, in which case checking only child bundles would be okay. But still, we kind of have a problem that packagers have access to the entire `BundleGraph` and we aren't totally sure what they are going to do with it. If we are only going to use direct child bundle ids in the hash, we need to make sure that's all packagers have access to. That or add another method to packagers that can narrow down what should go in the cache key before packaging.

Another thing I just discovered was that scope hoisting brings in the possibility of bundles referencing parent bundles. They reference not just their names, but their exports too, which means we probably also have to consider parent bundle content in the hash? This is based on my findings working on #4188.

## ✔️ PR Todo

- [ ] Add some tests
- [ ] Maybe consider parent bundle's content based on scope hoisting findings
