### PR TITLE
Parses process.env.PORT to a number

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -84,7 +84,7 @@ var hmrOptions = {
   '-p, --port <port>': [
     'set the port to serve on. defaults to $PORT or 1234',
     value => parseInt(value, 10),
-    process.env.PORT || 1234,
+    parseInt(process.env.PORT, 10) || 1234,
   ],
   '--host <host>':
     'set the host to listen on, defaults to listening on all interfaces',


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR is to avoid the following issue when setting a port with env:

``` bash
TypeError: (options.port || []).reduce is not a function
    at getPort (/home/sant821/Desktop/testing-parcel/node_modules/get-port/index.js:23:30)
    at module.exports (/home/sant821/Desktop/testing-parcel/node_modules/get-port/index.js:32:2)
    at normalizeOptions (/home/sant821/Desktop/testing-parcel/node_modules/parcel/lib/cli.js:251:18)
    at Command.run (/home/sant821/Desktop/testing-parcel/node_modules/parcel/lib/cli.js:133:23)
    at Command.listener (/home/sant821/Desktop/testing-parcel/node_modules/commander/index.js:315:8)
    at Command.emit (events.js:315:20)
    at Command.parseArgs (/home/sant821/Desktop/testing-parcel/node_modules/commander/index.js:651:12)
    at Command.parse (/home/sant821/Desktop/testing-parcel/node_modules/commander/index.js:474:21)
    at Object.<anonymous> (/home/sant821/Desktop/testing-parcel/node_modules/parcel/lib/cli.js:120:9)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
```

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

This works 🥳
``` bash
PORT=4646 parcel serve ./src/index.html
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
