### PR TITLE
Fixed crash "Cannot read property 'type' of undefined"

### DIFF
--- a/packages/core/parcel-bundler/src/Bundler.js
+++ b/packages/core/parcel-bundler/src/Bundler.js
@@ -654,7 +654,7 @@ class Bundler extends EventEmitter {
 
         // If the common bundle's type matches the asset's, move the asset to the common bundle.
         // Otherwise, proceed with adding the asset to the new bundle below.
-        if (asset.parentBundle.type === commonBundle.type) {
+        if (commonBundle && asset.parentBundle.type === commonBundle.type) {
           this.moveAssetToBundle(asset, commonBundle);
           return;
         }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This fixes an error where `bundle.findCommonAncestor()` will return `undefined`, which crashes when rebuilding a project due to a file change. I believe this fixes the bug #2749

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
To test: start with https://github.com/ourcade/phaser3-parcel-template, clone and follow instructions. Without the fix, `npm run start` will crash with above exception when a watched file is changed (for example, modifying HelloWorldScene.js). With this PR, the automatic rebuild will succeed.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
