### PR TITLE
feat(cli): Add --global option in commonOptions in cli

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -47,10 +47,11 @@ if (typeof process.env.PARCEL_BUILD_ENV === 'string') {
 
 program.version(version);
 
-// --no-cache, --cache-dir, --no-source-maps, --no-autoinstall, --global?, --public-url, --log-level
+// --no-cache, --cache-dir, --no-source-maps, --no-autoinstall, --public-url, --log-level
 // --no-content-hash, --experimental-scope-hoisting, --detailed-report
 
 const commonOptions = {
+  '--global <variable>': 'expose your module through a global variable',,
   '--no-cache': 'disable the filesystem cache',
   '--cache-dir <path>': 'set the cache directory. defaults to ".parcel-cache"',
   '--no-source-maps': 'disable sourcemaps',

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -320,5 +320,6 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     env: {
       NODE_ENV: nodeEnv,
     },
+    global: command.global
   };
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -204,7 +204,7 @@ export type InitialParcelOptions = {|
   +workerFarm?: WorkerFarm,
   +packageManager?: PackageManager,
   +defaultEngines?: Engines,
-
+  +global: string
   // contentHash
   // throwErrors
   // global?
@@ -226,6 +226,7 @@ export interface PluginOptions {
   +outputFS: FileSystem;
   +packageManager: PackageManager;
   +instanceId: string;
+  +global: string
 }
 
 export type ServerOptions = {|

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -185,7 +185,7 @@ export default new Packager({
         '},{},' +
         JSON.stringify(entries.map(asset => asset.id)) +
         ', ' +
-        'null' +
+        JSON.stringify(this.options.global || null) +
         ')' +
         '\n\n' +
         (await getSourceMapSuffix(getSourceMapReference, map)),


### PR DESCRIPTION
# ↪️ Pull Request
With this pr I want to add --global option to cli like this other pr that was merge into Parcel1 code:
https://github.com/parcel-bundler/parcel/pull/453/files

The purpose is to reestablish the functionality of having access globally to the exports
