### PR TITLE
Use uniqueKey for asset cache key

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -360,6 +360,7 @@ export default class Transformation {
     let assetsKeyInfo = assets.map(a => ({
       filePath: a.value.filePath,
       hash: a.value.hash,
+      uniqueKey: a.value.uniqueKey,
     }));
 
     return md5FromObject({

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -783,6 +783,35 @@ describe('html', function() {
     ]);
   });
 
+  it('should process inline element styles', async function() {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/html-inline-styles-element/index.html',
+      ),
+      {disableCache: false},
+    );
+
+    assertBundles(b, [
+      {
+        type: 'css',
+        assets: ['index.html'],
+      },
+      {
+        type: 'css',
+        assets: ['index.html'],
+      },
+      {
+        type: 'css',
+        assets: ['index.html'],
+      },
+      {
+        name: 'index.html',
+        assets: ['index.html'],
+      },
+    ]);
+  });
+
   it('should process inline styles using lang', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-inline-sass/index.html'),

--- a/packages/core/integration-tests/test/integration/html-inline-styles-element/index.html
+++ b/packages/core/integration-tests/test/integration/html-inline-styles-element/index.html
@@ -1,0 +1,3 @@
+<img src="http://example.com/img.png" style="margin-top: 5px;" />
+<img src="http://example.com/img.png" style="width: 120px;" />
+<span style="font-size: 25px;">REPL</span>


### PR DESCRIPTION
# ↪️ Pull Request

Closes #4367

(Inline) child assets seemed to actually have a cache collision, because `uniqueKey` (`Transformation#getCacheKey`) wasn't factored in and `hash` and `filePath` are inherited from the parent asset.