### PR TITLE
Allow plugins like `@org/parcel-${type}`

### DIFF
--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -25,8 +25,9 @@ export function validatePackageName(
   } else if (pkg.startsWith('@')) {
     let [scope, name] = pkg.split('/');
     assert(
-      name.startsWith(`parcel-${pluginType}-`),
-      `Scoped parcel ${pluginType} packages must be named according to "${scope}/parcel-${pluginType}-{name}"`,
+      name.startsWith(`parcel-${pluginType}-`) ||
+        name === `parcel-${pluginType}`,
+      `Scoped parcel ${pluginType} packages must be named according to "${scope}/parcel-${pluginType}[-{name}]"`,
     );
   } else {
     assert(

--- a/packages/core/core/test/loadParcelConfig.test.js
+++ b/packages/core/core/test/loadParcelConfig.test.js
@@ -21,6 +21,10 @@ describe('loadParcelConfig', () => {
       assert.throws(() => {
         validatePackageName('@parcel/foo-bar', 'transform', 'transformers');
       }, /Official parcel transform packages must be named according to "@parcel\/transform-{name}"/);
+
+      assert.throws(() => {
+        validatePackageName('@parcel/transformer', 'transform', 'transformers');
+      }, /Official parcel transform packages must be named according to "@parcel\/transform-{name}"/);
     });
 
     it('should succeed on a valid official package', () => {
@@ -35,6 +39,10 @@ describe('loadParcelConfig', () => {
       assert.throws(() => {
         validatePackageName('parcel-foo-bar', 'transform', 'transformers');
       }, /Parcel transform packages must be named according to "parcel-transform-{name}"/);
+
+      assert.throws(() => {
+        validatePackageName('parcel-transform', 'transform', 'transformers');
+      }, /Parcel transform packages must be named according to "parcel-transform-{name}"/);
     });
 
     it('should succeed on a valid community package', () => {
@@ -44,7 +52,7 @@ describe('loadParcelConfig', () => {
     it('should error on an invalid scoped package', () => {
       assert.throws(() => {
         validatePackageName('@test/foo-bar', 'transform', 'transformers');
-      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform-{name}"/);
+      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform\[-{name}\]"/);
 
       assert.throws(() => {
         validatePackageName(
@@ -52,12 +60,18 @@ describe('loadParcelConfig', () => {
           'transform',
           'transformers',
         );
-      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform-{name}"/);
+      }, /Scoped parcel transform packages must be named according to "@test\/parcel-transform\[-{name}\]"/);
     });
 
     it('should succeed on a valid scoped package', () => {
       validatePackageName(
         '@test/parcel-transform-bar',
+        'transform',
+        'transformers',
+      );
+
+      validatePackageName(
+        '@test/parcel-transform',
         'transform',
         'transformers',
       );


### PR DESCRIPTION
# ↪️ Pull Request

Allow `@babel/parcel-transformer` or `@prefresh/parcel-config`.

Closes T-498

The readme was already correct