### PR TITLE
Fix worker crash

### DIFF
--- a/packages/core/utils/src/md5.js
+++ b/packages/core/utils/src/md5.js
@@ -20,12 +20,17 @@ export function md5FromString(
 
 export function md5FromReadableStream(stream: Readable): Promise<string> {
   return new Promise((resolve, reject) => {
+    stream.on('error', err => {
+      reject(err);
+    });
     stream
       .pipe(crypto.createHash('md5').setEncoding('hex'))
       .on('finish', function() {
         resolve(this.read());
       })
-      .on('error', reject);
+      .on('error', err => {
+        reject(err);
+      });
   });
 }
 


### PR DESCRIPTION
# ↪️ Pull Request
This fixes an issue where the stream passed into `md5FromStream` has an error (like the file it is trying to open a stream to doesn't exist), but it is not caught inside the process, which causes the process to exit. The WorkerFarm attempts to start a new process and retry the failed request, but this kicks off an infinite loop of crashing the worker and retrying. 

## 🚨 Test instructions
Was able to consistently reproduce this issue in a private project, noticed failure and infinite loop of spinning up workers and retrying failed requests. Implemented fix and noticed no workers exited and the build passed because the request that failed ended up getting removed by a different request.