### PR TITLE
AssetGraph doesn't properly respond to fs events

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -32,8 +32,8 @@
     "clone": "^2.1.1",
     "dotenv": "^7.0.0",
     "dotenv-expand": "^5.1.0",
-    "json5": "^1.0.1",
     "json-source-map": "^0.6.1",
+    "json5": "^1.0.1",
     "micromatch": "^4.0.2",
     "nullthrows": "^1.1.1",
     "semver": "^5.4.1"

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -142,8 +142,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     });
 
     if (changes) {
-      this.requestGraph.invalidateUnpredictableNodes();
-      this.requestTracker.respondToFSEvents(changes);
+      this.respondToFSEvents(changes);
     } else {
       this.assetGraph.initialize({
         entries,
@@ -316,7 +315,8 @@ export default class AssetGraphBuilder extends EventEmitter {
   }
 
   respondToFSEvents(events: Array<Event>) {
-    return this.requestGraph.respondToFSEvents(events);
+    this.requestGraph.invalidateUnpredictableNodes();
+    return this.requestTracker.respondToFSEvents(events);
   }
 
   getWatcherOptions() {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -77,7 +77,6 @@ export class RequestGraph extends Graph<
     deserialized.incompleteNodeIds = opts.incompleteNodeIds;
     deserialized.globNodeIds = opts.globNodeIds;
     deserialized.unpredicatableNodeIds = opts.unpredicatableNodeIds;
-    // $FlowFixMe
     return deserialized;
   }
 

--- a/packages/dev/babel-register/babel-plugin-module-translate.js
+++ b/packages/dev/babel-register/babel-plugin-module-translate.js
@@ -11,7 +11,7 @@ function resolveSource(specifier, from) {
         }
       }
       return pkg;
-    }
+    },
   });
 }
 
@@ -35,7 +35,7 @@ module.exports = ({types: t}) => ({
       if (t.isStringLiteral(source)) {
         source.value = getSourceField(
           source.value,
-          state.file.opts.filename || process.cwd()
+          state.file.opts.filename || process.cwd(),
         );
       }
     },
@@ -50,7 +50,7 @@ module.exports = ({types: t}) => ({
         try {
           node.arguments[0].value = getSourceField(
             node.arguments[0].value,
-            state.file.opts.filename || process.cwd()
+            state.file.opts.filename || process.cwd(),
           );
         } catch (e) {
           let exprStmtParent = path
@@ -58,13 +58,13 @@ module.exports = ({types: t}) => ({
             .find(v => v.isExpressionStatement());
           if (exprStmtParent) {
             exprStmtParent.replaceWith(
-              t.throwStatement(t.stringLiteral(e.message))
+              t.throwStatement(t.stringLiteral(e.message)),
             );
           }
         }
       }
-    }
-  }
+    },
+  },
 });
 
 module.exports.resolveSource = resolveSource;

--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -8,10 +8,10 @@ require('@babel/register')({
     // Don't run babel over ignore integration tests fixtures.
     // These may include relative babel plugins, and running babel on those causes
     // the plugin to be loaded to compile the plugin.
-    path.resolve(__dirname, '../../core/integration-tests/test/integration')
+    path.resolve(__dirname, '../../core/integration-tests/test/integration'),
   ],
   presets: [parcelBabelPreset],
-  plugins: [require('./babel-plugin-module-translate')]
+  plugins: [require('./babel-plugin-module-translate')],
 });
 
 // This adds the registration to the Node args, which are passed

--- a/packages/dev/eslint-config-browser/index.js
+++ b/packages/dev/eslint-config-browser/index.js
@@ -2,14 +2,14 @@ module.exports = {
   extends: '@parcel/eslint-config',
   parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 5
+    ecmaVersion: 5,
   },
   env: {
-    browser: true
+    browser: true,
   },
   rules: {
     'no-global-assign': 1,
     'no-unused-vars': 0,
-    'no-console': 0
-  }
+    'no-console': 0,
+  },
 };


