### PR TITLE
Correct `addBundleImport`s with  re-exports across bundle boundaries

### DIFF
--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -170,8 +170,16 @@ export default class BundleGraph implements IBundleGraph {
       .map(bundle => new Bundle(bundle, this.#graph, this.#options));
   }
 
-  resolveSymbol(asset: IAsset, symbol: Symbol): SymbolResolution {
-    let res = this.#graph.resolveSymbol(assetToAssetValue(asset), symbol);
+  resolveSymbol(
+    asset: IAsset,
+    symbol: Symbol,
+    boundary: ?IBundle,
+  ): SymbolResolution {
+    let res = this.#graph.resolveSymbol(
+      assetToAssetValue(asset),
+      symbol,
+      boundary ? bundleToInternalBundle(boundary) : null,
+    );
     return {
       asset: assetFromValue(res.asset, this.#options),
       exportSymbol: res.exportSymbol,

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/async.js
@@ -1,0 +1,2 @@
+import {UI_EVENT_TYPE} from "./switcher";
+export default UI_EVENT_TYPE;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/index.js
@@ -1,0 +1,3 @@
+import { OPERATIONAL_EVENT_TYPE } from "./types";
+
+output = import("./async").then(({default: v}) => [OPERATIONAL_EVENT_TYPE, v])

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/switcher/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/switcher/index.js
@@ -1,0 +1,2 @@
+import { UI_EVENT_TYPE } from "../types";
+export { UI_EVENT_TYPE };

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/switcher/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/switcher/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/types/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/types/index.js
@@ -1,0 +1,5 @@
+export var UI_EVENT_TYPE = "ui";
+export var TRACK_EVENT_TYPE = "track";
+export var SCREEN_EVENT_TYPE = "screen";
+export var OPERATIONAL_EVENT_TYPE = "operational";
+export var DEFAULT_SOURCE = "unknown";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/async.js
@@ -1,0 +1,2 @@
+import {UI_EVENT_TYPE} from "./switcher";
+export default UI_EVENT_TYPE;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/index.js
@@ -1,0 +1,3 @@
+import { OPERATIONAL_EVENT_TYPE } from "./types";
+
+output = import("./async").then(({default: v}) => [OPERATIONAL_EVENT_TYPE, v])

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/switcher/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/switcher/index.js
@@ -1,0 +1,2 @@
+import { UI_EVENT_TYPE } from "../types";
+export { UI_EVENT_TYPE };

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/types/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-bundle-boundary/types/index.js
@@ -1,0 +1,5 @@
+export var UI_EVENT_TYPE = "ui";
+export var TRACK_EVENT_TYPE = "track";
+export var SCREEN_EVENT_TYPE = "screen";
+export var OPERATIONAL_EVENT_TYPE = "operational";
+export var DEFAULT_SOURCE = "unknown";

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -199,6 +199,30 @@ describe('scope hoisting', function() {
       assert.equal(output, 15);
     });
 
+    it('can import from a different bundle via a re-export', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-bundle-boundary/index.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, ['operational', 'ui']);
+    });
+
+    it('can import from a different bundle via a re-export (sideEffects: false)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-bundle-boundary-side-effects/index.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, ['operational', 'ui']);
+    });
+
     it('supports importing all exports re-exported from multiple modules deep', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -647,7 +647,11 @@ export interface BundleGraph {
   isAssetReferenced(asset: Asset): boolean;
   isAssetReferencedByAnotherBundleOfType(asset: Asset, type: string): boolean;
   hasParentBundleOfType(bundle: Bundle, type: string): boolean;
-  resolveSymbol(asset: Asset, symbol: Symbol): SymbolResolution;
+  resolveSymbol(
+    asset: Asset,
+    symbol: Symbol,
+    boundary: ?Bundle,
+  ): SymbolResolution;
   getExportedSymbols(asset: Asset): Array<SymbolResolution>;
   traverseBundles<TContext>(
     visit: GraphTraversalCallback<Bundle, TContext>,

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -119,10 +119,11 @@ export function link({
     }
   });
 
-  function resolveSymbol(inputAsset, inputSymbol: Symbol) {
+  function resolveSymbol(inputAsset, inputSymbol: Symbol, bundle) {
     let {asset, exportSymbol, symbol} = bundleGraph.resolveSymbol(
       inputAsset,
       inputSymbol,
+      bundle,
     );
     if (asset.meta.resolveExportsBailedOut) {
       return {
@@ -151,6 +152,7 @@ export function link({
     let {asset: mod, symbol, identifier} = resolveSymbol(
       originalModule,
       originalName,
+      bundle,
     );
 
     let node;
@@ -160,8 +162,8 @@ export function link({
 
     // If the module is not in this bundle, create a `require` call for it.
     if (!node && (!mod.meta.id || !assets.has(assertString(mod.meta.id)))) {
-      node = addBundleImport(originalModule, path);
-      return node ? interop(originalModule, originalName, path, node) : null;
+      node = addBundleImport(mod, path);
+      return node ? interop(mod, symbol, path, node) : null;
     }
 
     // If this is an ES6 module, throw an error if we cannot resolve the module


### PR DESCRIPTION
# ↪️ Pull Request

In `replaceImportNode`, we shouldn't blindly use `originalModule` but instead the first asset after we crossed the bundle boundary (which will be exported by that other bundle via `referencedAssets`). This is achieved by making `BundleGraph#resolveSymbol` stop once the optional parameter `boundary` bundle was "left".

cc @wbinnssmith 

## 💻 Examples

Assets: a imports b which reexport c
Bundles: (a, b) and (c).

The import above should add a bundle import to the bundle with c. Previously we used `originalModule` which would be b (and therefore a bundles tried to import itself).
