### PR TITLE
Split InternalAsset into UncommittedAsset and CommittedAsset (Cache ASTs followup)

### DIFF
--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -1,0 +1,161 @@
+// @flow strict-local
+
+import type {
+  AST,
+  Blob,
+  ConfigResult,
+  File,
+  FilePath,
+  PackageJSON,
+} from '@parcel/types';
+import type {Asset, Dependency, ParcelOptions} from './types';
+
+import v8 from 'v8';
+import {Readable} from 'stream';
+import SourceMap from '@parcel/source-map';
+import {bufferStream, blobToStream, streamFromPromise} from '@parcel/utils';
+import {getConfig, generateFromAST} from './assetUtils';
+
+export default class CommittedAsset {
+  value: Asset;
+  options: ParcelOptions;
+  content: ?Promise<Buffer | string>;
+  mapBuffer: ?Promise<?Buffer>;
+  map: ?Promise<?SourceMap>;
+  ast: ?Promise<AST>;
+  idBase: ?string;
+  generatingPromise: ?Promise<void>;
+
+  constructor(value: Asset, options: ParcelOptions) {
+    this.value = value;
+    this.options = options;
+  }
+
+  getContent(): Blob | Promise<Buffer | string> {
+    if (this.content == null) {
+      if (this.value.contentKey != null) {
+        return this.options.cache.getStream(this.value.contentKey);
+      } else if (this.value.astKey != null) {
+        return streamFromPromise(
+          generateFromAST(this).then(({code}) => {
+            if (!(code instanceof Readable)) {
+              this.content = Promise.resolve(code);
+            }
+            return code;
+          }),
+        );
+      } else {
+        throw new Error('Asset has no content');
+      }
+    }
+
+    return this.content;
+  }
+
+  async getCode(): Promise<string> {
+    let content = await this.getContent();
+
+    if (typeof content === 'string' || content instanceof Buffer) {
+      return content.toString();
+    } else if (content != null) {
+      this.content = bufferStream(content);
+      return (await this.content).toString();
+    }
+
+    return '';
+  }
+
+  async getBuffer(): Promise<Buffer> {
+    let content = await this.getContent();
+
+    if (content == null) {
+      return Buffer.alloc(0);
+    } else if (typeof content === 'string' || content instanceof Buffer) {
+      return Buffer.from(content);
+    }
+
+    this.content = bufferStream(content);
+    return this.content;
+  }
+
+  getStream(): Readable {
+    let content = this.getContent();
+    return content instanceof Promise
+      ? streamFromPromise(content)
+      : blobToStream(content);
+  }
+
+  getMapBuffer(): Promise<?Buffer> {
+    let mapKey = this.value.mapKey;
+    if (mapKey != null && this.mapBuffer == null) {
+      this.mapBuffer = (async () => {
+        try {
+          return await this.options.cache.getBlob(mapKey);
+        } catch (err) {
+          if (err.code === 'ENOENT' && this.value.astKey != null) {
+            return (await generateFromAST(this)).map?.toBuffer();
+          } else {
+            throw err;
+          }
+        }
+      })();
+    }
+
+    return this.mapBuffer ?? Promise.resolve();
+  }
+
+  getMap(): Promise<?SourceMap> {
+    if (this.map == null) {
+      this.map = (async () => {
+        let mapBuffer = await this.getMapBuffer();
+        if (mapBuffer) {
+          // Get sourcemap from flatbuffer
+          let map = new SourceMap();
+          map.addBufferMappings(mapBuffer);
+          return map;
+        }
+      })();
+    }
+
+    return this.map;
+  }
+
+  getAST(): Promise<AST> {
+    if (this.value.astKey == null) {
+      throw new Error('Asset does not have an AST');
+    }
+
+    if (this.ast == null) {
+      this.ast = this.options.cache
+        .getBlob(this.value.astKey)
+        .then(serializedAst =>
+          // $FlowFixMe
+          v8.deserialize(serializedAst),
+        );
+    }
+
+    return this.ast;
+  }
+
+  getIncludedFiles(): Array<File> {
+    return Array.from(this.value.includedFiles.values());
+  }
+
+  getDependencies(): Array<Dependency> {
+    return Array.from(this.value.dependencies.values());
+  }
+
+  async getConfig(
+    filePaths: Array<FilePath>,
+    options: ?{|
+      packageKey?: string,
+      parse?: boolean,
+    |},
+  ): Promise<ConfigResult | null> {
+    return (await getConfig(this, filePaths, options))?.config;
+  }
+
+  getPackage(): Promise<PackageJSON | null> {
+    return this.getConfig(['package.json']);
+  }
+}

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -382,8 +382,6 @@ export class BuildError extends ThrowableDiagnostic {
   }
 }
 
