### PR TITLE
Be sure to run requests that have not produced a valid result

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -292,7 +292,7 @@ export default class AssetGraphBuilder extends EventEmitter {
 
   processIncompleteAssetGraphNode(node: AssetGraphNode, signal: ?AbortSignal) {
     let request = nullthrows(this.getCorrespondingRequest(node));
-    if (!this.requestTracker.isTracked(request.id)) {
+    if (!this.requestTracker.hasValidResult(request.id)) {
       this.queueRequest(request, {
         signal,
       });

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -298,6 +298,7 @@ export default class RequestTracker {
 
   hasValidResult(id: string) {
     return (
+      this.graph.nodes.has(id) &&
       !this.graph.invalidNodeIds.has(id) &&
       !this.graph.incompleteNodeIds.has(id)
     );


### PR DESCRIPTION
# ↪️ Pull Request
This fixes an issue where running Parcel after previously exiting Parcel in the middle of building the `AssetGraph` would skip building out the rest of the graph and go straight to bundling.

## 🚨 Test instructions
Ran a clean Parcel build and exited during the `AssetGraph` building phase. Reran and confirmed it finished building out the `AssetGraph` before continuing to bundling.
