### PR TITLE
Rename "code" to "content" in GenerateOutput, TransformerResult

### DIFF
--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -37,11 +37,11 @@ export default class CommittedAsset {
         return this.options.cache.getStream(this.value.contentKey);
       } else if (this.value.astKey != null) {
         return streamFromPromise(
-          generateFromAST(this).then(({code}) => {
-            if (!(code instanceof Readable)) {
-              this.content = Promise.resolve(code);
+          generateFromAST(this).then(({content}) => {
+            if (!(content instanceof Readable)) {
+              this.content = Promise.resolve(content);
             }
-            return code;
+            return content;
           }),
         );
       } else {

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -301,7 +301,7 @@ export default class Transformation {
           .map(async asset => {
             if (asset.isASTDirty) {
               let output = await generate(asset);
-              asset.content = output.code;
+              asset.content = output.content;
               asset.mapBuffer = output.map?.toBuffer();
             }
 
@@ -545,7 +545,7 @@ async function runTransformer(
     pipeline.generate
   ) {
     let output = await pipeline.generate(asset);
-    asset.content = output.code;
+    asset.content = output.content;
     asset.mapBuffer = output.map?.toBuffer();
   }
 
@@ -635,19 +635,19 @@ function normalizeAssets(
 
       let internalAsset = mutableAssetToUncommittedAsset(result);
       return {
-        type: result.type,
-        content: await internalAsset.content,
         ast: internalAsset.ast,
-        mapBuffer: internalAsset.mapBuffer,
+        content: await internalAsset.content,
         // $FlowFixMe
         dependencies: [...internalAsset.value.dependencies.values()],
+        env: internalAsset.value.env,
+        filePath: result.filePath,
         includedFiles: result.getIncludedFiles(),
-        // $FlowFixMe
-        env: result.env,
-        isIsolated: result.isIsolated,
         isInline: result.isInline,
-        pipeline: internalAsset.value.pipeline,
+        isIsolated: result.isIsolated,
+        map: internalAsset.map,
         meta: result.meta,
+        pipeline: internalAsset.value.pipeline,
+        type: result.type,
         uniqueKey: internalAsset.value.uniqueKey,
       };
     }),

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -264,7 +264,7 @@ export default class UncommittedAsset {
     plugin: PackageName,
     configPath: FilePath,
   ): UncommittedAsset {
-    let content = result.content ?? result.code ?? null;
+    let content = result.content ?? null;
 
     let asset = new UncommittedAsset({
       value: createAsset({

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -120,7 +120,7 @@ async function _generateFromAST(asset: CommittedAsset | UncommittedAsset) {
     throw new Error(`${pluginName} does not have a generate method`);
   }
 
-  let {code, map} = await plugin.generate({
+  let {content, map} = await plugin.generate({
     asset: new PublicAsset(asset),
     ast,
     options: new PluginOptions(asset.options),
@@ -132,17 +132,17 @@ async function _generateFromAST(asset: CommittedAsset | UncommittedAsset) {
   await Promise.all([
     asset.options.cache.setStream(
       nullthrows(asset.value.contentKey),
-      blobToStream(code),
+      blobToStream(content),
     ),
     mapBuffer != null &&
       asset.options.cache.setBlob(nullthrows(asset.value.mapKey), mapBuffer),
   ]);
 
   return {
-    code:
-      code instanceof Readable
+    content:
+      content instanceof Readable
         ? asset.options.cache.getStream(nullthrows(asset.value.contentKey))
-        : code,
+        : content,
     map,
   };
 }

--- a/packages/core/integration-tests/test/integration/custom-config/node_modules/parcel-transformer-mock/index.js
+++ b/packages/core/integration-tests/test/integration/custom-config/node_modules/parcel-transformer-mock/index.js
@@ -5,7 +5,7 @@ module.exports = new Transformer({
     return [
         {
           type: 'js',
-          code: 'TRANSFORMED CODE',
+          content: 'TRANSFORMED CODE',
         },
       ];
   }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -250,10 +250,7 @@ export type SourceLocation = {|
   |},
 |};
 
-export type Meta = {
-  [string]: JSONValue,
-  ...,
-};
+export type Meta = JSONObject;
 
 export type Symbol = string;
 
@@ -398,31 +395,31 @@ export type Stats = {|
 |};
 
 export type GenerateOutput = {|
-  +code: Blob,
+  +content: Blob,
   +map?: ?SourceMap,
 |};
 
 export type Blob = string | Buffer | Readable;
 
-export interface TransformerResult {
-  +type: string;
-  +code?: string;
-  +map?: ?SourceMap;
-  +content?: ?Blob;
-  +ast?: ?AST;
-  +dependencies?: $ReadOnlyArray<DependencyOptions>;
-  +includedFiles?: $ReadOnlyArray<File>;
-  +isIsolated?: boolean;
-  +isInline?: boolean;
-  +isSplittable?: boolean;
-  +isSource?: boolean;
-  +env?: EnvironmentOpts;
-  +meta?: Meta;
-  +pipeline?: ?string;
-  +symbols?: Map<Symbol, Symbol>;
-  +sideEffects?: boolean;
-  +uniqueKey?: ?string;
-}
+export type TransformerResult = {|
+  +ast?: ?AST,
+  +content?: ?Blob,
+  +dependencies?: $ReadOnlyArray<DependencyOptions>,
+  +env?: EnvironmentOpts,
+  +filePath?: FilePath,
+  +includedFiles?: $ReadOnlyArray<File>,
+  +isInline?: boolean,
+  +isIsolated?: boolean,
+  +isSource?: boolean,
+  +isSplittable?: boolean,
+  +map?: ?SourceMap,
+  +meta?: Meta,
+  +pipeline?: ?string,
+  +sideEffects?: boolean,
+  +symbols?: Map<Symbol, Symbol>,
+  +type: string,
+  +uniqueKey?: ?string,
+|};
 
 export type Async<T> = T | Promise<T>;
 

--- a/packages/shared/babel-ast-utils/src/index.js
+++ b/packages/shared/babel-ast-utils/src/index.js
@@ -59,7 +59,7 @@ export async function generate({
   }
 
   return {
-    code: generated.code,
+    content: generated.code,
     map,
   };
 }

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -198,7 +198,7 @@ export default new Transformer({
     });
 
     return {
-      code,
+      content: code,
     };
   },
 });

--- a/packages/transformers/html/src/HTMLTransformer.js
+++ b/packages/transformers/html/src/HTMLTransformer.js
@@ -33,7 +33,7 @@ export default new Transformer({
 
   generate({ast}) {
     return {
-      code: render(ast.program),
+      content: render(ast.program),
     };
   },
 });

--- a/packages/transformers/html/src/inline.js
+++ b/packages/transformers/html/src/inline.js
@@ -88,7 +88,7 @@ export default function extractInlineAssets(
 
         parts.push({
           type,
-          code: value,
+          content: value,
           uniqueKey: parcelKey,
           isIsolated: true,
           isInline: true,
@@ -102,15 +102,15 @@ export default function extractInlineAssets(
     }
 
     // Process inline style attributes.
-    if (node.attrs && node.attrs.style) {
+    let style = node.attrs?.style;
+    if (style != null) {
       asset.addDependency({
         moduleSpecifier: parcelKey,
       });
 
       parts.push({
         type: 'css',
-        // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
-        code: node.attrs.style,
+        content: style,
         uniqueKey: parcelKey,
         isIsolated: true,
         isInline: true,

--- a/packages/transformers/postcss/src/PostCSSTransformer.js
+++ b/packages/transformers/postcss/src/PostCSSTransformer.js
@@ -188,7 +188,7 @@ export default new Transformer({
       assets.push({
         type: 'js',
         filePath: asset.filePath + '.js',
-        code,
+        content: code,
       });
     }
     return assets;
@@ -201,7 +201,7 @@ export default new Transformer({
     });
 
     return {
-      code,
+      content: code,
     };
   },
 });

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -77,7 +77,7 @@ export default new Transformer({
 
   generate({ast}) {
     return {
-      code: render(ast.program),
+      content: render(ast.program),
     };
   },
 });

--- a/packages/transformers/typescript-tsc/src/TSCTransformer.js
+++ b/packages/transformers/typescript-tsc/src/TSCTransformer.js
@@ -40,7 +40,7 @@ export default new Transformer({
     return [
       {
         type: 'js',
-        code: transpiled.outputText,
+        content: transpiled.outputText,
       },
     ];
   },

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -147,7 +147,7 @@ export default new Transformer({
     return [
       {
         type: 'ts',
-        code,
+        content: code,
         map: sourceMap,
         includedFiles,
       },


### PR DESCRIPTION
This renames `code` to `content` in `GenerateOutput` and `TransformerResult`. This way, whenever `code` is referred to throughout Parcel (such as in `ResolveResult` and `RuntimeAsset`), it's a string, and whenever the main asset content or generated content is referred to, it's a blob named `content`.

This also makes `TransformerResult` a strict object type, which revealed a few bugs that were fixed as a result.

Test Plan: `yarn test`