### PR TITLE
Expose publicUrl in the pluginOptions

### DIFF
--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -54,6 +54,10 @@ export default class PluginOptions implements IPluginOptions {
     return this.#options.serve;
   }
 
+  get publicUrl(): string {
+    return this.#options.publicUrl;
+  }
+
   get autoinstall(): boolean {
     return this.#options.autoinstall;
   }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -230,6 +230,7 @@ export interface PluginOptions {
   +env: EnvMap;
   +hot: ?HMROptions;
   +serve: ServerOptions | false;
+  +publicUrl: string;
   +autoinstall: boolean;
   +logLevel: LogLevel;
   +rootDir: FilePath;

--- a/packages/reporters/cli/test/CLIReporter.test.js
+++ b/packages/reporters/cli/test/CLIReporter.test.js
@@ -20,6 +20,7 @@ const EMPTY_OPTIONS = {
   autoinstall: false,
   hot: undefined,
   serve: false,
+  publicUrl: '/',
   mode: 'development',
   scopeHoist: false,
   minify: false,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Exposing publicUrl would be useful for reporters that create some kind of manifest or bundle report. Do these can be mapped to actual deployed assets.

Related to a plugin I ported to Parcel 2 https://github.com/kicker-matchday/parcel-reporter-bundle-manifest
