### PR TITLE
Really no sourcemaps

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -460,7 +460,11 @@ export default class PackagerRunner {
     };
 
     let mapKey = cacheKeys.map;
-    if (await this.options.cache.blobExists(mapKey)) {
+    let o = bundle.target.sourceMap ?? this.options.sourceMaps;
+    if (
+      (typeof o === 'object' ? !o.inline : o) &&
+      (await this.options.cache.blobExists(mapKey))
+    ) {
       let mapStream = this.options.cache.getStream(mapKey);
       await writeFileStream(
         outputFS,

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -460,9 +460,10 @@ export default class PackagerRunner {
     };
 
     let mapKey = cacheKeys.map;
-    let o = bundle.target.sourceMap ?? this.options.sourceMaps;
     if (
-      (typeof o === 'object' ? !o.inline : o) &&
+      (typeof bundle.target.sourceMap === 'object'
+        ? !bundle.target.sourceMap.inline
+        : bundle.target.sourceMap) &&
       (await this.options.cache.blobExists(mapKey))
     ) {
       let mapStream = this.options.cache.getStream(mapKey);

--- a/packages/core/core/src/TargetResolver.js
+++ b/packages/core/core/src/TargetResolver.js
@@ -139,7 +139,7 @@ export default class TargetResolver {
               scopeHoist:
                 this.options.scopeHoist && descriptor.scopeHoist !== false,
             }),
-            sourceMap: descriptor.sourceMap,
+            sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           };
         });
       }
@@ -351,7 +351,7 @@ export default class TargetResolver {
             scopeHoist:
               this.options.scopeHoist && descriptor.scopeHoist !== false,
           }),
-          sourceMap: descriptor.sourceMap,
+          sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           loc,
         });
       }
@@ -430,7 +430,7 @@ export default class TargetResolver {
             scopeHoist:
               this.options.scopeHoist && descriptor.scopeHoist !== false,
           }),
-          sourceMap: descriptor.sourceMap,
+          sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           loc,
         });
       }
@@ -450,6 +450,7 @@ export default class TargetResolver {
           minify: this.options.minify,
           scopeHoist: this.options.scopeHoist,
         }),
+        sourceMap: this.options.sourceMaps ? {} : undefined,
       });
     }
 
@@ -575,5 +576,17 @@ function assertNoDuplicateTargets(targets, pkgFilePath, pkgContents) {
     throw new ThrowableDiagnostic({
       diagnostic: diagnostics,
     });
+  }
+}
+
+function normalizeSourceMap(options: ParcelOptions, sourceMap) {
+  if (options.sourceMaps) {
+    if (typeof sourceMap === 'boolean') {
+      return sourceMap ? {} : undefined;
+    } else {
+      return sourceMap ?? {};
+    }
+  } else {
+    return undefined;
   }
 }

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -4,11 +4,10 @@ import assert from 'assert';
 import path from 'path';
 import tempy from 'tempy';
 import {inputFS as fs} from '@parcel/test-utils';
+import TargetResolver from '../src/TargetResolver';
 import {DEFAULT_OPTIONS as _DEFAULT_OPTIONS} from './utils';
 
 const DEFAULT_OPTIONS = {..._DEFAULT_OPTIONS, sourceMaps: true};
-
-import TargetResolver from '../src/TargetResolver';
 
 const COMMON_TARGETS_FIXTURE_PATH = path.join(
   __dirname,

--- a/packages/core/core/test/TargetResolver.test.js
+++ b/packages/core/core/test/TargetResolver.test.js
@@ -4,7 +4,9 @@ import assert from 'assert';
 import path from 'path';
 import tempy from 'tempy';
 import {inputFS as fs} from '@parcel/test-utils';
-import {DEFAULT_OPTIONS} from './utils';
+import {DEFAULT_OPTIONS as _DEFAULT_OPTIONS} from './utils';
+
+const DEFAULT_OPTIONS = {..._DEFAULT_OPTIONS, sourceMaps: true};
 
 import TargetResolver from '../src/TargetResolver';
 
@@ -87,7 +89,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
           },
           {
             name: 'customB',
@@ -104,7 +106,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
           },
         ],
       },
