### PR TITLE
Scope hoisting: async bundles named-importing a re-exported namespace

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/async.js
@@ -1,0 +1,3 @@
+import {ns, ns2} from './reexports';
+
+export default [ns.foo, ns2.foo];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/index.js
@@ -1,0 +1,3 @@
+import {ns, ns2} from './reexports';
+
+export default import('./async').then(mod => [ns.foo, ns2.foo].concat(mod.default));

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/ns.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/ns.js
@@ -1,0 +1,1 @@
+export const foo = 42;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/reexports.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/reexports.js
@@ -1,0 +1,4 @@
+import * as ns from './ns';
+
+export {ns};
+export * as ns2 from './ns';

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1889,4 +1889,15 @@ describe('scope hoisting', function() {
       global: true,
     });
   });
+
+  it('should be able to named import a reexported namespace in an async bundle', async function() {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/scope-hoisting/es6/async-named-import-ns-reexport/index.js',
+      ),
+    );
+
+    assert.deepEqual(await (await run(b)).default, [42, 42, 42, 42]);
+  });
 });

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -153,7 +153,7 @@ export function link({
     // If the module is not in this bundle, create a `require` call for it.
     if (!node && (!mod.meta.id || !assets.has(assertString(mod.meta.id)))) {
       node = addBundleImport(originalModule, path);
-      return node ? interop(originalModule, symbol, path, node) : null;
+      return node ? interop(originalModule, originalName, path, node) : null;
     }
 
     // If this is an ES6 module, throw an error if we cannot resolve the module


### PR DESCRIPTION
When both a parent and child bundle named-import from module that re-exports another module as a namespace, only the parent bundle gets the correct references to values in that namespace. References to the namespace object (a reference of `ns` whose value should be `{foo: 42}`) are rewritten to be the entire exports object of the re-exporter (`{ns: {foo: 42}}`). This is probably better explained by the test.

This PR currently only implements the test for this issue. @mischnic, do you have any insight into how this could be solved?

Test Plan: `yarn test` (currently fails)