### PR TITLE
Import asset from reachable bundle in ESM output format

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -481,6 +481,59 @@ export default class BundleGraph {
     });
   }
 
+  findReachableBundleWithAsset(bundle: Bundle, asset: Asset) {
+    let bundleGroups = this.getBundleGroupsContainingBundle(bundle);
+
+    for (let bundleGroup of bundleGroups) {
+      // If the asset is in any sibling bundles, return that bundle.
+      let bundles = this.getBundlesInBundleGroup(bundleGroup);
+      let res = bundles.find(
+        b => b.id !== bundle.id && this.bundleHasAsset(b, asset),
+      );
+      if (res != null) {
+        return res;
+      }
+
+      // Get a list of parent bundle nodes pointing to the bundle group
+      let parentBundleNodes = this._graph.getNodesConnectedTo(
+        nullthrows(this._graph.getNode(getBundleGroupId(bundleGroup))),
+        'bundle',
+      );
+
+      // Find the nearest ancestor bundle that includes the asset.
+      for (let bundleNode of parentBundleNodes) {
+        this._graph.traverseAncestors(
+          bundleNode,
+          (node, ctx, actions) => {
+            if (node.type === 'bundle_group') {
+              let childBundles = this.getBundlesInBundleGroup(node.value);
+
+              res = childBundles.find(
+                b => b.id !== bundle.id && this.bundleHasAsset(b, asset),
+              );
+              if (res != null) {
+                actions.stop();
+              }
+            }
+
+            // Stop when context changes
+            if (
+              node.type === 'bundle' &&
+              node.value.env.context !== bundle.env.context
+            ) {
+              actions.skipChildren();
+            }
+          },
+          'bundle',
+        );
+
+        if (res != null) {
+          return res;
+        }
+      }
+    }
+  }
+
   traverseBundle<TContext>(
     bundle: Bundle,
     visit: GraphVisitor<AssetNode | DependencyNode, TContext>,

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -119,19 +119,15 @@ export default class BundleGraph implements IBundleGraph {
   }
 
   isAssetReachableFromBundle(asset: IAsset, bundle: IBundle): boolean {
-    let internalNode = this.#graph._graph.getNode(bundle.id);
-    invariant(internalNode != null && internalNode.type === 'bundle');
     return this.#graph.isAssetReachableFromBundle(
       assetToAssetValue(asset),
-      internalNode.value,
+      bundleToInternalBundle(bundle),
     );
   }
 
   findReachableBundleWithAsset(bundle: IBundle, asset: IAsset): ?IBundle {
-    let internalNode = this.#graph._graph.getNode(bundle.id);
-    invariant(internalNode != null && internalNode.type === 'bundle');
     let result = this.#graph.findReachableBundleWithAsset(
-      internalNode.value,
+      bundleToInternalBundle(bundle),
       assetToAssetValue(asset),
     );
 

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -13,7 +13,6 @@ import type {
 import type {ParcelOptions} from '../types';
 import type InternalBundleGraph from '../BundleGraph';
 
-import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {DefaultWeakMap} from '@parcel/utils';
 

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -127,6 +127,21 @@ export default class BundleGraph implements IBundleGraph {
     );
   }
 
+  findReachableBundleWithAsset(bundle: IBundle, asset: IAsset): ?IBundle {
+    let internalNode = this.#graph._graph.getNode(bundle.id);
+    invariant(internalNode != null && internalNode.type === 'bundle');
+    let result = this.#graph.findReachableBundleWithAsset(
+      internalNode.value,
+      assetToAssetValue(asset),
+    );
+
+    if (result != null) {
+      return new Bundle(result, this.#graph, this.#options);
+    }
+
+    return null;
+  }
+
   isAssetReferenced(asset: IAsset): boolean {
     return this.#graph.isAssetReferenced(assetToAssetValue(asset));
   }

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1276,6 +1276,47 @@ describe('html', function() {
     });
   });
 
