### PR TITLE
Named pipelines should have precedence to other pipelines

### DIFF
--- a/packages/core/core/test/loadParcelConfig.test.js
+++ b/packages/core/core/test/loadParcelConfig.test.js
@@ -436,14 +436,23 @@ describe('loadParcelConfig', () => {
     });
 
     it('should ensure that extension properties have a higher precidence than base properties', () => {
-      assert.deepEqual(
-        mergeMaps({'*.{js,jsx}': 'base-js'}, {'*.js': 'ext-js'}),
-        {'*.js': 'ext-js', '*.{js,jsx}': 'base-js'},
+      let merged = mergeMaps({'*.{js,jsx}': 'base-js'}, {'*.js': 'ext-js'});
+      assert.deepEqual(merged, {'*.js': 'ext-js', '*.{js,jsx}': 'base-js'});
+      assert.deepEqual(Object.keys(merged), ['*.js', '*.{js,jsx}']);
+    });
+
+    it('should ensure that named pipelines have a higher precidence than extension properties', () => {
+      let merged = mergeMaps(
+        {'types:*.ts': 'base-types-ts'},
+        {'*.ts': 'ext-ts'},
+        undefined,
+        true,
       );
-      assert.deepEqual(
-        Object.keys(mergeMaps({'*.{js,jsx}': 'base-js'}, {'*.js': 'ext-js'})),
-        ['*.js', '*.{js,jsx}'],
-      );
+      assert.deepEqual(merged, {
+        'types:*.ts': 'base-types-ts',
+        '*.ts': 'ext-ts',
+      });
+      assert.deepEqual(Object.keys(merged), ['types:*.ts', '*.ts']);
     });
 
     it('should call a merger function if provided', () => {

--- a/packages/core/integration-tests/test/integration/typescript-types-parcelrc/.parcelrc
+++ b/packages/core/integration-tests/test/integration/typescript-types-parcelrc/.parcelrc
@@ -1,0 +1,8 @@
+{
+    "extends": "@parcel/config-default",
+    "transformers": {
+      "*.ts": [
+        "@parcel/transformer-typescript-tsc"
+      ]
+    }
+  }

--- a/packages/core/integration-tests/test/integration/typescript-types-parcelrc/index.ts
+++ b/packages/core/integration-tests/test/integration/typescript-types-parcelrc/index.ts
@@ -1,0 +1,5 @@
+export class Foo {
+  run(){
+    return "bar";
+  }
+}

--- a/packages/core/integration-tests/test/integration/typescript-types-parcelrc/package.json
+++ b/packages/core/integration-tests/test/integration/typescript-types-parcelrc/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "typescript-types-parcelrc",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "private": true
+}

--- a/packages/core/integration-tests/test/typescript-tsc.js
+++ b/packages/core/integration-tests/test/typescript-tsc.js
@@ -1,6 +1,12 @@
 import assert from 'assert';
 import path from 'path';
-import {bundle, run, distDir, outputFS} from '@parcel/test-utils';
+import {
+  assertBundles,
+  bundle,
+  run,
+  distDir,
+  outputFS,
+} from '@parcel/test-utils';
 import {readFileSync} from 'fs';
 
 const configPath = path.join(
@@ -38,5 +44,25 @@ describe('typescript tsc', function() {
 
     let js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
     assert(!js.includes('/* test comment */'));
+  });
+
+  it('should produce a type declaration file when overriding the ts pipeline', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-types-parcelrc/index.ts'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.ts'],
+      },
+      {
+        name: 'index.d.ts',
+        assets: ['index.ts'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(new output.Foo().run(), 'bar');
   });
 });


### PR DESCRIPTION
# ↪️ Pull Request

The entry asset for `types: "dist/index.d.ts"` was being transformed with the `*.ts` pipeline in a custom parcelrc.

Closes #4666:

Only happens with a custom parcelrc that overrides the `ts` pipeline because when determining the pipeline for `types:index.ts`, the custom parcelrc takes precedence and it is processed like any other ts asset.

The current logic is:
1. select pipeline with matching named pipeline and type
2. otherwise select pipeline with matching type
3. otherwise continue search in parent config

Should be:
1. select pipeline with matching named pipeline and type
2. otherwise select pipeline with matching named pipeline and type in nearest parent config
3. otherwise select pipeline with matching type in current config
4. otherwise select pipeline with matching type in nearest parent config

The flattened parcelrc (custom + default) has these transformers:
```js
 {
  '*.{ts,tsx}': [
    {
      packageName: '@parcel/transformer-typescript-tsc',
      resolveFrom: '/Users/niklas/Desktop/asd/.parcelrc'
    }
  ],
  // custom pipelines above, default pipelines below
  'types:*.{ts,tsx}': [
    {
      packageName: '@parcel/transformer-typescript-types',
      resolveFrom: '/Users/niklas/Desktop/asd/node_modules/@parcel/config-default/index.json'
    }
  ],
  'bundle-text:*': [
    {
      packageName: '@parcel/transformer-inline-string',
      resolveFrom: '/Users/niklas/Desktop/asd/node_modules/@parcel/config-default/index.json'
    },
    '...'
  ],
  'data-url:*': [
  ...
```

So it looks like this call needs to always keep named pipelines on top:
https://github.com/parcel-bundler/parcel/blob/a008be3991c8fd3dcae6689b28ef4fb6bf7c1f06/packages/core/core/src/loadParcelConfig.js#L262-L266