### PR TITLE
Ensure port via env var is a number (#3249)

### DIFF
--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -237,7 +237,7 @@ async function bundle(main, command) {
 
   command.target = command.target || 'browser';
   if (command.name() === 'serve' && command.target === 'browser') {
-    const port = command.port || process.env.PORT || 1234;
+    const port = command.port || parseInt(process.env.PORT) || 1234;
     const server = await bundler.serve(port, command.https, command.host);
     if (server && command.open) {
       await require('./utils/openInBrowser')(


### PR DESCRIPTION
# ↪️ Pull Request

When port which is NOT in use is given via an env variable parcel reports that port can't be used but uses it anyway.

See: https://github.com/parcel-bundler/parcel/issues/3249 

## 💻 Examples
```bash
env PORT=3000 parcel <path to entrypoint>
```
Should give: `Server running at http://localhost:3000`
Instead gives: `Server running at http://localhost:3000 - configured port 3000 could not be used.`

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
As far as I can tell there is no tests specifically for the CLI command. If they existed that's where any tests to check that the port is a number would go. Since it doesn't look like they exist to me and this just corrects already broken behavior rather than adding new functionality I'm considering testing to be out of scope of this ticket. If I was more familiar with the project and had more capacity I'd add those tests and include a test for the port type but unfortunately I don't.

## ✔️ PR Todo

- [NA] Added/updated unit tests for this change
- [NA] Filled out test instructions (In case there aren't any unit tests)
- [✔️] Included links to related issues/PRs
