### PR TITLE
Make BundleGraph parameterized on a particular Bundle type

### DIFF
--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Namer, FilePath} from '@parcel/types';
+import type {Bundle as IBundle, Namer, FilePath} from '@parcel/types';
 import type {Bundle as InternalBundle, ParcelOptions} from './types';
 import type ParcelConfig from './ParcelConfig';
 import type WorkerFarm from '@parcel/workers';
@@ -16,7 +16,7 @@ import AssetGraph from './AssetGraph';
 import BundleGraph from './public/BundleGraph';
 import InternalBundleGraph, {removeAssetGroups} from './BundleGraph';
 import MutableBundleGraph from './public/MutableBundleGraph';
-import {Bundle} from './public/Bundle';
+import {Bundle, NamedBundle} from './public/Bundle';
 import {report} from './ReporterRunner';
 import dumpGraphToGraphViz from './dumpGraphToGraphViz';
 import {normalizeSeparators, unique, md5FromObject} from '@parcel/utils';
@@ -166,7 +166,12 @@ export default class BundlerRunner {
     internalBundleGraph: InternalBundleGraph,
   ): Promise<void> {
     let bundle = new Bundle(internalBundle, internalBundleGraph, this.options);
-    let bundleGraph = new BundleGraph(internalBundleGraph, this.options);
+    let bundleGraph = new BundleGraph<IBundle>(
+      internalBundleGraph,
+      (bundle, bundleGraph, options) =>
+        new NamedBundle(bundle, bundleGraph, options),
+      this.options,
+    );
 
     for (let namer of namers) {
       try {

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -6,6 +6,7 @@ import type {
   BundleResult,
   Bundle as BundleType,
   BundleGraph as BundleGraphType,
+  NamedBundle as NamedBundleType,
   Async,
 } from '@parcel/types';
 import type SourceMap from '@parcel/source-map';
@@ -237,7 +238,12 @@ export default class PackagerRunner {
     try {
       return await packager.plugin.package({
         bundle,
-        bundleGraph: new BundleGraph(bundleGraph, this.options),
+        bundleGraph: new BundleGraph<NamedBundleType>(
+          bundleGraph,
+          (bundle, bundleGraph, options) =>
+            new NamedBundle(bundle, bundleGraph, options),
+          this.options,
+        ),
         getSourceMapReference: map => {
           return this.getSourceMapReference(bundle, map);
         },
@@ -245,7 +251,7 @@ export default class PackagerRunner {
         logger: new PluginLogger({origin: packager.name}),
         getInlineBundleContents: async (
           bundle: BundleType,
-          bundleGraph: BundleGraphType,
+          bundleGraph: BundleGraphType<NamedBundleType>,
         ) => {
           if (!bundle.isInline) {
             throw new Error(
@@ -255,6 +261,7 @@ export default class PackagerRunner {
 
           let res = await this.getBundleResult(
             bundleToInternalBundle(bundle),
+            // $FlowFixMe
             bundleGraphToInternalBundleGraph(bundleGraph),
           );
 

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -8,6 +8,7 @@ import type {
   FilePath,
   InitialParcelOptions,
   ModuleSpecifier,
+  NamedBundle as INamedBundle,
 } from '@parcel/types';
 import type {ParcelOptions} from './types';
 import type {FarmOptions} from '@parcel/workers';
@@ -19,6 +20,7 @@ import ThrowableDiagnostic, {anyToDiagnostic} from '@parcel/diagnostic';
 import {createDependency} from './Dependency';
 import {createEnvironment} from './Environment';
 import {assetFromValue} from './public/Asset';
+import {NamedBundle} from './public/Bundle';
 import BundleGraph from './public/BundleGraph';
 import BundlerRunner from './BundlerRunner';
 import WorkerFarm from '@parcel/workers';
@@ -144,7 +146,7 @@ export default class Parcel {
     this.#initialized = true;
   }
 
-  async run(): Promise<IBundleGraph> {
+  async run(): Promise<IBundleGraph<INamedBundle>> {
     let startTime = Date.now();
     if (!this.#initialized) {
       await this.init();
@@ -276,7 +278,12 @@ export default class Parcel {
             assetFromValue(asset, options),
           ]),
         ),
-        bundleGraph: new BundleGraph(bundleGraph, options),
+        bundleGraph: new BundleGraph(
+          bundleGraph,
+          (bundle, bundleGraph, options) =>
+            new NamedBundle(bundle, bundleGraph, options),
+          options,
+        ),
         buildTime: Date.now() - startTime,
       };
 

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Dependency} from '@parcel/types';
+import type {Dependency, NamedBundle as INamedBundle} from '@parcel/types';
 import type {
   AssetRequestDesc,
   Bundle as InternalBundle,
@@ -51,7 +51,12 @@ export default async function applyRuntimes({
       try {
         let applied = await runtime.plugin.apply({
           bundle: new NamedBundle(bundle, bundleGraph, options),
-          bundleGraph: new BundleGraph(bundleGraph, options),
+          bundleGraph: new BundleGraph<INamedBundle>(
+            bundleGraph,
+            (bundle, bundleGraph, options) =>
+              new NamedBundle(bundle, bundleGraph, options),
+            options,
+          ),
           options: pluginOptions,
           logger: new PluginLogger({origin: runtime.name}),
         });

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -11,47 +11,54 @@ import type {
   Symbol,
   SymbolResolution,
 } from '@parcel/types';
-import type {ParcelOptions} from '../types';
+import type {Bundle as InternalBundle, ParcelOptions} from '../types';
 import type InternalBundleGraph from '../BundleGraph';
 
 import nullthrows from 'nullthrows';
-import {DefaultWeakMap} from '@parcel/utils';
 
 import {assetFromValue, assetToAssetValue} from './Asset';
-import {Bundle, bundleToInternalBundle} from './Bundle';
+import {bundleToInternalBundle} from './Bundle';
 import Dependency, {dependencyToInternalDependency} from './Dependency';
 import {mapVisitor} from '../Graph';
 
-const internalBundleGraphToBundleGraph: DefaultWeakMap<
-  ParcelOptions,
-  WeakMap<InternalBundleGraph, BundleGraph>,
-> = new DefaultWeakMap(() => new WeakMap());
 // Friendly access for other modules within this package that need access
 // to the internal bundle.
 const _bundleGraphToInternalBundleGraph: WeakMap<
-  IBundleGraph,
+  IBundleGraph<IBundle>,
   InternalBundleGraph,
 > = new WeakMap();
 export function bundleGraphToInternalBundleGraph(
-  bundleGraph: IBundleGraph,
+  bundleGraph: IBundleGraph<IBundle>,
 ): InternalBundleGraph {
   return nullthrows(_bundleGraphToInternalBundleGraph.get(bundleGraph));
 }
 
-export default class BundleGraph implements IBundleGraph {
-  #graph; // InternalBundleGraph
-  #options; // ParcelOptions
+type BundleFactory<TBundle: IBundle> = (
+  InternalBundle,
+  InternalBundleGraph,
+  ParcelOptions,
+) => TBundle;
 
-  constructor(graph: InternalBundleGraph, options: ParcelOptions) {
-    let existing = internalBundleGraphToBundleGraph.get(options).get(graph);
-    if (existing != null) {
-      return existing;
-    }
+export default class BundleGraph<TBundle: IBundle>
+  implements IBundleGraph<TBundle> {
+  #graph: InternalBundleGraph;
+  #options: ParcelOptions;
+  // This is invoked as `this.#createBundle.call(null, ...)` below, as private
+  // properties aren't currently callable in Flow:
+  // https://github.com/parcel-bundler/parcel/pull/4591#discussion_r422661115
+  // https://github.com/facebook/flow/issues/7877
+  #createBundle: BundleFactory<TBundle>;
 
+  constructor(
+    graph: InternalBundleGraph,
+    createBundle: BundleFactory<TBundle>,
+    options: ParcelOptions,
+  ) {
     this.#graph = graph;
     this.#options = options;
+    this.#createBundle = createBundle;
+    // $FlowFixMe
     _bundleGraphToInternalBundleGraph.set(this, graph);
-    internalBundleGraphToBundleGraph.get(options).set(graph, this);
   }
 
   isDependencyDeferred(dep: IDependency): boolean {
@@ -82,16 +89,20 @@ export default class BundleGraph implements IBundleGraph {
     );
   }
 
-  getSiblingBundles(bundle: IBundle): Array<IBundle> {
+  getSiblingBundles(bundle: IBundle): Array<TBundle> {
     return this.#graph
       .getSiblingBundles(bundleToInternalBundle(bundle))
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 
-  getReferencedBundles(bundle: IBundle): Array<IBundle> {
+  getReferencedBundles(bundle: IBundle): Array<TBundle> {
     return this.#graph
       .getReferencedBundles(bundleToInternalBundle(bundle))
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 
   resolveExternalDependency(
@@ -131,14 +142,14 @@ export default class BundleGraph implements IBundleGraph {
     );
   }
 
-  findReachableBundleWithAsset(bundle: IBundle, asset: IAsset): ?IBundle {
+  findReachableBundleWithAsset(bundle: IBundle, asset: IAsset): ?TBundle {
     let result = this.#graph.findReachableBundleWithAsset(
       bundleToInternalBundle(bundle),
       assetToAssetValue(asset),
     );
 
     if (result != null) {
-      return new Bundle(result, this.#graph, this.#options);
+      return this.#createBundle.call(null, result, this.#graph, this.#options);
     }
 
     return null;
@@ -162,7 +173,7 @@ export default class BundleGraph implements IBundleGraph {
     );
   }
 
-  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<IBundle> {
+  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<TBundle> {
     return this.#graph
       .getBundlesInBundleGroup(bundleGroup)
       .sort(
@@ -170,26 +181,34 @@ export default class BundleGraph implements IBundleGraph {
           bundleGroup.bundleIds.indexOf(a.id) -
           bundleGroup.bundleIds.indexOf(b.id),
       )
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options))
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      )
       .reverse();
   }
 
-  getBundles(): Array<IBundle> {
+  getBundles(): Array<TBundle> {
     return this.#graph
       .getBundles()
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 
-  getChildBundles(bundle: IBundle): Array<IBundle> {
+  getChildBundles(bundle: IBundle): Array<TBundle> {
     return this.#graph
       .getChildBundles(bundleToInternalBundle(bundle))
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 
-  getParentBundles(bundle: IBundle): Array<IBundle> {
+  getParentBundles(bundle: IBundle): Array<TBundle> {
     return this.#graph
       .getParentBundles(bundleToInternalBundle(bundle))
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 
   resolveSymbol(
@@ -222,27 +241,32 @@ export default class BundleGraph implements IBundleGraph {
   }
 
   traverseBundles<TContext>(
-    visit: GraphVisitor<IBundle, TContext>,
+    visit: GraphVisitor<TBundle, TContext>,
     startBundle: ?IBundle,
   ): ?TContext {
     return this.#graph.traverseBundles(
       mapVisitor(
-        bundle => new Bundle(bundle, this.#graph, this.#options),
+        bundle =>
+          this.#createBundle.call(null, bundle, this.#graph, this.#options),
         visit,
       ),
       startBundle == null ? undefined : bundleToInternalBundle(startBundle),
     );
   }
 
-  findBundlesWithAsset(asset: IAsset): Array<IBundle> {
+  findBundlesWithAsset(asset: IAsset): Array<TBundle> {
     return this.#graph
       .findBundlesWithAsset(assetToAssetValue(asset))
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 
-  findBundlesWithDependency(dependency: IDependency): Array<IBundle> {
+  findBundlesWithDependency(dependency: IDependency): Array<TBundle> {
     return this.#graph
       .findBundlesWithDependency(dependencyToInternalDependency(dependency))
-      .map(bundle => new Bundle(bundle, this.#graph, this.#options));
+      .map(bundle =>
+        this.#createBundle.call(null, bundle, this.#graph, this.#options),
+      );
   }
 }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type {
-  Bundle,
   BuildEvent,
   BundleGraph,
   FilePath,
@@ -156,8 +155,8 @@ export function getNextBuild(b: Parcel): Promise<BuildEvent> {
 type RunOpts = {require?: boolean, ...};
 
 export async function runBundles(
-  parent: Bundle,
-  bundles: Array<Bundle>,
+  parent: NamedBundle,
+  bundles: Array<NamedBundle>,
   globals: mixed,
   opts: RunOpts = {},
 ): Promise<mixed> {
@@ -170,23 +169,20 @@ export async function runBundles(
   let ctx, promises;
   switch (target) {
     case 'browser': {
-      let prepared = prepareBrowserContext(
-        nullthrows(parent.filePath),
-        globals,
-      );
+      let prepared = prepareBrowserContext(parent.filePath, globals);
       ctx = prepared.ctx;
       promises = prepared.promises;
       break;
     }
     case 'node':
     case 'electron-main':
-      ctx = prepareNodeContext(nullthrows(parent.filePath), globals);
+      ctx = prepareNodeContext(parent.filePath, globals);
       break;
     case 'electron-renderer': {
-      let browser = prepareBrowserContext(nullthrows(parent.filePath), globals);
+      let browser = prepareBrowserContext(parent.filePath, globals);
       ctx = {
         ...browser.ctx,
-        ...prepareNodeContext(nullthrows(parent.filePath), globals),
+        ...prepareNodeContext(parent.filePath, globals),
       };
       promises = browser.promises;
       break;
@@ -232,7 +228,7 @@ export async function runBundles(
 }
 
 export function runBundle(
-  bundle: Bundle,
+  bundle: NamedBundle,
   globals: mixed,
   opts: RunOpts = {},
 ): Promise<mixed> {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -6,6 +6,7 @@ import type {
   BundleGraph,
   FilePath,
   InitialParcelOptions,
+  NamedBundle,
 } from '@parcel/types';
 
 import invariant from 'assert';
@@ -122,7 +123,7 @@ export function bundler(
 export async function bundle(
   entries: FilePath | Array<FilePath>,
   opts?: InitialParcelOptions,
-): Promise<BundleGraph> {
+): Promise<BundleGraph<NamedBundle>> {
   return nullthrows(await bundler(entries, opts).run());
 }
 
@@ -239,7 +240,7 @@ export function runBundle(
 }
 
 export async function run(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   globals: mixed,
   opts: RunOpts = {},
 ): Promise<mixed> {
@@ -275,7 +276,7 @@ export async function run(
 }
 
 export function assertBundles(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   expectedBundles: Array<{|
     name?: string | RegExp,
     type?: string,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -644,7 +644,7 @@ export type BundleGroup = {|
   bundleIds: Array<string>,
 |};
 
-export interface MutableBundleGraph extends BundleGraph {
+export interface MutableBundleGraph extends BundleGraph<Bundle> {
   addAssetGraphToBundle(Asset, Bundle): void;
   addBundleToBundleGroup(Bundle, BundleGroup): void;
   createAssetReference(Dependency, Asset): void;
@@ -665,14 +665,14 @@ export interface MutableBundleGraph extends BundleGraph {
   ): ?TContext;
 }
 
-export interface BundleGraph {
-  getBundles(): Array<Bundle>;
+export interface BundleGraph<TBundle: Bundle> {
+  getBundles(): Array<TBundle>;
   getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
-  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<Bundle>;
-  getChildBundles(bundle: Bundle): Array<Bundle>;
-  getParentBundles(bundle: Bundle): Array<Bundle>;
-  getSiblingBundles(bundle: Bundle): Array<Bundle>;
-  getReferencedBundles(bundle: Bundle): Array<Bundle>;
+  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<TBundle>;
+  getChildBundles(bundle: Bundle): Array<TBundle>;
+  getParentBundles(bundle: Bundle): Array<TBundle>;
+  getSiblingBundles(bundle: Bundle): Array<TBundle>;
+  getReferencedBundles(bundle: Bundle): Array<TBundle>;
   getDependencies(asset: Asset): Array<Dependency>;
   getIncomingDependencies(asset: Asset): Array<Dependency>;
   resolveExternalDependency(
@@ -684,10 +684,10 @@ export interface BundleGraph {
   );
   isDependencyDeferred(dependency: Dependency): boolean;
   getDependencyResolution(dependency: Dependency, bundle: ?Bundle): ?Asset;
-  findBundlesWithAsset(Asset): Array<Bundle>;
-  findBundlesWithDependency(Dependency): Array<Bundle>;
+  findBundlesWithAsset(Asset): Array<TBundle>;
+  findBundlesWithDependency(Dependency): Array<TBundle>;
   isAssetReachableFromBundle(asset: Asset, bundle: Bundle): boolean;
-  findReachableBundleWithAsset(bundle: Bundle, asset: Asset): ?Bundle;
+  findReachableBundleWithAsset(bundle: Bundle, asset: Asset): ?TBundle;
   isAssetReferenced(asset: Asset): boolean;
   isAssetReferencedByDependant(bundle: Bundle, asset: Asset): boolean;
   hasParentBundleOfType(bundle: Bundle, type: string): boolean;
@@ -704,7 +704,7 @@ export interface BundleGraph {
   ): SymbolResolution;
   getExportedSymbols(asset: Asset): Array<ExportSymbolResolution>;
   traverseBundles<TContext>(
-    visit: GraphVisitor<Bundle, TContext>,
+    visit: GraphVisitor<TBundle, TContext>,
     startBundle: ?Bundle,
   ): ?TContext;
 }
@@ -738,7 +738,7 @@ export type Bundler = {|
 export type Namer = {|
   name({|
     bundle: Bundle,
-    bundleGraph: BundleGraph,
+    bundleGraph: BundleGraph<Bundle>,
     options: PluginOptions,
     logger: PluginLogger,
   |}): Async<?FilePath>,
@@ -754,7 +754,7 @@ export type RuntimeAsset = {|
 export type Runtime = {|
   apply({|
     bundle: NamedBundle,
-    bundleGraph: BundleGraph,
+    bundleGraph: BundleGraph<NamedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
   |}): Async<void | RuntimeAsset | Array<RuntimeAsset>>,
@@ -763,10 +763,13 @@ export type Runtime = {|
 export type Packager = {|
   package({|
     bundle: NamedBundle,
-    bundleGraph: BundleGraph,
+    bundleGraph: BundleGraph<NamedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
-    getInlineBundleContents: (Bundle, BundleGraph) => Async<{|contents: Blob|}>,
+    getInlineBundleContents: (
+      Bundle,
+      BundleGraph<NamedBundle>,
+    ) => Async<{|contents: Blob|}>,
     getSourceMapReference: (map: ?SourceMap) => Async<?string>,
   |}): Async<BundleResult>,
 |};
@@ -862,7 +865,7 @@ export type BuildProgressEvent =
 
 export type BuildSuccessEvent = {|
   +type: 'buildSuccess',
-  +bundleGraph: BundleGraph,
+  +bundleGraph: BundleGraph<NamedBundle>,
   +buildTime: number,
   +changedAssets: Map<string, Asset>,
 |};

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -616,12 +616,11 @@ export interface Bundle {
   +hashReference: string;
   +type: string;
   +env: Environment;
+  +filePath: ?FilePath;
   +isEntry: ?boolean;
   +isInline: ?boolean;
   +isSplittable: ?boolean;
   +target: Target;
-  +filePath: ?FilePath;
-  +name: ?string;
   +stats: Stats;
   getEntryAssets(): Array<Asset>;
   getMainEntry(): ?Asset;

--- a/packages/core/utils/src/generateBuildMetrics.js
+++ b/packages/core/utils/src/generateBuildMetrics.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Asset, Bundle, FilePath, NamedBundle} from '@parcel/types';
+import type {Asset, FilePath, NamedBundle} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import SourceMap from '@parcel/source-map';
 import nullthrows from 'nullthrows';
@@ -94,11 +94,11 @@ async function getSourcemapSizes(
 }
 
 async function createBundleStats(
-  bundle: Bundle,
+  bundle: NamedBundle,
   fs: FileSystem,
   projectRoot: FilePath,
 ) {
-  let filePath = nullthrows(bundle.filePath);
+  let filePath = bundle.filePath;
   let sourcemapSizes = await getSourcemapSizes(filePath, fs, projectRoot);
 
   let assets: Array<Asset> = [];

--- a/packages/core/utils/src/generateBuildMetrics.js
+++ b/packages/core/utils/src/generateBuildMetrics.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {Asset, Bundle, FilePath} from '@parcel/types';
+import type {Asset, Bundle, FilePath, NamedBundle} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import SourceMap from '@parcel/source-map';
 import nullthrows from 'nullthrows';
@@ -136,7 +136,7 @@ async function createBundleStats(
 }
 
 export default async function generateBuildMetrics(
-  bundles: Array<Bundle>,
+  bundles: Array<NamedBundle>,
   fs: FileSystem,
   projectRoot: FilePath,
 ): Promise<BuildMetrics> {

--- a/packages/core/utils/src/relativeBundlePath.js
+++ b/packages/core/utils/src/relativeBundlePath.js
@@ -1,17 +1,16 @@
 // @flow strict-local
 
-import type {Bundle} from '@parcel/types';
+import type {NamedBundle} from '@parcel/types';
 
 import path from 'path';
-import nullthrows from 'nullthrows';
 
 export function relativeBundlePath(
-  from: Bundle,
-  to: Bundle,
+  from: NamedBundle,
+  to: NamedBundle,
   opts: {|leadingDotSlash: boolean|} = {leadingDotSlash: true},
 ) {
   let p = path
-    .relative(path.dirname(nullthrows(from.filePath)), nullthrows(to.filePath))
+    .relative(path.dirname(from.filePath), to.filePath)
     .replace(/\\/g, '/');
   if (opts.leadingDotSlash && p[0] !== '.') {
     p = './' + p;

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -35,7 +35,7 @@ export function replaceURLReferences({
   map,
   relative = true,
 }: {|
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
   contents: string,
   relative?: boolean,
@@ -159,8 +159,8 @@ function getURLReplacement({
   relative,
 }: {|
   dependency: Dependency,
-  fromBundle: Bundle,
-  toBundle: Bundle,
+  fromBundle: NamedBundle,
+  toBundle: NamedBundle,
   relative: boolean,
 |}) {
   let url = URL.parse(dependency.moduleSpecifier);

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -1,7 +1,14 @@
 // @flow strict-local
 
 import type SourceMap from '@parcel/source-map';
-import type {Async, Blob, Bundle, BundleGraph, Dependency} from '@parcel/types';
+import type {
+  Async,
+  Blob,
+  Bundle,
+  BundleGraph,
+  Dependency,
+  NamedBundle,
+} from '@parcel/types';
 
 import invariant from 'assert';
 import {Readable} from 'stream';
@@ -29,7 +36,7 @@ export function replaceURLReferences({
   relative = true,
 }: {|
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   contents: string,
   relative?: boolean,
   map?: ?SourceMap,
@@ -91,14 +98,17 @@ export async function replaceInlineReferences({
   getInlineBundleContents,
 }: {|
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   contents: string,
   getInlineReplacement: (
     Dependency,
     ?'string',
     string,
   ) => {|from: string, to: string|},
-  getInlineBundleContents: (Bundle, BundleGraph) => Async<{|contents: Blob|}>,
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph<NamedBundle>,
+  ) => Async<{|contents: Blob|}>,
   map?: ?SourceMap,
 |}): Promise<{|+contents: string, +map: ?SourceMap|}> {
   let replacements = new Map();

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import type {Bundle, BundleGraph} from '@parcel/types';
+import type {Bundle, BundleGraph, NamedBundle} from '@parcel/types';
 
 import assert from 'assert';
 import {Readable} from 'stream';
@@ -89,7 +89,7 @@ export default new Packager({
 });
 
 async function getAssetContent(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   getInlineBundleContents,
   assetId,
 ) {
@@ -115,7 +115,7 @@ async function getAssetContent(
 }
 
 async function replaceInlineAssetContent(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   getInlineBundleContents,
   tree,
 ) {

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Bundle, BundleGraph, Async} from '@parcel/types';
+import type {Bundle, BundleGraph, NamedBundle, Async} from '@parcel/types';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -193,7 +193,10 @@ export default new Packager({
   },
 });
 
-function getPrefix(bundle: Bundle, bundleGraph: BundleGraph): string {
+function getPrefix(
+  bundle: Bundle,
+  bundleGraph: BundleGraph<NamedBundle>,
+): string {
   let interpreter: ?string;
   if (isEntry(bundle, bundleGraph) && !bundle.target.env.isBrowser()) {
     let _interpreter = nullthrows(bundle.getMainEntry()).meta.interpreter;
@@ -215,7 +218,10 @@ function getPrefix(bundle: Bundle, bundleGraph: BundleGraph): string {
   );
 }
 
-function isEntry(bundle: Bundle, bundleGraph: BundleGraph): boolean {
+function isEntry(
+  bundle: Bundle,
+  bundleGraph: BundleGraph<NamedBundle>,
+): boolean {
   return (
     !bundleGraph.hasParentBundleOfType(bundle, 'js') || bundle.env.isIsolated()
   );

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Bundle, BundleGraph, NamedBundle, Async} from '@parcel/types';
+import type {BundleGraph, NamedBundle, Async} from '@parcel/types';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -194,7 +194,7 @@ export default new Packager({
 });
 
 function getPrefix(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ): string {
   let interpreter: ?string;
@@ -219,7 +219,7 @@ function getPrefix(
 }
 
 function isEntry(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ): boolean {
   return (

--- a/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
+++ b/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Bundle, FilePath, PluginOptions} from '@parcel/types';
+import type {FilePath, NamedBundle, PluginOptions} from '@parcel/types';
 
 import invariant from 'assert';
 import {Reporter} from '@parcel/plugin';
@@ -19,7 +19,7 @@ export default new Reporter({
 
     let bundlesByTarget: DefaultMap<
       string /* target name */,
-      Array<Bundle>,
+      Array<NamedBundle>,
     > = new DefaultMap(() => []);
     for (let bundle of event.bundleGraph.getBundles()) {
       bundlesByTarget.get(bundle.target.name).push(bundle);
@@ -98,7 +98,7 @@ type BundleData = {|
 |};
 
 async function getBundleData(
-  bundles: Array<Bundle>,
+  bundles: Array<NamedBundle>,
   options: PluginOptions,
 ): Promise<BundleData> {
   let groups = await Promise.all(
@@ -117,7 +117,7 @@ type DirMapValue = File | DirMap;
 type DirMap = DefaultMap<FilePath, DirMapValue>;
 let createMap: () => DirMap = () => new DefaultMap(() => createMap());
 
-async function getBundleNode(bundle: Bundle, options: PluginOptions) {
+async function getBundleNode(bundle: NamedBundle, options: PluginOptions) {
   let buildMetrics = await generateBuildMetrics(
     [bundle],
     options.outputFS,

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -1,5 +1,5 @@
 // @flow
-import type {BundleGraph, FilePath} from '@parcel/types';
+import type {BundleGraph, FilePath, NamedBundle} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 
 import {generateBuildMetrics, prettifyTime} from '@parcel/utils';
@@ -19,7 +19,7 @@ const COLUMNS = [
 ];
 
 export default async function bundleReport(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   fs: FileSystem,
   projectRoot: FilePath,
   assetCount: number,

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -1,7 +1,12 @@
 // @flow
 
 import type {DevServerOptions, Request, Response} from './types.js.flow';
-import type {BundleGraph, FilePath, PluginOptions} from '@parcel/types';
+import type {
+  BundleGraph,
+  FilePath,
+  PluginOptions,
+  NamedBundle,
+} from '@parcel/types';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {FileSystem} from '@parcel/fs';
 
@@ -52,7 +57,7 @@ export default class Server extends EventEmitter {
   pending: boolean;
   options: DevServerOptions;
   rootPath: string;
-  bundleGraph: BundleGraph | null;
+  bundleGraph: BundleGraph<NamedBundle> | null;
   errors: Array<{|
     message: string,
     stack: string,
@@ -78,7 +83,7 @@ export default class Server extends EventEmitter {
     this.pending = true;
   }
 
-  buildSuccess(bundleGraph: BundleGraph) {
+  buildSuccess(bundleGraph: BundleGraph<NamedBundle>) {
     this.bundleGraph = bundleGraph;
     this.errors = null;
     this.pending = false;

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -6,6 +6,7 @@ import type {
   BundleGroup,
   Dependency,
   Environment,
+  NamedBundle,
   RuntimeAsset,
 } from '@parcel/types';
 
@@ -178,7 +179,7 @@ function getLoaderRuntimes({
   bundle: Bundle,
   dependency: Dependency,
   bundleGroup: BundleGroup,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
 |}) {
   let assets = [];
   // Sort so the bundles containing the entry asset appear last
@@ -276,7 +277,10 @@ function getLoaderRuntimes({
   return assets;
 }
 
-function isNewContext(bundle: Bundle, bundleGraph: BundleGraph): boolean {
+function isNewContext(
+  bundle: Bundle,
+  bundleGraph: BundleGraph<NamedBundle>,
+): boolean {
   return (
     bundle.isEntry ||
     bundleGraph
@@ -311,7 +315,7 @@ function getURLRuntime(
 
 function getRegisterCode(
   entryBundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
 ): string {
   let idToName = {};
   bundleGraph.traverseBundles((bundle, _, actions) => {

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -1,7 +1,6 @@
 // @flow strict-local
 
 import type {
-  Bundle,
   BundleGraph,
   BundleGroup,
   Dependency,
@@ -176,7 +175,7 @@ function getLoaderRuntimes({
   bundleGroup,
   bundleGraph,
 }: {|
-  bundle: Bundle,
+  bundle: NamedBundle,
   dependency: Dependency,
   bundleGroup: BundleGroup,
   bundleGraph: BundleGraph<NamedBundle>,
@@ -278,7 +277,7 @@ function getLoaderRuntimes({
 }
 
 function isNewContext(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ): boolean {
   return (
@@ -294,8 +293,8 @@ function isNewContext(
 
 function getURLRuntime(
   dependency: Dependency,
-  from: Bundle,
-  to: Bundle,
+  from: NamedBundle,
+  to: NamedBundle,
 ): RuntimeAsset {
   let relativePathExpr = getRelativePathExpr(from, to);
   if (dependency.meta.webworker === true) {
@@ -314,7 +313,7 @@ function getURLRuntime(
 }
 
 function getRegisterCode(
-  entryBundle: Bundle,
+  entryBundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ): string {
   let idToName = {};
@@ -338,7 +337,7 @@ function getRegisterCode(
   );
 }
 
-function getRelativePathExpr(from: Bundle, to: Bundle): string {
+function getRelativePathExpr(from: NamedBundle, to: NamedBundle): string {
   if (shouldUseRuntimeManifest(from)) {
     return `require('./relative-path')(${JSON.stringify(
       getPublicBundleId(from),
@@ -348,11 +347,11 @@ function getRelativePathExpr(from: Bundle, to: Bundle): string {
   return JSON.stringify(relativeBundlePath(from, to, {leadingDotSlash: false}));
 }
 
-function shouldUseRuntimeManifest(bundle: Bundle): boolean {
+function shouldUseRuntimeManifest(bundle: NamedBundle): boolean {
   let env = bundle.env;
   return !env.isLibrary && env.outputFormat === 'global' && env.isBrowser();
 }
 
-function getPublicBundleId(bundle: Bundle): string {
+function getPublicBundleId(bundle: NamedBundle): string {
   return bundle.id.slice(-16);
 }

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -2,7 +2,6 @@
 
 import type {
   Asset,
-  Bundle,
   BundleGraph,
   PluginOptions,
   NamedBundle,
@@ -64,7 +63,7 @@ export async function concat({
   options,
   wrappedAssets,
 }: {|
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
   options: PluginOptions,
   wrappedAssets: Set<string>,
@@ -162,7 +161,7 @@ export async function concat({
 
 async function processAsset(
   options: PluginOptions,
-  bundle: Bundle,
+  bundle: NamedBundle,
   asset: Asset,
   wrappedAssets: Set<string>,
 ) {
@@ -197,7 +196,7 @@ function parse(code, sourceFilename) {
 }
 
 function getUsedExports(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ): Map<string, Set<Symbol>> {
   let usedExports: Map<string, Set<Symbol>> = new Map();
@@ -289,7 +288,7 @@ const FIND_REQUIRES_VISITOR = {
       asset,
       result,
     }: {|
-      bundle: Bundle,
+      bundle: NamedBundle,
       bundleGraph: BundleGraph<NamedBundle>,
       asset: Asset,
       result: Array<Asset>,
@@ -320,7 +319,7 @@ const FIND_REQUIRES_VISITOR = {
 };
 
 function findRequires(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
   asset: Asset,
   ast: Node,

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -5,6 +5,7 @@ import type {
   Bundle,
   BundleGraph,
   PluginOptions,
+  NamedBundle,
   Symbol,
 } from '@parcel/types';
 import type {
@@ -64,7 +65,7 @@ export async function concat({
   wrappedAssets,
 }: {|
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   options: PluginOptions,
   wrappedAssets: Set<string>,
 |}) {
@@ -197,7 +198,7 @@ function parse(code, sourceFilename) {
 
 function getUsedExports(
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
 ): Map<string, Set<Symbol>> {
   let usedExports: Map<string, Set<Symbol>> = new Map();
 
@@ -263,7 +264,7 @@ function getUsedExports(
 }
 
 function shouldSkipAsset(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   asset: Asset,
   usedExports: Map<string, Set<Symbol>>,
 ) {
@@ -289,7 +290,7 @@ const FIND_REQUIRES_VISITOR = {
       result,
     }: {|
       bundle: Bundle,
-      bundleGraph: BundleGraph,
+      bundleGraph: BundleGraph<NamedBundle>,
       asset: Asset,
       result: Array<Asset>,
     |},
@@ -320,7 +321,7 @@ const FIND_REQUIRES_VISITOR = {
 
 function findRequires(
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   asset: Asset,
   ast: Node,
 ): Array<Asset> {

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -5,6 +5,7 @@ import type {
   Bundle,
   BundleGraph,
   PluginOptions,
+  NamedBundle,
   Symbol,
 } from '@parcel/types';
 import type {
@@ -368,7 +369,7 @@ export function generateExternalImport(
 }
 
 export function generateExports(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   bundle: Bundle,
   referencedAssets: Set<Asset>,
   path: NodePath<Program>,

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -2,7 +2,6 @@
 
 import type {
   Asset,
-  Bundle,
   BundleGraph,
   PluginOptions,
   NamedBundle,
@@ -140,7 +139,7 @@ function generateDestructuringAssignment(
 }
 
 export function generateBundleImports(
-  from: Bundle,
+  from: NamedBundle,
   {bundle, assets}: ExternalBundle,
   path: NodePath<Program>,
 ) {
@@ -184,7 +183,7 @@ export function generateBundleImports(
 }
 
 export function generateExternalImport(
-  bundle: Bundle,
+  bundle: NamedBundle,
   external: ExternalModule,
   path: NodePath<Program>,
 ) {
@@ -370,7 +369,7 @@ export function generateExternalImport(
 
 export function generateExports(
   bundleGraph: BundleGraph<NamedBundle>,
-  bundle: Bundle,
+  bundle: NamedBundle,
   referencedAssets: Set<Asset>,
   path: NodePath<Program>,
   replacements: Map<Symbol, Symbol>,

--- a/packages/shared/scope-hoisting/src/formats/esmodule.js
+++ b/packages/shared/scope-hoisting/src/formats/esmodule.js
@@ -38,7 +38,7 @@ import {
 } from '../utils';
 
 export function generateBundleImports(
-  from: Bundle,
+  from: NamedBundle,
   {bundle, assets}: ExternalBundle,
   path: NodePath<Program>,
 ) {

--- a/packages/shared/scope-hoisting/src/formats/esmodule.js
+++ b/packages/shared/scope-hoisting/src/formats/esmodule.js
@@ -4,6 +4,7 @@ import type {
   Asset,
   Bundle,
   BundleGraph,
+  NamedBundle,
   PluginOptions,
   Symbol,
 } from '@parcel/types';
@@ -120,7 +121,7 @@ export function generateExternalImport(
 }
 
 export function generateExports(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   bundle: Bundle,
   referencedAssets: Set<Asset>,
   programPath: NodePath<Program>,

--- a/packages/shared/scope-hoisting/src/formats/global.js
+++ b/packages/shared/scope-hoisting/src/formats/global.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type {Asset, Bundle, BundleGraph, Symbol} from '@parcel/types';
+import type {
+  Asset,
+  Bundle,
+  BundleGraph,
+  NamedBundle,
+  Symbol,
+} from '@parcel/types';
 import type {NodePath} from '@babel/traverse';
 import type {
   ExpressionStatement,
@@ -75,7 +81,7 @@ export function generateExternalImport(_: Bundle, {loc}: ExternalModule) {
 }
 
 export function generateExports(
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   bundle: Bundle,
   referencedAssets: Set<Asset>,
   path: NodePath<Program>,

--- a/packages/shared/scope-hoisting/src/formats/global.js
+++ b/packages/shared/scope-hoisting/src/formats/global.js
@@ -50,7 +50,7 @@ const IMPORTSCRIPTS_TEMPLATE = template.statement<
 >('importScripts(BUNDLE);');
 
 export function generateBundleImports(
-  from: Bundle,
+  from: NamedBundle,
   {bundle, assets}: ExternalBundle,
   path: NodePath<Program>,
 ) {
@@ -82,7 +82,7 @@ export function generateExternalImport(_: Bundle, {loc}: ExternalModule) {
 
 export function generateExports(
   bundleGraph: BundleGraph<NamedBundle>,
-  bundle: Bundle,
+  bundle: NamedBundle,
   referencedAssets: Set<Asset>,
   path: NodePath<Program>,
 ) {

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type {Asset, Bundle, BundleGraph, PluginOptions} from '@parcel/types';
+import type {
+  Asset,
+  Bundle,
+  BundleGraph,
+  NamedBundle,
+  PluginOptions,
+} from '@parcel/types';
 import type {
   ArrayExpression,
   ExpressionStatement,
@@ -45,7 +51,7 @@ export function generate({
   referencedAssets,
   options,
 }: {|
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   bundle: Bundle,
   ast: File,
   options: PluginOptions,

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -2,7 +2,6 @@
 
 import type {
   Asset,
-  Bundle,
   BundleGraph,
   NamedBundle,
   PluginOptions,
@@ -52,7 +51,7 @@ export function generate({
   options,
 }: {|
   bundleGraph: BundleGraph<NamedBundle>,
-  bundle: Bundle,
+  bundle: NamedBundle,
   ast: File,
   options: PluginOptions,
   referencedAssets: Set<Asset>,

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -2,7 +2,6 @@
 
 import type {
   Asset,
-  Bundle,
   BundleGraph,
   NamedBundle,
   PluginOptions,
@@ -81,7 +80,7 @@ export function link({
   options,
   wrappedAssets,
 }: {|
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
   ast: File,
   options: PluginOptions,

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -4,6 +4,7 @@ import type {
   Asset,
   Bundle,
   BundleGraph,
+  NamedBundle,
   PluginOptions,
   Symbol,
   SourceLocation,
@@ -81,7 +82,7 @@ export function link({
   wrappedAssets,
 }: {|
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
   ast: File,
   options: PluginOptions,
   wrappedAssets: Set<string>,

--- a/packages/shared/scope-hoisting/src/types.js
+++ b/packages/shared/scope-hoisting/src/types.js
@@ -4,6 +4,7 @@ import type {
   Bundle,
   BundleGraph,
   ModuleSpecifier,
+  NamedBundle,
   PluginOptions,
   Symbol,
   SourceLocation,
@@ -36,7 +37,7 @@ export type OutputFormat = {|
     path: NodePath<Program>,
   ): void,
   generateExports(
-    bundleGraph: BundleGraph,
+    bundleGraph: BundleGraph<NamedBundle>,
     bundle: Bundle,
     referencedAssets: Set<Asset>,
     path: NodePath<Program>,

--- a/packages/shared/scope-hoisting/src/types.js
+++ b/packages/shared/scope-hoisting/src/types.js
@@ -1,7 +1,6 @@
 // @flow strict-local
 import type {
   Asset,
-  Bundle,
   BundleGraph,
   ModuleSpecifier,
   NamedBundle,
@@ -20,25 +19,25 @@ export type ExternalModule = {|
 |};
 
 export type ExternalBundle = {|
-  bundle: Bundle,
+  bundle: NamedBundle,
   assets: Set<Asset>,
   loc?: ?SourceLocation,
 |};
 
 export type OutputFormat = {|
   generateBundleImports(
-    from: Bundle,
+    from: NamedBundle,
     external: ExternalBundle,
     path: NodePath<Program>,
   ): void,
   generateExternalImport(
-    bundle: Bundle,
+    bundle: NamedBundle,
     external: ExternalModule,
     path: NodePath<Program>,
   ): void,
   generateExports(
     bundleGraph: BundleGraph<NamedBundle>,
-    bundle: Bundle,
+    bundle: NamedBundle,
     referencedAssets: Set<Asset>,
     path: NodePath<Program>,
     replacements: Map<Symbol, Symbol>,

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -4,6 +4,7 @@ import type {
   Bundle,
   BundleGraph,
   MutableAsset,
+  NamedBundle,
   SourceLocation,
 } from '@parcel/types';
 import type {NodePath, Scope, VariableDeclarationKind} from '@babel/traverse';
@@ -59,7 +60,10 @@ export function getExportIdentifier(asset: Asset | MutableAsset, name: string) {
   return getIdentifier(asset, 'export', name);
 }
 
-export function needsPrelude(bundle: Bundle, bundleGraph: BundleGraph) {
+export function needsPrelude(
+  bundle: Bundle,
+  bundleGraph: BundleGraph<NamedBundle>,
+) {
   if (bundle.env.outputFormat !== 'global') {
     return false;
   }
@@ -79,7 +83,7 @@ export function needsPrelude(bundle: Bundle, bundleGraph: BundleGraph) {
   );
 }
 
-export function isEntry(bundle: Bundle, bundleGraph: BundleGraph) {
+export function isEntry(bundle: Bundle, bundleGraph: BundleGraph<NamedBundle>) {
   // If there is no parent JS bundle (e.g. in an HTML page), or environment is isolated (e.g. worker)
   // then this bundle is an "entry"
   return (
@@ -87,7 +91,10 @@ export function isEntry(bundle: Bundle, bundleGraph: BundleGraph) {
   );
 }
 
-export function isReferenced(bundle: Bundle, bundleGraph: BundleGraph) {
+export function isReferenced(
+  bundle: Bundle,
+  bundleGraph: BundleGraph<NamedBundle>,
+) {
   let isReferenced = false;
   bundle.traverseAssets((asset, _, actions) => {
     // A bundle is potentially referenced if any of its assets is referenced
@@ -105,7 +112,7 @@ export function isReferenced(bundle: Bundle, bundleGraph: BundleGraph) {
 
 export function hasAsyncDescendant(
   bundle: Bundle,
-  bundleGraph: BundleGraph,
+  bundleGraph: BundleGraph<NamedBundle>,
 ): boolean {
   let _hasAsyncDescendant = false;
   bundleGraph.traverseBundles((b, _, actions) => {

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -1,7 +1,6 @@
 // @flow
 import type {
   Asset,
-  Bundle,
   BundleGraph,
   MutableAsset,
   NamedBundle,
@@ -61,7 +60,7 @@ export function getExportIdentifier(asset: Asset | MutableAsset, name: string) {
 }
 
 export function needsPrelude(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ) {
   if (bundle.env.outputFormat !== 'global') {
@@ -83,7 +82,10 @@ export function needsPrelude(
   );
 }
 
-export function isEntry(bundle: Bundle, bundleGraph: BundleGraph<NamedBundle>) {
+export function isEntry(
+  bundle: NamedBundle,
+  bundleGraph: BundleGraph<NamedBundle>,
+) {
   // If there is no parent JS bundle (e.g. in an HTML page), or environment is isolated (e.g. worker)
   // then this bundle is an "entry"
   return (
@@ -92,7 +94,7 @@ export function isEntry(bundle: Bundle, bundleGraph: BundleGraph<NamedBundle>) {
 }
 
 export function isReferenced(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ) {
   let isReferenced = false;
@@ -111,7 +113,7 @@ export function isReferenced(
 }
 
 export function hasAsyncDescendant(
-  bundle: Bundle,
+  bundle: NamedBundle,
   bundleGraph: BundleGraph<NamedBundle>,
 ): boolean {
   let _hasAsyncDescendant = false;


### PR DESCRIPTION
This allows the public `BundleGraph` to be constructed with a given Bundle factory, and makes the `BundleGraph` polymorphic on anything that implements `IBundle`, allowing the public `BundleGraph` to return either `Bundle`s or `NamedBundle`s.

The `MutableBundleGraph` only returns `Bundle`s for now, as that is all that is needed.

This allows namers to receive `BundleGraph<Bundle>` — an immutable BundleGraph that produces unnamed `Bundle`s — and things like runtimes and packagers to receive `BundleGraph<NamedBundle>`, a BundleGraph which produces `NamedBundle`s

As a simplification, this removes the caching behavior for re-using public BundleGraph wrappers. These are not created at the rate of other public wrappers, and I believe that the way we pass them to plugins, they don't really benefit from referential equality guarantees. cc @devongovett 

Test Plan: `yarn flow check && yarn test`