### PR TITLE
Fixup bailing out exports.symbol resolving when `exports` is used freely

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-entry.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-entry.js
@@ -1,0 +1,3 @@
+import {COMMENT_KEYS} from './exports-assign-imported';
+
+output = COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-imported.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-imported.js
@@ -1,0 +1,5 @@
+var t = exports;
+exports.COMMENT_KEYS = undefined;
+
+let v = "COMMENT_KEYS"
+exports[v] = 5;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-reexport-entry.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-reexport-entry.js
@@ -1,0 +1,3 @@
+import { COMMENT_KEYS, other } from "./exports-assign-reexport";
+
+output = [COMMENT_KEYS, other.COMMENT_KEYS];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-reexport.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-reexport.js
@@ -1,0 +1,2 @@
+export * from "./exports-assign";
+export * as other from "./exports-assign";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define-entry.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define-entry.js
@@ -1,0 +1,3 @@
+import {COMMENT_KEYS} from './exports-define-imported';
+
+output = COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define-imported.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define-imported.js
@@ -1,0 +1,7 @@
+exports.COMMENT_KEYS = undefined;
+
+Object.defineProperty(exports, "COMMENT_KEYS", {
+	get() {
+		return 5;
+	}
+});

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign-entry.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign-entry.js
@@ -1,0 +1,3 @@
+import {COMMENT_KEYS} from './module-exports-assign-imported';
+
+output = COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign-imported.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign-imported.js
@@ -1,0 +1,4 @@
+module.exports.COMMENT_KEYS = undefined;
+
+let v = "COMMENT_KEYS"
+module.exports[v] = 5;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define-entry.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define-entry.js
@@ -1,0 +1,3 @@
+import {COMMENT_KEYS} from './module-exports-define-imported';
+
+output = COMMENT_KEYS;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define-imported.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define-imported.js
@@ -1,0 +1,7 @@
+module.exports.COMMENT_KEYS = undefined;
+
+Object.defineProperty(module.exports, "COMMENT_KEYS", {
+	get() {
+		return 5;
+	}
+});

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1248,6 +1248,18 @@ describe('scope hoisting', function() {
       assert.equal(output, 5);
     });
 
+    it('bails out imported exports access resolving if it is accessed freely (exports reexport)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-reexport-entry.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, [5, 5]);
+    });
+
     it('builds commonjs modules that assigns to exports before module.exports', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1200,6 +1200,54 @@ describe('scope hoisting', function() {
       assert.equal(output, 5);
     });
 
+    it('bails out imported exports access resolving if it is accessed freely (exports assign)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/exports-assign-entry.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
+    it('bails out imported exports access resolving if it is accessed freely (exports define)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/exports-define-entry.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
+    it('bails out imported exports access resolving if it is accessed freely (module.exports assign)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-assign-entry.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
+    it('bails out imported exports access resolving if it is accessed freely (module.exports define)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/exports-access-bailout/module-exports-define-entry.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 5);
+    });
+
     it('builds commonjs modules that assigns to exports before module.exports', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -120,18 +120,18 @@ export function link({
   });
 
   function resolveSymbol(inputAsset, inputSymbol: Symbol) {
-    if (inputAsset.meta.resolveExportsBailedOut) {
-      return {
-        asset: inputAsset,
-        symbol: inputSymbol,
-        identifier: undefined,
-      };
-    }
-
     let {asset, exportSymbol, symbol} = bundleGraph.resolveSymbol(
       inputAsset,
       inputSymbol,
     );
+    if (asset.meta.resolveExportsBailedOut) {
+      return {
+        asset: asset,
+        symbol: exportSymbol,
+        identifier: undefined,
+      };
+    }
+
     let identifier = symbol;
 
     // If this is a wildcard import, resolve to the exports object.

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -120,6 +120,14 @@ export function link({
   });
 
   function resolveSymbol(inputAsset, inputSymbol: Symbol) {
+    if (inputAsset.meta.resolveExportsBailedOut) {
+      return {
+        asset: inputAsset,
+        symbol: inputSymbol,
+        identifier: undefined,
+      };
+    }
+
     let {asset, exportSymbol, symbol} = bundleGraph.resolveSymbol(
       inputAsset,
       inputSymbol,
@@ -144,8 +152,8 @@ export function link({
       originalModule,
       originalName,
     );
-    let node;
 
+    let node;
     if (identifier) {
       node = findSymbol(path, identifier);
     }

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -138,8 +138,8 @@ export function link({
     return {asset: asset, symbol: exportSymbol, identifier};
   }
 
-  // path is an Identifier that directly imports originalName from originalModule
-  function replaceExportNode(originalModule, originalName, path) {
+  // path is an Identifier like $id$import$foo that directly imports originalName from originalModule
+  function replaceImportNode(originalModule, originalName, path) {
     let {asset: mod, symbol, identifier} = resolveSymbol(
       originalModule,
       originalName,
@@ -549,7 +549,7 @@ export function link({
         }
 
         let asset = exportsMap.get(object.name);
-        if (!asset || asset.meta.resolveExportsBailedOut) {
+        if (!asset) {
           return;
         }
 
@@ -582,7 +582,7 @@ export function link({
           node = t.objectExpression([]);
         } else {
           let [asset, symbol] = imported;
-          node = replaceExportNode(asset, symbol, path);
+          node = replaceImportNode(asset, symbol, path);
 
           // If the export does not exist, replace with an empty object.
           if (!node) {


### PR DESCRIPTION
# ↪️ Pull Request

Tests by @wbinnssmith 

Put the check in a more central location where applies to the resolution of member expressions *and* import identifiers: