### PR TITLE
Fix `pkg#alias` on Windows and make asset hash more stable

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -132,7 +132,12 @@ export default class Transformation {
 
     // If the transformer request passed code rather than a filename,
     // use a hash as the base for the id to ensure it is unique.
-    let idBase = code != null ? hash : filePath;
+    let idBase =
+      code != null
+        ? hash
+        : path
+            .relative(this.options.projectRoot, filePath)
+            .replace(/[\\/]+/g, '/');
     return new InternalAsset({
       idBase,
       value: createAsset({

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -126,7 +126,12 @@ export default class Validation {
 
     // If the transformer request passed code rather than a filename,
     // use a hash as the base for the id to ensure it is unique.
-    let idBase = code != null ? hash : filePath;
+    let idBase =
+      code != null
+        ? hash
+        : path
+            .relative(this.options.projectRoot, filePath)
+            .replace(/[\\/]+/g, '/');
     return new InternalAsset({
       idBase,
       value: createAsset({

--- a/packages/core/integration-tests/test/integration/alias/bar.js
+++ b/packages/core/integration-tests/test/integration/alias/bar.js
@@ -1,0 +1,1 @@
+export default "bar";

--- a/packages/core/integration-tests/test/integration/alias/exclude-local.js
+++ b/packages/core/integration-tests/test/integration/alias/exclude-local.js
@@ -1,0 +1,3 @@
+import bar from "./bar-exclude";
+
+export default bar;

--- a/packages/core/integration-tests/test/integration/alias/exclude-package.js
+++ b/packages/core/integration-tests/test/integration/alias/exclude-package.js
@@ -1,0 +1,3 @@
+import bar from "foo-exclude";
+
+export default bar;

--- a/packages/core/integration-tests/test/integration/alias/package-to-local.js
+++ b/packages/core/integration-tests/test/integration/alias/package-to-local.js
@@ -1,0 +1,3 @@
+import bar from "bar";
+
+export default bar;

--- a/packages/core/integration-tests/test/integration/alias/package-to-package.js
+++ b/packages/core/integration-tests/test/integration/alias/package-to-package.js
@@ -1,0 +1,3 @@
+import {add} from "foo";
+
+export default add(1, 2);

--- a/packages/core/integration-tests/test/integration/alias/package.json
+++ b/packages/core/integration-tests/test/integration/alias/package.json
@@ -1,0 +1,8 @@
+{
+  "alias": {
+    "foo": "lodash",
+    "bar": "./bar.js",
+    "foo-exclude": false,
+    "./bar-exclude": false
+  }
+}

--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -91,4 +91,40 @@ describe('resolver', function() {
 
     assert(didThrow);
   });
+
+  it('should resolve packages to packages through the alias field', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/alias/package-to-package.js'),
+    );
+
+    let output = await run(b);
+    assert.strictEqual(output.default, 3);
+  });
+
+  it('should resolve packages to local files through the alias field', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/alias/package-to-local.js'),
+    );
+
+    let output = await run(b);
+    assert.strictEqual(output.default, 'bar');
+  });
+
+  it('should exclude local files using the alias field', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/alias/exclude-local.js'),
+    );
+
+    let output = await run(b);
+    assert.deepEqual(output.default, {});
+  });
+
+  it('should exclude packages using the alias field', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/alias/exclude-package.js'),
+    );
+
+    let output = await run(b);
+    assert.deepEqual(output.default, {});
+  });
 });

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -521,17 +521,25 @@ export default class NodeResolver {
         filename = './' + filename;
       }
 
-      alias = await this.lookupAlias(aliases, filename, dir);
+      alias = await this.lookupAlias(
+        aliases,
+        filename.replace(/\\/g, '/'),
+        dir,
+      );
     } else {
       // It is a node_module. First try the entire filename as a key.
-      alias = await this.lookupAlias(aliases, filename, dir);
+      alias = await this.lookupAlias(
+        aliases,
+        filename.replace(/\\/g, '/'),
+        dir,
+      );
       if (alias == null) {
         // If it didn't match, try only the module name.
-        let parts = this.getModuleParts(filename);
-        alias = await this.lookupAlias(aliases, parts[0], dir);
+        let [mod, ...rest] = this.getModuleParts(filename);
+        alias = await this.lookupAlias(aliases, mod, dir);
         if (typeof alias === 'string') {
           // Append the filename back onto the aliased module.
-          alias = path.join(alias, ...parts.slice(1));
+          alias = path.join(alias, ...rest);
         }
       }
     }


### PR DESCRIPTION
# ↪️ Pull Request

- In the `pkg#alias` and `pkg#browser` field, a relative path can be specified. So the path needs to be normalized on Windows.
- While debugging this, I found out that the ids in the output bundle (of the identifiers) between Windows and macOS were different. The absolute file path was used in the hash, so I changed that to `path.relative(options.projectRoot, filePath).replace(/\\/g,"/")`.
(cc @padmaia Might be helpful for a multi-user cache?)

Fixes the CI for https://github.com/parcel-bundler/parcel/pull/4275