### PR TITLE
Don't treeshake assignments to unknown objects

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/tree-shaking-no-unknown-objects/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/tree-shaking-no-unknown-objects/a.js
@@ -1,0 +1,1 @@
+module.exports = window;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/tree-shaking-no-unknown-objects/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/tree-shaking-no-unknown-objects/index.js
@@ -1,0 +1,3 @@
+const foo = require('./a');
+foo.bar = 42;
+output = window.bar;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/a.js
@@ -1,0 +1,1 @@
+export const foo = window;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/index.js
@@ -1,0 +1,5 @@
+import {foo} from './a';
+
+foo.bar = 42;
+
+output = window.bar;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -929,6 +929,17 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output.foo, 'bar');
     });
+
+    it('does not tree-shake assignments to unknown objects', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), 42);
+    });
   });
 
   describe('commonjs', function() {
@@ -1878,6 +1889,17 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.deepEqual(output, [4, 2]);
     });
+
+    it('does not tree-shake assignments to unknown objects', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/tree-shaking-no-unknown-objects/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), 42);
+    });
   });
 
   it('should not throw with JS included from HTML', async function() {
@@ -2168,17 +2190,6 @@ describe('scope hoisting', function() {
     ]);
 
     assert.deepEqual(await run(b), [3, 5]);
-  });
-
-  it('does not tree-shake assignments to unknown objects', async () => {
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/index.js',
-      ),
-    );
-
-    assert.equal(await run(b), 42);
   });
 
   it('can run an entry bundle whose entry asset is present in another bundle', async () => {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -904,8 +904,7 @@ describe('scope hoisting', function() {
         b.getBundles()[0].filePath,
         'utf8',
       );
-      assert(!/bar/.test(contents));
-      assert(!/displayName/.test(contents));
+      assert(!contents.includes('exports.bar ='));
     });
 
     it('should correctly rename references to default exported classes', async function() {
@@ -2169,6 +2168,17 @@ describe('scope hoisting', function() {
     ]);
 
     assert.deepEqual(await run(b), [3, 5]);
+  });
+
+  it('does not tree-shake assignments to unknown objects', async () => {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/scope-hoisting/es6/tree-shaking-no-unknown-objects/index.js',
+      ),
+    );
+
+    assert.equal(await run(b), 42);
   });
 
   it('can run an entry bundle whose entry asset is present in another bundle', async () => {

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -695,7 +695,7 @@ export function link({
           verifyScopeState(path.scope);
         }
 
-        treeShake(path.scope, exported);
+        treeShake(path.scope, exported, exportsMap);
       },
     },
   });

--- a/packages/shared/scope-hoisting/src/shake.js
+++ b/packages/shared/scope-hoisting/src/shake.js
@@ -34,6 +34,9 @@ export default function treeShake(
     removed = false;
 
     Object.keys(scope.bindings).forEach((name: string) => {
+      if (name.includes('foo')) {
+        debugger;
+      }
       let binding = getUnusedBinding(scope.path, name);
 
       // If it is not safe to remove the binding don't touch it.


### PR DESCRIPTION
This changes `shake.js`'s `isExport` to only consider `AssignmentExpression`s to known exports objects as removable. This prevents tree shaking from removing assignments to imports that corresponded to unknown objects.

This involved updating a tree shake test to only ensure that it removes an assignment to the export object, as it appears terser should remove the export corresponding identifier.

Thanks @devongovett for the suggestion of using the `exportsMap` 😄

Test Plan: Added an integration test. `yarn test`.