### PR TITLE
Fix #4429: dev server entry detection

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -142,25 +142,17 @@ export default class Server extends EventEmitter {
 
   sendIndex(req: Request, res: Response) {
     if (this.bundleGraph) {
-      // If the main asset is an HTML file, serve it
-      let htmlBundle = this.bundleGraph.traverseBundles(
-        (bundle, context, {stop}) => {
-          if (bundle.type !== 'html' || !bundle.isEntry) return;
-
-          if (!context) {
-            context = bundle;
-          }
-
-          if (
-            context &&
+      // If there is exactly one entry HTML file, serve it
+      const htmlBundles = this.bundleGraph
+        .getBundles()
+        .filter(
+          bundle =>
+            bundle.type === 'html' &&
+            bundle.isEntry &&
             bundle.filePath &&
-            bundle.filePath.endsWith('index.html')
-          ) {
-            stop();
-            return bundle;
-          }
-        },
-      );
+            bundle.filePath.endsWith('.html'),
+        );
+      const htmlBundle = htmlBundles.length === 1 ? htmlBundles[0] : undefined;
 
       if (htmlBundle) {
         req.url = `/${path.relative(

--- a/packages/reporters/dev-server/src/templates/404.html
+++ b/packages/reporters/dev-server/src/templates/404.html
@@ -10,7 +10,7 @@
         margin: 0;
         font-family: sans-serif;
       }
-      
+
       .error-title {
         color: #282c33;
         font-size: 3rem;
@@ -25,10 +25,16 @@
         padding: 0 25px;
         margin: 0;
       }
+
+      .long-desc {
+        color: #282c33;
+        padding: 0 25px;
+      }
     </style>
   </head>
   <body>
     <h1 class="error-title">404</h1>
     <h2 class="short-desc">Page not found.</h2>
+    <p class="long-desc">You may have zero or multiple HTML entries.</p>
   </body>
 </html>


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #4429.

## 💻 Examples

Before the entry detection served the first `index.html` bundle it found.

This would yield a 404 when running any other html file.

```
parcel serve test.html
```

I updated the logic, as suggested, to serve any single HTML entry.

## 🚨 Test instructions

I didn't see any tests for the dev server. Let me know if or where I can do so.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
