### PR TITLE
Ignore `url(#...)` (`behavior` property) in Less assets

### DIFF
--- a/packages/core/integration-tests/test/integration/less-url-behavior/index.less
+++ b/packages/core/integration-tests/test/integration/less-url-behavior/index.less
@@ -1,0 +1,3 @@
+.index {
+  behavior: url(#default#VML);
+}

--- a/packages/core/integration-tests/test/less.js
+++ b/packages/core/integration-tests/test/less.js
@@ -216,4 +216,21 @@ describe('less', function() {
     assert(css.includes('.a'));
     assert(css.includes('.b'));
   });
+
+  it('should ignore url() with IE behavior specifiers', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/less-url-behavior/index.less'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.css',
+        assets: ['index.less'],
+      },
+    ]);
+
+    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
+
+    assert(css.includes('url(#default#VML)'));
+  });
 });

--- a/packages/transformers/less/src/LessTransformer.js
+++ b/packages/transformers/less/src/LessTransformer.js
@@ -55,10 +55,14 @@ function urlPlugin({asset}) {
     install(less, pluginManager) {
       const visitor = new less.visitors.Visitor({
         visitUrl(node) {
-          node.value.value = asset.addURLDependency(
-            node.value.value,
-            node.currentFileInfo.filename,
-          );
+          if (
+            !node.value.value.startsWith('#') // IE's `behavior: url(#default#VML)`)
+          ) {
+            node.value.value = asset.addURLDependency(
+              node.value.value,
+              node.currentFileInfo.filename,
+            );
+          }
           return node;
         },
       });


### PR DESCRIPTION
# ↪️ Pull Request

Ignore this syntax in less assets as well (pure CSS support added in https://github.com/parcel-bundler/parcel/pull/3887).

```css
.lvml {
	behavior: url(#default#VML);
	display: inline-block;
	position: absolute;
}
```


cc @iamyellow @pojntfx 