### PR TITLE
Fix html referencing wrong bundle

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -14,7 +14,7 @@ import {
 } from '@parcel/test-utils';
 import path from 'path';
 
-describe.only('html', function() {
+describe('html', function() {
   beforeEach(async () => {
     await removeDistDirectory();
   });
@@ -1370,7 +1370,7 @@ describe.only('html', function() {
     checkHtml('g.html');
   });
 
-  it.only('should include the correct paths when using multiple entries and referencing style from html and js', async function() {
+  it('should include the correct paths when using multiple entries and referencing style from html and js', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-multi-entry/*.html'),
       {

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -14,7 +14,7 @@ import {
 } from '@parcel/test-utils';
 import path from 'path';
 
-describe('html', function() {
+describe.only('html', function() {
   beforeEach(async () => {
     await removeDistDirectory();
   });
@@ -1368,6 +1368,73 @@ describe('html', function() {
     checkHtml('e.html');
     checkHtml('f.html');
     checkHtml('g.html');
+  });
+
+  it.only('should include the correct paths when using multiple entries and referencing style from html and js', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/html-multi-entry/*.html'),
+      {
+        production: true,
+        scopeHoist: true,
+      },
+    );
+
+    await assertBundles(b, [
+      {
+        name: 'a.html',
+        type: 'html',
+        assets: ['a.html'],
+      },
+      {
+        name: 'b.html',
+        type: 'html',
+        assets: ['b.html'],
+      },
+      {
+        type: 'css',
+        assets: ['style.css'],
+      },
+      {
+        type: 'js',
+        assets: ['index.js'],
+      },
+    ]);
+
+    let firstHtmlFile = await outputFS.readFile(
+      path.join(distDir, 'a.html'),
+      'utf8',
+    );
+
+    let secondHtmlFile = await outputFS.readFile(
+      path.join(distDir, 'b.html'),
+      'utf8',
+    );
+
+    let bundles = b.getBundles();
+    let cssBundle = path.basename(
+      bundles.find(bundle => bundle.filePath.endsWith('.css')).filePath,
+    );
+    let jsBundle = path.basename(
+      bundles.find(bundle => bundle.filePath.endsWith('.js')).filePath,
+    );
+
+    assert(
+      firstHtmlFile.includes(cssBundle),
+      `a.html should include a reference to ${cssBundle}`,
+    );
+    assert(
+      secondHtmlFile.includes(cssBundle),
+      `b.html should include a reference to ${cssBundle}`,
+    );
+
+    assert(
+      firstHtmlFile.includes(jsBundle),
+      `a.html should include a reference to ${jsBundle}`,
+    );
+    assert(
+      secondHtmlFile.includes(jsBundle),
+      `b.html should include a reference to ${jsBundle}`,
+    );
   });
 
   it('should invalidate parent bundle when inline bundles change', async function() {

--- a/packages/core/integration-tests/test/integration/html-multi-entry/a.html
+++ b/packages/core/integration-tests/test/integration/html-multi-entry/a.html
@@ -1,0 +1,7 @@
+<head>
+	<link rel="stylesheet" href="./style.css">
+</head>
+
+<body>
+	<script src="./index.js"></script>
+</body>

--- a/packages/core/integration-tests/test/integration/html-multi-entry/b.html
+++ b/packages/core/integration-tests/test/integration/html-multi-entry/b.html
@@ -1,0 +1,7 @@
+<head>
+	<link rel="stylesheet" href="./style.css">
+</head>
+
+<body>
+	<script src="./index.js"></script>
+</body>

--- a/packages/core/integration-tests/test/integration/html-multi-entry/index.js
+++ b/packages/core/integration-tests/test/integration/html-multi-entry/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -64,8 +64,13 @@ export function replaceURLReferences({
     }
 
     invariant(resolved.type === 'bundle_group');
-    let entryBundle = bundleGraph.getBundlesInBundleGroup(resolved.value).pop();
-    if (entryBundle.isInline) {
+    let entryAssetId = resolved.value.entryAssetId;
+    let entryBundle = bundleGraph
+      .getBundlesInBundleGroup(resolved.value)
+      .find(b => {
+        return !!b.getEntryAssets().find(a => a.id === entryAssetId);
+      });
+    if (!entryBundle || entryBundle.isInline) {
       // If a bundle is inline, it should be replaced with inline contents,
       // not a URL.
       continue;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR fixes a bug in `replaceURLReferences` where it sometimes returns a reference to an incorrect bundle as it does not actually use the entryBundle.

Thanks @mischnic for mentioning bundle_group has an entryAssetId

See #4772 for context

Fixes #4772
