### PR TITLE
Use fs-write-stream-atomic to write atomic fs streams

### DIFF
--- a/flow-libs/fs-write-stream-atomic.js.flow
+++ b/flow-libs/fs-write-stream-atomic.js.flow
@@ -1,0 +1,24 @@
+// @flow
+
+// Derived from the README and source of fs-write-stream-atomic located at
+// https://github.com/npm/fs-write-stream-atomic
+// Which is licensed ISC
+
+declare module 'fs-write-stream-atomic' {
+  import type {Writable} from 'stream';
+
+  declare type FsWriteStreamAtomicOptions = $Shape<{|
+    chown: $Shape<{|
+      uid: number,
+      gid: number,
+    |}>,
+    encoding: buffer$Encoding,
+    mode: number,
+    flags: string,
+  |}>;
+
+  declare module.exports: (
+    filename: string,
+    options: FsWriteStreamAtomicOptions,
+  ) => Writable;
+}

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -529,12 +529,15 @@ function writeFileStream(
     let fsStreamClosed = new Promise(resolve => {
       fsStream.on('close', () => resolve());
     });
+    let bytesWritten = 0;
     initialStream
-      .pipe(fsStream)
-      .on('finish', () =>
-        // $FlowFixMe
-        resolve(fsStreamClosed.then(() => fsStream.bytesWritten)),
+      .pipe(
+        new TapStream(buf => {
+          bytesWritten += buf.length;
+        }),
       )
+      .pipe(fsStream)
+      .on('finish', () => resolve(fsStreamClosed.then(() => bytesWritten)))
       .on('error', reject);
   });
 }

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -16,6 +16,7 @@
     "node": ">= 10.0.0"
   },
   "dependencies": {
+    "fs-write-stream-atomic": "github:atlassian-forks/fs-write-stream-atomic#4edf1a95433a9936229c7f768c9ea9bb5884b487",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "@parcel/watcher": "^2.0.0-alpha.5",
     "@parcel/workers": "^2.0.0-alpha.3.1",

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -667,10 +667,6 @@ class WriteStream extends Writable {
       .then(callback)
       .catch(callback);
   }
-
-  get bytesWritten() {
-    return this.buffer.byteLength;
-  }
 }
 
 const S_IFREG = 0o100000;

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -1,5 +1,5 @@
 // @flow
-import type {WriteStream} from 'fs';
+import type {Writable} from 'stream';
 import type {FileOptions, FileSystem} from './types';
 import type {FilePath} from '@parcel/types';
 import type {
@@ -42,8 +42,7 @@ export class NodeFS implements FileSystem {
   existsSync = fs.existsSync;
   readdirSync = (fs.readdirSync: any);
 
-  createWriteStream(filePath: string, options: any): WriteStream {
-    // $FlowFixMe
+  createWriteStream(filePath: string, options: any): Writable {
     return fsWriteStreamAtomic(filePath, options);
   }
 

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -14,6 +14,7 @@ import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 import {promisify} from '@parcel/utils';
 import {registerSerializableClass} from '@parcel/core';
+import fsWriteStreamAtomic from 'fs-write-stream-atomic';
 import watcher from '@parcel/watcher';
 import packageJSON from '../package.json';
 
@@ -42,13 +43,8 @@ export class NodeFS implements FileSystem {
   readdirSync = (fs.readdirSync: any);
 
   createWriteStream(filePath: string, options: any): WriteStream {
-    let tmpFilePath = getTempFilePath(filePath);
-    let stream = fs.createWriteStream(tmpFilePath, {
-      ...options,
-      emitClose: true,
-    });
-    stream.on('close', () => fs.renameSync(tmpFilePath, filePath));
-    return stream;
+    // $FlowFixMe
+    return fsWriteStreamAtomic(filePath, options);
   }
 
   async writeFile(

--- a/packages/core/is-v2-ready-yet/package.json
+++ b/packages/core/is-v2-ready-yet/package.json
@@ -22,7 +22,6 @@
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/preset-env": "^7.2.0",
-    "@babel/preset-react": "^7.0.0",
-    "eslint-plugin-react": "^7.12.0"
+    "@babel/preset-react": "^7.0.0"
   }
 }

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -9,6 +9,7 @@
     "eslint-plugin-flowtype": "^3.1.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-mocha": "^6.2.2",
-    "eslint-plugin-monorepo": "^0.2.1"
+    "eslint-plugin-monorepo": "^0.2.1",
+    "eslint-plugin-react": "^7.12.0"
   }
 }

--- a/packages/dev/eslint-plugin/src/rules/no-self-package-imports.js
+++ b/packages/dev/eslint-plugin/src/rules/no-self-package-imports.js
@@ -52,7 +52,7 @@ module.exports = {
       CallExpression(node) {
         if (
           isStaticRequireOrResolve(node) &&
-          getRequiredPath(node).startsWith(pkgName)
+          isSelfImport(pkgName, getRequiredPath(node))
         ) {
           context.report({
             node,
@@ -75,7 +75,7 @@ module.exports = {
       },
       ImportDeclaration(node) {
         let request = node.source.value.trim();
-        if (request.startsWith(pkgName)) {
+        if (isSelfImport(pkgName, request)) {
           context.report({
             node,
             message,
@@ -101,4 +101,8 @@ module.exports = {
 
 function quote(str) {
   return "'" + str + "'";
+}
+
+function isSelfImport(packageName, descriptor) {
+  return descriptor === packageName || descriptor.startsWith(packageName + '/');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,6 +6194,15 @@ fs-write-stream-atomic@^1.0.8:
     imurmurhash "^0.1.4"
     readable-stream "1 || 2"
 
+"fs-write-stream-atomic@github:atlassian-forks/fs-write-stream-atomic#4edf1a95433a9936229c7f768c9ea9bb5884b487":
+  version "1.0.10"
+  resolved "https://codeload.github.com/atlassian-forks/fs-write-stream-atomic/tar.gz/4edf1a95433a9936229c7f768c9ea9bb5884b487"
+  dependencies:
+    graceful-fs "^4.1.2"
+    iferr "^1.0.2"
+    imurmurhash "^0.1.4"
+    readable-stream "1 || 2"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -7139,6 +7148,11 @@ iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
+
+iferr@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/iferr/-/iferr-1.0.2.tgz#e9fde49a9da06dc4a4194c6c9ed6d08305037a6d"
+  integrity sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==
 
 ignore-walk@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
Rather than implement this ourselves, use fs-write-stream-atomic [0] to atomically write streams to the filesystem in NodeFS. Resolves #4614. May resolve #4495 (cc @mischnic @sdjnes @Banou26)

It currently uses a modified version of `fs-write-stream-atomic` to provide safety across worker threads when applicable. This change has been submitted upstream [1] but this PR currently relies on a fork of the package [2].

Test Plan: 
* `yarn flow check && yarn test`
* Build the kitchen sink example and verify no failures (such as from errors re: renaming files in the disk cache)

[0] https://github.com/npm/fs-write-stream-atomic
[1] https://github.com/npm/fs-write-stream-atomic/pull/22
[2] https://github.com/parcel-bundler/parcel/blob/f69399aa6c8ce3793dce0467747e465996975e0c/packages/core/fs/package.json#L19

cc @akpwebdesign