### PR TITLE
eslint validator: display hightlights for parse error

### DIFF
--- a/packages/core/integration-tests/test/eslint-validation.js
+++ b/packages/core/integration-tests/test/eslint-validation.js
@@ -22,14 +22,63 @@ describe('eslint-validator', function() {
       });
     } catch (e) {
       assert.equal(e.name, 'BuildError');
-      assert(!!Array.isArray(e.diagnostics));
-      assert(!!e.diagnostics[0].codeFrame);
+      assert(Array.isArray(e.diagnostics));
+      assert(e.diagnostics[0].codeFrame);
+      assert.equal(e.diagnostics[0].origin, '@parcel/validator-eslint');
+      assert.equal(
+        e.diagnostics[0].message,
+        'ESLint found **1** __errors__ and **1** __warnings__.',
+      );
+      assert.equal(e.diagnostics[0].filePath, entry);
+
+      let codeframe = e.diagnostics[0].codeFrame;
+      assert(codeframe);
+      assert.equal(codeframe.codeHighlights.length, 2);
+      codeframe.codeHighlights.sort(
+        ({start: {line: a}}, {start: {line: b}}) => a - b,
+      );
+      assert.equal(
+        codeframe.codeHighlights[0].message,
+        'Unexpected console statement.',
+      );
+      assert.equal(
+        codeframe.codeHighlights[1].message,
+        "'hey' is assigned a value but never used.",
+      );
+      didThrow = true;
+    }
+
+    assert(didThrow);
+  });
+
+  it('should throw a correct codeframe for a parse error', async function() {
+    let didThrow = false;
+    let entry = path.join(
+      __dirname,
+      '/integration/eslint-parse-error/index.js',
+    );
+    try {
+      await bundle(entry, {
+        defaultConfig: config,
+      });
+    } catch (e) {
+      assert.equal(e.name, 'BuildError');
+      assert(Array.isArray(e.diagnostics));
       assert.equal(e.diagnostics[0].origin, '@parcel/validator-eslint');
       assert.equal(
         e.diagnostics[0].message,
         'ESLint found **1** __errors__ and **0** __warnings__.',
       );
       assert.equal(e.diagnostics[0].filePath, entry);
+
+      let codeframe = e.diagnostics[0].codeFrame;
+      assert(codeframe);
+      assert.equal(codeframe.codeHighlights.length, 1);
+      assert(codeframe.codeHighlights[0].start.line != null);
+      assert(codeframe.codeHighlights[0].start.column != null);
+      assert(codeframe.codeHighlights[0].end.line != null);
+      assert(codeframe.codeHighlights[0].end.column != null);
+      assert(codeframe.codeHighlights[0].message.startsWith('Parsing error'));
 
       didThrow = true;
     }

--- a/packages/core/integration-tests/test/integration/eslint-parse-error/.eslintrc.json
+++ b/packages/core/integration-tests/test/integration/eslint-parse-error/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "root": true,
-  "parserOptions": {
-    "ecmaVersion": 2018
-  },
   "rules": {
     "no-console": "error",
     "no-unused-vars": "warn"

--- a/packages/core/integration-tests/test/integration/eslint-parse-error/index.js
+++ b/packages/core/integration-tests/test/integration/eslint-parse-error/index.js
@@ -1,0 +1,7 @@
+module.exports = function hello() {
+  console.log('Say hello world...');
+
+  let hey = '';
+
+  return 'hello';
+};

--- a/packages/validators/eslint/src/EslintValidator.js
+++ b/packages/validators/eslint/src/EslintValidator.js
@@ -29,15 +29,20 @@ export default new Validator({
         let codeframe: DiagnosticCodeFrame = {
           code: result.source,
           codeHighlights: result.messages.map(message => {
+            let start = {
+              line: message.line,
+              column: message.column,
+            };
             return {
-              start: {
-                line: message.line,
-                column: message.column,
-              },
-              end: {
-                line: message.endLine,
-                column: message.endColumn,
-              },
+              start,
+              // Parse errors have no ending
+              end:
+                message.endLine != null
+                  ? {
+                      line: message.endLine,
+                      column: message.endColumn,
+                    }
+                  : start,
               message: message.message,
             };
           }),


### PR DESCRIPTION
# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/4605

eslint sets `endLine` and `endColumn` to `undefined` on a parser error. This caused no highlights to be displayed in the printed codeframe (see linked issue).