### PR TITLE
Fix buffer overrun in cargo metadata command

### DIFF
--- a/packages/core/parcel-bundler/src/assets/RustAsset.js
+++ b/packages/core/parcel-bundler/src/assets/RustAsset.js
@@ -127,9 +127,13 @@ class RustAsset extends Asset {
     await exec('cargo', args, {cwd: cargoDir});
 
     // Get output file paths
-    let [stdout] = await exec('cargo', ['metadata', '--format-version', '1'], {
-      cwd: cargoDir
-    });
+    let [stdout] = await exec(
+      'cargo',
+      ['metadata', '--format-version', '1', '--no-deps'],
+      {
+        cwd: cargoDir
+      }
+    );
     const cargoMetadata = JSON.parse(stdout);
     const cargoTargetDir = cargoMetadata.target_directory;
     let outDir = path.join(cargoTargetDir, RUST_TARGET, 'release');


### PR DESCRIPTION
# ↪️ Pull Request

Adds the `--no-deps` argument to reduce output length. A quick local test
cuts the output from ~1MB to ~10KB so with a default buffer of 1024*1024
bytes this should open up a lot more overhead.

Closes #1573

## 💻 Examples

Running `parcel build` or `parcel path/to/index.html` now no longer fails with `src/lib.rs: stdout maxBuffer length exceeded`

## 🚨 Test instructions

I believe this issue only occurs with larger projects. I have a cargo workspace containing an API server with a bunch of dependencies which I believe causes a huge amount of output. Testing this PR in that workspace with the added `--no-deps` flag makes it work. 

I guess the test instructions would be to create/find a project with a bunch of dependencies and check the NPM version of parcel against an `yarn link`/`npm link` of this PR.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
