### PR TITLE
Stub `require.cache` with an empty object

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/commonjs/require-cache.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs/require-cache.js
@@ -1,0 +1,1 @@
+module.exports = require.cache;

--- a/packages/core/integration-tests/test/integration/formats/esm/require-cache.js
+++ b/packages/core/integration-tests/test/integration/formats/esm/require-cache.js
@@ -1,0 +1,1 @@
+module.exports = require.cache;

--- a/packages/core/integration-tests/test/integration/formats/global-require-cache/index.js
+++ b/packages/core/integration-tests/test/integration/formats/global-require-cache/index.js
@@ -1,0 +1,1 @@
+module.exports = require.cache;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-cache/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-cache/a.js
@@ -1,0 +1,1 @@
+output = require.cache;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2058,16 +2058,16 @@ describe('javascript', function() {
     assert(output.includes('Other page'));
   });
 
-  it.skip('should stub require.cache', async function() {
-    let b = await bundle(
-      path.join(__dirname, '/integration/node_require_cache/main.js'),
-      {
-        target: 'node',
-      },
-    );
+  // it.skip('(skipped old test) should stub require.cache', async function() {
+  //   let b = await bundle(
+  //     path.join(__dirname, '/integration/node_require_cache/main.js'),
+  //     {
+  //       target: 'node',
+  //     },
+  //   );
 
-    await run(b);
-  });
+  //   await run(b);
+  // });
 
   it('should support async importing the same module from different bundles', async () => {
     let b = await bundle(

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -42,6 +42,16 @@ describe('output formats', function() {
       assert.equal((await run(b)).bar, 5);
     });
 
+    it('should support commonjs output with require.cache', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/commonjs/require-cache.js'),
+      );
+
+      let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      // console.log(dist);
+      assert(dist.includes('require.cache'));
+    });
+
     it('should support commonjs output from esmodule input (re-export rename)', async function() {
       let b = await bundle(
         path.join(
@@ -438,6 +448,16 @@ describe('output formats', function() {
   });
 
   describe('esmodule', function() {
+    it('should support esmodule output (stub require.cache)', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/esm/require-cache.js'),
+      );
+
+      let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      // console.log(dist);
+      assert(!dist.includes('require.cache'));
+    });
+
     it('should support esmodule output (named export)', async function() {
       let b = await bundle(
         path.join(__dirname, '/integration/formats/esm/named.js'),
@@ -1029,6 +1049,19 @@ describe('output formats', function() {
   });
 
   describe('global', function() {
+    it('should support global module output (stub require.cache)', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/formats/global-require-cache/index.js',
+        ),
+      );
+
+      let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      // console.log(dist);
+      assert(!dist.includes('require.cache'));
+    });
+
     it('should support async split bundles for workers', async function() {
       await bundle(
         path.join(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2005,6 +2005,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 42);
     });
 
+    it('should stub require.cache', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/require-cache/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, {});
+    });
+
     it('should insert __esModule interop flag when importing from an ES module', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -276,7 +276,7 @@ const VISITOR: Visitor<MutableAsset> = {
     }
 
     if (t.matchesPattern(path.node, 'require.cache') && !asset.env.isNode()) {
-      path.replaceWith(t.identifier('{}'));
+      path.replaceWith(t.objectExpression([]));
     }
 
     if (t.matchesPattern(path.node, 'module.bundle')) {

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -275,6 +275,10 @@ const VISITOR: Visitor<MutableAsset> = {
       path.replaceWith(t.identifier('null'));
     }
 
+    if (t.matchesPattern(path.node, 'require.cache') && !asset.env.isNode()) {
+      path.replaceWith(t.identifier('{}'));
+    }
+
     if (t.matchesPattern(path.node, 'module.bundle')) {
       path.replaceWith(t.identifier('parcelRequire'));
     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/4616

I wonder if more tests are needed here? e.g. verify that `require.cache` is _not_ stubbed when the output format is cjs. Guidance welcome :)
## 🚨 Test instructions

`yarn test:integration`

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
