### PR TITLE
JSRuntime: take URL of last bundle in bundle group

### DIFF
--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "scripts": {
-    "test": "cross-env NODE_ENV=test mocha",
+    "test": "cross-env NODE_ENV=test PARCEL_BUILD_ENV=test mocha",
     "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json"
   },
   "devDependencies": {

--- a/packages/core/integration-tests/test/integration/html-shared-worker/index.js
+++ b/packages/core/integration-tests/test/integration/html-shared-worker/index.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
-console.log('index', _);
+
+output("main", _.add(1, 2));
 
 new Worker('worker.js');

--- a/packages/core/integration-tests/test/integration/html-shared-worker/worker.js
+++ b/packages/core/integration-tests/test/integration/html-shared-worker/worker.js
@@ -1,2 +1,3 @@
 import _ from 'lodash';
-console.log('worker', _);
+
+output("worker", _.add(1, 2));

--- a/packages/core/integration-tests/test/typescript.js
+++ b/packages/core/integration-tests/test/typescript.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import path from 'path';
+import url from 'url';
 import {
   bundle,
   run,
@@ -123,8 +124,12 @@ describe('typescript', function() {
 
       let output = await run(b);
       assert.equal(typeof output.getRaw, 'function');
-      assert(/^\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()));
-      assert(await outputFS.exists(path.join(distDir, output.getRaw())));
+      assert(/http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()));
+      assert(
+        await outputFS.exists(
+          path.join(distDir, url.parse(output.getRaw()).pathname),
+        ),
+      );
     });
 
     it('should minify with minify enabled', async function() {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -408,7 +408,10 @@ function prepareBrowserContext(
               if (el.tag === 'script') {
                 vm.runInContext(
                   overlayFS.readFileSync(
-                    path.join(path.dirname(filePath), el.src),
+                    path.join(
+                      path.dirname(filePath),
+                      url.parse(el.src).pathname,
+                    ),
                     'utf8',
                   ),
                   ctx,
@@ -432,6 +435,9 @@ function prepareBrowserContext(
         return null;
       },
     },
+    currentScript: {
+      src: 'http://localhost/script.js',
+    },
   };
 
   var exports = {};
@@ -442,7 +448,7 @@ function prepareBrowserContext(
       document: fakeDocument,
       WebSocket,
       console,
-      location: {hostname: 'localhost'},
+      location: {hostname: 'localhost', origin: 'http://localhost'},
       fetch(url) {
         return Promise.resolve({
           async arrayBuffer() {
@@ -468,11 +474,12 @@ function prepareBrowserContext(
       btoa(str) {
         return Buffer.from(str, 'binary').toString('base64');
       },
+      URL,
     },
     globals,
   );
 
-  ctx.window = ctx;
+  ctx.window = ctx.self = ctx;
   return {ctx, promises};
 }
 

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -133,8 +133,12 @@ export default new Runtime({
       }
 
       let bundleGroup = resolved.value;
-      let bundlesInGroup = bundleGraph.getBundlesInBundleGroup(bundleGroup);
-      let mainBundle = bundlesInGroup[bundlesInGroup.length - 1];
+      let mainBundle = nullthrows(
+        bundleGraph.getBundlesInBundleGroup(bundleGroup).find(b => {
+          let main = b.getMainEntry();
+          return main && bundleGroup.entryAssetId === main.id;
+        }),
+      );
 
       if (mainBundle.isInline) {
         assets.push({

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -134,11 +134,11 @@ export default new Runtime({
 
       let bundleGroup = resolved.value;
       let bundlesInGroup = bundleGraph.getBundlesInBundleGroup(bundleGroup);
+      let mainBundle = bundlesInGroup[bundlesInGroup.length - 1];
 
-      let [firstBundle] = bundlesInGroup;
-      if (firstBundle.isInline) {
+      if (mainBundle.isInline) {
         assets.push({
-          filePath: path.join(__dirname, `/bundles/${firstBundle.id}.js`),
+          filePath: path.join(__dirname, `/bundles/${mainBundle.id}.js`),
           code: `module.exports = ${JSON.stringify(dependency.id)};`,
           dependency,
         });
@@ -146,7 +146,7 @@ export default new Runtime({
       }
 
       // URL dependency or not, fall back to including a runtime that exports the url
-      assets.push(getURLRuntime(dependency, bundle, firstBundle));
+      assets.push(getURLRuntime(dependency, bundle, mainBundle));
     }
 
     if (

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -1,3 +1,5 @@
+/* globals document:readonly */
+
 var bundleURL = null;
 function getBundleURLCached() {
   if (!bundleURL) {
@@ -9,6 +11,10 @@ function getBundleURLCached() {
 
 function getBundleURL() {
   // Attempt to find the URL of the current script and use that as the base URL
+  if ('currentScript' in document) {
+    return getBaseURL(document.currentScript.src);
+  }
+
   try {
     throw new Error();
   } catch (err) {

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -11,7 +11,7 @@ function getBundleURLCached() {
 
 function getBundleURL() {
   // Attempt to find the URL of the current script and use that as the base URL
-  if ('currentScript' in document) {
+  if (typeof document !== 'undefined' && 'currentScript' in document) {
     return getBaseURL(document.currentScript.src);
   }
 

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -11,8 +11,10 @@ function getBundleURLCached() {
 
 function getBundleURL() {
   // Attempt to find the URL of the current script and use that as the base URL
-  if (typeof document !== 'undefined' && 'currentScript' in document) {
-    return getBaseURL(document.currentScript.src);
+  if (process.env.PARCEL_BUILD_ENV === 'test') {
+    if (typeof document !== 'undefined' && 'currentScript' in document) {
+      return getBaseURL(document.currentScript.src);
+    }
   }
 
   try {


### PR DESCRIPTION
# ↪️ Pull Request

Caused by #4469 and #4391, this broke the REPL.

- Use the last bundle in a bundle group for url-like dependencies
- Make getBundleURL use `document.currentScript` if possible, to enable testing this. (A suitable test for this actually already existed, it was just not asserted.)

cc @wbinnssmith You added the `firstBundle` part in the internalize-async PR. 

## 💻 Examples

The main bundle importing a worker url would use the first bundle in the bundlegroup (in this case the bundle group has a shared bundle and the worker). 

The result was: `new Worker("./worker")` would incorrectly do `new Worker("./shared-bundle")`.


## TODO

- [ ]  ~Make sure the getBundleURL cache is populated when the bundle runs synchronously (because document.currentScript doesn't work in callbacks)~
- [x] Is using the last bundle the correct approach? Or should it be based on `Bundlegroup#entryAssetId`?