### PR TITLE
Named export before decl generated wrong assignment order

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-before-declaration/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-before-declaration/a.js
@@ -1,0 +1,2 @@
+import * as b from "./b.js";
+output = b;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-before-declaration/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-before-declaration/b.js
@@ -1,0 +1,2 @@
+export { x };
+const x = 2;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -422,6 +422,17 @@ describe('scope hoisting', function() {
       assert.equal(await run(b), 123);
     });
 
+    it('supports named exports before the variable declaration', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/export-before-declaration/a.js',
+        ),
+      );
+
+      assert.deepEqual(await run(b), {x: 2});
+    });
+
     it('should not export function arguments', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -713,7 +713,7 @@ function addExport(asset: MutableAsset, path, local, exported) {
 
   let binding = scope.getBinding(local.name);
   let constantViolations = binding
-    ? binding.constantViolations.concat(path)
+    ? binding.constantViolations.concat(binding.path.getStatementParent())
     : [path];
 
   if (!asset.symbols.hasExportSymbol(exported.name)) {
@@ -726,7 +726,9 @@ function addExport(asset: MutableAsset, path, local, exported) {
 
   rename(scope, local.name, identifier.name);
 
-  constantViolations.forEach(path => path.insertAfter(t.cloneDeep(assignNode)));
+  for (let p of constantViolations) {
+    p.insertAfter(t.cloneDeep(assignNode));
+  }
 }
 
 function hasImport(asset: MutableAsset, id) {


### PR DESCRIPTION
# ↪️ Pull Request

Closes #4594

The `exports.foo = foo` assignment was inserted after the `ExportDeclaration`, not the `VariableDeclaration`.

## 💻 Examples

```js
import * as o from "./other.js";
console.log(o);
// other.js
export {x};
const x = 2;
```
Previous output:
```js
(function () {
  // ASSET: /app/src/other.js
  var $ddb4d6c67f65e26420a93ba58f2a194$exports = {};
  $ddb4d6c67f65e26420a93ba58f2a194$exports.x = $ddb4d6c67f65e26420a93ba58f2a194$export$x;
  const $ddb4d6c67f65e26420a93ba58f2a194$export$x = 2;
  console.log($ddb4d6c67f65e26420a93ba58f2a194$exports);
})();
```
Now:
Previous output:
```js
(function () {
  // ASSET: /app/src/other.js
  var $ddb4d6c67f65e26420a93ba58f2a194$exports = {};
  const $ddb4d6c67f65e26420a93ba58f2a194$export$x = 2;
  $ddb4d6c67f65e26420a93ba58f2a194$exports.x = $ddb4d6c67f65e26420a93ba58f2a194$export$x;  console.log($ddb4d6c67f65e26420a93ba58f2a194$exports);
})();
```