### PR TITLE
Use punycode 1.x for IE 11/es5 compatibility

### DIFF
--- a/packages/utils/node-libs-browser/package.json
+++ b/packages/utils/node-libs-browser/package.json
@@ -28,7 +28,7 @@
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.0",
     "process": "^0.11.10",
-    "punycode": "^2.1.1",
+    "punycode": "^1.4.1",
     "querystring-es3": "^0.2.1",
     "readable-stream": "^3.6.0",
     "stream-http": "^3.1.0",


### PR DESCRIPTION
Resolves #4357.

This downgrades the bundled `punycode` module part of `@parcel/node-browser-libs` to the 1.x range, which is distributed as es5.

Test Plan: 
* Prepare the kitchen sink example to run in ie 11 by temporarily adding ie 11 to default engines.
* import`punycode` and log its export in the kitchen sink example.
* Run the development server and connect to it from ie 11.
* Verify there are no syntax errors and that the punycode object is logged to the console.