### PR TITLE
PnP: Support importing builtins from npm with `assert/`

### DIFF
--- a/packages/core/integration-tests/test/integration/pnp-builtin/.pnp.js
+++ b/packages/core/integration-tests/test/integration/pnp-builtin/.pnp.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+const resolve = request => {
+  if (request === 'module/') {
+    return path.join(__dirname, 'pnp', 'module');
+  } else {
+    // The plugins from the parcel config are also resolved through this function
+    return require.resolve(request);
+  }
+};
+
+module.exports = {resolveToUnqualified: resolve, resolveRequest: resolve};

--- a/packages/core/integration-tests/test/integration/pnp-builtin/index.js
+++ b/packages/core/integration-tests/test/integration/pnp-builtin/index.js
@@ -1,0 +1,6 @@
+const {a} = require('module/');
+const {b} = require('./local.js');
+
+module.exports = function() {
+  return a + b;
+};

--- a/packages/core/integration-tests/test/integration/pnp-builtin/local.js
+++ b/packages/core/integration-tests/test/integration/pnp-builtin/local.js
@@ -1,0 +1,1 @@
+exports.b = 2;

--- a/packages/core/integration-tests/test/integration/pnp-builtin/pnp/module/index.js
+++ b/packages/core/integration-tests/test/integration/pnp-builtin/pnp/module/index.js
@@ -1,0 +1,1 @@
+exports.a = 1;

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -300,7 +300,13 @@ export default class NodeResolver {
             ? _Module.findPnpApi(path.dirname(parent))
             : // $FlowFixMe injected at runtime
               require('pnpapi');
-        let res = pnp.resolveToUnqualified(moduleName, parent);
+
+        let res = pnp.resolveToUnqualified(
+          moduleName +
+            // retain slash in `require('assert/')` to force loading builtin from npm
+            (filename.indexOf(path.sep) === moduleName.length ? '/' : ''),
+          parent,
+        );
 
         resolved = {
           moduleName,

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -304,7 +304,7 @@ export default class NodeResolver {
         let res = pnp.resolveToUnqualified(
           moduleName +
             // retain slash in `require('assert/')` to force loading builtin from npm
-            (filename.indexOf(path.sep) === moduleName.length ? '/' : ''),
+            (filename[moduleName.length] === '/' ? '/' : ''),
           parent,
         );
 


### PR DESCRIPTION
# ↪️ Pull Request

This forces using the npm package "assert" instead of the Node builtin: `import assert from "assert/"`;

(Used in `node-libs-browser`)

https://github.com/parcel-bundler/parcel/discussions/4762