@@ -137,7 +139,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {
@@ -203,7 +205,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {
@@ -298,7 +300,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {
@@ -330,7 +332,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {
@@ -362,7 +364,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {
@@ -406,7 +408,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
           },
-          sourceMap: undefined,
+          sourceMap: {},
           loc: {
             filePath: path.join(CONTEXT_FIXTURE_PATH, 'package.json'),
             start: {
@@ -450,7 +452,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
           },
-          sourceMap: undefined,
+          sourceMap: {},
           loc: {
             filePath: path.join(fixture, 'package.json'),
             start: {
@@ -496,7 +498,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {
@@ -528,7 +530,7 @@ describe('TargetResolver', () => {
               minify: false,
               scopeHoist: false,
             },
-            sourceMap: undefined,
+            sourceMap: {},
             loc: {
               filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
               start: {

--- a/packages/core/core/test/fixtures/common-targets-ignore/package.json
+++ b/packages/core/core/test/fixtures/common-targets-ignore/package.json
@@ -6,6 +6,8 @@
   },
   "targets": {
     "main": false,
-    "app": {}
+    "app": {
+      "sourceMap": false
+    }
   }
 }

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -12,11 +12,10 @@ import {
   getNextBuild,
 } from '@parcel/test-utils';
 
-const bundle = (name, opts = {}) =>
-  _bundle(name, Object.assign({scopeHoist: true}, opts));
+const bundle = (name, opts = {}) => _bundle(name, {scopeHoist: true, ...opts});
 
 const bundler = (name, opts = {}) =>
-  _bundler(name, Object.assign({scopeHoist: true}, opts));
+  _bundler(name, {scopeHoist: true, ...opts});
 
 describe('scope hoisting', function() {
   describe('es6', function() {

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -5,6 +5,7 @@ import SourceMap from '@parcel/source-map';
 import {
   bundle,
   assertBundleTree,
+  distDir,
   inputFS,
   outputFS,
   shallowEqual,
@@ -876,6 +877,20 @@ describe('sourcemaps', function() {
     let map = mapUrlData.map;
     assert.equal(map.file, 'index.js.map');
     assert.deepEqual(map.sources, ['index.js']);
+  });
+
+  it('should respect --no-source-maps', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/sourcemap/index.js'),
+      {
+        sourceMaps: false,
+      },
+    );
+
+    assert.deepStrictEqual(
+      await outputFS.readdir(path.dirname(b.getBundles()[0].filePath)),
+      ['index.js'],
+    );
   });
 
   it.skip('should load existing sourcemaps for CSS files', async function() {

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -3,7 +3,7 @@ import path from 'path';
 import os from 'os';
 import SourceMap from '@parcel/source-map';
 import {
-  bundle,
+  bundle as _bundle,
   assertBundleTree,
   distDir,
   inputFS,
@@ -11,6 +11,8 @@ import {
   shallowEqual,
 } from '@parcel/test-utils';
 import {loadSourceMapUrl} from '@parcel/utils';
+
+const bundle = (name, opts = {}) => _bundle(name, {sourceMaps: true, ...opts});
 
 function indexToLineCol(str, index) {
   let beforeIndex = str.slice(0, index);

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -5,7 +5,6 @@ import SourceMap from '@parcel/source-map';
 import {
   bundle as _bundle,
   assertBundleTree,
-  distDir,
   inputFS,
   outputFS,
   shallowEqual,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -100,7 +100,7 @@ export type PackageTargetDescriptor = {|
   +outputFormat?: OutputFormat,
   +publicUrl?: string,
   +distDir?: FilePath,
-  +sourceMap?: TargetSourceMapOptions,
+  +sourceMap?: boolean | TargetSourceMapOptions,
   +isLibrary?: boolean,
   +minify?: boolean,
   +scopeHoist?: boolean,

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -84,7 +84,7 @@ export default new Packager({
         queue.add(async () => {
           let [code, mapBuffer] = await Promise.all([
             node.value.getCode(),
-            node.value.getMapBuffer(),
+            bundle.target.sourceMap && node.value.getMapBuffer(),
           ]);
           return {code, mapBuffer};
         });


### PR DESCRIPTION
# ↪️ Pull Request

Closes #4390

Previously, we relied on plugins to not return sourcemaps if `target.sourceMap` is false. 
But the non-hoisting JSPackager without running TerserOptimizer afterwards would still emit a sourcemap and therefore write a sourcemap file to dist despite of `--no-source-maps`

# Question

~Sourcemaps can be specified per target, but they are only accessible on `PluginOptions` (a boolean from the cli flag) and on `Target` (the actual settings object). So it would make sense to remove it from the `PluginOptions` and put them on `Target` only (and normalizing the value in the target resolver), but then transformers wouldn't know if sourcemaps are enabled.~