### PR TITLE
Add `--detailed-report` flag

### DIFF
--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -91,4 +91,8 @@ export default class PluginOptions implements IPluginOptions {
   get packageManager(): PackageManager {
     return this.#options.packageManager;
   }
+
+  get detailedReport(): number {
+    return this.#options.detailedReport || 0;
+  }
 }

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -72,6 +72,14 @@ export default async function resolveOptions(
   let mode = initialOptions.mode ?? 'development';
   let minify = initialOptions.minify ?? mode === 'production';
 
+  let detailedReport: number = 0;
+  if (initialOptions.detailedReport != null) {
+    detailedReport =
+      initialOptions.detailedReport === true
+        ? 10
+        : parseInt(initialOptions.detailedReport, 10);
+  }
+
   return {
     config: initialOptions.config,
     defaultConfig: initialOptions.defaultConfig,
@@ -111,5 +119,6 @@ export default async function resolveOptions(
     cache,
     packageManager,
     instanceId: generateInstanceId(entries),
+    detailedReport,
   };
 }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -153,6 +153,7 @@ export type ParcelOptions = {|
   lockFile: ?FilePath,
   profile: boolean,
   patchConsole: boolean,
+  detailedReport?: number,
 
   inputFS: FileSystem,
   outputFS: FileSystem,

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -68,6 +68,10 @@ const commonOptions = {
     'output directory to write to when unspecified by targets',
   '--profile': 'enable build profiling',
   '-V, --version': 'output the version number',
+  '--detailed-report [depth]': [
+    'Print the asset timings and sizes in the build report',
+    /^([0-9]+)$/,
+  ],
 };
 
 var hmrOptions = {
@@ -310,6 +314,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     autoinstall: command.autoinstall ?? true,
     logLevel: command.logLevel,
     profile: command.profile,
+    detailedReport: command.detailedReport,
     env: {
       NODE_ENV: nodeEnv,
     },

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -204,11 +204,11 @@ export type InitialParcelOptions = {|
   +workerFarm?: WorkerFarm,
   +packageManager?: PackageManager,
   +defaultEngines?: Engines,
+  +detailedReport?: number | boolean,
 
   // contentHash
   // throwErrors
   // global?
-  // detailedReport
 |};
 
 export interface PluginOptions {
@@ -227,6 +227,7 @@ export interface PluginOptions {
   +outputFS: FileSystem;
   +packageManager: PackageManager;
   +instanceId: string;
+  +detailedReport: number;
 }
 
 export type ServerOptions = {|

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -24,6 +24,7 @@
     "ora": "^4.0.3",
     "string-width": "^4.2.0",
     "strip-ansi": "^6.0.0",
+    "nullthrows": "^1.1.1",
     "term-size": "^2.1.1"
   }
 }

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -84,6 +84,7 @@ export async function _report(
           event.bundleGraph,
           options.outputFS,
           options.projectRoot,
+          options.detailedReport,
         );
       }
       break;

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -21,6 +21,7 @@ export default async function bundleReport(
   bundleGraph: BundleGraph,
   fs: FileSystem,
   projectRoot: FilePath,
+  assetCount: number,
 ) {
   // Get a list of bundles sorted by size
   let {bundles} = await generateBuildMetrics(
@@ -38,29 +39,31 @@ export default async function bundleReport(
       chalk.green.bold(prettifyTime(bundle.time)),
     ]);
 
-    let largestAssets = bundle.assets.slice(0, 10);
-    for (let asset of largestAssets) {
-      // Add a row for the asset.
-      rows.push([
-        (asset == largestAssets[largestAssets.length - 1] ? '└── ' : '├── ') +
-          formatFilename(asset.filePath, chalk.reset),
-        chalk.dim(prettifySize(asset.size)),
-        chalk.dim(chalk.green(prettifyTime(asset.time))),
-      ]);
-    }
+    if (assetCount > 0) {
+      let largestAssets = bundle.assets.slice(0, assetCount);
+      for (let asset of largestAssets) {
+        // Add a row for the asset.
+        rows.push([
+          (asset == largestAssets[largestAssets.length - 1] ? '└── ' : '├── ') +
+            formatFilename(asset.filePath, chalk.reset),
+          chalk.dim(prettifySize(asset.size)),
+          chalk.dim(chalk.green(prettifyTime(asset.time))),
+        ]);
+      }
 
-    if (bundle.assets.length > largestAssets.length) {
-      rows.push([
-        '└── ' +
-          chalk.dim(
-            `+ ${bundle.assets.length - largestAssets.length} more assets`,
-          ),
-      ]);
-    }
+      if (bundle.assets.length > largestAssets.length) {
+        rows.push([
+          '└── ' +
+            chalk.dim(
+              `+ ${bundle.assets.length - largestAssets.length} more assets`,
+            ),
+        ]);
+      }
 
-    // If this isn't the last bundle, add an empty row before the next one
-    if (bundle !== bundles[bundles.length - 1]) {
-      rows.push([]);
+      // If this isn't the last bundle, add an empty row before the next one
+      if (bundle !== bundles[bundles.length - 1]) {
+        rows.push([]);
+      }
     }
   }
 

--- a/packages/reporters/cli/test/CLIReporter.test.js
+++ b/packages/reporters/cli/test/CLIReporter.test.js
@@ -30,6 +30,7 @@ const EMPTY_OPTIONS = {
   outputFS,
   instanceId: 'test',
   packageManager: new NodePackageManager(inputFS),
+  detailedReport: 10,
 };
 
 describe('CLIReporter', () => {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR adds a flag for `--detailed-report` similar to Parcel 1, defaulting to not outputting assets, and outputting 10 largest assets when used and optionally allowing adding the amount of assets you'd like to show.

![Screenshot 2020-04-30 at 14 43 54](https://user-images.githubusercontent.com/2175521/80711722-18708480-8af1-11ea-9b91-2704db492905.png)
![Screenshot 2020-04-30 at 14 44 21](https://user-images.githubusercontent.com/2175521/80711730-1c040b80-8af1-11ea-8bc3-a5c34b094598.png)

