### PR TITLE
Upgrade to flow 0.121.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -37,4 +37,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.120.1
+0.121.0

--- a/flow-libs/posthtml.js.flow
+++ b/flow-libs/posthtml.js.flow
@@ -9,8 +9,7 @@
 declare module 'posthtml' {
   declare type PostHTMLNode = {
     tag: string,
-    // $FlowFixMe
-    attrs?: { [string]: string, ... },
+    attrs?: {[string]: string, ...},
     content?: Array<string>,
     ...
   };
@@ -30,7 +29,7 @@ declare module 'posthtml' {
   declare var walk: (fn: (node: PostHTMLNode) => PostHTMLNode) => void;
   declare var process: (
     tree: PostHTMLTree | string,
-    options: ?PostHTMLOptions
+    options: ?PostHTMLOptions,
   ) => Promise<{
     html: string,
     tree: PostHTMLTree,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "cross-env": "^7.0.0",
     "doctoc": "^1.4.0",
     "eslint": "^6.0.0",
-    "flow-bin": "0.120.1",
+    "flow-bin": "0.121.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "lerna": "^3.3.2",

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -100,7 +100,9 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
 
   // $FlowFixMe
   static deserialize(opts: SerializedAssetGraph): AssetGraph {
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
     let res = new AssetGraph(opts);
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
     res.incompleteNodeIds = opts.incompleteNodeIds;
     res.hash = opts.hash;
     return res;
@@ -108,6 +110,7 @@ export default class AssetGraph extends Graph<AssetGraphNode> {
 
   // $FlowFixMe
   serialize(): SerializedAssetGraph {
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
     return {
       ...super.serialize(),
       incompleteNodeIds: this.incompleteNodeIds,

--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -243,6 +243,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     }
 
     dumpToGraphViz(this.assetGraph, 'AssetGraph');
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
     dumpToGraphViz(this.requestGraph, 'RequestGraph');
 
     let changedAssets = this.changedAssets;

--- a/packages/core/core/src/InternalAsset.js
+++ b/packages/core/core/src/InternalAsset.js
@@ -442,7 +442,6 @@ export default class InternalAsset {
         includedFiles: new Map(this.value.includedFiles),
         meta: {
           ...this.value.meta,
-          // $FlowFixMe
           ...result.meta,
         },
         pipeline:

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -260,7 +260,9 @@ export default class Parcel {
       );
       dumpGraphToGraphViz(assetGraph, 'MainAssetGraph');
 
+      // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
       let bundleGraph = await this.#bundlerRunner.bundle(assetGraph, {signal});
+      // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381 (Windows only)
       dumpGraphToGraphViz(bundleGraph._graph, 'BundleGraph');
 
       await this.#packagerRunner.writeBundles(bundleGraph);

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -72,12 +72,13 @@ export class RequestGraph extends Graph<
 
   // $FlowFixMe
   static deserialize(opts: SerializedRequestGraph) {
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
     let deserialized = new RequestGraph(opts);
     deserialized.invalidNodeIds = opts.invalidNodeIds;
     deserialized.incompleteNodeIds = opts.incompleteNodeIds;
     deserialized.globNodeIds = opts.globNodeIds;
     deserialized.unpredicatableNodeIds = opts.unpredicatableNodeIds;
-    // $FlowFixMe
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381 (Windows only)
     return deserialized;
   }
 

--- a/packages/core/core/src/loadDotEnv.js
+++ b/packages/core/core/src/loadDotEnv.js
@@ -46,6 +46,5 @@ export default async function loadEnv(
     }),
   );
 
-  // $FlowFixMe
   return Object.assign({}, ...envs);
 }

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -82,7 +82,6 @@ function processPipeline(
   filePath: FilePath,
 ): any {
   if (pipeline) {
-    // $FlowFixMe
     return pipeline.map(pkg => {
       if (pkg === '...') return pkg;
 

--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -157,7 +157,6 @@ export default class Environment implements IEnvironment {
       let withoutMinBrowsers = browserslist([...browsers, ...minBrowsers]);
       return matchedBrowsers.length === withoutMinBrowsers.length;
     } else if (this.isNode() && this.engines.node != null && minVersions.node) {
-      // $FlowFixMe
       return !semver.intersects(`< ${minVersions.node}`, this.engines.node);
     }
 

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -72,7 +72,6 @@ export default async function resolveOptions(
       initialOptions.patchConsole ?? process.env.NODE_ENV !== 'test',
     env: {
       ...initialOptions.env,
-      // $FlowFixMe
       ...(await loadDotEnv(
         initialOptions.env ?? {},
         inputFS,

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -48,7 +48,6 @@ export function runTransform(
   return new Transformation({
     workerApi,
     report: reportWorker.bind(null, workerApi),
-    // $FlowFixMe
     options,
     config,
     ...rest,
@@ -70,7 +69,6 @@ export function runValidate(workerApi: WorkerApi, opts: WorkerValidationOpts) {
   return new Validation({
     workerApi,
     report: reportWorker.bind(null, workerApi),
-    // $FlowFixMe
     options,
     config,
     ...rest,
@@ -111,7 +109,6 @@ export function runPackage(
 
   return new PackagerRunner({
     config,
-    // $FlowFixMe
     options,
     report: reportWorker.bind(null, workerApi),
   }).getBundleInfo(bundle, bundleGraph, cacheKeys);

--- a/packages/core/core/test/loadParcelConfig.test.js
+++ b/packages/core/core/test/loadParcelConfig.test.js
@@ -83,9 +83,9 @@ describe('loadParcelConfig', () => {
     it('should require pipeline to be an array', () => {
       assert.throws(() => {
         validateConfigFile(
+          // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
           {
             filePath: '.parcelrc',
-            // $FlowFixMe
             resolvers: '123',
           },
           '.parcelrc',
@@ -111,7 +111,6 @@ describe('loadParcelConfig', () => {
         validateConfigFile(
           {
             filePath: '.parcelrc',
-            // $FlowFixMe
             resolvers: ['parcel-foo-bar'],
           },
           '.parcelrc',
@@ -123,7 +122,6 @@ describe('loadParcelConfig', () => {
       validateConfigFile(
         {
           filePath: '.parcelrc',
-          // $FlowFixMe
           resolvers: ['parcel-resolver-test'],
         },
         '.parcelrc',
@@ -134,7 +132,6 @@ describe('loadParcelConfig', () => {
       validateConfigFile(
         {
           filePath: '.parcelrc',
-          // $FlowFixMe
           resolvers: ['parcel-resolver-test', '...'],
         },
         '.parcelrc',
@@ -172,9 +169,9 @@ describe('loadParcelConfig', () => {
     it('should require extends to be a string or array of strings', () => {
       assert.throws(() => {
         validateConfigFile(
+          // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
           {
             filePath: '.parcelrc',
-            // $FlowFixMe
             extends: 2,
           },
           '.parcelrc',

--- a/packages/core/logger/src/Logger.js
+++ b/packages/core/logger/src/Logger.js
@@ -47,7 +47,6 @@ class Logger {
   }
 
   error(input: Diagnostifiable, realOrigin?: string): void {
-    // $FlowFixMe origin is undefined on PluginInputDiagnostic
     let diagnostic = anyToDiagnostic(input);
     if (typeof realOrigin === 'string') {
       diagnostic = Array.isArray(diagnostic)
@@ -130,7 +129,6 @@ export class PluginLogger {
       | DiagnosticWithoutOrigin
       | Array<DiagnosticWithoutOrigin>,
   ): void {
-    // $FlowFixMe it should work, don't really wanna mess with the types of logger.error though...
     logger.error(input, this.origin);
   }
 

--- a/packages/core/utils/src/glob.js
+++ b/packages/core/utils/src/glob.js
@@ -66,5 +66,6 @@ export function glob(
     },
   };
 
+  // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
   return fastGlob(normalizePath(p), options);
 }

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -287,7 +287,6 @@ export default class WorkerFarm extends EventEmitter {
       }
     } else {
       // ESModule default interop
-      // $FlowFixMe
       if (mod.__esModule && !mod[method] && mod.default) {
         mod = mod.default;
       }

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -189,6 +189,7 @@ export class Child {
       ...request,
       type: 'request',
       child: this.childId,
+      // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
       awaitResponse,
       resolve: () => {},
       reject: () => {},

--- a/packages/core/workers/src/cpuCount.js
+++ b/packages/core/workers/src/cpuCount.js
@@ -38,7 +38,6 @@ export function detectRealCores(): number {
 let cores;
 export default function getCores(bypassCache?: boolean = false) {
   // Do not re-run commands if we already have the count...
-  // $FlowFixMe
   if (cores && !bypassCache) {
     return cores;
   }

--- a/packages/optimizers/cssnano/src/CSSNanoOptimizer.js
+++ b/packages/optimizers/cssnano/src/CSSNanoOptimizer.js
@@ -1,7 +1,6 @@
 // @flow strict-local
 
 import {Optimizer} from '@parcel/plugin';
-// $FlowFixMe this is untyped
 import postcss from 'postcss';
 // $FlowFixMe this is untyped
 import cssnano from 'cssnano';

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -40,7 +40,6 @@ export default new Packager({
     return replaceInlineReferences({
       bundle,
       bundleGraph,
-      // $FlowFixMe
       contents: replaceURLReferences({
         bundle,
         bundleGraph,

--- a/packages/transformers/babel/src/BabelTransformer.js
+++ b/packages/transformers/babel/src/BabelTransformer.js
@@ -31,7 +31,6 @@ export default new Transformer({
           asset.meta.babelPlugins != null &&
           Array.isArray(asset.meta.babelPlugins)
         ) {
-          // $FlowFixMe
           await babel7(asset, options, config, asset.meta.babelPlugins);
         } else {
           await babel7(asset, options, config);

--- a/packages/transformers/html/src/inline.js
+++ b/packages/transformers/html/src/inline.js
@@ -59,6 +59,7 @@ export default function extractInlineAssets(
         }
 
         if (!node.attrs) {
+          // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
           node.attrs = {};
         }
 
@@ -108,6 +109,7 @@ export default function extractInlineAssets(
 
       parts.push({
         type: 'css',
+        // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
         code: node.attrs.style,
         uniqueKey: parcelKey,
         isIsolated: true,

--- a/packages/transformers/js/src/visitors/fs.js
+++ b/packages/transformers/js/src/visitors/fs.js
@@ -63,7 +63,6 @@ export default ({
         filename = Path.resolve(filename);
         res = fs.readFileSync(filename, ...args);
       } catch (_err) {
-        // $FlowFixMe yes it is an error
         let err: Error = _err;
 
         if (err instanceof NodeNotEvaluatedError) {
@@ -78,6 +77,7 @@ export default ({
         }
 
         // Add location info so we log a code frame with the error
+        // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
         err.loc =
           path.node.arguments.length > 0
             ? path.node.arguments[0].loc?.start

--- a/packages/transformers/postcss/src/PostCSSTransformer.js
+++ b/packages/transformers/postcss/src/PostCSSTransformer.js
@@ -145,6 +145,7 @@ export default new Transformer({
       });
     }
 
+    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
     let {messages, root} = await postcss(config.plugins).process(
       ast.program,
       config,
@@ -157,7 +158,6 @@ export default new Transformer({
     });
     for (let msg of messages) {
       if (msg.type === 'dependency') {
-        // $FlowFixMe merely a convention
         msg = (msg: {|
           type: 'dependency',
           plugin: string,

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -658,7 +658,6 @@ export default class NodeResolver {
 
         return {
           field,
-          // $FlowFixMe
           filename: pkg[field],
         };
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6034,10 +6034,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@0.120.1:
-  version "0.120.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.120.1.tgz#ab051d6df71829b70a26a2c90bb81f9d43797cae"
-  integrity sha512-KgE+d+rKzdXzhweYVJty1QIOOZTTbtnXZf+4SLnmArLvmdfeLreQOZpeLbtq5h79m7HhDzX/HkUkoyu/fmSC2A==
+flow-bin@0.121.0:
+  version "0.121.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.121.0.tgz#e206bdc3d510277f9a847920540f72c49e87c130"
+  integrity sha512-QYRMs+AoMLj/OTaSo9+8c3kzM/u8YgvfrInp0qzhtzC02Sc2jb3BV/QZWZGjPo+XK3twyyqXrcI3s8MuL1UQRg==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This:
* [x] Upgrades Flow to 0.121.0
* [x] Removes unnecessary Flow suppression comments with `flow/tool remove-comments --bin node_modules/.bin/flow --check status .`
* [x] Adds new Flow suppressions in primary locations with `flow/tool add-comments --all --bin node_modules/.bin/flow --check status --comment "\$FlowFixMe Added in Flow 0.121.0 upgrade in #4381" .`

Flow [now only respects the "primary location" for an error suppression](https://medium.com/flow-type/making-flow-error-suppressions-more-specific-280aa4e3c95c), so any suppressions that no longer apply were removed, and new ones were added.

~~This required a small modification to flowtool as~~ I had to first manually remove an unused suppression in `flow-libs/posthtml.js.flow` as there seems to be a bug where filenames include the string `"[LIB]"`: https://github.com/facebook/flow/issues/8334

Test Plan: `yarn flow check`