### PR TITLE
Add cli -ip option to generateCertificate() "altNames" alternative to 127.0.0.1

### DIFF
--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -127,6 +127,7 @@ console.log("Hello World");
     - [`--target [name]`](#--target-name)
     - [`--open, -o [browser]`](#--open--o-browser)
     - [`--host <host>`](#--host-host)
+    - [`--ip <ip>`](#--ip-ip)
     - [`--port <port>, -p`](#--port-port--p)
     - [`--https`](#--https)
       - [`--cert <path>`](#--cert-path)
@@ -297,6 +298,10 @@ browser you want to open, otherwise it will use your default browser.
 #### `--host <host>`
 
 Configure the host to serve assets on. The default is to listen on all interfaces.
+
+#### `--ip <ip>`
+
+Set the ip the certificate should match against, defaults to 127.0.0.1 (useful for local networks)
 
 #### `--port <port>, -p`
 

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "src/bin.js",
+  "bin": "lib/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "engines": {

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "lib/bin.js",
+  "bin": "src/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "engines": {

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -98,6 +98,10 @@ let serve = program
     'set the host to listen on, defaults to listening on all interfaces',
   )
   .option(
+    '--ip <ip>',
+    'set the ip the certificate should match against, defaults to 127.0.0.1 (useful for local networks)',
+  )
+  .option(
     '--open [browser]',
     'automatically open in specified browser, defaults to default browser',
   )
@@ -271,7 +275,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
 
   let serve = false;
   if (command.name() === 'serve') {
-    let {port = 1234, host, publicUrl} = command;
+    let {port = 1234, host, ip, publicUrl} = command;
     port = await getPort({port, host});
 
     if (command.port && port !== command.port) {
@@ -285,6 +289,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
       https,
       port,
       host,
+      ip,
       publicUrl,
     };
   }

--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -8,6 +8,7 @@ export default async function generateCertificate(
   fs: FileSystem,
   cacheDir: string,
   host: ?string,
+  ip: ?string,
 ) {
   let certDirectory = cacheDir;
 
@@ -71,7 +72,7 @@ export default async function generateCertificate(
     },
     {
       type: 7, // IP
-      ip: '127.0.0.1',
+      ip: ip ? ip : '127.0.0.1',
     },
   ];
 

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -18,6 +18,7 @@ type CreateHTTPServerOpts = {|
   cacheDir: FilePath,
   listener?: (mixed, mixed) => void,
   host?: string,
+  ip?: string,
 |};
 
 export type HTTPServer = HTTPOnlyServer | HTTPSServer;
@@ -39,6 +40,7 @@ export async function createHTTPServer(
         options.outputFS,
         options.cacheDir,
         options.host,
+        options.ip,
       ),
       options.listener,
     );


### PR DESCRIPTION
Related Issue: ([1746](https://github.com/parcel-bundler/parcel/issues/1746))

**Problem**
Self-signed Certificate always use 127.0.0.1 as its IP and there is no way to change it.

## 💻 Examples
Self-signed certificates work well for local machine development, it also work well for testing websites on iOS simulator, as its smart enough to understand 127.0.0.1 is its host IP, and it will trust the exported & installed certificate.

But devices on the same network aren't able to trust the certifcate even after manually installing it and trying to access the hostname "hostmachine.local" from bonjour. They resolve the host and load the page, but wont trust the certificate.

This PR is intended to add a -ip argument to the cli so it will override the hardcoded 127.0.0.1 when generating a self-signed certificate.

## ✔️ PR Todo
- [ ] Added/updated unit tests for this change
