### PR TITLE
[README only] update package.json target definition

### DIFF
--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -398,13 +398,19 @@ When you do need to configure Parcel, it will be in one of 3 places.
   "source": "src/index.js",
   "targets": {
     "main": {
-      "node": ["^4.0.0"]
+      "engines": {
+        "node": ">=4.x"
+      }
     },
     "module": {
-      "node": ["^8.0.0"]
+      "engines": {
+        "node": ">=8.x"
+      }
     },
     "browser": {
-      "browsers": ["> 1%", "not dead"]
+      "engines": {
+        "browsers": ["> 1%", "not dead"]
+      }
     }
   },
   "alias": {


### PR DESCRIPTION
I believe the `package.json` example has an out of date format for it's targets section, specifically missing the `engines` key. Was seeing this error when I tried the old format:
```
Invalid target descriptor for target "main"
 ^^^^^^ Possible values: "context", "includeNodeModules", "outputFormat", "distDir", "publicUrl", "isLibrary", "sourceMap", "engines", "minify"
```