### PR TITLE
Skip validation requests if there are no validators configured

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -254,7 +254,11 @@ export default class AssetGraphBuilder extends EventEmitter {
 
   async validate(): Promise<void> {
     let trackedRequestsDesc = this.assetRequests
-      .filter(request => this.requestTracker.isTracked(request.id))
+      .filter(
+        request =>
+          this.requestTracker.isTracked(request.id) &&
+          this.config.getValidatorNames(request.request.filePath).length > 0,
+      )
       .map(({request}) => request);
 
     // Schedule validations on workers for all plugins that implement the one-asset-at-a-time "validate" method.
@@ -265,6 +269,11 @@ export default class AssetGraphBuilder extends EventEmitter {
         configRef: this.configRef,
       }),
     );
+
+    // Skip sending validation requests if no validators were no validators configured
+    if (trackedRequestsDesc.length === 0) {
+      return;
+    }
 
     // Schedule validations on the main thread for all validation plugins that implement "validateAll".
     promises.push(


### PR DESCRIPTION
# ↪️ Pull Request
This PR skips validation if there are no validators configured for any of the changed assets so we can skip loading files and hashing them for no reason. 

We should also consider not loading files up front and allowing validators to request that content only if they need it, but that can be a follow up task. We also need to look into throttling local worker requests and/or the fs, because currently validating a large project can lead "too many open file" errors.

## 🚨 Test instructions
I was running into "too many open file" errors because validation was reading every asset in the graph at once even though we had no validators configured. This change resolved the issue.  

