### PR TITLE
Bugfixes for TS types transformer

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/externals/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/externals/expected.d.ts
@@ -1,10 +1,11 @@
 import * as React from "react";
 import { ReactNode } from "react";
-import { External } from "external";
+import External from "external";
+import Default, { Named } from "other-external";
 interface Props {
     children: ReactNode;
 }
 export const Component: React.FC<Props>;
-export { External };
+export { External, Default, Named };
 
 //# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/externals/index.tsx
+++ b/packages/core/integration-tests/test/integration/ts-types/externals/index.tsx
@@ -1,7 +1,8 @@
 import {ReactNode} from 'react';
 import * as React from 'react';
 import {OtherComponent} from './other';
-import {External} from 'external';
+import External from 'external';
+import Default, {Named} from 'other-external';
 
 interface Props {
   children: ReactNode
@@ -11,4 +12,4 @@ export const Component: React.FC<Props> = (props) => {
   return <OtherComponent>{props.children}</OtherComponent>;
 }
 
-export {External};
+export {External, Default, Named};

--- a/packages/transformers/typescript-types/src/collect.js
+++ b/packages/transformers/typescript-types/src/collect.js
@@ -42,9 +42,11 @@ export function collect(
             '*',
           );
         }
-      } else if (node.importClause.name) {
+      }
+
+      if (node.importClause.name) {
         currentModule.addImport(
-          node.importClause.name,
+          node.importClause.name.text,
           node.moduleSpecifier.text,
           'default',
         );
@@ -84,7 +86,7 @@ export function collect(
       }
     }
 
-    if (ts.isVariableStatement(node)) {
+    if (ts.isVariableStatement(node) && node.modifiers) {
       let isExported = node.modifiers.some(
         m => m.kind === ts.SyntaxKind.ExportKeyword,
       );

--- a/packages/transformers/typescript-types/src/shake.js
+++ b/packages/transformers/typescript-types/src/shake.js
@@ -233,7 +233,9 @@ function generateImports(ts: TypeScriptModule, moduleGraph: TSModuleGraph) {
     if (defaultSpecifier || namedSpecifiers.length > 0) {
       let importClause = ts.createImportClause(
         defaultSpecifier,
-        ts.createNamedImports(namedSpecifiers),
+        namedSpecifiers.length > 0
+          ? ts.createNamedImports(namedSpecifiers)
+          : undefined,
       );
       importStatements.push(
         ts.createImportDeclaration(


### PR DESCRIPTION
Fixes three small issues in the TS types transformer:

* Crash when `node.modifiers` was not set on a variable declaration node
* Incorrect handling of default imports
* Broken when both a default and named import were on the same node