### PR TITLE
Bailout exports.foo resolving when exports is used freely

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign.js
@@ -1,0 +1,7 @@
+var t = exports;
+exports.COMMENT_KEYS = undefined;
+
+let v = "COMMENT_KEYS"
+exports[v] = 5;
+
+output = t.COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define.js
@@ -1,0 +1,10 @@
+var t = exports;
+exports.COMMENT_KEYS = undefined;
+
+Object.defineProperty(exports, "COMMENT_KEYS", {
+	get() {
+		return 5;
+	}
+});
+
+output = t.COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign.js
@@ -1,0 +1,7 @@
+var t = module.exports;
+module.exports.COMMENT_KEYS = undefined;
+
+let v = "COMMENT_KEYS"
+module.exports[v] = 5;
+
+output = t.COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define.js
@@ -1,0 +1,10 @@
+var t = module.exports;
+module.exports.COMMENT_KEYS = undefined;
+
+Object.defineProperty(module.exports, "COMMENT_KEYS", {
+	get() {
+		return 5;
+	}
+});
+
+output = t.COMMENT_KEYS;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1057,6 +1057,54 @@ describe('scope hoisting', function() {
       assert.equal(output, 5);
     });
 
+    it('bails out exports access resolving if it is accessed freely (exports assign)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
+    it('bails out exports access resolving if it is accessed freely (exports define)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
+    it('bails out exports access resolving if it is accessed freely (module.exports assign)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
+    it('bails out exports access resolving if it is accessed freely (module.exports define)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
     it('builds commonjs modules that assigns to exports before module.exports', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -354,7 +354,11 @@ const VISITOR: Visitor<MutableAsset> = {
     //   }
     // }
 
-    if (isIdentifier(left) && left.name === 'exports') {
+    if (
+      isIdentifier(left) &&
+      left.name === 'exports' &&
+      !path.scope.hasBinding('exports')
+    ) {
       path.scope.getProgramParent().setData('cjsExportsReassigned', true);
       path
         .get<NodePath<LVal>>('left')

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -145,6 +145,39 @@ const VISITOR: Visitor<MutableAsset> = {
             shouldWrap = true;
             path.stop();
           }
+
+          // We must disable resolving $..$exports.foo if `exports`
+          // is referenced as a free identifier rather
+          // than a statically resolvable member expression.
+          if (
+            node.name === 'exports' &&
+            (!isMemberExpression(parent) ||
+              !(isIdentifier(parent.property) && !parent.computed) ||
+              isStringLiteral(parent.property)) &&
+            !path.scope.hasBinding('exports') &&
+            !path.scope.getData('shouldWrap')
+          ) {
+            asset.meta.isCommonJS = true;
+            asset.meta.resolveExportsBailedOut = true;
+          }
+        },
+
+        MemberExpression(path) {
+          let {node, parent} = path;
+
+          // We must disable resolving $..$exports.foo if `exports`
+          // is referenced as a free identifier rather
+          // than a statically resolvable member expression.
+          if (
+            t.matchesPattern(node, 'module.exports') &&
+            (!isMemberExpression(parent) ||
+              !(isIdentifier(parent.property) && !parent.computed) ||
+              isStringLiteral(parent.property)) &&
+            !path.scope.hasBinding('module') &&
+            !path.scope.getData('shouldWrap')
+          ) {
+            asset.meta.resolveExportsBailedOut = true;
+          }
         },
       });
 
@@ -321,10 +354,6 @@ const VISITOR: Visitor<MutableAsset> = {
     //   }
     // }
 
-    if (path.scope.hasBinding('exports')) {
-      return;
-    }
-
     if (isIdentifier(left) && left.name === 'exports') {
       path.scope.getProgramParent().setData('cjsExportsReassigned', true);
       path
@@ -337,7 +366,10 @@ const VISITOR: Visitor<MutableAsset> = {
     // This allows us to remove the CommonJS export object completely in many cases.
     if (
       isMemberExpression(left) &&
-      isIdentifier(left.object, {name: 'exports'}) &&
+      ((isIdentifier(left.object, {name: 'exports'}) &&
+        !path.scope.hasBinding('exports')) ||
+        (t.matchesPattern(left.object, 'module.exports') &&
+          !path.scope.hasBinding('module'))) &&
       ((isIdentifier(left.property) && !left.computed) ||
         isStringLiteral(left.property))
     ) {

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -513,14 +513,14 @@ export function link({
           return;
         }
 
-        let module = exportsMap.get(object.name);
-        if (!module) {
+        let asset = exportsMap.get(object.name);
+        if (!asset || asset.meta.resolveExportsBailedOut) {
           return;
         }
 
         // If it's a $id$exports.name expression.
         let name = isIdentifier(property) ? property.name : property.value;
-        let {identifier} = resolveSymbol(module, name);
+        let {identifier} = resolveSymbol(asset, name);
 
         // Check if $id$export$name exists and if so, replace the node by it.
         if (identifier) {

--- a/packages/shared/scope-hoisting/src/shake.js
+++ b/packages/shared/scope-hoisting/src/shake.js
@@ -10,6 +10,7 @@ import {
   isIdentifier,
   isMemberExpression,
   isSequenceExpression,
+  isStringLiteral,
   isVariableDeclarator,
 } from '@babel/types';
 import invariant from 'assert';
@@ -97,7 +98,12 @@ function isPure(binding) {
 function isExportAssignment(path) {
   let {parent} = path;
   // match "path.foo = bar;"
-  if (isMemberExpression(parent) && parent.object === path.node) {
+  if (
+    isMemberExpression(parent) &&
+    parent.object === path.node &&
+    ((isIdentifier(parent.property) && !parent.computed) ||
+      isStringLiteral(parent.property))
+  ) {
     let parentParent = path.parentPath.parent;
     return isAssignmentExpression(parentParent) && parentParent.left === parent;
   }


### PR DESCRIPTION
# ↪️ Pull Request

(This is needed for `babel-types` (v6 that is) to work with scope hoisting.)

We usually resolve `module.exports.foo` to the export id `$...$export$foo`, but if `module.exports` is used freely (see example), we need to bailout that resolving.

## 💻 Examples

```js
var t = module.exports;
module.exports.COMMENT_KEYS = undefined;

Object.defineProperty(module.exports, "COMMENT_KEYS", {
	get() {
		return [1];
	}
});
// or
let v = "COMMENT_KEYS"
module.exports[v] = [1];

console.log(t.COMMENT_KEYS);
```