### PR TITLE
Remove crawl calls in shake & outputformat

### DIFF
--- a/flow-libs/babel-traverse.js.flow
+++ b/flow-libs/babel-traverse.js.flow
@@ -381,7 +381,7 @@ declare module "@babel/traverse" {
     isDescendant(NodePath<Node>): boolean;
 
     remove(): void;
-    replaceWith<U: Node>(U): NodePath<U>;
+    replaceWith<U: Node>(U): $ReadOnlyArray<NodePath<U>>;
     replaceWithMultiple<U: Node>(Array<U>): $ReadOnlyArray<NodePath<U>>;
     insertBefore<U: Node>(
       Array<U> | U

--- a/flow-libs/babel-traverse.js.flow
+++ b/flow-libs/babel-traverse.js.flow
@@ -299,7 +299,7 @@ declare module "@babel/traverse" {
       | FunctionDeclaration
       | ModuleSpecifier
     >;
-    referencePaths: Array<NodePath<Identifier>>;
+    referencePaths: Array<NodePath<Identifier | ExportDefaultDeclaration | ExportNamedDeclaration>>;
     constantViolations: Array<
       NodePath<AssignmentExpression | UpdateExpression>
     >;
@@ -309,7 +309,7 @@ declare module "@babel/traverse" {
     referenced: boolean;
     references: number;
     constant: boolean;
-    reference(NodePath<Identifier>): void;
+    reference(NodePath<Identifier | ExportDefaultDeclaration | ExportNamedDeclaration>): void;
     reassign(NodePath<AssignmentExpression | UpdateExpression>): void;
     dereference(): void;
   }

--- a/flow-libs/babel-traverse.js.flow
+++ b/flow-libs/babel-traverse.js.flow
@@ -284,7 +284,7 @@ declare module "@babel/traverse" {
                 RestProperty,
                 SpreadProperty } from "@babel/types";
 
-  declare type VariableDeclarationKind =
+  declare export type VariableDeclarationKind =
     | "var"
     | "let"
     | "const"
@@ -330,7 +330,7 @@ declare module "@babel/traverse" {
     getOwnBinding(name: string): ?Binding;
     getBindingIdentifier(name: string): ?Identifier;
     getOwnBindingIdentifier(name: string): ?Identifier;
-    hasOwnBinding(name: string): ?Binding;
+    hasOwnBinding(name: string): boolean;
     hasBinding(name: string, noGlobals?: boolean): boolean;
     parentHasBinding(name: string, noGlobals?: boolean): boolean;
     removeBinding(name: string): void;

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -851,7 +851,7 @@ describe('output formats', function() {
         // async import both bundles in parallel for performance
         assert(
           entry.includes(
-            `import("./" + "${sharedBundle.name}"), import("./" + "${bundle.name}");`,
+            `import("./" + "${sharedBundle.name}"), import("./" + "${bundle.name}")`,
           ),
         );
       }

--- a/packages/shared/scope-hoisting/src/formats/global.js
+++ b/packages/shared/scope-hoisting/src/formats/global.js
@@ -9,25 +9,20 @@ import type {
   Program,
   Statement,
   StringLiteral,
-  VariableDeclaration,
+  CallExpression,
 } from '@babel/types';
 
 import invariant from 'assert';
 import * as t from '@babel/types';
 import template from '@babel/template';
 import {relativeBundlePath} from '@parcel/utils';
-import {
-  assertString,
-  getName,
-  getIdentifier,
-  isEntry,
-  isReferenced,
-} from '../utils';
+import {assertString, getName, isEntry, isReferenced} from '../utils';
+import nullthrows from 'nullthrows';
 
-const IMPORT_TEMPLATE = template.statement<
-  {|IDENTIFIER: Identifier, ASSET_ID: StringLiteral|},
-  VariableDeclaration,
->('var IDENTIFIER = parcelRequire(ASSET_ID);');
+const IMPORT_TEMPLATE = template.expression<
+  {|ASSET_ID: StringLiteral|},
+  CallExpression,
+>('parcelRequire(ASSET_ID)');
 const EXPORT_TEMPLATE = template.statement<
   {|IDENTIFIER: Identifier, ASSET_ID: StringLiteral|},
   ExpressionStatement,
@@ -45,9 +40,9 @@ export function generateBundleImports(
   from: Bundle,
   bundle: Bundle,
   assets: Set<Asset>,
+  path: NodePath<Program>,
 ) {
   let statements = [];
-
   if (from.env.isWorker()) {
     statements.push(
       IMPORTSCRIPTS_TEMPLATE({
@@ -55,17 +50,14 @@ export function generateBundleImports(
       }),
     );
   }
+  path.unshiftContainer('body', statements);
 
   for (let asset of assets) {
-    statements.push(
-      IMPORT_TEMPLATE({
-        IDENTIFIER: getIdentifier(asset, 'init'),
-        ASSET_ID: t.stringLiteral(asset.id),
-      }),
-    );
+    // `var ${id};` was inserted already, add RHS
+    nullthrows(path.scope.getBinding(getName(asset, 'init')))
+      .path.get('init')
+      .replaceWith(IMPORT_TEMPLATE({ASSET_ID: t.stringLiteral(asset.id)}));
   }
-
-  return statements;
 }
 
 export function generateExternalImport() {

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -649,6 +649,10 @@ export function link({
           }
         }
 
+        if (process.env.PARCEL_BUILD_ENV !== 'production') {
+          verifyScopeState(path.scope);
+        }
+
         if (referencedAssets.size > 0) {
           // Insert fake init functions that will be imported in other bundles,
           // because `asset.meta.shouldWrap` isn't set in a packager if `asset` is
@@ -684,6 +688,10 @@ export function link({
           replacements,
           options,
         );
+
+        if (process.env.PARCEL_BUILD_ENV !== 'production') {
+          verifyScopeState(path.scope);
+        }
 
         treeShake(path.scope, exported);
       },

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -663,6 +663,7 @@ export function link({
           replacements,
           options,
         );
+        path.scope.crawl();
 
         treeShake(path.scope, exported);
       },

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -673,9 +673,11 @@ export function link({
             let returnId = decl.get<NodePath<Identifier>>(
               'body.body.0.argument',
             );
-            nullthrows(path.scope.getBinding(returnId.node.name)).reference(
-              returnId,
-            );
+
+            // TODO Somehow deferred/excluded assets are referenced, causing this function to
+            // become `function $id$init() { return {}; }` (because of the ReferencedIdentifier visitor).
+            // But a asset that isn't here should never be referenced in the first place.
+            path.scope.getBinding(returnId.node.name)?.reference(returnId);
           }
         }
 

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -663,7 +663,6 @@ export function link({
           replacements,
           options,
         );
-        path.scope.crawl();
 
         treeShake(path.scope, exported);
       },

--- a/packages/shared/scope-hoisting/src/types.js
+++ b/packages/shared/scope-hoisting/src/types.js
@@ -7,8 +7,8 @@ import type {
   PluginOptions,
   Symbol,
 } from '@parcel/types';
-import type {NodePath, Scope} from '@babel/traverse';
-import type {Node, Program} from '@babel/types';
+import type {NodePath} from '@babel/traverse';
+import type {Program} from '@babel/types';
 
 export type ExternalModule = {|
   source: ModuleSpecifier,
@@ -26,13 +26,13 @@ export type OutputFormat = {|
     from: Bundle,
     bundle: Bundle,
     assets: Set<Asset>,
-    scope: Scope,
-  ): Array<Node>,
+    path: NodePath<Program>,
+  ): void,
   generateExternalImport(
     bundle: Bundle,
     external: ExternalModule,
-    scope: Scope,
-  ): Array<Node>,
+    path: NodePath<Program>,
+  ): void,
   generateExports(
     bundleGraph: BundleGraph,
     bundle: Bundle,

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -197,3 +197,45 @@ export function removeReplaceBinding(
     binding.kind = newKind;
   }
 }
+
+export function verifyScopeState(scope: Scope) {
+  let oldBindings = scope.bindings;
+  scope.crawl();
+  let newBindings = scope.bindings;
+
+  invariant(
+    Object.keys(oldBindings).length === Object.keys(newBindings).length,
+  );
+  for (let name of Object.keys(newBindings)) {
+    invariant(newBindings[name], name);
+    let {
+      scope: aScope,
+      constantViolations: aConstantViolations,
+      referencePaths: aReferencePaths,
+      identifier: aId,
+      path: aPath,
+      ...a
+    } = oldBindings[name];
+    let {
+      scope: bScope,
+      constantViolations: bConstantViolations,
+      referencePaths: bReferencePaths,
+      identifier: bId,
+      path: bPath,
+      ...b
+    } = newBindings[name];
+    invariant(aPath === bPath, name);
+    invariant(aId === bId, name);
+    invariant(aScope === bScope, name);
+    invariant.deepStrictEqual(a, b, name);
+
+    invariant(aConstantViolations.length === bConstantViolations.length, name);
+    for (let p of bConstantViolations) {
+      invariant(aConstantViolations.indexOf(p) >= 0, name);
+    }
+    invariant(aReferencePaths.length === bReferencePaths.length, name);
+    for (let p of bReferencePaths) {
+      invariant(aReferencePaths.indexOf(p) >= 0, name);
+    }
+  }
+}


### PR DESCRIPTION
# ↪️ Pull Request

Remove `path.crawl()` calls after the linking phase (so for the imports/exports and shaking).
This brings it down from `O(2) + O((number of global bindings)^2)` per bundle to `O(1)`. 
(So if `path.crawl()` is `O(n^2)`, this would switch from `O(n^4)` to `O(n^2)`)

I plan on removing the last call in `link.js` as well in a follow up, but this PR should contain most of the performance benefits and I want to avoid rebasing this once again.


This is my 5th ~4th~ attempt at this - first for Parcel 1, then for Parcel 2, then trying to make `path.unshiftContainer` et al. smarter but I ended up reimplementing babel-traverse)

## ✔️ PR Todo

- [x] Test if bindings aren't removed
- [x] Test in a real app?
- [x] Benchmark/Profile
