### PR TITLE
Fix #2622: Consider<amp-img> elements

### DIFF
--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -9,6 +9,7 @@ const ATTRS = {
   src: [
     'script',
     'img',
+    'amp-img',
     'audio',
     'video',
     'source',


### PR DESCRIPTION
Actual version doesn't resolve image file pointed in src attribute of <amp-img> elements. This change should fix that.