### PR TITLE
Deduplicate bundles following asset graph order

### DIFF
--- a/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/a.js
+++ b/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/a.js
@@ -1,0 +1,4 @@
+import 'lodash/clone';
+import 'lodash/assign';
+
+export default 'a';

--- a/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/b.js
+++ b/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/b.js
@@ -1,0 +1,4 @@
+import 'lodash/clone';
+import 'lodash/pick';
+
+export default 'b';

--- a/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/c.js
+++ b/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/c.js
@@ -1,0 +1,4 @@
+import 'lodash/assign';
+import 'lodash/omit';
+
+export default 'c';

--- a/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/index.js
+++ b/packages/core/integration-tests/test/integration/shared-sibling-scope-hoist/index.js
@@ -1,0 +1,5 @@
+output = Promise.all([
+  import('./a').then(mod => mod.default),
+  import('./b').then(mod => mod.default),
+  import('./c').then(mod => mod.default)
+]);

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2328,6 +2328,14 @@ describe('scope hoisting', function() {
     assert.deepEqual(await run(b), [3, 5]);
   });
 
+  it('deduplicates shared sibling assets between bundle groups', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/shared-sibling-scope-hoist/index.js'),
+    );
+
+    assert.deepEqual(await run(b), ['a', 'b', 'c']);
+  });
+
   it('can run an entry bundle whose entry asset is present in another bundle', async () => {
     let b = await bundle(
       ['index.js', 'value.js'].map(basename =>


### PR DESCRIPTION
Following #4295 and #4545, we ran into some cases where we received the `No reachable bundle found containing ${asset}` error in scope hoisting. After much debugging, I determined that this was due to bundles being deduplicated in the wrong order. For example, a deeper asset might get removed from one bundle, and later an ancestor might get removed from another bundle. When we remove this ancestor, we'd also remove the child. This could result in no bundles in a bundle group containing the required child asset, because it got removed along with the ancestor.

This PR ensures that we consider all bundles for an asset at the same time, following asset graph order. This way, parent assets are always considered before children.

@wbinnssmith also came across a case where shared bundles were executing out of order, and causing missing asset errors. This was because we did not wrap bundles without a main entry in a function, and therefore they executed immediately. We now always wrap all async loaded bundles to avoid this case.