### PR DESCRIPTION
## ↪️ Pull Request  or: *A call for help (@padmaia ?)*



When invoking `run` on a `Parcel` instance multiple times, the AssetGraph (or some other graph 🤷‍♂) doesn't invalidate the related nodes:

##### `disableCache: true`

With the change I commited (running `AssetGraph#init` again on `Parcel#build` - running once in `Parcel#init` isn't enough), the example below works correctly.

##### `disableCache: false`

Running only `respondToFSEvents` somehow doesn't cascade all the needed changes. I have no idea, this is really hard to track because of all these callbacks between the graphs.

## 💻 Examples

Put this in the monorepo and run with
`PARCEL_WORKERS=0 node -r @parcel/babel-register  test.js`

It should print:
```js
start
// ASSET: .../input/other.js
const $c0ecb00daffdfc9e8fc5c097e0a79543$export$foo = 1;
console.log($c0ecb00daffdfc9e8fc5c097e0a79543$export$foo);

finished
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
start
// ASSET: .../input/other.js
const $c0ecb00daffdfc9e8fc5c097e0a79543$export$foo = 1000;
console.log($c0ecb00daffdfc9e8fc5c097e0a79543$export$foo);

finished
```

```js
/* eslint-disable */
import Parcel, {createWorkerFarm} from '@parcel/core';
import {NodeFS} from '@parcel/fs';

const defaultConfig = {
  bundler: '@parcel/bundler-default',
  transformers: {
    '*.{js,mjs,jsm,jsx,es6,ts,tsx}': ['@parcel/transformer-js'],
    'url:*': ['@parcel/transformer-raw'],
  },
  namers: ['@parcel/namer-default'],
  runtimes: {
    browser: ['@parcel/runtime-js'],
    'service-worker': ['@parcel/runtime-js'],
    'web-worker': ['@parcel/runtime-js'],
    node: ['@parcel/runtime-js'],
  },
  packagers: {
    '*.js': '@parcel/packager-js',
    '*': '@parcel/packager-raw',
  },
  resolvers: ['@parcel/resolver-default'],
  reporters: [],
};

const ASSETS = [
  {
    name: 'index.js',
    content: `import {foo} from "./other.js";\nconsole.log(foo);`,
  },
  {
    name: 'other.js',
    content: `export const foo = 1;`,
  },
];
const ASSETS2 = [
  {
    name: 'index.js',
    content: `import {foo} from "./other.js";\nconsole.log(foo);`,
  },
  {
    name: 'other.js',
    content: `export const foo = 1000;`,
  },
];

async function bundle(fs, bundler, assets) {
  console.log('start');

  await fs.mkdirp('input');
  for (let {name, content} of assets) {
    await fs.writeFile(`input/${name}`, content);
  }
  await fs.rimraf(`dist`);
  await fs.mkdirp('dist');

  await bundler.run();

  for (let name of await fs.readdir(`dist`)) {
    console.log(await fs.readFile(`dist/${name}`, 'utf8'));
    console.log();
  }

  console.log('finished');
}

async function run() {
  let workerFarm = createWorkerFarm();
  let fs = new NodeFS();

  const bundler = new Parcel({
    entries: ['input/index.js'],
    autoinstall: false,
    disableCache: true,
    mode: 'production',
    minify: false,
    logLevel: 'verbose',
    defaultConfig: {
      ...defaultConfig,
      filePath: require.resolve('@parcel/config-default'),
    },
    distDir: 'dist',
    hot: false,
    inputFS: fs,
    outputFS: fs,
    patchConsole: false,
    scopeHoist: true,
    workerFarm,
    defaultEngines: {
      browsers: ['last 1 Chrome version'],
      node: '10',
    },
  });

  await bundle(fs, bundler, ASSETS);
  console.log(
    '++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++',
  );
  await bundle(fs, bundler, ASSETS2);

  await workerFarm.end();
}

run();
```
