### PR TITLE
Optimize for HTTP/2 by default and support configuring bundler options

### DIFF
--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -20,6 +20,7 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
+    "@parcel/diagnostic": "^2.0.0-beta.1",
     "@parcel/plugin": "2.0.0-beta.1",
     "@parcel/utils": "2.0.0-beta.1",
     "nullthrows": "^1.1.1"

--- a/packages/core/integration-tests/test/integration/shared-many/package.json
+++ b/packages/core/integration-tests/test/integration/shared-many/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "shared-many",
+  "private": true,
+  "@parcel/bundler-default": {
+    "http": 1
+  }
+}

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -736,14 +736,25 @@ export type ResolveResult = {|
   +code?: string,
 |};
 
+export type ConfigOutput = {|
+  config: ConfigResult,
+  files: Array<File>,
+|};
+
 export type Bundler = {|
+  loadConfig?: ({|
+    options: PluginOptions,
+    logger: PluginLogger,
+  |}) => Async<ConfigOutput>,
   bundle({|
     bundleGraph: MutableBundleGraph,
+    config: ?ConfigResult,
     options: PluginOptions,
     logger: PluginLogger,
   |}): Async<void>,
   optimize({|
     bundleGraph: MutableBundleGraph,
+    config: ?ConfigResult,
     options: PluginOptions,
     logger: PluginLogger,
   |}): Async<void>,

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -10,6 +10,7 @@ export type SchemaEntity =
   | SchemaArray
   | SchemaBoolean
   | SchemaString
+  | SchemaNumber
   | SchemaEnum
   | SchemaOneOf
   | SchemaAllOf
@@ -38,6 +39,11 @@ export type SchemaString = {|
   type: 'string',
   enum?: Array<string>,
   __validate?: (val: string) => ?string,
+  __type?: string,
+|};
+export type SchemaNumber = {|
+  type: 'number',
+  enum?: Array<number>,
   __type?: string,
 |};
 export type SchemaEnum = {|
@@ -166,6 +172,23 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   dataType: 'value',
                   dataPath,
                   message: validationError,
+                  actualValue: value,
+                  ancestors: schemaAncestors,
+                };
+              }
+            }
+            break;
+          }
+          case 'number': {
+            // $FlowFixMe type was already checked
+            let value: number = dataNode;
+            if (schemaNode.enum) {
+              if (!schemaNode.enum.includes(value)) {
+                return {
+                  type: 'enum',
+                  dataType: 'value',
+                  dataPath,
+                  expectedValues: schemaNode.enum,
                   actualValue: value,
                   ancestors: schemaAncestors,
                 };
@@ -384,7 +407,7 @@ validateSchema.diagnostic = function(
             .map(v => JSON.stringify(v))
             .join(', ')}?`;
         } else if (expectedValues.length > 0) {
-          message = `Possible values: ${expectedValues
+          message = `Possible values: ${e.expectedValues
             .map(v => JSON.stringify(v))
             .join(', ')}`;
         } else {


### PR DESCRIPTION
Depends on #4786.

This changes the default options for the bundler to optimize for HTTP/2. In particular, it raises the number of parallel requests allowed from 6 to 25, and lowers the minimum bundle size from 30kb to 20kb. This should allow more granular caching while keeping good performance for apps served with HTTP/2. This is based on the work the Chrome team did with the Next.js team on more granular chunking. See https://web.dev/granular-chunking-nextjs/.

Since HTTP/2 is very widely supported by all browsers and most CDNs/servers, we believe that this is a good default. However, if you are still using HTTP/1.1, or otherwise wish the change these thresholds, you can now configure the bundler. This is done through the package.json in the project root.

This will use the default options for HTTP/1.1:

```json
{
  "@parcel/bundler-default": {
    "http": 1
  }
}
```

If you'd like to override individual options, you can do so as well:

```json
{
  "@parcel/bundler-default": {
    "minBundles": 1,
    "minBundleSize": 0,
    "maxParallelRequests": 10
  }
}
```

I'm not 100% sure about this method of configuring vs others (e.g. `.bundlerrc` file, targets?). Let me know what you think!