### PR TITLE
Atomic writes: rename on close, not finish

### DIFF
--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -44,7 +44,7 @@ export class NodeFS implements FileSystem {
   createWriteStream(filePath: string, options: any): WriteStream {
     let tmpFilePath = getTempFilePath(filePath);
     let stream = fs.createWriteStream(tmpFilePath, options);
-    stream.on('finish', () => fs.renameSync(tmpFilePath, filePath));
+    stream.on('close', () => fs.renameSync(tmpFilePath, filePath));
     return stream;
   }
 

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2127,9 +2127,6 @@ describe('javascript', function() {
   it('should inline binary content as url-encoded base64 and mime type with `data-url:*` imports', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/data-url/binary.js'),
-      {
-        outputFS: inputFS,
-      },
     );
 
     assert((await run(b)).default.startsWith('data:image/webp;base64,UklGR'));


### PR DESCRIPTION
Closes #4382, which doesn't seem to have been the issue. We're probably attempting to rename the file while the file descriptor is still used by the write stream. The `'close'` event on `fs.WriteStream` is emitted after the file descriptor is released, as opposed to simply the `'finish'` event on a `Writable`.

Test Plan: `yarn test` locally and verify CI passes on Windows in Azure.