### PR TITLE
Allow passing config to posthtml-render to control HTML rendering.

### DIFF
--- a/packages/core/parcel-bundler/src/transforms/posthtml.js
+++ b/packages/core/parcel-bundler/src/transforms/posthtml.js
@@ -35,6 +35,7 @@ async function getConfig(asset) {
   }
 
   config = config || {};
+  delete config.render;
   const plugins = config.plugins;
   if (typeof plugins === 'object') {
     // This is deprecated in favor of result messages but kept for compatibility

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -53,6 +53,14 @@ export default (new Packager({
       .getSiblingBundles(bundle)
       .filter(b => !b.isInline && !referenced.has(b.id));
 
+    let posthtmlConfig = await asset.getConfig(
+      ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
+      {
+        packageKey: 'posthtml',
+      },
+    );
+    let renderConfig = posthtmlConfig?.render;
+
     let {html} = await posthtml([
       insertBundleReferences.bind(this, bundles),
       replaceInlineAssetContent.bind(
@@ -60,7 +68,7 @@ export default (new Packager({
         bundleGraph,
         getInlineBundleContents,
       ),
-    ]).process(code);
+    ]).process(code, renderConfig);
 
     let {contents, map} = replaceURLReferences({
       bundle,

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -28,6 +28,7 @@ export default (new Transformer({
 
       // tells posthtml that we have already called parse
       configFile.contents.skipParse = true;
+      delete configFile.contents.render;
 
       config.setResult({
         contents: configFile.contents,


### PR DESCRIPTION
# ↪️ Pull Request

Allow passing config to posthtml-render to control HTML rendering.

## 💻 Examples

```
"posthtml-render": { quoteAllAttributes: false },
```

This option would allow your HTML to be smaller and easier to read. However this change is generic and provides access to any posthtml-render options.

## 🚨 Test instructions

- Add a "posthtml-render" property to `package.json` and see the effect.
- Create a `posthtml-render.config.js` file and see the effect.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
