### PR TITLE
Set ora discardStdin option to false

### DIFF
--- a/packages/reporters/cli/src/render.js
+++ b/packages/reporters/cli/src/render.js
@@ -32,6 +32,7 @@ export function _setStdio(stdoutLike: Writable, stderrLike: Writable) {
 let spinner = ora({
   color: 'green',
   stream: stdout,
+  discardStdin: false,
 });
 let persistedMessages = [];
 


### PR DESCRIPTION
# ↪️ Pull Request
This fixes an issue where ora keeps Parcel from receiving key presses, which is necessary for exiting properly when run with `yarn`. Without this option set to false, the shell can get into a weird state where it prints the ANSI escape sequences for arrow keys instead of navigating previous commands.

>Discard stdin input (except Ctrl+C) while running if it's TTY. This prevents the spinner from twitching on input, outputting broken lines on Enter key presses, and prevents buffering of input while the spinner is running.

The discardStdin option defaults to true to avoid this issues above, but I did not witness any of these behaviors when setting it to false. I think it should be okay since we set stdin to raw mode anyway.

## 💻 Examples
Here you can see yarn gives control back to the shell before Parcel is done exiting. You can also see the ANSI escape sequences for arrow keys once it's done. Hitting control-c or enter again brings the shell back to normal.

![Screen Shot 2020-02-26 at 6 53 03 PM](https://user-images.githubusercontent.com/2865858/75495042-74445300-5972-11ea-857d-9b38e16f325f.png)

## 🚨 Test instructions
This is really only noticeable when the AssetGraph is sufficiently large enough because it takes longer to serialize it and write it to disk than it does for Yarn to shut down. You can simulate this in the small examples by sleeping for a second or two in the unsubscribe function in `Parcel.js`. If you log key presses, you'll notice you no longer receive them after a build success. Setting the discardStdin option to false resolves the issue.

