### PR TITLE
Fix page reload loop with React Refresh

### DIFF
--- a/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
+++ b/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
@@ -37,6 +37,10 @@ module.exports.postlude = function(module) {
 
     if (module.hot) {
       module.hot.dispose(function(data) {
+        if (Refresh.hasUnrecoverableErrors()) {
+          window.location.reload();
+        }
+
         data.prevExports = module.exports;
       });
 
@@ -70,9 +74,6 @@ module.exports.postlude = function(module) {
         }
         enqueueUpdate();
       });
-    }
-    if (Refresh.hasUnrecoverableErrors()) {
-      window.location.reload();
     }
   }
 };


### PR DESCRIPTION
# ↪️ Pull Request

Close T-449

The `if(unrecoverableError) location.reload()` check was always executed (so on startup). Now it only happens on `module.hot.dispose(...)` so that it only executes when an HMR update happens.

## 💻 Examples

```js
import React, { Suspense, lazy, useState } from "react";

const Async = lazy(() => {});
import("./Async")

let App = () => {
	const [x] = useState(Math.random());

	return (
		<Suspense fallback={"Loading"}>
			{x} <Async />
		</Suspense>
	);
};

export default App;
```

## 🚨 Test instructions

I wasn't able test this because https://github.com/facebook/react/issues/18768 breaks JSDOM's error handling.
Can be added later on as part of the ongoing cross-bundler React Refresh test suite project.
