### PR TITLE
Never wrap sideEffect free assets

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/a.js
@@ -1,0 +1,4 @@
+if (Date.now() > 0) {
+  const bar = require("bar");
+  output = bar.default(2);
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/foo.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/foo.js
@@ -1,0 +1,3 @@
+export default function foo(a) {
+  return a * a;
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+export {default} from "./other.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/other.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/other.js
@@ -1,0 +1,1 @@
+export {default} from "./foo.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/node_modules/bar/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "bar",
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -748,6 +748,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'bar');
     });
 
+    it('correctly handles excluded and wrapped reexport assets with sideEffects: false', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/a.js',
+        ),
+      );
+      let output = await run(b);
+
+      assert.deepEqual(output, 4);
+    });
+
     it('supports the package.json sideEffects flag with an array', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -78,7 +78,7 @@ export async function concat({
             node.value,
             bundle,
           );
-          if (resolved) {
+          if (resolved && resolved.sideEffects) {
             wrappedAssets.add(resolved.id);
           }
           return true;


### PR DESCRIPTION
# ↪️ Pull Request

We don't need to wrap sideeffect-free assets (right?), because the whole point of wrapping is not causing sideeffects.

This has two benefits:
- (Smaller output, maybe faster build?)
- In the added test case
`app -conditional import-> lodash-es/lodash.js -reexports-> lodash-es/first.js -reexports-> lodash-es/head.js`,
`lodash-es/first.js` was excluded in concat but the init call for that assets was still generated. Now, we never wrap sideeffect-free asssets, so when an asset is excluded there will never be a dangling init call.
