### PR TITLE
test-utils: adjust run() to consider outputFormat

### DIFF
--- a/packages/core/integration-tests/test/integration/html-js-dynamic/index.js
+++ b/packages/core/integration-tests/test/integration/html-js-dynamic/index.js
@@ -1,6 +1,6 @@
 const local = import('./local');
 
-export default function () {
+output = function () {
   return local.then(function (v) {
     return "Imported: " + v.default;
   });

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/interop-require-es-module-code-split-intermediate/main.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/interop-require-es-module-code-split-intermediate/main.js
@@ -1,4 +1,4 @@
 import mainValue from './main_child';
 const importBundle = import('./import');
 
-export default importBundle.then(importValue => importValue.default + ':' + mainValue);
+output = importBundle.then(importValue => importValue.default + ':' + mainValue);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/interop-require-es-module-code-split/main.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/interop-require-es-module-code-split/main.js
@@ -1,4 +1,4 @@
 import sharedBundle from './shared';
 const importBundle = import('./import');
 
-export default importBundle.then(importValue => importValue.default + ':' + sharedBundle.foo);
+output = importBundle.then(importValue => importValue.default + ':' + sharedBundle.foo);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-resolve-excluded/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-resolve-excluded/a.js
@@ -1,1 +1,1 @@
-output = require.resolve('fs');
+module.exports = require.resolve('fs');

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-codesplit/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-codesplit/a.js
@@ -2,4 +2,4 @@ if (Date.now() < 0) {
 	let x = require("./c.js");
 }
 
-module.exports = import("./b.js");
+output = import("./b.js");

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-named-import-ns-reexport/index.js
@@ -1,3 +1,3 @@
 import {ns, ns2} from './reexports';
 
-export default import('./async').then(mod => [ns.foo, ns2.foo].concat(mod.default));
+output = import('./async').then(mod => [ns.foo, ns2.foo].concat(mod.default));

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-default-interop/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-default-interop/a.js
@@ -1,3 +1,3 @@
 import shared from './shared';
 
-module.exports = import('./b').then(b => b.out + shared);
+output = import('./b').then(b => b.out + shared);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import-dynamic/a.js
@@ -1,1 +1,1 @@
-export default import("./b.js").then(b => b.default);
+output = import("./b.js").then(b => b.default);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/dynamic-import/a.js
@@ -2,6 +2,6 @@ import {compute} from './c'
 
 var b = import('./b');
 
-export default b.then(function ({foo, bar}) {
+output = b.then(function ({foo, bar}) {
   return compute(foo, 0) + compute(bar, 0);
 });

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-commonjs/a.js
@@ -1,6 +1,6 @@
 import {foo} from './c';
 
-module.exports = import('./b').then(function (b) {
+output = import('./b').then(function (b) {
   return foo + b.foo;
 });
 

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/a.js
@@ -1,3 +1,3 @@
 import * as lodash from "./b";
 
-output = lodash.add(10,2);
+export default lodash.add(10,2);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-split/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-split/a.js
@@ -1,4 +1,4 @@
 // ensure lib is hoisted (without using any exports) to simulate bundle reference in b.js
 import 'lib';
 
-module.exports = import('./b').then(p => p.default + p.foo + 456);
+output = import('./b').then(p => p.default + p.foo + 456);

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -157,10 +157,10 @@ describe('scope hoisting', function() {
       );
       assert(match);
       let [, id] = match;
-      assert(contents.includes(`output = ${id}.add(10, 2);`));
+      assert(contents.includes(`default = ${id}.add(10, 2);`));
 
       let output = await run(b);
-      assert.deepEqual(output, 12);
+      assert.deepEqual(output.default, 12);
     });
 
     it('supports namespace imports of theoretically excluded reexporting assets (sideEffects: false)', async function() {
@@ -310,8 +310,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.equal(await output.default, 5);
+      assert.equal(await run(b), 5);
     });
 
     it('supports nested dynamic imports', async function() {
@@ -322,8 +321,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.equal(await output.default, 123);
+      assert.equal(await run(b), 123);
     });
 
     it('should not export function arguments', async function() {
@@ -401,8 +399,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.deepEqual(await output, 6);
+      assert.deepEqual(await run(b), 6);
     });
 
     it('supports exporting an import', async function() {
@@ -687,8 +684,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.deepEqual(await output, 581);
+      assert.deepEqual(await run(b), 581);
     });
 
     it('missing exports should be replaced with an empty object', async function() {
@@ -711,8 +707,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.deepEqual(await output, 4);
+      assert.deepEqual(await run(b), 4);
     });
 
     it('supports importing a namespace from a wrapped module', async function() {
@@ -1378,8 +1373,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.deepEqual(output, {exports: {foo: 2}});
+      assert.deepEqual(await run(b), {exports: {foo: 2}});
     });
 
     it('should call init for wrapped modules when codesplitting', async function() {
@@ -1390,8 +1384,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.deepEqual(output, 2);
+      assert.deepEqual(await run(b), 2);
     });
 
     it('should wrap modules that non-statically access `module`', async function() {
@@ -1799,8 +1792,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.equal(await output.default, 'bar:bar');
+      assert.equal(await run(b), 'bar:bar');
     });
 
     it('should export the same values for interop shared modules in main and child bundle if shared bundle is deep nested', async function() {
@@ -1811,8 +1803,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let output = await run(b);
-      assert.equal(await output.default, 'bar:bar');
+      assert.equal(await run(b), 'bar:bar');
     });
 
     it('should support assigning to exports from inside a function', async function() {
@@ -1916,7 +1907,7 @@ describe('scope hoisting', function() {
       },
     ]);
 
-    let output = (await run(b)).default;
+    let output = await run(b);
     assert.equal(typeof output, 'function');
     assert.equal(await output(), 'Imported: foobar');
   });
@@ -2012,6 +2003,6 @@ describe('scope hoisting', function() {
       ),
     );
 
-    assert.deepEqual(await (await run(b)).default, [42, 42, 42, 42]);
+    assert.deepEqual(await run(b), [42, 42, 42, 42]);
   });
 });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -199,15 +199,22 @@ export async function run(
   }
 
   if (opts.require !== false) {
-    if (ctx.parcelRequire) {
-      // $FlowFixMe
-      return ctx.parcelRequire(entryAsset.id);
-    } else if (ctx.output) {
-      return ctx.output;
-    }
-    if (ctx.module) {
-      // $FlowFixMe
-      return ctx.module.exports;
+    switch (bundle.env.outputFormat) {
+      case 'global':
+        if (bundle.env.scopeHoist) {
+          return typeof ctx.output !== 'undefined' ? ctx.output : undefined;
+        } else if (ctx.parcelRequire) {
+          // $FlowFixMe
+          return ctx.parcelRequire(entryAsset.id);
+        }
+        return;
+      case 'commonjs':
+        invariant(typeof ctx.module === 'object' && ctx.module != null);
+        return ctx.module.exports;
+      default:
+        throw new Error(
+          'Unable to run bundle with outputFormat ' + bundle.env.outputFormat,
+        );
     }
   }
 


### PR DESCRIPTION
This adjusts test-utils's `run(bundleGraph, ...)` to consider the output format of the bundle it runs. This means that if the target is `global`, `output` will be used to retrieve the main export in scope hoisted bundles and `parcelRequire` will be used without scope hoisting.

Likewise, in commonjs bundles, `module.exports` will be used as the bundle exports.
 Existing tests and assertions have been adjusted to reflect their output format.

Test Plan: `yarn test`