### PR TITLE
Add option to enable content hashing when in watch mode

### DIFF
--- a/packages/core/parcel-bundler/src/cli.js
+++ b/packages/core/parcel-bundler/src/cli.js
@@ -101,6 +101,7 @@ program
   .option('--no-cache', 'disable the filesystem cache')
   .option('--no-source-maps', 'disable sourcemaps')
   .option('--no-autoinstall', 'disable autoinstall')
+  .option('--content-hash', 'enable content hashing')
   .option(
     '-t, --target [target]',
     'set the runtime environment, either "node", "browser" or "electron". defaults to "browser"',


### PR DESCRIPTION
# ↪️ Pull Request

This adds the ability to enable content hashing for watch mode. It is the inverse of `--no-content-hash`. This is useful if you want content hashing enabled when in development mode. See https://github.com/parcel-bundler/parcel/issues/188 and https://github.com/parcel-bundler/parcel/pull/1025 for reference.

## 💻 Examples

`parcel watch app/entry.html --content-hash`