-export {default as Asset} from './InternalAsset';
-
 export function createWorkerFarm(options: $Shape<FarmOptions> = {}) {
   return new WorkerFarm({
     ...options,

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -2,126 +2,51 @@
 
 import type {
   AST,
-  ASTGenerator,
   Blob,
   ConfigResult,
   DependencyOptions,
   File,
   FilePath,
-  Meta,
   PackageJSON,
   PackageName,
-  Stats,
-  Symbol,
-  Transformer,
   TransformerResult,
 } from '@parcel/types';
-import type {Asset, Dependency, Environment, ParcelOptions} from './types';
+import type {Asset, Dependency, ParcelOptions} from './types';
 
 import v8 from 'v8';
 import {Readable} from 'stream';
 import SourceMap from '@parcel/source-map';
 import {
   bufferStream,
-  loadConfig,
   md5FromString,
   blobToStream,
   streamFromPromise,
-  fallbackStream,
   TapStream,
 } from '@parcel/utils';
-import nullthrows from 'nullthrows';
 import {createDependency, mergeDependencies} from './Dependency';
-import {mergeEnvironments, getEnvironmentHash} from './Environment';
+import {mergeEnvironments} from './Environment';
 import {PARCEL_VERSION} from './constants';
-import loadPlugin from './loadParcelPlugin';
-import PluginOptions from './public/PluginOptions';
-import {Asset as PublicAsset} from './public/Asset';
-import {PluginLogger} from '@parcel/logger';
+import {createAsset, getConfig} from './assetUtils';
 
-type AssetOptions = {|
-  id?: string,
-  hash?: ?string,
-  idBase?: ?string,
-  filePath: FilePath,
-  type: string,
-  contentKey?: ?string,
-  mapKey?: ?string,
-  astKey?: ?string,
-  astGenerator?: ?ASTGenerator,
-  dependencies?: Map<string, Dependency>,
-  includedFiles?: Map<FilePath, File>,
-  isIsolated?: boolean,
-  isInline?: boolean,
-  isSplittable?: ?boolean,
-  isSource: boolean,
-  env: Environment,
-  meta?: Meta,
-  outputHash?: ?string,
-  pipeline?: ?string,
-  stats: Stats,
-  symbols?: Map<Symbol, Symbol>,
-  sideEffects?: boolean,
-  uniqueKey?: ?string,
-  plugin?: PackageName,
-  configPath?: FilePath,
-|};
-
-export function createAsset(options: AssetOptions): Asset {
-  let idBase = options.idBase != null ? options.idBase : options.filePath;
-  let uniqueKey = options.uniqueKey || '';
-  return {
-    id:
-      options.id != null
-        ? options.id
-        : md5FromString(
-            idBase + options.type + getEnvironmentHash(options.env) + uniqueKey,
-          ),
-    hash: options.hash,
-    filePath: options.filePath,
-    isIsolated: options.isIsolated == null ? false : options.isIsolated,
-    isInline: options.isInline == null ? false : options.isInline,
-    isSplittable: options.isSplittable,
-    type: options.type,
-    contentKey: options.contentKey,
-    mapKey: options.mapKey,
-    astKey: options.astKey,
-    astGenerator: options.astGenerator,
-    dependencies: options.dependencies || new Map(),
-    includedFiles: options.includedFiles || new Map(),
-    isSource: options.isSource,
-    outputHash: options.outputHash,
-    pipeline: options.pipeline,
-    env: options.env,
-    meta: options.meta || {},
-    stats: options.stats,
-    symbols: options.symbols || new Map(),
-    sideEffects: options.sideEffects != null ? options.sideEffects : true,
-    uniqueKey: uniqueKey,
-    plugin: options.plugin,
-    configPath: options.configPath,
-  };
-}
-
-type InternalAssetOptions = {|
+type UncommittedAssetOptions = {|
   value: Asset,
   options: ParcelOptions,
-  content?: ?(Blob | Promise<Buffer>),
+  content?: ?Blob,
   mapBuffer?: ?Buffer,
   ast?: ?AST,
   isASTDirty?: ?boolean,
   idBase?: ?string,
 |};
 
-export default class InternalAsset {
+export default class UncommittedAsset {
   value: Asset;
   options: ParcelOptions;
   content: ?(Blob | Promise<Buffer>);
   mapBuffer: ?Buffer;
+  map: ?SourceMap;
   ast: ?AST;
   isASTDirty: boolean;
   idBase: ?string;
-  generatingPromise: ?Promise<void>;
 
   constructor({
     value,
@@ -131,7 +56,7 @@ export default class InternalAsset {
     ast,
     isASTDirty,
     idBase,
-  }: InternalAssetOptions) {
+  }: UncommittedAssetOptions) {
     this.value = value;
     this.options = options;
     this.content = content;
@@ -164,26 +89,24 @@ export default class InternalAsset {
     // Since we can only read from the stream once, compute the content length
     // and hash while it's being written to the cache.
     await Promise.all([
-      contentKey == null
-        ? Promise.resolve()
-        : this.options.cache.setStream(
-            contentKey,
-            this.getStream().pipe(
-              new TapStream(buf => {
-                size += buf.length;
-              }),
-            ),
+      contentKey != null &&
+        this.options.cache.setStream(
+          contentKey,
+          this.getStream().pipe(
+            new TapStream(buf => {
+              size += buf.length;
+            }),
           ),
-      this.mapBuffer == null || mapKey == null
-        ? Promise.resolve()
-        : this.options.cache.setBlob(mapKey, this.mapBuffer),
-      astKey == null
-        ? Promise.resolve()
-        : this.options.cache.setBlob(
-            astKey,
-            // $FlowFixMe
-            v8.serialize(this.ast),
-          ),
+        ),
+      this.mapBuffer != null &&
+        mapKey != null &&
+        this.options.cache.setBlob(mapKey, this.mapBuffer),
+      astKey != null &&
+        this.options.cache.setBlob(
+          astKey,
+          // $FlowFixMe
+          v8.serialize(this.ast),
+        ),
     ]);
     this.value.contentKey = contentKey;
     this.value.mapKey = mapKey;
@@ -192,68 +115,11 @@ export default class InternalAsset {
       [this.value.hash, pipelineKey].join(':'),
     );
 
-    // TODO: how should we set the size when we only store an AST?
     if (this.content != null) {
       this.value.stats.size = size;
     }
-  }
 
-  async generateFromAST() {
-    if (this.generatingPromise == null) {
-      this.generatingPromise = this._generateFromAST();
-    }
-
-    await this.generatingPromise;
-    return this.content || '';
-  }
-
-  async _generateFromAST() {
-    let ast = await this.getAST();
-    if (ast == null) {
-      throw new Error('Asset has no AST');
-    }
-
-    let pluginName = nullthrows(this.value.plugin);
-    let plugin: Transformer = await loadPlugin(
-      this.options.packageManager,
-      pluginName,
-      nullthrows(this.value.configPath),
-    );
-    if (!plugin.generate) {
-      throw new Error(`${pluginName} does not have a generate method`);
-    }
-
-    let {code, map} = await plugin.generate({
-      asset: new PublicAsset(this),
-      ast,
-      options: new PluginOptions(this.options),
-      logger: new PluginLogger({origin: pluginName}),
-    });
-
-    this.content = code;
-    let mapBuffer = (this.mapBuffer = map?.toBuffer());
-
-    // Store the results in the cache so we can avoid generating again next time
-    await Promise.all([
-      this.options.cache.setStream(
-        nullthrows(this.value.contentKey),
-        this.getStream(),
-      ),
-      mapBuffer == null
-        ? Promise.resolve()
-        : this.options.cache.setBlob(nullthrows(this.value.mapKey), mapBuffer),
-    ]);
-  }
-
-  ensureContent() {
-    let contentKey = this.value.contentKey;
-    if (contentKey != null && this.content == null) {
-      // First try the contentKey, and if it doesn't exist, fall back to generating from AST
-      this.content = fallbackStream(
-        this.options.cache.getStream(contentKey),
-        () => streamFromPromise(this.generateFromAST()),
-      );
-    }
+    this.value.committed = true;
   }
 
   async getCode(): Promise<string> {
@@ -263,9 +129,7 @@ export default class InternalAsset {
       );
     }
 
-    this.ensureContent();
     let content = await this.content;
-
     if (typeof content === 'string' || content instanceof Buffer) {
       return content.toString();
     } else if (content != null) {
@@ -277,9 +141,7 @@ export default class InternalAsset {
   }
 
   async getBuffer(): Promise<Buffer> {
-    this.ensureContent();
     let content = await this.content;
-
     if (content == null) {
       return Buffer.alloc(0);
     } else if (typeof content === 'string' || content instanceof Buffer) {
@@ -291,20 +153,18 @@ export default class InternalAsset {
   }
 
   getStream(): Readable {
-    this.ensureContent();
-
-    let content = this.content;
-    if (content instanceof Readable) {
+    if (this.content instanceof Readable) {
       // Remove content if it's a stream, as it should not be reused.
+      let content = this.content;
       this.content = null;
       return content;
     }
 
-    if (content instanceof Promise) {
-      return streamFromPromise(content);
+    if (this.content instanceof Promise) {
+      return streamFromPromise(this.content);
     }
 
-    return blobToStream(content ?? Buffer.alloc(0));
+    return blobToStream(this.content ?? Buffer.alloc(0));
   }
 
   setCode(code: string) {
@@ -322,48 +182,30 @@ export default class InternalAsset {
     this.clearAST();
   }
 
-  async getMapBuffer(): Promise<?Buffer> {
-    if (this.value.mapKey != null && this.mapBuffer == null) {
-      try {
-        this.mapBuffer = await this.options.cache.getBlob(this.value.mapKey);
-      } catch (err) {
-        if (err.code === 'ENOENT' && this.value.astKey != null) {
-          await this.generateFromAST();
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    return this.mapBuffer;
+  getMapBuffer(): Promise<?Buffer> {
+    return Promise.resolve(this.mapBuffer);
   }
 
   async getMap(): Promise<?SourceMap> {
-    let mapBuffer = this.mapBuffer ?? (await this.getMapBuffer());
-    if (mapBuffer) {
-      // Get sourcemap from flatbuffer
-      let map = new SourceMap();
-      map.addBufferMappings(mapBuffer);
-      return map;
-    }
-  }
-
-  setMap(map: ?SourceMap): void {
-    if (map) {
-      this.mapBuffer = map.toBuffer();
-    }
-  }
-
-  async getAST(): Promise<?AST> {
-    if (this.value.astKey != null) {
-      let serializedAst = await this.options.cache.getBlob(this.value.astKey);
-      if (serializedAst != null) {
-        // $FlowFixMe
-        this.ast = v8.deserialize(serializedAst);
+    if (this.map == null) {
+      let mapBuffer = this.mapBuffer ?? (await this.getMapBuffer());
+      if (mapBuffer) {
+        // Get sourcemap from flatbuffer
+        let map = new SourceMap();
+        map.addBufferMappings(mapBuffer);
+        this.map = map;
       }
     }
 
-    return this.ast;
+    return this.map;
+  }
+
+  setMap(map: ?SourceMap): void {
+    this.mapBuffer = map?.toBuffer();
+  }
+
+  getAST(): Promise<?AST> {
+    return Promise.resolve(this.ast);
   }
 
   setAST(ast: AST): void {
@@ -421,10 +263,10 @@ export default class InternalAsset {
     result: TransformerResult,
     plugin: PackageName,
     configPath: FilePath,
-  ): InternalAsset {
+  ): UncommittedAsset {
     let content = result.content ?? result.code ?? null;
 
-    let asset = new InternalAsset({
+    let asset = new UncommittedAsset({
       value: createAsset({
         idBase: this.idBase,
         hash: this.value.hash,
@@ -493,23 +335,8 @@ export default class InternalAsset {
       parse?: boolean,
     |},
   ): Promise<ConfigResult | null> {
-    let packageKey = options?.packageKey;
-    let parse = options && options.parse;
-
-    if (packageKey != null) {
-      let pkg = await this.getPackage();
-      if (pkg && pkg[packageKey]) {
-        return pkg[packageKey];
-      }
-    }
-
-    let conf = await loadConfig(
-      this.options.inputFS,
-      this.value.filePath,
-      filePaths,
-      parse == null ? null : {parse},
-    );
-    if (!conf) {
+    let conf = await getConfig(this, filePaths, options);
+    if (conf == null) {
       return null;
     }
 

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -15,7 +15,8 @@ import logger, {PluginLogger} from '@parcel/logger';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 import ParcelConfig from './ParcelConfig';
 import ConfigLoader from './ConfigLoader';
-import InternalAsset, {createAsset} from './InternalAsset';
+import UncommittedAsset from './UncommittedAsset';
+import {createAsset} from './assetUtils';
 import {Asset} from './public/Asset';
 import PluginOptions from './public/PluginOptions';
 import summarizeRequest from './summarizeRequest';
@@ -34,7 +35,7 @@ export type ValidationOpts = {|
 |};
 
 export default class Validation {
-  allAssets: {[validatorName: string]: InternalAsset[], ...} = {};
+  allAssets: {[validatorName: string]: UncommittedAsset[], ...} = {};
   allValidators: {[validatorName: string]: Validator, ...} = {};
   dedicatedThread: boolean;
   configRequests: Array<ConfigRequestDesc>;
@@ -176,7 +177,7 @@ export default class Validation {
     }
   }
 
-  async loadAsset(request: AssetRequestDesc): Promise<InternalAsset> {
+  async loadAsset(request: AssetRequestDesc): Promise<UncommittedAsset> {
     let {filePath, env, code, sideEffects} = request;
     let {content, size, hash, isSource} = await summarizeRequest(
       this.options.inputFS,
@@ -191,7 +192,7 @@ export default class Validation {
         : path
             .relative(this.options.projectRoot, filePath)
             .replace(/[\\/]+/g, '/');
-    return new InternalAsset({
+    return new UncommittedAsset({
       idBase,
       value: createAsset({
         idBase,

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -1,0 +1,179 @@
+// @flow strict-local
+
+import type {
+  ASTGenerator,
+  ConfigResult,
+  File,
+  FilePath,
+  GenerateOutput,
+  Meta,
+  PackageName,
+  Stats,
+  Symbol,
+  Transformer,
+} from '@parcel/types';
+import type {Asset, Dependency, Environment} from './types';
+
+import {Readable} from 'stream';
+import {PluginLogger} from '@parcel/logger';
+import nullthrows from 'nullthrows';
+import CommittedAsset from './CommittedAsset';
+import UncommittedAsset from './UncommittedAsset';
+import loadPlugin from './loadParcelPlugin';
+import {Asset as PublicAsset} from './public/Asset';
+import PluginOptions from './public/PluginOptions';
+import {blobToStream, loadConfig, md5FromString} from '@parcel/utils';
+import {getEnvironmentHash} from './Environment';
+
+type AssetOptions = {|
+  id?: string,
+  committed?: boolean,
+  hash?: ?string,
+  idBase?: ?string,
+  filePath: FilePath,
+  type: string,
+  contentKey?: ?string,
+  mapKey?: ?string,
+  astKey?: ?string,
+  astGenerator?: ?ASTGenerator,
+  dependencies?: Map<string, Dependency>,
+  includedFiles?: Map<FilePath, File>,
+  isIsolated?: boolean,
+  isInline?: boolean,
+  isSplittable?: ?boolean,
+  isSource: boolean,
+  env: Environment,
+  meta?: Meta,
+  outputHash?: ?string,
+  pipeline?: ?string,
+  stats: Stats,
+  symbols?: Map<Symbol, Symbol>,
+  sideEffects?: boolean,
+  uniqueKey?: ?string,
+  plugin?: PackageName,
+  configPath?: FilePath,
+|};
+
+export function createAsset(options: AssetOptions): Asset {
+  let idBase = options.idBase != null ? options.idBase : options.filePath;
+  let uniqueKey = options.uniqueKey || '';
+  return {
+    id:
+      options.id != null
+        ? options.id
+        : md5FromString(
+            idBase + options.type + getEnvironmentHash(options.env) + uniqueKey,
+          ),
+    committed: options.committed ?? false,
+    hash: options.hash,
+    filePath: options.filePath,
+    isIsolated: options.isIsolated == null ? false : options.isIsolated,
+    isInline: options.isInline == null ? false : options.isInline,
+    isSplittable: options.isSplittable,
+    type: options.type,
+    contentKey: options.contentKey,
+    mapKey: options.mapKey,
+    astKey: options.astKey,
+    astGenerator: options.astGenerator,
+    dependencies: options.dependencies || new Map(),
+    includedFiles: options.includedFiles || new Map(),
+    isSource: options.isSource,
+    outputHash: options.outputHash,
+    pipeline: options.pipeline,
+    env: options.env,
+    meta: options.meta || {},
+    stats: options.stats,
+    symbols: options.symbols || new Map(),
+    sideEffects: options.sideEffects != null ? options.sideEffects : true,
+    uniqueKey: uniqueKey,
+    plugin: options.plugin,
+    configPath: options.configPath,
+  };
+}
+
+const generateResults: WeakMap<Asset, Promise<GenerateOutput>> = new WeakMap();
+
+export function generateFromAST(
+  asset: CommittedAsset | UncommittedAsset,
+): Promise<GenerateOutput> {
+  let output = generateResults.get(asset.value);
+  if (output == null) {
+    output = _generateFromAST(asset);
+    generateResults.set(asset.value, output);
+  }
+  return output;
+}
+
+async function _generateFromAST(asset: CommittedAsset | UncommittedAsset) {
+  let ast = await asset.getAST();
+  if (ast == null) {
+    throw new Error('Asset has no AST');
+  }
+
+  let pluginName = nullthrows(asset.value.plugin);
+  let plugin: Transformer = await loadPlugin(
+    asset.options.packageManager,
+    pluginName,
+    nullthrows(asset.value.configPath),
+  );
+  if (!plugin.generate) {
+    throw new Error(`${pluginName} does not have a generate method`);
+  }
+
+  let {code, map} = await plugin.generate({
+    asset: new PublicAsset(asset),
+    ast,
+    options: new PluginOptions(asset.options),
+    logger: new PluginLogger({origin: pluginName}),
+  });
+
+  let mapBuffer = map?.toBuffer();
+  // Store the results in the cache so we can avoid generating again next time
+  await Promise.all([
+    asset.options.cache.setStream(
+      nullthrows(asset.value.contentKey),
+      blobToStream(code),
+    ),
+    mapBuffer != null &&
+      asset.options.cache.setBlob(nullthrows(asset.value.mapKey), mapBuffer),
+  ]);
+
+  return {
+    code:
+      code instanceof Readable
+        ? asset.options.cache.getStream(nullthrows(asset.value.contentKey))
+        : code,
+    map,
+  };
+}
+
+export async function getConfig(
+  asset: CommittedAsset | UncommittedAsset,
+  filePaths: Array<FilePath>,
+  options: ?{|
+    packageKey?: string,
+    parse?: boolean,
+  |},
+): Promise<ConfigResult | null> {
+  let packageKey = options?.packageKey;
+  let parse = options && options.parse;
+
+  if (packageKey != null) {
+    let pkg = await asset.getPackage();
+    if (pkg && pkg[packageKey]) {
+      return pkg[packageKey];
+    }
+  }
+
+  let conf = await loadConfig(
+    asset.options.inputFS,
+    asset.value.filePath,
+    filePaths,
+    parse == null ? null : {parse},
+  );
+  if (!conf) {
+    return null;
+  }
+
+  return conf;
+}

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -19,7 +19,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {DefaultWeakMap} from '@parcel/utils';
 
-import {assetToInternalAsset, assetFromValue} from './Asset';
+import {assetToAssetValue, assetFromValue} from './Asset';
 import {mapVisitor} from '../Graph';
 import Environment from './Environment';
 import Dependency from './Dependency';
@@ -120,7 +120,7 @@ export class Bundle implements IBundle {
   hasAsset(asset: IAsset): boolean {
     return this.#bundleGraph.bundleHasAsset(
       this.#bundle,
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
     );
   }
 

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -17,7 +17,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {DefaultWeakMap} from '@parcel/utils';
 
-import {assetFromValue, assetToInternalAsset, Asset} from './Asset';
+import {assetFromValue, assetToAssetValue, Asset} from './Asset';
 import {Bundle, bundleToInternalBundle} from './Bundle';
 import Dependency, {dependencyToInternalDependency} from './Dependency';
 import {mapVisitor} from '../Graph';
@@ -66,7 +66,7 @@ export default class BundleGraph implements IBundleGraph {
 
   getIncomingDependencies(asset: IAsset): Array<IDependency> {
     return this.#graph
-      .getIncomingDependencies(assetToInternalAsset(asset).value)
+      .getIncomingDependencies(assetToAssetValue(asset))
       .map(dep => new Dependency(dep));
   }
 
@@ -115,7 +115,7 @@ export default class BundleGraph implements IBundleGraph {
 
   getDependencies(asset: IAsset): Array<IDependency> {
     return this.#graph
-      .getDependencies(assetToInternalAsset(asset).value)
+      .getDependencies(assetToAssetValue(asset))
       .map(dep => new Dependency(dep));
   }
 
@@ -124,17 +124,17 @@ export default class BundleGraph implements IBundleGraph {
     invariant(internalNode != null && internalNode.type === 'bundle');
     return this.#graph.isAssetInAncestorBundles(
       internalNode.value,
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
     );
   }
 
   isAssetReferenced(asset: IAsset): boolean {
-    return this.#graph.isAssetReferenced(assetToInternalAsset(asset).value);
+    return this.#graph.isAssetReferenced(assetToAssetValue(asset));
   }
 
   isAssetReferencedByAnotherBundleOfType(asset: IAsset, type: string): boolean {
     return this.#graph.isAssetReferencedByAnotherBundleOfType(
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
       type,
     );
   }
@@ -171,10 +171,7 @@ export default class BundleGraph implements IBundleGraph {
   }
 
   resolveSymbol(asset: IAsset, symbol: Symbol): SymbolResolution {
-    let res = this.#graph.resolveSymbol(
-      assetToInternalAsset(asset).value,
-      symbol,
-    );
+    let res = this.#graph.resolveSymbol(assetToAssetValue(asset), symbol);
     return {
       asset: assetFromValue(res.asset, this.#options),
       exportSymbol: res.exportSymbol,
@@ -183,7 +180,7 @@ export default class BundleGraph implements IBundleGraph {
   }
 
   getExportedSymbols(asset: IAsset): Array<SymbolResolution> {
-    let res = this.#graph.getExportedSymbols(assetToInternalAsset(asset).value);
+    let res = this.#graph.getExportedSymbols(assetToAssetValue(asset));
     return res.map(e => ({
       asset: assetFromValue(e.asset, this.#options),
       exportSymbol: e.exportSymbol,
@@ -206,7 +203,7 @@ export default class BundleGraph implements IBundleGraph {
 
   findBundlesWithAsset(asset: IAsset): Array<IBundle> {
     return this.#graph
-      .findBundlesWithAsset(assetToInternalAsset(asset).value)
+      .findBundlesWithAsset(assetToAssetValue(asset))
       .map(bundle => new Bundle(bundle, this.#graph, this.#options));
   }
 }

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -19,7 +19,7 @@ import {DefaultWeakMap, md5FromString} from '@parcel/utils';
 import InternalBundleGraph from '../BundleGraph';
 import {Bundle, bundleToInternalBundle} from './Bundle';
 import {mapVisitor, ALL_EDGE_TYPES} from '../Graph';
-import {assetFromValue, assetToInternalAsset} from './Asset';
+import {assetFromValue, assetToAssetValue} from './Asset';
 import {getBundleGroupId} from '../utils';
 import Dependency, {dependencyToInternalDependency} from './Dependency';
 import {environmentToInternalEnvironment} from './Environment';
@@ -52,7 +52,7 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
 
   addAssetGraphToBundle(asset: IAsset, bundle: IBundle) {
     this.#graph.addAssetGraphToBundle(
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
       bundleToInternalBundle(bundle),
     );
   }
@@ -115,13 +115,13 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
 
   createBundle(opts: CreateBundleOpts): Bundle {
     let entryAsset = opts.entryAsset
-      ? assetToInternalAsset(opts.entryAsset)
+      ? assetToAssetValue(opts.entryAsset)
       : null;
 
     let target = targetToInternalTarget(opts.target);
     let bundleId = md5FromString(
       'bundle:' +
-        (opts.uniqueKey ?? nullthrows(entryAsset?.value.id)) +
+        (opts.uniqueKey ?? nullthrows(entryAsset?.id)) +
         target.distDir,
     );
     let bundleNode = {
@@ -130,16 +130,16 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
       value: {
         id: bundleId,
         hashReference: HASH_REF_PREFIX + bundleId,
-        type: opts.type ?? nullthrows(entryAsset).value.type,
+        type: opts.type ?? nullthrows(entryAsset).type,
         env: opts.env
           ? environmentToInternalEnvironment(opts.env)
-          : nullthrows(entryAsset).value.env,
-        entryAssetIds: entryAsset ? [entryAsset.value.id] : [],
-        pipeline: entryAsset ? entryAsset.value.pipeline : null,
+          : nullthrows(entryAsset).env,
+        entryAssetIds: entryAsset ? [entryAsset.id] : [],
+        pipeline: entryAsset ? entryAsset.pipeline : null,
         filePath: null,
         isEntry: opts.isEntry,
         isInline: opts.isInline,
-        isSplittable: opts.isSplittable ?? entryAsset?.value.isSplittable,
+        isSplittable: opts.isSplittable ?? entryAsset?.isSplittable,
         target,
         name: null,
         displayName: null,
@@ -170,7 +170,7 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
   createAssetReference(dependency: IDependency, asset: IAsset): void {
     return this.#graph.createAssetReference(
       dependencyToInternalDependency(dependency),
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
     );
   }
 
@@ -213,7 +213,7 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
 
   findBundlesWithAsset(asset: IAsset): Array<IBundle> {
     return this.#graph
-      .findBundlesWithAsset(assetToInternalAsset(asset).value)
+      .findBundlesWithAsset(assetToAssetValue(asset))
       .map(bundle => new Bundle(bundle, this.#graph, this.#options));
   }
 
@@ -230,19 +230,19 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
   }
 
   getTotalSize(asset: IAsset): number {
-    return this.#graph.getTotalSize(assetToInternalAsset(asset).value);
+    return this.#graph.getTotalSize(assetToAssetValue(asset));
   }
 
   isAssetInAncestorBundles(bundle: IBundle, asset: IAsset): boolean {
     return this.#graph.isAssetInAncestorBundles(
       bundleToInternalBundle(bundle),
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
     );
   }
 
   removeAssetGraphFromBundle(asset: IAsset, bundle: IBundle) {
     this.#graph.removeAssetGraphFromBundle(
-      assetToInternalAsset(asset).value,
+      assetToAssetValue(asset),
       bundleToInternalBundle(bundle),
     );
   }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -100,6 +100,7 @@ export type Dependency = {|
 
 export type Asset = {|
   id: string,
+  committed: boolean,
   hash: ?string,
   filePath: FilePath,
   type: string,
@@ -120,9 +121,9 @@ export type Asset = {|
   astGenerator: ?ASTGenerator,
   symbols: Map<Symbol, Symbol>,
   sideEffects: boolean,
-  uniqueKey?: ?string,
+  uniqueKey: ?string,
   configPath?: FilePath,
-  plugin?: ?PackageName,
+  plugin: ?PackageName,
 |};
 
 export type ParcelOptions = {|

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -7,7 +7,7 @@ import AssetGraph, {
   nodeFromEntryFile,
 } from '../src/AssetGraph';
 import {createDependency} from '../src/Dependency';
-import {createAsset} from '../src/InternalAsset';
+import {createAsset} from '../src/assetUtils';
 import {createEnvironment} from '../src/Environment';
 
 const DEFAULT_ENV = createEnvironment({

--- a/packages/core/core/test/InternalAsset.test.js
+++ b/packages/core/core/test/InternalAsset.test.js
@@ -1,7 +1,8 @@
 // @flow strict-local
 
 import assert from 'assert';
-import Asset, {createAsset} from '../src/InternalAsset';
+import UncommittedAsset from '../src/UncommittedAsset';
+import {createAsset} from '../src/assetUtils';
 import {createEnvironment} from '../src/Environment';
 import {DEFAULT_OPTIONS} from './utils';
 
@@ -9,7 +10,7 @@ const stats = {time: 0, size: 0};
 
 describe('InternalAsset', () => {
   it('only includes connected files once per filePath', () => {
-    let asset = new Asset({
+    let asset = new UncommittedAsset({
       value: createAsset({
         filePath: '/foo/asset.js',
         env: createEnvironment(),
@@ -30,7 +31,7 @@ describe('InternalAsset', () => {
   });
 
   it('only includes dependencies once per id', () => {
-    let asset = new Asset({
+    let asset = new UncommittedAsset({
       value: createAsset({
         filePath: '/foo/asset.js',
         env: createEnvironment(),
@@ -49,7 +50,7 @@ describe('InternalAsset', () => {
   });
 
   it('includes different dependencies if their id differs', () => {
-    let asset = new Asset({
+    let asset = new UncommittedAsset({
       value: createAsset({
         filePath: '/foo/asset.js',
         env: createEnvironment(),

--- a/packages/core/core/test/PublicAsset.test.js
+++ b/packages/core/core/test/PublicAsset.test.js
@@ -2,14 +2,15 @@
 
 import assert from 'assert';
 import {Asset, MutableAsset} from '../src/public/Asset';
-import InternalAsset, {createAsset} from '../src/InternalAsset';
+import UncommittedAsset from '../src/UncommittedAsset';
+import {createAsset} from '../src/assetUtils';
 import {createEnvironment} from '../src/Environment';
 import {DEFAULT_OPTIONS} from './utils';
 
 describe('Public Asset', () => {
   let internalAsset;
   beforeEach(() => {
-    internalAsset = new InternalAsset({
+    internalAsset = new UncommittedAsset({
       options: DEFAULT_OPTIONS,
       value: createAsset({
         filePath: '/does/not/exist',

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -24,6 +24,7 @@
     "@babel/plugin-transform-typescript": "^7.4.5",
     "@babel/preset-env": "^7.0.0",
     "@babel/traverse": "^7.0.0",
+    "@parcel/babel-ast-utils": "^2.0.0-alpha.3.1",
     "@parcel/babel-preset-env": "^2.0.0-alpha.3.1",
     "@parcel/plugin": "^2.0.0-alpha.3.1",
     "@parcel/utils": "^2.0.0-alpha.3.1",

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -25,8 +25,6 @@ export default async function babel7(
         range: BABEL_RANGE,
       });
 
-  let sourceFilename: string = relativeUrl(options.projectRoot, asset.filePath);
-
   let config = {
     ...babelOptions.config,
     plugins: additionalPlugins.concat(babelOptions.config.plugins),
@@ -37,7 +35,7 @@ export default async function babel7(
     configFile: false,
     parserOpts: {
       ...babelOptions.config.parserOpts,
-      sourceFilename,
+      sourceFilename: relativeUrl(options.projectRoot, asset.filePath),
       allowReturnOutsideFunction: true,
       strictMode: false,
       sourceType: 'module',
@@ -51,13 +49,15 @@ export default async function babel7(
   };
 
   let ast = await asset.getAST();
-  let code = await asset.getCode();
-
   let res;
   if (ast) {
-    res = babel.transformFromAstSync(ast.program, code, config);
+    res = await babel.transformFromAstAsync(
+      ast.program,
+      asset.isASTDirty() ? undefined : await asset.getCode(),
+      config,
+    );
   } else {
-    res = babel.transformSync(code, config);
+    res = await babel.transformAsync(await asset.getCode(), config);
   }
 
   if (res.ast) {


### PR DESCRIPTION
This is a followup based on my experience implementing parts of #3695, and also integrates some feedback from that PR.

This splits `InternalAsset` into `UncommittedAsset` and `CommittedAsset`. The former implements a mutable interface for transformers, only holding into values in memory (with the exception of generation), and the latter implements an immutable interface that loads content from disk and caches it in memory.

Previously, `InternalAsset` implemented both, in some situations branching on the state. This also allows for simpler implementations in each case. Common code was extracted into `assetUtils.js` in the same directory.

This also cleans up `babel7.js` to safely use `getAST()` and moves it to use the `Async` methods as we don't require synchronous behavior.

Test Plan: `yarn test`