### PR TITLE
Don't crash on `...` in `runtimes`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log*
 tmp
 parcel-bundle-reports/
 .verdaccio_storage/
+sourcemap-info.json

--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -158,7 +158,7 @@ export default class ParcelConfig {
     return this.loadPlugins<Resolver>(this._getResolverNodes());
   }
 
-  _getValidatorNodes(filePath: FilePath): Array<ParcelPluginNode> {
+  _getValidatorNodes(filePath: FilePath): $ReadOnlyArray<ParcelPluginNode> {
     let validators: PureParcelConfigPipeline =
       this.matchGlobMapPipelines(filePath, this.validators) || [];
 
@@ -186,7 +186,7 @@ export default class ParcelConfig {
   _getTransformerNodes(
     filePath: FilePath,
     pipeline?: ?string,
-  ): Array<ParcelPluginNode> {
+  ): $ReadOnlyArray<ParcelPluginNode> {
     let transformers: PureParcelConfigPipeline | null = this.matchGlobMapPipelines(
       filePath,
       this.transformers,

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -253,7 +253,6 @@ export function mergeConfigs(
   return new ParcelConfig(
     {
       filePath: ext.filePath,
-      // $FlowFixMe this seems like a flow bug, ExtendableParcelConfigPipeline is compatible with PureParcelConfigPipeline
       resolvers: mergePipelines(base.resolvers, ext.resolvers),
       transformers: mergeMaps(
         base.transformers,
@@ -262,12 +261,10 @@ export function mergeConfigs(
       ),
       validators: mergeMaps(base.validators, ext.validators, mergePipelines),
       bundler: ext.bundler || base.bundler,
-      // $FlowFixMe this seems like a flow bug, ExtendableParcelConfigPipeline is compatible with PureParcelConfigPipeline
       namers: mergePipelines(base.namers, ext.namers),
       runtimes: mergeMaps(base.runtimes, ext.runtimes),
       packagers: mergeMaps(base.packagers, ext.packagers),
       optimizers: mergeMaps(base.optimizers, ext.optimizers, mergePipelines),
-      // $FlowFixMe this seems like a flow bug, ExtendableParcelConfigPipeline is compatible with PureParcelConfigPipeline
       reporters: mergePipelines(base.reporters, ext.reporters),
     },
     base.packageManager,

--- a/packages/core/core/src/loadParcelConfig.js
+++ b/packages/core/core/src/loadParcelConfig.js
@@ -262,7 +262,7 @@ export function mergeConfigs(
       validators: mergeMaps(base.validators, ext.validators, mergePipelines),
       bundler: ext.bundler || base.bundler,
       namers: mergePipelines(base.namers, ext.namers),
-      runtimes: mergeMaps(base.runtimes, ext.runtimes),
+      runtimes: mergeMaps(base.runtimes, ext.runtimes, mergePipelines),
       packagers: mergeMaps(base.packagers, ext.packagers),
       optimizers: mergeMaps(base.optimizers, ext.optimizers, mergePipelines),
       reporters: mergePipelines(base.reporters, ext.reporters),

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -39,8 +39,10 @@ export type ParcelPluginNode = {|
   resolveFrom: FilePath,
 |};
 
-export type PureParcelConfigPipeline = Array<ParcelPluginNode>;
-export type ExtendableParcelConfigPipeline = Array<ParcelPluginNode | '...'>;
+export type PureParcelConfigPipeline = $ReadOnlyArray<ParcelPluginNode>;
+export type ExtendableParcelConfigPipeline = $ReadOnlyArray<
+  ParcelPluginNode | '...',
+>;
 
 export type ProcessedParcelConfig = {|
   extends?: PackageName | FilePath | Array<PackageName | FilePath>,


### PR DESCRIPTION
# ↪️ Pull Request

Closes T-462

## 💻 Examples

```json
{
  "extends": "@parcel/config-default",
  "transformers": {
    "*.{js,mjs,jsm,jsx,es6,cjs,ts,tsx}": [
      "@prefresh/parcel-transformer-preact-refresh-babel",
      "...",
      "@prefresh/parcel-transformer-preact-refresh-wrap"
    ]
  },
  "runtimes": {
    "browser": ["...", "@prefresh/parcel-runtime-preact-refresh"]
  }
}
```

