### PR TITLE
Server: hold requests open during rebuilds

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -74,6 +74,10 @@ export default class Server extends EventEmitter {
     this.errors = null;
   }
 
+  buildStart() {
+    this.pending = true;
+  }
+
   buildSuccess(bundleGraph: BundleGraph) {
     this.bundleGraph = bundleGraph;
     this.errors = null;
@@ -83,6 +87,7 @@ export default class Server extends EventEmitter {
   }
 
   buildError(diagnostics: Array<Diagnostic>) {
+    this.pending = false;
     this.errors = diagnostics.map(d => {
       let ansiDiagnostic = prettyDiagnostic(d);
 

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -1,9 +1,10 @@
 // @flow
 
 import {Reporter} from '@parcel/plugin';
-import Server from './Server';
-import HMRServer from './HMRServer';
 import path from 'path';
+import nullthrows from 'nullthrows';
+import HMRServer from './HMRServer';
+import Server from './Server';
 
 let servers: Map<number, Server> = new Map();
 let hmrServers: Map<number, HMRServer> = new Map();
@@ -66,6 +67,9 @@ export default new Reporter({
         await server.stop();
         servers.delete(serve.port);
         hmrServers.delete(serve.port);
+        break;
+      case 'buildStart':
+        nullthrows(server).buildStart();
         break;
       case 'buildSuccess':
         if (!server) {


### PR DESCRIPTION
This sets the server state to `pending` after `buildStart` and clears it after `buildError` (it was already cleared on `buildSuccess`). This holds requests open during subsequent builds so that stale bundles aren't served during build.

Test Plan:

In both the kitchen-sink and react-hmr examples:

* Clear cache.
* Introduce an async `sleep` in the `BundlerRunner` to simulate a long build.
* Start the example with `parcel serve`. Verify that the request for the document is held open until initial build completes. Refresh and verify response doesn't wait.
* Make a change, refresh the page, and verify that the request is held open until build completes. Verify the change is reflected.
* For HMR, make another change without refreshing the browser and verify HMR continues to function.
* Introduce an error, refresh, and verify the error page is shown.
* Resolve the error, refresh, and verify the request is held open until the page loads correctly again.