### PR TITLE
add an unknown-origin asset to add mappings that have no defined source

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -23,7 +23,7 @@
     "@parcel/logger": "^2.0.0-alpha.3.1",
     "@parcel/package-manager": "^2.0.0-alpha.3.1",
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/types": "^2.0.0-alpha.3.1",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "@parcel/workers": "^2.0.0-alpha.3.1",

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -298,8 +298,8 @@ describe('css', () => {
     assert.equal(map.file, 'index.css.map');
     assert.equal(map.mappings, 'AAAA,OACA,WACA,CCFA,OACA,SACA');
     assert.deepEqual(map.sources, [
-      'integration/cssnano/local.css',
-      'integration/cssnano/index.css',
+      './integration/cssnano/local.css',
+      './integration/cssnano/index.css',
     ]);
   });
 

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -131,7 +131,7 @@ describe('sourcemaps', function() {
     let sourceMap = new SourceMap();
     sourceMap.addRawMappings(map.mappings, map.sources, map.names);
     let input = await inputFS.readFile(sourceFilename, 'utf8');
-    let sourcePath = 'index.js';
+    let sourcePath = './index.js';
 
     checkSourceMapping({
       map: sourceMap,
@@ -184,7 +184,7 @@ describe('sourcemaps', function() {
     let sourceMap = new SourceMap();
     sourceMap.addRawMappings(map.mappings, map.sources, map.names);
     let input = await inputFS.readFile(sourceFilename, 'utf8');
-    let sourcePath = 'index.js';
+    let sourcePath = './index.js';
     let mapData = sourceMap.getMap();
     assert.equal(mapData.sources.length, 1);
 
@@ -262,7 +262,7 @@ describe('sourcemaps', function() {
       source: inputs[0],
       generated: raw,
       str: 'const local',
-      sourcePath: 'index.js',
+      sourcePath: './index.js',
     });
 
     checkSourceMapping({
@@ -270,7 +270,7 @@ describe('sourcemaps', function() {
       source: inputs[0],
       generated: raw,
       str: 'local.a',
-      sourcePath: 'index.js',
+      sourcePath: './index.js',
     });
 
     checkSourceMapping({
@@ -278,7 +278,7 @@ describe('sourcemaps', function() {
       source: inputs[1],
       generated: raw,
       str: 'exports.a',
-      sourcePath: 'local.js',
+      sourcePath: './local.js',
     });
 
     checkSourceMapping({
@@ -287,7 +287,7 @@ describe('sourcemaps', function() {
       generated: raw,
       str: 'exports.count = function(a, b) {',
       generatedStr: 'exports.count = function (a, b) {',
-      sourcePath: 'utils/util.js',
+      sourcePath: './utils/util.js',
     });
 
     checkSourceMapping({
@@ -295,7 +295,7 @@ describe('sourcemaps', function() {
       source: inputs[2],
       generated: raw,
       str: 'return a + b',
-      sourcePath: 'utils/util.js',
+      sourcePath: './utils/util.js',
     });
   });
 
@@ -353,7 +353,7 @@ describe('sourcemaps', function() {
       generated: raw,
       str: 'const local',
       generatedStr: 'const t',
-      sourcePath: 'index.js',
+      sourcePath: './index.js',
     });
 
     checkSourceMapping({
@@ -362,7 +362,7 @@ describe('sourcemaps', function() {
       generated: raw,
       str: 'local.a',
       generatedStr: 't.a',
-      sourcePath: 'index.js',
+      sourcePath: './index.js',
     });
 
     checkSourceMapping({
@@ -371,7 +371,7 @@ describe('sourcemaps', function() {
       generated: raw,
       str: 'exports.a',
       generatedStr: 'o.a',
-      sourcePath: 'local.js',
+      sourcePath: './local.js',
     });
 
     checkSourceMapping({
@@ -380,7 +380,7 @@ describe('sourcemaps', function() {
       generated: raw,
       str: 'exports.count = function(a, b) {',
       generatedStr: 'o.count=function(e,n){',
-      sourcePath: 'utils/util.js',
+      sourcePath: './utils/util.js',
     });
 
     checkSourceMapping({
@@ -389,7 +389,7 @@ describe('sourcemaps', function() {
       generated: raw,
       str: 'return a + b',
       generatedStr: 'return e+n',
-      sourcePath: 'utils/util.js',
+      sourcePath: './utils/util.js',
     });
   });
 
@@ -418,7 +418,7 @@ describe('sourcemaps', function() {
 
     let mapData = sourceMap.getMap();
     assert.equal(mapData.sources.length, 1);
-    assert.deepEqual(mapData.sources, ['index.ts']);
+    assert.deepEqual(mapData.sources, ['./index.ts']);
 
     let input = await inputFS.readFile(inputFilePath, 'utf-8');
     checkSourceMapping({
@@ -426,7 +426,7 @@ describe('sourcemaps', function() {
       source: input,
       generated: raw,
       str: 'function env()',
-      sourcePath: 'index.ts',
+      sourcePath: './index.ts',
     });
   });
 
@@ -455,7 +455,7 @@ describe('sourcemaps', function() {
 
     let mapData = sourceMap.getMap();
     assert.equal(mapData.sources.length, 2);
-    assert.deepEqual(mapData.sources, ['index.ts', 'local.ts']);
+    assert.deepEqual(mapData.sources, ['./index.ts', './local.ts']);
 
     let input = await inputFS.readFile(inputFilePath, 'utf-8');
     checkSourceMapping({
@@ -463,7 +463,7 @@ describe('sourcemaps', function() {
       source: input,
       generated: raw,
       str: 'function env()',
-      sourcePath: 'index.ts',
+      sourcePath: './index.ts',
     });
 
     let local = await inputFS.readFile(
@@ -475,7 +475,7 @@ describe('sourcemaps', function() {
       source: local,
       generated: raw,
       str: 'exports.local',
-      sourcePath: 'local.ts',
+      sourcePath: './local.ts',
     });
   });
 
@@ -507,14 +507,14 @@ describe('sourcemaps', function() {
 
       let mapData = sourceMap.getMap();
       assert.equal(mapData.sources.length, 1);
-      assert.deepEqual(mapData.sources, ['style.css']);
+      assert.deepEqual(mapData.sources, ['./style.css']);
 
       checkSourceMapping({
         map: sourceMap,
         source: input,
         generated: raw,
         str: 'body',
-        sourcePath: 'style.css',
+        sourcePath: './style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -523,7 +523,7 @@ describe('sourcemaps', function() {
         source: input,
         generated: raw,
         str: 'background-color',
-        sourcePath: 'style.css',
+        sourcePath: './style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
     }
@@ -575,10 +575,10 @@ describe('sourcemaps', function() {
       let mapData = sourceMap.getMap();
       assert.equal(mapData.sources.length, 3);
       assert.deepEqual(mapData.sources, [
-        'other-style.css',
-        'another-style.css',
+        './other-style.css',
+        './another-style.css',
         // TODO: Is this a bug?
-        'test/integration/sourcemap-css-import/style.css',
+        './test/integration/sourcemap-css-import/style.css',
       ]);
 
       checkSourceMapping({
@@ -586,7 +586,7 @@ describe('sourcemaps', function() {
         source: style,
         generated: raw,
         str: 'body',
-        sourcePath: 'test/integration/sourcemap-css-import/style.css',
+        sourcePath: './test/integration/sourcemap-css-import/style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -595,7 +595,7 @@ describe('sourcemaps', function() {
         source: style,
         generated: raw,
         str: 'background-color',
-        sourcePath: 'test/integration/sourcemap-css-import/style.css',
+        sourcePath: './test/integration/sourcemap-css-import/style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -604,7 +604,7 @@ describe('sourcemaps', function() {
         source: otherStyle,
         generated: raw,
         str: 'div',
-        sourcePath: 'other-style.css',
+        sourcePath: './other-style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -613,7 +613,7 @@ describe('sourcemaps', function() {
         source: otherStyle,
         generated: raw,
         str: 'width',
-        sourcePath: 'other-style.css',
+        sourcePath: './other-style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -622,7 +622,7 @@ describe('sourcemaps', function() {
         source: anotherStyle,
         generated: raw,
         str: 'main',
-        sourcePath: 'another-style.css',
+        sourcePath: './another-style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -631,7 +631,7 @@ describe('sourcemaps', function() {
         source: anotherStyle,
         generated: raw,
         str: 'font-family',
-        sourcePath: 'another-style.css',
+        sourcePath: './another-style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
     }
@@ -667,14 +667,14 @@ describe('sourcemaps', function() {
       let input = await inputFS.readFile(inputFilePath, 'utf-8');
       let mapData = sourceMap.getMap();
       assert.equal(mapData.sources.length, minify ? 2 : 1);
-      assert.deepEqual(mapData.sources[0], 'style.scss');
+      assert.deepEqual(mapData.sources[0], './style.scss');
 
       checkSourceMapping({
         map: sourceMap,
         source: input,
         generated: raw,
         str: 'body',
-        sourcePath: 'style.scss',
+        sourcePath: './style.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -683,7 +683,7 @@ describe('sourcemaps', function() {
         source: input,
         generated: raw,
         str: 'color',
-        sourcePath: 'style.scss',
+        sourcePath: './style.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
     }
@@ -723,11 +723,11 @@ describe('sourcemaps', function() {
       );
       let mapData = sourceMap.getMap();
       assert.equal(mapData.sources.length, minify ? 3 : 2);
-      assert.deepEqual(mapData.sources[0], 'other.scss');
+      assert.deepEqual(mapData.sources[0], './other.scss');
       // TODO: Figure out why this happens?
       assert.deepEqual(
         mapData.sources[minify ? 2 : 1],
-        'test/integration/sourcemap-sass-imported/style.css',
+        './test/integration/sourcemap-sass-imported/style.css',
       );
 
       checkSourceMapping({
@@ -735,7 +735,7 @@ describe('sourcemaps', function() {
         source: style,
         generated: raw,
         str: 'body',
-        sourcePath: 'test/integration/sourcemap-sass-imported/style.css',
+        sourcePath: './test/integration/sourcemap-sass-imported/style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -744,7 +744,7 @@ describe('sourcemaps', function() {
         source: style,
         generated: raw,
         str: 'color',
-        sourcePath: 'test/integration/sourcemap-sass-imported/style.css',
+        sourcePath: './test/integration/sourcemap-sass-imported/style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -753,7 +753,7 @@ describe('sourcemaps', function() {
         source: other,
         generated: raw,
         str: 'div',
-        sourcePath: 'other.scss',
+        sourcePath: './other.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -762,7 +762,7 @@ describe('sourcemaps', function() {
         source: other,
         generated: raw,
         str: 'font-family',
-        sourcePath: 'other.scss',
+        sourcePath: './other.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
     }
@@ -796,7 +796,7 @@ describe('sourcemaps', function() {
 
       let mapData = sourceMap.getMap();
       assert.equal(mapData.sources.length, minify ? 2 : 1);
-      assert.deepEqual(mapData.sources[0], 'style.less');
+      assert.deepEqual(mapData.sources[0], './style.less');
       let input = await inputFS.readFile(inputFilePath, 'utf-8');
 
       checkSourceMapping({
@@ -804,7 +804,7 @@ describe('sourcemaps', function() {
         source: input,
         generated: raw,
         str: 'div',
-        sourcePath: 'style.less',
+        sourcePath: './style.less',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -813,7 +813,7 @@ describe('sourcemaps', function() {
         source: input,
         generated: raw,
         str: 'width',
-        sourcePath: 'style.less',
+        sourcePath: './style.less',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
     }
@@ -846,7 +846,7 @@ describe('sourcemaps', function() {
 
     let map = mapData.map;
     assert.equal(map.file, 'index.js.map');
-    assert.deepEqual(map.sources, ['index.js']);
+    assert.deepEqual(map.sources, ['./index.js']);
     assert.equal(map.sourcesContent[0], sourceContent);
   });
 
@@ -877,7 +877,7 @@ describe('sourcemaps', function() {
 
     let map = mapUrlData.map;
     assert.equal(map.file, 'index.js.map');
-    assert.deepEqual(map.sources, ['index.js']);
+    assert.deepEqual(map.sources, ['./index.js']);
   });
 
   it('should respect --no-source-maps', async function() {
@@ -942,7 +942,7 @@ describe('sourcemaps', function() {
 
       let sourceMap = await new SourceMap().addMap(map);
       assert.equal(Object.keys(sourceMap.sources).length, 2);
-      assert.equal(sourceMap.sources['style.css'], style);
+      assert.equal(sourceMap.sources['./style.css'], style);
       assert.equal(
         sourceMap.sources[path.normalize('test/library.scss')],
         library.replace(new RegExp(os.EOL, 'g'), '\n'),
@@ -953,7 +953,7 @@ describe('sourcemaps', function() {
         source: style,
         generated: raw,
         str: 'main',
-        sourcePath: 'style.css',
+        sourcePath: './style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -962,7 +962,7 @@ describe('sourcemaps', function() {
         source: style,
         generated: raw,
         str: 'display',
-        sourcePath: 'style.css',
+        sourcePath: './style.css',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -971,7 +971,7 @@ describe('sourcemaps', function() {
         source: library,
         generated: raw,
         str: 'body',
-        sourcePath: path.normalize('test/library.scss'),
+        sourcePath: './test/library.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -981,7 +981,7 @@ describe('sourcemaps', function() {
         generated: raw,
         str: 'div',
         generatedStr: 'body div',
-        sourcePath: path.normalize('test/library.scss'),
+        sourcePath: './test/library.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
 
@@ -990,7 +990,7 @@ describe('sourcemaps', function() {
         source: library,
         generated: raw,
         str: 'background-color',
-        sourcePath: path.normalize('test/library.scss'),
+        sourcePath: './test/library.scss',
         msg: ' ' + (minify ? 'with' : 'without') + ' minification',
       });
     }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -21,7 +21,7 @@
     "@parcel/diagnostic": "^2.0.0-alpha.3.1",
     "@parcel/logger": "^2.0.0-alpha.3.1",
     "@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "ansi-html": "^0.0.7",
     "chalk": "^2.4.2",
     "clone": "^2.1.1",

--- a/packages/core/utils/src/generateBuildMetrics.js
+++ b/packages/core/utils/src/generateBuildMetrics.js
@@ -86,10 +86,6 @@ async function getSourcemapSizes(
     }
 
     let sizeMap = new Map();
-    for (let source of sources) {
-      sizeMap.set(source, 0);
-    }
-
     for (let i = 0; i < sourceSizes.length; i++) {
       sizeMap.set(sources[i], sourceSizes[i]);
     }

--- a/packages/core/utils/src/generateBuildMetrics.js
+++ b/packages/core/utils/src/generateBuildMetrics.js
@@ -94,7 +94,7 @@ async function getSourcemapSizes(
       sizeMap.set(sources[i], sourceSizes[i]);
     }
 
-    sizeMap.set('unknown-origin', unknownOrigin);
+    sizeMap.set('', unknownOrigin);
 
     return sizeMap;
   }

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "cssnano": "^4.1.10",
     "postcss": "^7.0.5"
   }

--- a/packages/optimizers/terser/package.json
+++ b/packages/optimizers/terser/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@parcel/diagnostic": "^2.0.0-alpha.3.1",
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "nullthrows": "^1.1.1",
     "terser": "^4.3.0"

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1"
   }
 }

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -19,7 +19,7 @@
     "@babel/traverse": "^7.2.3",
     "@parcel/plugin": "^2.0.0-alpha.3.1",
     "@parcel/scope-hoisting": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "nullthrows": "^1.1.1"
   },

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -53,13 +53,20 @@ export default async function bundleReport(
     if (assetCount > 0) {
       let largestAssets = bundle.assets.slice(0, assetCount);
       for (let asset of largestAssets) {
-        // Add a row for the asset.
-        rows.push([
-          (asset == largestAssets[largestAssets.length - 1] ? '└── ' : '├── ') +
-            formatFilename(asset.filePath, chalk.reset),
+        let columns: Array<string> = [
+          asset == largestAssets[largestAssets.length - 1] ? '└── ' : '├── ',
           chalk.dim(prettifySize(asset.size)),
           chalk.dim(chalk.green(prettifyTime(asset.time))),
-        ]);
+        ];
+
+        if (asset.filePath !== '') {
+          columns[0] += formatFilename(asset.filePath, chalk.reset);
+        } else {
+          columns[0] += 'Code from unknown sourcefile';
+        }
+
+        // Add a row for the asset.
+        rows.push(columns);
       }
 
       if (bundle.assets.length > largestAssets.length) {

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -62,7 +62,7 @@ export default async function bundleReport(
         if (asset.filePath !== '') {
           columns[0] += formatFilename(asset.filePath, chalk.reset);
         } else {
-          columns[0] += 'Code from unknown sourcefile';
+          columns[0] += 'Code from unknown sourcefiles';
         }
 
         // Add a row for the asset.

--- a/packages/shared/babel-ast-utils/package.json
+++ b/packages/shared/babel-ast-utils/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/generator": "^7.0.0",
     "@babel/parser": "^7.0.0",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1"
   }
 }

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -23,7 +23,7 @@
     "@babel/types": "^7.3.3",
     "@parcel/babylon-walk": "^2.0.0-alpha.3.1",
     "@parcel/diagnostic": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "nullthrows": "^1.1.1"
   }

--- a/packages/transformers/coffeescript/package.json
+++ b/packages/transformers/coffeescript/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "coffeescript": "^2.0.3",
     "nullthrows": "^1.1.1",

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/utils": "^2.0.0-alpha.3.1",
     "postcss": "^7.0.5",
     "postcss-value-parser": "^3.3.1",

--- a/packages/transformers/less/package.json
+++ b/packages/transformers/less/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9"
+    "@parcel/source-map": "2.0.0-alpha.4.11"
   },
   "devDependencies": {
     "less": "^3.9.0"

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -19,7 +19,7 @@
     "@parcel/fs": "^2.0.0-alpha.3.1",
     "@parcel/plugin": "^2.0.0-alpha.3.1",
     "@parcel/utils": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9"
+    "@parcel/source-map": "2.0.0-alpha.4.11"
   },
   "devDependencies": {
     "sass": "^1.22.9"

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "^2.0.0-alpha.3.1",
-    "@parcel/source-map": "2.0.0-alpha.4.9",
+    "@parcel/source-map": "2.0.0-alpha.4.11",
     "@parcel/ts-utils": "^2.0.0-alpha.3.1",
     "nullthrows": "^1.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,13 +1924,13 @@
     ora "^2.1.0"
     strip-ansi "^4.0.0"
 
-"@parcel/source-map@2.0.0-alpha.4.9":
-  version "2.0.0-alpha.4.9"
-  resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0-alpha.4.9.tgz#773567807eac8a16a3e1d06896ed2be7de7bcc2b"
-  integrity sha512-j14RzSRBWQMLtC1BoHm+h8XMOYMFp5k8GpSDzY0zIxjW4EpIY3mTBLK68HLKPrVJPyKHADO7JiSSgde96dZLog==
+"@parcel/source-map@2.0.0-alpha.4.11":
+  version "2.0.0-alpha.4.11"
+  resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0-alpha.4.11.tgz#1223a060dc7687c00d6bdb27c59e7a3e8642accd"
+  integrity sha512-Vwm6PftbW6oLk2k8MUFzjZOLOpn0cjg5Z0rSiNPlC7vpH1gIKY9GkuWN2K9N9NHwc2nQFvq8KmFKXz7N60otSg==
   dependencies:
     node-addon-api "^2.0.0"
-    node-gyp-build "^4.2.1"
+    node-gyp-build "^4.2.2"
 
 "@parcel/utils@^1.11.0":
   version "1.11.0"
@@ -9278,10 +9278,10 @@ node-forge@^0.8.1:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
   integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
 
-node-gyp-build@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.1.tgz#f28f0d3d3ab268d48ab76c6f446f19bc3d0db9dc"
-  integrity sha512-XyCKXsqZfLqHep1hhsMncoXuUNt/cXCjg1+8CLbu69V1TKuPiOeSGbL9n+k/ByKH8UT0p4rdIX8XkTRZV0i7Sw==
+node-gyp-build@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.2.tgz#3f44b65adaafd42fb6c3d81afd630e45c847eb66"
+  integrity sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==
 
 node-gyp@^5.0.2:
   version "5.0.7"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR rewrites the build report utility slightly to include an `unknown-origin` dummy asset to highlight mappings that have no source. This mainly happens when adding in additional data into an ast as these do not originate from a specific file.

This also solves the issue where some assets are larger than the complete bundle by normalising paths and making sure once it's a sourcemap based bundlereport we only care about the sources in the sourcemap and don't use sizes from the original assets as a reference.

This has been discovered by @mischnic in the ReactHN benchmark

With scope-hoisting

![Screenshot 2020-05-29 at 13 42 08](https://user-images.githubusercontent.com/2175521/83256482-cb94d200-a1b2-11ea-9c08-5f7849b1d35a.png)

Without scope-hoisting

![Screenshot 2020-05-29 at 13 47 42](https://user-images.githubusercontent.com/2175521/83256690-26c6c480-a1b3-11ea-90a3-bcd9cbaea798.png)

