### PR TITLE
Fix wrong error reporting in specific directory

### DIFF
--- a/packages/core/core/src/ResolverRunner.js
+++ b/packages/core/core/src/ResolverRunner.js
@@ -13,6 +13,8 @@ import {report} from './ReporterRunner';
 import PublicDependency from './public/Dependency';
 import PluginOptions from './public/PluginOptions';
 
+import {escapeMarkdown} from '@parcel/utils';
+
 type Opts = {|
   config: ParcelConfig,
   options: ParcelOptions,
@@ -133,7 +135,7 @@ export default class ResolverRunner {
     }
 
     let dir = dependency.sourcePath
-      ? path.dirname(dependency.sourcePath)
+      ? escapeMarkdown(path.dirname(dependency.sourcePath))
       : '<none>';
 
     let err: any = await this.getThrowableDiagnostic(

--- a/packages/core/markdown-ansi/src/markdown-ansi.js
+++ b/packages/core/markdown-ansi/src/markdown-ansi.js
@@ -18,7 +18,7 @@ export default function markdownParser(input: string): string {
   input = input.replace(ITALIC_REGEX, (...args) =>
     chalk.italic(args[1] || args[2]),
   );
-  input = input.replace(/\\/g, '');
+  input = input.replace(/(?<!\\)\\/g, '');
 
   return input;
 }

--- a/packages/core/markdown-ansi/src/markdown-ansi.js
+++ b/packages/core/markdown-ansi/src/markdown-ansi.js
@@ -7,7 +7,7 @@ const UNDERLINE_REGEX = /_{2}([^_]+)_{2}/g;
 const STRIKETHROUGH_REGEX = /~{2}([^~]+)~{2}/g;
 
 // single char markdown matchers
-const ITALIC_REGEX = /\*([^*]+)\*|_([^_]+)_/g;
+const ITALIC_REGEX = /(?<!\\)\*(.+)(?<!\\)\*|(?<!\\)_(.+)(?<!\\)_/g;
 
 export default function markdownParser(input: string): string {
   input = input.replace(BOLD_REGEX, (...args) => chalk.bold(args[1]));
@@ -18,6 +18,7 @@ export default function markdownParser(input: string): string {
   input = input.replace(ITALIC_REGEX, (...args) =>
     chalk.italic(args[1] || args[2]),
   );
+  input = input.replace(/\\/g, '');
 
   return input;
 }

--- a/packages/core/markdown-ansi/test/markdown-ansi.js
+++ b/packages/core/markdown-ansi/test/markdown-ansi.js
@@ -27,4 +27,14 @@ describe('markdown-ansi', () => {
     let res = mdAnsi('~~strikethrough~~');
     assert.equal(res, '\u001b[9mstrikethrough\u001b[29m');
   });
+
+  it('should support escape 01', () => {
+    let res = mdAnsi('\\*\\*bold\\*\\*');
+    assert.equal(res, '**bold**');
+  });
+
+  it('should support italic with escape', () => {
+    let res = mdAnsi('\\__italic_\\_');
+    assert.equal(res, '_\u001b[3mitalic\u001b[23m_');
+  });
 });

--- a/packages/core/markdown-ansi/test/markdown-ansi.js
+++ b/packages/core/markdown-ansi/test/markdown-ansi.js
@@ -28,12 +28,12 @@ describe('markdown-ansi', () => {
     assert.equal(res, '\u001b[9mstrikethrough\u001b[29m');
   });
 
-  it('should support escape 01', () => {
-    let res = mdAnsi('\\*\\*bold\\*\\*');
-    assert.equal(res, '**bold**');
+  it('should support escape character', () => {
+    let res = mdAnsi('\\*\\*bold\\*\\* \\\\escape\\\\');
+    assert.equal(res, '**bold** \\escape\\');
   });
 
-  it('should support italic with escape', () => {
+  it('should support italic with escape character', () => {
     let res = mdAnsi('\\__italic_\\_');
     assert.equal(res, '_\u001b[3mitalic\u001b[23m_');
   });

--- a/packages/core/parcel-bundler/src/Resolver.js
+++ b/packages/core/parcel-bundler/src/Resolver.js
@@ -5,6 +5,7 @@ const {isGlob} = require('./utils/glob');
 const fs = require('@parcel/fs');
 const micromatch = require('micromatch');
 const getModuleParts = require('./utils/getModuleParts');
+const {escapeMarkdown} = require('@parcel/utils');
 
 const EMPTY_SHIM = require.resolve('./builtins/_empty');
 
@@ -67,7 +68,7 @@ class Resolver {
     }
 
     if (!resolved) {
-      let dir = parent ? path.dirname(parent) : process.cwd();
+      let dir = escapeMarkdown(parent ? path.dirname(parent) : process.cwd());
       let err = new Error(`Cannot find module '${input}' from '${dir}'`);
       err.code = 'MODULE_NOT_FOUND';
       throw err;

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "src/bin.js",
+  "bin": "lib/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "engines": {

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "lib/bin.js",
+  "bin": "src/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "engines": {

--- a/packages/core/utils/src/escape-markdown.js
+++ b/packages/core/utils/src/escape-markdown.js
@@ -1,5 +1,5 @@
 // @flow
-const escapeCharacters = ['*', '_', '~'];
+const escapeCharacters = ['\\', '*', '_', '~'];
 
 export function escapeMarkdown(s: string): string {
   for (const char of escapeCharacters) {

--- a/packages/core/utils/src/escape-markdown.js
+++ b/packages/core/utils/src/escape-markdown.js
@@ -1,0 +1,10 @@
+// @flow
+const escapeCharacters = ['*', '_', '~'];
+
+export function escapeMarkdown(s: string): string {
+  for (const char of escapeCharacters) {
+    s = s.replace(new RegExp(`\\${char}`, 'g'), `\\${char}`);
+  }
+
+  return s;
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -39,3 +39,4 @@ export * from './resolve';
 export * from './relativeBundlePath';
 export * from './ansi-html';
 export * from './escape-html';
+export * from './escape-markdown';

--- a/packages/core/utils/test/escapeMarkdown.test.js
+++ b/packages/core/utils/test/escapeMarkdown.test.js
@@ -3,19 +3,27 @@ import assert from 'assert';
 import {escapeMarkdown} from '../src/';
 
 describe('escapeMarkdown', () => {
-  it('returns a escaped string 01', () => {
+  it('returns an escaped string 01', () => {
     assert.equal('\\*test\\*', escapeMarkdown('*test*'));
   });
 
-  it('returns a escaped string 02', () => {
+  it('returns an escaped string 02', () => {
     assert.equal('\\_test\\_', escapeMarkdown('_test_'));
   });
 
-  it('returns a escaped string 03', () => {
+  it('returns an escaped string 03', () => {
     assert.equal('\\~test\\~', escapeMarkdown('~test~'));
   });
 
-  it('returns a escaped string 04', () => {
+  it('returns an escaped string 04', () => {
     assert.equal('\\*\\_\\~test\\~\\_\\*', escapeMarkdown('*_~test~_*'));
+  });
+
+  it('returns an escaped string with backslash 01', () => {
+    assert.equal('\\\\test\\\\', escapeMarkdown('\\test\\'));
+  });
+
+  it('returns an escaped string with backslash 02', () => {
+    assert.equal('\\\\\\*test\\*\\\\', escapeMarkdown('\\*test*\\'));
   });
 });

--- a/packages/core/utils/test/escapeMarkdown.test.js
+++ b/packages/core/utils/test/escapeMarkdown.test.js
@@ -1,0 +1,21 @@
+import assert from 'assert';
+
+import {escapeMarkdown} from '../src/';
+
+describe('escapeMarkdown', () => {
+  it('returns a escaped string 01', () => {
+    assert.equal('\\*test\\*', escapeMarkdown('*test*'));
+  });
+
+  it('returns a escaped string 02', () => {
+    assert.equal('\\_test\\_', escapeMarkdown('_test_'));
+  });
+
+  it('returns a escaped string 03', () => {
+    assert.equal('\\~test\\~', escapeMarkdown('~test~'));
+  });
+
+  it('returns a escaped string 04', () => {
+    assert.equal('\\*\\_\\~test\\~\\_\\*', escapeMarkdown('*_~test~_*'));
+  });
+});


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This pull-request is fix markdown problem in specific directory
If development in like a below directory,  error reports is return wrong output.

```
/my_awesome_projects/foo
```
In the case of CLI (underscore is not shown)
```
Cannot find module 'bar' from '/myawesomeprojects/foo'
```
In the case of Browser, Underscore is not shown and italic text displayed.

Please tell me if you have any problems

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