+  it('should support split bundles with many pages with esmodule output', async function() {
+    await bundle(path.join(__dirname, '/integration/shared-many-esm/*.html'), {
+      scopeHoist: true,
+    });
+
+    let checkHtml = async filename => {
+      // Find all scripts referenced in the HTML file
+      let html = await outputFS.readFile(path.join(distDir, filename), 'utf8');
+      let re = /<script.*?src="(.*?)"/g;
+      let match;
+      let scripts = new Set();
+      while ((match = re.exec(html))) {
+        scripts.add(path.join(distDir, match[1]));
+      }
+
+      assert(scripts.size > 0, 'no scripts found');
+
+      // Ensure that those scripts don't import anything other than what's in the HTML.
+      for (let script of scripts) {
+        let js = await outputFS.readFile(script, 'utf8');
+        let re = /import .*? from "(.*?)"/g;
+        let match;
+        while ((match = re.exec(js))) {
+          let imported = path.join(distDir, match[1]);
+          assert(
+            scripts.has(imported),
+            `unknown script ${match[1]} imported in ${path.basename(script)}`,
+          );
+        }
+      }
+    };
+
+    checkHtml('a.html');
+    checkHtml('b.html');
+    checkHtml('c.html');
+    checkHtml('d.html');
+    checkHtml('e.html');
+    checkHtml('f.html');
+    checkHtml('g.html');
+  });
+
   it('should invalidate parent bundle when inline bundles change', async function() {
     // copy into memory fs
     await ncp(

--- a/packages/core/integration-tests/test/integration/shared-many-esm/a.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/a.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="a.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/a.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/a.js
@@ -1,0 +1,2 @@
+import 'lodash/cloneDeep';
+import 'lodash/assign';

--- a/packages/core/integration-tests/test/integration/shared-many-esm/b.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/b.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="b.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/b.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/b.js
@@ -1,0 +1,4 @@
+import 'lodash/cloneDeep';
+import 'lodash/pick';
+import 'lodash/omit';
+import 'lodash/difference';

--- a/packages/core/integration-tests/test/integration/shared-many-esm/c.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/c.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="c.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/c.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/c.js
@@ -1,0 +1,2 @@
+import 'lodash/pick';
+import 'lodash/omit';

--- a/packages/core/integration-tests/test/integration/shared-many-esm/d.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/d.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="d.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/d.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/d.js
@@ -1,0 +1,2 @@
+import 'lodash/omit';
+import 'lodash/flatten';

--- a/packages/core/integration-tests/test/integration/shared-many-esm/e.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/e.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="e.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/e.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/e.js
@@ -1,0 +1,2 @@
+import 'lodash/flatten';
+import 'lodash/drop';

--- a/packages/core/integration-tests/test/integration/shared-many-esm/f.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/f.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="f.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/f.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/f.js
@@ -1,0 +1,2 @@
+import 'lodash/drop';
+import 'lodash/fill';

--- a/packages/core/integration-tests/test/integration/shared-many-esm/g.html
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/g.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<script type="module" src="g.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many-esm/g.js
+++ b/packages/core/integration-tests/test/integration/shared-many-esm/g.js
@@ -1,0 +1,2 @@
+import 'lodash/fill';
+import 'lodash/difference';

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -656,6 +656,7 @@ export interface BundleGraph {
   findBundlesWithAsset(Asset): Array<Bundle>;
   findBundlesWithDependency(Dependency): Array<Bundle>;
   isAssetReachableFromBundle(asset: Asset, bundle: Bundle): boolean;
+  findReachableBundleWithAsset(bundle: Bundle, asset: Asset): ?Bundle;
   isAssetReferenced(asset: Asset): boolean;
   isAssetReferencedByDependant(bundle: Bundle, asset: Asset): boolean;
   hasParentBundleOfType(bundle: Bundle, type: string): boolean;

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -329,12 +329,18 @@ export function link({
   }
 
   function addBundleImport(mod, path) {
-    // Find the first bundle containing this asset, and create an import for it if needed.
-    // An asset may be duplicated in multiple bundles, so try to find one that matches
-    // the current environment if possible and fall back to the first one.
-    let bundles = bundleGraph.findBundlesWithAsset(mod);
-    let importedBundle =
-      bundles.find(b => b.env.context === bundle.env.context) || bundles[0];
+    // Find a bundle that's reachable from the current bundle (sibling or ancestor)
+    // containing this asset, and create an import for it if needed.
+    let importedBundle = bundleGraph.findReachableBundleWithAsset(bundle, mod);
+    if (!importedBundle) {
+      throw new Error(
+        `No reachable bundle found containing ${relative(
+          options.inputFS.cwd(),
+          mod.filePath,
+        )}`,
+      );
+    }
+
     let filePath = nullthrows(importedBundle.filePath);
     let imported = importedFiles.get(filePath);
     if (!imported) {


### PR DESCRIPTION
Previously, we would import from the first bundle containing the asset when it wasn't in the current bundle in scope hoisting. This was incorrect because it could have been from a different part of the site completely rather than a bundle that was already loaded in the current bundle's ancestry.

This PR finds a reachable bundle containing the asset to import from the current bundle. This includes sibling bundles as well as ancestors and siblings of ancestors. It follows a similar algorithm to the one I added in #4295, but returns the first bundle it finds containing the asset rather than checking if all of the ancestors contain it. This is verified by ensuring that any ESM import is already loaded by the parent HTML file.