### PR TITLE
removeBundleGroup: Only remove bundles entirely if they are only part of this group

### DIFF
--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -119,7 +119,9 @@ export default class MutableBundleGraph extends BundleGraph
 
   removeBundleGroup(bundleGroup: BundleGroup): void {
     for (let bundle of this.getBundlesInBundleGroup(bundleGroup)) {
-      this.#graph._graph.removeById(bundle.id);
+      if (this.getBundleGroupsContainingBundle(bundle).length === 1) {
+        this.#graph._graph.removeById(bundle.id);
+      }
     }
     this.#graph._graph.removeById(getBundleGroupId(bundleGroup));
   }


### PR DESCRIPTION
This corrects an oversight from #4391 where bundles in a group were unconditionally removed from the graph if their parent group was. Bundles can belong to multiple groups, however.

cc @highvoltag3