### PR TITLE
Share bundles when their entries exist in others

### DIFF
--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -229,6 +229,12 @@ export default class MutableBundleGraph implements IMutableBundleGraph {
     }
   }
 
+  getSiblingBundles(bundle: IBundle): Array<IBundle> {
+    return this.#graph
+      .getSiblingBundles(bundleToInternalBundle(bundle))
+      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+  }
+
   traverse<TContext>(
     visit: GraphVisitor<BundlerBundleGraphTraversable, TContext>,
   ): ?TContext {

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1016,16 +1016,16 @@ describe('html', function() {
       {production: true, scopeHoist: true},
     );
 
-    // a.html should point to a CSS bundle containing a.css and b.css.
-    // It should not point to the bundle for b.css from b.html.
+    // a.html should point to a CSS bundle containing a.css as well as
+    // reuse the b.css bundle from b.html.
     let html = await outputFS.readFile(path.join(distDir, 'a.html'), 'utf8');
     assert.equal(
       html.match(/<link rel="stylesheet" href="\/a\.[a-z0-9]+\.css">/g).length,
       1,
     );
     assert.equal(
-      html.match(/<link rel="stylesheet" href="\/b\.[a-z0-9]+\.css">/g),
-      null,
+      html.match(/<link rel="stylesheet" href="\/b\.[a-z0-9]+\.css">/g).length,
+      1,
     );
 
     let css = await outputFS.readFile(
@@ -1033,7 +1033,7 @@ describe('html', function() {
       'utf8',
     );
     assert(css.includes('.a'));
-    assert(css.includes('.b'));
+    assert(!css.includes('.b'));
 
     // b.html should point to a CSS bundle containing only b.css
     // It should not point to the bundle containing a.css from a.html

--- a/packages/core/integration-tests/test/integration/async-entry-shared/async.js
+++ b/packages/core/integration-tests/test/integration/async-entry-shared/async.js
@@ -1,0 +1,3 @@
+import value from './value';
+
+export default value + 1;

--- a/packages/core/integration-tests/test/integration/async-entry-shared/index.js
+++ b/packages/core/integration-tests/test/integration/async-entry-shared/index.js
@@ -1,0 +1,4 @@
+export default Promise.all([
+  import('./value').then(mod => mod.default),
+  import('./async').then(mod => mod.default),
+]);

--- a/packages/core/integration-tests/test/integration/async-entry-shared/scope-hoisting.js
+++ b/packages/core/integration-tests/test/integration/async-entry-shared/scope-hoisting.js
@@ -1,0 +1,4 @@
+output = Promise.all([
+  import('./value').then(mod => mod.default),
+  import('./async').then(mod => mod.default),
+]);

--- a/packages/core/integration-tests/test/integration/async-entry-shared/value.js
+++ b/packages/core/integration-tests/test/integration/async-entry-shared/value.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/core/integration-tests/test/integration/sync-entry-shared/async.js
+++ b/packages/core/integration-tests/test/integration/sync-entry-shared/async.js
@@ -1,0 +1,3 @@
+import value from './value';
+
+export default value + 1;

--- a/packages/core/integration-tests/test/integration/sync-entry-shared/index.js
+++ b/packages/core/integration-tests/test/integration/sync-entry-shared/index.js
@@ -1,0 +1,1 @@
+export default import('./async').then(mod => mod.default);

--- a/packages/core/integration-tests/test/integration/sync-entry-shared/value.js
+++ b/packages/core/integration-tests/test/integration/sync-entry-shared/value.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2454,4 +2454,59 @@ describe('javascript', function() {
 
     assert.deepEqual(await (await run(b)).default, [3, 5]);
   });
+
+  it('can run an entry bundle whose entry asset is present in another bundle', async () => {
+    let b = await bundle(
+      ['index.js', 'value.js'].map(basename =>
+        path.join(__dirname, '/integration/sync-entry-shared', basename),
+      ),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'index.js',
+          'bundle-manifest.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'relative-path.js',
+        ],
+      },
+      {name: 'value.js', assets: ['value.js']},
+      {assets: ['async.js']},
+    ]);
+
+    assert.equal(await (await run(b)).default, 43);
+  });
+
+  it('can run an async bundle whose entry asset is present in another bundle', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/async-entry-shared/index.js'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'index.js',
+          'bundle-manifest.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'relative-path.js',
+        ],
+      },
+      {assets: ['value.js']},
+      {assets: ['async.js']},
+    ]);
+
+    assert.deepEqual(await (await run(b)).default, [42, 43]);
+  });
 });

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3,6 +3,7 @@ import path from 'path';
 import {
   bundle as _bundle,
   bundler as _bundler,
+  distDir,
   run,
   runBundle,
   outputFS,
@@ -2168,5 +2169,52 @@ describe('scope hoisting', function() {
     ]);
 
     assert.deepEqual(await run(b), [3, 5]);
+  });
+
+  it('can run an entry bundle whose entry asset is present in another bundle', async () => {
+    let b = await bundle(
+      ['index.js', 'value.js'].map(basename =>
+        path.join(__dirname, '/integration/sync-entry-shared', basename),
+      ),
+      {targets: {main: {context: 'node', distDir}}},
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'JSRuntime.js'],
+      },
+      {name: 'value.js', assets: ['value.js']},
+      {assets: ['async.js']},
+    ]);
+
+    assert.equal(await (await run(b)).default, 43);
+  });
+
+  it('can run an async bundle whose entry asset is present in another bundle', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/async-entry-shared/scope-hoisting.js'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'scope-hoisting.js',
+        assets: [
+          'scope-hoisting.js',
+          'bundle-manifest.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'JSRuntime.js',
+          'relative-path.js',
+        ],
+      },
+      {assets: ['value.js']},
+      {assets: ['async.js']},
+    ]);
+
+    assert.deepEqual(await run(b), [42, 43]);
   });
 });

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -625,6 +625,7 @@ export interface MutableBundleGraph {
   getParentBundlesOfBundleGroup(BundleGroup): Array<Bundle>;
   getBundleGroupsContainingBundle(Bundle): Array<BundleGroup>;
   getBundlesInBundleGroup(BundleGroup): Array<Bundle>;
+  getSiblingBundles(bundle: Bundle): Array<Bundle>;
   getTotalSize(Asset): number;
   isAssetInAncestorBundles(Bundle, Asset): boolean;
   removeAssetGraphFromBundle(Asset, Bundle): void;

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -255,7 +255,11 @@ function getLoaderRuntimes({
     }
 
     if (bundle.env.outputFormat === 'global') {
-      loaders += `.then(() => parcelRequire('${bundleGroup.entryAssetId}'))`;
+      loaders += `.then(() => parcelRequire('${bundleGroup.entryAssetId}')${
+        // In global output with scope hoisting, functions return exports are
+        // always returned. Otherwise, the exports are returned.
+        bundle.env.scopeHoist ? '()' : ''
+      })`;
     }
 
     assets.push({

--- a/packages/shared/scope-hoisting/src/formats/global.js
+++ b/packages/shared/scope-hoisting/src/formats/global.js
@@ -29,6 +29,10 @@ const EXPORT_TEMPLATE = template.statement<
   {|IDENTIFIER: Identifier, ASSET_ID: StringLiteral|},
   Statement,
 >('parcelRequire.register(ASSET_ID, IDENTIFIER)');
+const EXPORT_FN_TEMPLATE = template.statement<
+  {|IDENTIFIER: Identifier, ASSET_ID: StringLiteral|},
+  Statement,
+>('parcelRequire.register(ASSET_ID, function() { return IDENTIFIER; })');
 const IMPORTSCRIPTS_TEMPLATE = template.statement<
   {|BUNDLE: StringLiteral|},
   Statement,
@@ -97,7 +101,9 @@ export function generateExports(
     exported.add(exportsId);
 
     statements.push(
-      EXPORT_TEMPLATE({
+      // Export a function returning the exports, as other cases of global output
+      // register init functions.
+      EXPORT_FN_TEMPLATE({
         ASSET_ID: t.stringLiteral(entry.id),
         IDENTIFIER: t.identifier(assertString(entry.meta.exportsIdentifier)),
       }),

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -45,7 +45,12 @@ export function needsPrelude(bundle: Bundle, bundleGraph: BundleGraph) {
 
   return (
     isEntry(bundle, bundleGraph) &&
+    // If this bundle has an async descendant, it will use the JSRuntime,
+    // which uses parcelRequire. It's also possible that the descendant needs
+    // to register exports for its own descendants.
     (hasAsyncDescendant(bundle, bundleGraph) ||
+      // If an asset in this bundle is referenced, this bundle will use
+      //`parcelRequire.register` to register the asset.
       isReferenced(bundle, bundleGraph))
   );
 }


### PR DESCRIPTION
Depends on #4391.

When a bundle `a`'s entry asset is present in bundle `b`, share bundle `a` by placing it (and its siblings) in `b`'s bundle group. This takes place in optimization in a similar way as other shared bundle extraction. See tests for  examples. 

This required making scope hoisted bundles always register init functions. @mischnic may have a better idea or may remove this with the symbol propagation work.

Test Plan: `yarn test`