### PR TITLE
Ignore dynamic sourcemap code

### DIFF
--- a/packages/core/parcel-bundler/src/utils/loadSourceMap.js
+++ b/packages/core/parcel-bundler/src/utils/loadSourceMap.js
@@ -2,7 +2,7 @@ const logger = require('@parcel/logger');
 const path = require('path');
 const fs = require('@parcel/fs');
 
-const SOURCEMAP_RE = /(?:\/\*|\/\/)\s*[@#]\s*sourceMappingURL\s*=\s*([^\r\n*]+)(?:\s*\*\/)?/;
+const SOURCEMAP_RE = /(?:\/\*|\/\/)\s*[@#]\s*sourceMappingURL\s*=\s*([^\r\n*'"$]+)(?:\s*\*\/)?/;
 const DATA_URL_RE = /^data:[^;]+(?:;charset=[^;]+)?;base64,(.*)/;
 
 async function loadSourceMap(asset) {


### PR DESCRIPTION
# ↪️ Pull Request

Dependencies built with tools like Webpack's 'style-loader' will try to inject sourcemap mappings. The regex in Parcel mistakenly picks this code up as an actual sourcemap mapping, and tries (and fails) to load the code: https://github.com/webpack-contrib/style-loader/blob/236b2436fb0003eeba5f0aa33e7caf9f35d4fc7a/src/runtime/injectStylesIntoStyleTag.js#L191

Note: the above link is in ES6 interpolated format (so we truncate at $), but may also be downcompiled to ``\n/*# sourceMappingURL=data:application/json;base64,".concat(btoa(unescape(encodeURIComponent(JSON.stringify(sourceMap)))), "*/`)` if in some targetting scenarios, so we also need to truncate at " and '.
