### PR TITLE
Fix `getConfig` with `packageKey`

### DIFF
--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -2,7 +2,6 @@
 
 import type {
   ASTGenerator,
-  ConfigResult,
   File,
   FilePath,
   GenerateOutput,
@@ -14,6 +13,7 @@ import type {
   Transformer,
 } from '@parcel/types';
 import type {Asset, Dependency, Environment} from './types';
+import type {ConfigOutput} from '@parcel/utils';
 
 import {Readable} from 'stream';
 import {PluginLogger} from '@parcel/logger';
@@ -156,14 +156,18 @@ export async function getConfig(
     packageKey?: string,
     parse?: boolean,
   |},
-): Promise<ConfigResult | null> {
+): Promise<ConfigOutput | null> {
   let packageKey = options?.packageKey;
   let parse = options && options.parse;
 
   if (packageKey != null) {
     let pkg = await asset.getPackage();
     if (pkg && pkg[packageKey]) {
-      return pkg[packageKey];
+      return {
+        config: pkg[packageKey],
+        // The package.json file was already registered by asset.getPackage() -> asset.getConfig()
+        files: [],
+      };
     }
   }
 

--- a/packages/core/integration-tests/test/integration/postcss-config-package/package.json
+++ b/packages/core/integration-tests/test/integration/postcss-config-package/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "postcss-config-package",
+    "postcss": {
+        "plugins": {
+            "postcss-custom-properties": {}
+        }
+    }
+}

--- a/packages/core/integration-tests/test/integration/postcss-config-package/style.css
+++ b/packages/core/integration-tests/test/integration/postcss-config-package/style.css
@@ -1,0 +1,7 @@
+:root {
+  --varColor: red;
+}
+
+body {
+  background-color: var(--varColor);
+}

--- a/packages/core/integration-tests/test/postcss.js
+++ b/packages/core/integration-tests/test/postcss.js
@@ -300,4 +300,24 @@ describe('postcss', () => {
 
     assert.equal(css.split('red').length - 1, 2);
   });
+
+  it('should support using a postcss config in package.json', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/postcss-config-package/style.css'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'style.css',
+        assets: ['style.css'],
+        includedFiles: {
+          'style.css': ['package.json'],
+        },
+      },
+    ]);
+
+    let css = await outputFS.readFile(path.join(distDir, 'style.css'), 'utf8');
+
+    assert(/background-color:\s*red/.test(css));
+  });
 });

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -5,12 +5,12 @@ import type {FileSystem} from '@parcel/fs';
 import path from 'path';
 import clone from 'clone';
 
-type ConfigOutput = {|
+export type ConfigOutput = {|
   config: ConfigResult,
   files: Array<File>,
 |};
 
-type ConfigOptions = {|
+export type ConfigOptions = {|
   parse?: boolean,
 |};
 

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+export type * from './config';
 export type * from './generateBuildMetrics';
 export type * from './prettyDiagnostic';
 


### PR DESCRIPTION
# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/4603

The lesson here: `any` (`= ConfigResult`) is bad.

## 💻 Examples

Having a `postcss` object as config in `package.json`

