### PR TITLE
Add PARCEL_WORKER_BACKEND environment variable

### DIFF
--- a/packages/core/workers/src/backend.js
+++ b/packages/core/workers/src/backend.js
@@ -2,6 +2,12 @@
 import type {BackendType, WorkerImpl} from './types';
 
 export function detectBackend(): BackendType {
+  switch (process.env.PARCEL_WORKER_BACKEND) {
+    case 'threads':
+    case 'process':
+      return process.env.PARCEL_WORKER_BACKEND;
+  }
+
   try {
     require('worker_threads');
     return 'threads';


### PR DESCRIPTION
This introduces an environment variable to explicitly control the worker backend that Parcel uses. This allows using the process backend on Node 12+, which is sometimes necessary to work around issues with some native modules that don't expect to be run from multiple threads.