### PR TITLE
Scope hoisting: conditional reference of an imported, interopDefault symbol from another bundle in a case clause

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-interop-conditional/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-interop-conditional/async.js
@@ -1,0 +1,13 @@
+import value from './value';
+
+let out;
+switch (3) {
+  case false:
+    value.foo;
+    break;
+  case 3:
+    out = value.foo;
+    break;
+}
+
+export default out;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-interop-conditional/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-interop-conditional/index.js
@@ -1,0 +1,3 @@
+import value from './value';
+
+output = import('./async').then(mod => mod.default);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-interop-conditional/value.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/async-interop-conditional/value.js
@@ -1,0 +1,1 @@
+module.exports = {foo: 42};

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1048,6 +1048,18 @@ describe('scope hoisting', function() {
       let output = await run(b);
       assert.equal(output, 'hello');
     });
+
+    it('can conditionally reference an imported symbol from another bundle in a case clause', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/async-interop-conditional/index.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(await output, 42);
+    });
   });
 
   describe('commonjs', function() {

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -217,28 +217,23 @@ export function link({
     if (mod.meta.isCommonJS && originalName === 'default') {
       let name = getName(mod, '$interop$default');
       if (!path.scope.getBinding(name)) {
-        // Hoist to the nearest path with the same scope as the exports is declared in
-        let binding = path.scope.getBinding(
-          bundle.hasAsset(mod)
-            ? assertString(mod.meta.exportsIdentifier)
-            : // If this bundle doesn't have the asset, use the binding for
-              // the `parcelRequire`d init function.
-              getIdentifier(mod, 'init').name,
+        let binding = nullthrows(
+          path.scope.getBinding(
+            bundle.hasAsset(mod)
+              ? assertString(mod.meta.exportsIdentifier)
+              : // If this bundle doesn't have the asset, use the binding for
+                // the `parcelRequire`d init function.
+                getIdentifier(mod, 'init').name,
+          ),
         );
 
-        let parent;
-        if (binding) {
-          invariant(
-            binding.path.getStatementParent().parentPath.isProgram(),
-            "Expected binding declaration's parent to be the program",
-          );
-          parent = path.findParent(p => t.isProgram(p.parent));
-        }
+        invariant(
+          binding.path.getStatementParent().parentPath.isProgram(),
+          "Expected binding declaration's parent to be the program",
+        );
 
-        if (!parent) {
-          parent = path.getStatementParent();
-        }
-
+        // Hoist to the nearest path with the same scope as the exports is declared in.
+        let parent = nullthrows(path.findParent(p => t.isProgram(p.parent)));
         let [decl] = parent.insertBefore(
           DEFAULT_INTEROP_TEMPLATE({
             NAME: t.identifier(name),
@@ -246,11 +241,9 @@ export function link({
           }),
         );
 
-        if (binding) {
-          binding.reference(
-            decl.get<NodePath<Identifier>>('declarations.0.init'),
-          );
-        }
+        binding.reference(
+          decl.get<NodePath<Identifier>>('declarations.0.init'),
+        );
 
         getScopeBefore(parent).registerDeclaration(decl);
       }

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -223,7 +223,7 @@ export function link({
               ? assertString(mod.meta.exportsIdentifier)
               : // If this bundle doesn't have the asset, use the binding for
                 // the `parcelRequire`d init function.
-                getIdentifier(mod, 'init').name,
+                getName(mod, 'init'),
           ),
         );
 

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -219,8 +219,13 @@ export function link({
       if (!path.scope.getBinding(name)) {
         // Hoist to the nearest path with the same scope as the exports is declared in
         let binding = path.scope.getBinding(
-          assertString(mod.meta.exportsIdentifier),
+          bundle.hasAsset(mod)
+            ? assertString(mod.meta.exportsIdentifier)
+            : // If this bundle doesn't have the asset, use the binding for
+              // the `parcelRequire`d init function.
+              getIdentifier(mod, 'init').name,
         );
+
         let parent;
         if (binding) {
           invariant(


### PR DESCRIPTION
Similar to #4487, conditionally referencing an imported symbol originating from another bundle causes the binding to be inserted at the first reference.

This seems to only occur when the conditional reference is in a `switch` case clause that is not a block.

This PR also makes `binding` and `parent` invariant rather than conditionally used.

To do:
* [x] Implement a fix

Test Plan: Added test