### PR TITLE
Treat SVG to react transform as JSX instead of JS

### DIFF
--- a/packages/transformers/svg-react/src/SvgReactTransformer.js
+++ b/packages/transformers/svg-react/src/SvgReactTransformer.js
@@ -28,7 +28,7 @@ export default new Transformer({
     }
     `;
 
-    asset.type = 'js';
+    asset.type = 'jsx';
     asset.setCode(code);
 
     return [asset];


### PR DESCRIPTION
This makes the SVG to react transformer output JSX instead of JS. This means you don't need to configure babel to handle JSX because we automatically do that for assets of type JSX.