### PR TITLE
Apply CommonJS exports.foo assignments

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/mutated-exports-object/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/mutated-exports-object/index.js
@@ -1,0 +1,4 @@
+require('./mutates');
+const value = require('./value');
+
+output = value.foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/mutated-exports-object/mutates.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/mutated-exports-object/mutates.js
@@ -1,0 +1,2 @@
+const value = require('./value');
+value.foo = 43;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/mutated-exports-object/value.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/mutated-exports-object/value.js
@@ -1,0 +1,1 @@
+exports.foo = 42;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1653,6 +1653,17 @@ describe('scope hoisting', function() {
       });
     });
 
+    it('supports mutations of the exports objects', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/mutated-exports-object/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), 43);
+    });
+
     it('supports require.resolve calls for excluded modules', async function() {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
# ↪️ Pull Request

Collaboration with @wbinnssmith and ideas from @devongovett 

## 💻 Examples

```js
// index.js
const v = require("./value");
v.foo = 2;
console.log(v.foo);

// value.js
exports.foo = 1;
```

would previously result in (shaken statements commented out)
```js
// ---- value.js
// var $value$exports = {};
var $value$export$foo = 2;
// $value$exports.foo = $value$export$foo;
// ---- index.js
// $value$exports.foo = 1;
console.log($value$export$foo);
```

The new behaviour is:
```js
// ---- value.js
// var $value$exports = {};
var $value$export$foo = 2;
// $value$exports.foo = $value$export$foo;
// ---- index.js
$value$exports$foo = 1;
// $value$exports.foo = 1;
console.log($value$export$foo);
```
(Terser will collapse the two assignments)