### PR TITLE
Fix logs not being generated on Windows

### DIFF
--- a/packages/core/logger/src/Logger.js
+++ b/packages/core/logger/src/Logger.js
@@ -75,7 +75,7 @@ class Logger {
     if (this.logLevel > 4) {
       if (!this.logFile) {
         this.logFile = fs.createWriteStream(
-          path.join(process.cwd(), `parcel-debug-${currDate.toISOString()}.log`)
+          path.join(process.cwd(), `parcel-debug-${currDate.toISOString().replace(/\:/g, '-')}.log`)
         );
       }
       this.logFile.write(stripAnsi(message) + '\n');


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #3116

As @oddeirik noticed, Parcel attempts to create a log file with colons (:) in the filename, which is not allowed on Windows. This simple fix replaces those colons with hyphens.

## 💻 Examples

```powershell
parcel build src/index.hbs --log-level 5
```

Previously this command would fail on Windows, now it should succeed.

## 🚨 Test instructions

Run the following command on Windows:

```powershell
parcel build src/index.hbs --log-level 5
```

## ✔️ PR Todo

- [x] Create pull request of oddeirik's change, as requested 
- [ ] Investigate whether a meaningful unit test can be added
