### PR TITLE
ensure to not rename tmp file twice

### DIFF
--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -47,7 +47,7 @@ export class NodeFS implements FileSystem {
       ...options,
       emitClose: true,
     });
-    stream.on('close', () => fs.renameSync(tmpFilePath, filePath));
+    stream.once('close', () => fs.renameSync(tmpFilePath, filePath));
     return stream;
   }
 


### PR DESCRIPTION
# ↪️ Pull Request

With the change in #4552 close can be called twice, therefore the second rename will fail.
Only executing it once prevents it.

Closes #4614