### PR TITLE
Don't exclude assets that were imported with a namespace

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -569,7 +569,8 @@ export default class BundleGraph {
       // If this module exports wildcards, resolve the original module.
       // Default exports are excluded from wildcard exports.
       if (dep.symbols.get('*') === '*' && symbol !== 'default') {
-        let resolved = nullthrows(this.getDependencyResolution(dep));
+        let resolved = this.getDependencyResolution(dep);
+        if (!resolved) continue;
         let result = this.resolveSymbol(resolved, symbol);
         if (result.symbol != null) {
           return {
@@ -594,7 +595,8 @@ export default class BundleGraph {
     let deps = this.getDependencies(asset);
     for (let dep of deps) {
       if (dep.symbols.get('*') === '*') {
-        let resolved = nullthrows(this.getDependencyResolution(dep));
+        let resolved = this.getDependencyResolution(dep);
+        if (!resolved) continue;
         let exported = this.getExportedSymbols(resolved).filter(
           s => s.exportSymbol !== 'default',
         );

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -33,7 +33,6 @@
     "lodash": "^4.17.15",
     "marked": "^0.6.1",
     "ncp": "^2.0.0",
-    "nyc": "^11.1.0",
     "parcel": "^2.0.0-alpha.3.2",
     "parcel-bundler": "^2.0.0-alpha.3.1",
     "postcss-custom-properties": "^8.0.9",

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/a.js
@@ -1,0 +1,3 @@
+import * as all from './b';
+
+output = all;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/b.js
@@ -1,0 +1,3 @@
+export * from './c';
+
+export const foo = 1;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/c.js
@@ -1,0 +1,4 @@
+Object.defineProperty(module.exports, "__esModule", { value: true });
+
+module.exports.default = 2;
+module.exports.bar = 3;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/a.js
@@ -1,0 +1,3 @@
+import * as lodash from "./b";
+
+output = lodash.add(10,2);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/b.js
@@ -1,0 +1,1 @@
+export * from "lodash";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/package.json
@@ -1,0 +1,8 @@
+{
+    "default": "build.js",
+    "targets": {
+        "default": {
+            "context": "node"
+        }
+    }
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/package.json
@@ -1,5 +1,5 @@
 {
-    "default": "build.js",
+    "default": "dist/index.js",
     "targets": {
         "default": {
             "context": "node"

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/index.js
@@ -1,0 +1,3 @@
+import * as lib from "./other";
+
+output = lib;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/exports.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/exports.js
@@ -1,0 +1,2 @@
+export { a } from "./version";
+export { b } from "./version2";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/index.js
@@ -1,0 +1,3 @@
+export * from "./exports";
+
+export const Main = "main";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"private": true,
+	"sideEffects": false
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/version.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/version.js
@@ -1,0 +1,1 @@
+export var a = "foo";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/version2.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-sideEffects/other/version2.js
@@ -1,0 +1,1 @@
+export var b = "bar";

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -163,7 +163,7 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 12);
     });
 
-    it('supports namespace imports of excluded reexporting assets (sideEffects: false)', async function() {
+    it('supports namespace imports of theoretically excluded reexporting assets (sideEffects: false)', async function() {
       let b = await bundle(
         path.join(
           __dirname,

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -629,14 +629,15 @@ describe('scope hoisting', function() {
           '/integration/scope-hoisting/es6/side-effects-false-wildcards/a.js',
         ),
       );
-      let called = false;
+      // let called = false;
       let output = await run(b, {
         sideEffect: () => {
-          called = true;
+          // called = true;
         },
       });
 
-      assert(!called, 'side effect called');
+      // TODO (from PR #4385) - maybe comply to this once we have better symbol information?
+      //assert(!called, 'side effect called');
       assert.deepEqual(output, 'bar');
     });
 

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -137,6 +137,44 @@ describe('scope hoisting', function() {
       assert.equal(output, 2);
     });
 
+    it('supports namespace imports of excluded assets (node_modules)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-namespace-external/a.js',
+        ),
+      );
+
+      let contents = await outputFS.readFile(
+        b.getBundles()[0].filePath,
+        'utf8',
+      );
+
+      assert(contents.includes('require("lodash")'));
+
+      let match = contents.match(
+        /\$parcel\$exportWildcard\((\$[a-f0-9]+\$exports), _lodash\);/,
+      );
+      assert(match);
+      let [, id] = match;
+      assert(contents.includes(`output = ${id}.add(10, 2);`));
+
+      let output = await run(b);
+      assert.deepEqual(output, 12);
+    });
+
+    it('supports namespace imports of excluded reexporting assets (sideEffects: false)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-namespace-sideEffects/index.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, {Main: 'main', a: 'foo', b: 'bar'});
+    });
+
     it('supports re-exporting all exports from another module', async function() {
       let b = await bundle(
         path.join(
@@ -640,7 +678,7 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 6);
     });
 
-    it('supports the package.json sideEffects: false flag with shared dependencies', async function() {
+    it('supports the package.json sideEffects: false flag with shared dependencies and code splitting', async function() {
       let b = await bundle(
         path.join(
           __dirname,
@@ -692,6 +730,21 @@ describe('scope hoisting', function() {
 
       let output = await run(b);
       assert.deepEqual(await output, 1);
+    });
+
+    it('supports importing a namespace from a transpiled CommonJS module', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-namespace-commonjs-transpiled/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(await output, {
+        bar: 3,
+        foo: 1,
+      });
     });
 
     it('removes unused exports', async function() {


### PR DESCRIPTION
# ↪️ Pull Request

Supersedes https://github.com/parcel-bundler/parcel/pull/4220

Closes https://github.com/parcel-bundler/parcel/issues/4216

- Don't exclude assets that were imported with a namespace because they themselves might be needed

- This also fixes namespace reexports of excluded assets

We might be able to optimize this further in the future when we have better knowledge of symbols in the bundle graph (https://github.com/parcel-bundler/parcel/pull/4375)

## 💻 Examples

Doing a wildcard import of this (with `sideEffects: false`)
```js
export * from "./exports";

export const Main = "main";
```
would make `Main` disappear because the identifier of that very asset is missing an d was replaced with an empty object: `$parcel$exportWildcard(..., {})`.



cc @wbinnssmith 
