### PR TITLE
[POC] Parallelized packaging and code generation

### DIFF
--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -87,19 +87,19 @@ export default class CommittedAsset {
 
   getMapBuffer(): Promise<?Buffer> {
     let mapKey = this.value.mapKey;
-    if (mapKey != null && this.mapBuffer == null) {
-      this.mapBuffer = (async () => {
-        try {
-          return await this.options.cache.getBlob(mapKey);
-        } catch (err) {
-          if (err.code === 'ENOENT' && this.value.astKey != null) {
-            return (await generateFromAST(this)).map?.toBuffer();
-          } else {
-            throw err;
-          }
-        }
-      })();
-    }
+    // if (mapKey != null && this.mapBuffer == null && !this.isGenerating) {
+    //   this.mapBuffer = (async () => {
+    //     try {
+    //       return await this.options.cache.getBlob(mapKey);
+    //     } catch (err) {
+    //       if (err.code === 'ENOENT' && this.value.astKey != null) {
+    //         return (await generateFromAST(this)).map?.toBuffer();
+    //       } else {
+    //         throw err;
+    //       }
+    //     }
+    //   })();
+    // }
 
     return this.mapBuffer ?? Promise.resolve();
   }
@@ -152,7 +152,7 @@ export default class CommittedAsset {
       parse?: boolean,
     |},
   ): Promise<ConfigResult | null> {
-    return (await getConfig(this, filePaths, options))?.config;
+    return await getConfig(this, filePaths, options)?.config;
   }
 
   getPackage(): Promise<PackageJSON | null> {

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -363,13 +363,14 @@ export default class Transformation {
             impactfulOptions: this.impactfulOptions,
             configs: getImpactfulConfigInfo(configs),
           }),
+          this.workerApi,
         ),
       ),
     );
-    this.options.cache.set(
-      cacheKey,
-      assets.map(a => a.value),
-    );
+    // this.options.cache.set(
+    //   cacheKey,
+    //   assets.map(a => a.value),
+    // );
   }
 
   getCacheKey(assets: Array<UncommittedAsset>, configs: ConfigMap): string {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -126,6 +126,8 @@ export type Asset = {|
   uniqueKey: ?string,
   configPath?: FilePath,
   plugin: ?PackageName,
+  farmId?: number,
+  workerId?: number,
 |};
 
 export type ParcelOptions = {|

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -17,15 +17,17 @@ const bundle = (name, opts = {}) => _bundle(name, {scopeHoist: true, ...opts});
 const bundler = (name, opts = {}) =>
   _bundler(name, {scopeHoist: true, ...opts});
 
-describe('scope hoisting', function() {
+describe.only('scope hoisting', function() {
   describe('es6', function() {
-    it('supports default imports and exports of expressions', async function() {
+    it.only('supports default imports and exports of expressions', async function() {
       let b = await bundle(
         path.join(
           __dirname,
           '/integration/scope-hoisting/es6/default-export-expression/a.js',
         ),
       );
+
+      console.log(outputFS.readFileSync(b.getBundles()[0].filePath, 'utf8'));
 
       let output = await run(b);
       assert.equal(output, 2);
@@ -2372,10 +2374,9 @@ describe('scope hoisting', function() {
 
   it('can static import and dynamic import in the same bundle when another bundle requires async', async () => {
     let b = await bundle(
-      [
-        'same-bundle-scope-hoisting.js',
-        'get-dep-scope-hoisting.js',
-      ].map(entry => path.join(__dirname, '/integration/sync-async/', entry)),
+      ['same-bundle-scope-hoisting.js', 'get-dep-scope-hoisting.js'].map(
+        entry => path.join(__dirname, '/integration/sync-async/', entry),
+      ),
     );
 
     assertBundles(b, [

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -555,6 +555,14 @@ export type Transformer = {|
     options: PluginOptions,
     logger: PluginLogger,
   |}) => Async<GenerateOutput>,
+  generateForBundle?: ({|
+    asset: Asset,
+    bundleGraph: BundleGraph<NamedBundle>,
+    bundle: NamedBundle,
+    ast: AST,
+    options: PluginOptions,
+    logger: PluginLogger,
+  |}) => Async<GenerateOutput>,
   postProcess?: ({|
     assets: Array<MutableAsset>,
     config: ?ConfigResult,

--- a/packages/core/workers/src/threads/ThreadsChild.js
+++ b/packages/core/workers/src/threads/ThreadsChild.js
@@ -28,11 +28,13 @@ export default class ThreadsChild implements ChildImpl {
   }
 
   handleMessage(data: WorkerMessage) {
-    this.onMessage(restoreDeserializedObject(data));
+    this.onMessage(data.raw ? data : restoreDeserializedObject(data));
   }
 
   send(data: WorkerMessage) {
-    nullthrows(parentPort).postMessage(prepareForSerialization(data));
+    nullthrows(parentPort).postMessage(
+      data.raw ? data : prepareForSerialization(data),
+    );
   }
 }
 

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -54,10 +54,10 @@ export default class ThreadsWorker implements WorkerImpl {
   }
 
   handleMessage(data: WorkerMessage) {
-    this.onMessage(restoreDeserializedObject(data));
+    this.onMessage(data.raw ? data : restoreDeserializedObject(data));
   }
 
-  send(data: WorkerMessage) {
-    this.worker.postMessage(prepareForSerialization(data));
+  send(data: WorkerMessage, raw?: boolean) {
+    this.worker.postMessage(raw ? data : prepareForSerialization(data));
   }
 }

--- a/packages/core/workers/src/types.js
+++ b/packages/core/workers/src/types.js
@@ -6,6 +6,8 @@ export type LocationCallRequest = {|
   args: $ReadOnlyArray<mixed>,
   location: string,
   method?: string,
+  farmId?: number,
+  workerId?: number,
 |};
 
 export type HandleCallRequest = {|

--- a/packages/shared/scope-hoisting/src/index.js
+++ b/packages/shared/scope-hoisting/src/index.js
@@ -1,5 +1,5 @@
 // @flow
 export {hoist} from './hoist';
-export {concat} from './concat';
+export {concat, processAsset} from './concat';
 export {link} from './link';
 export {generate} from './generate';

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -364,3 +364,28 @@ export function getHelpers(): Map<string, BabelNode> {
 
   return helpersCache;
 }
+
+export function findParentIndex(
+  ancestors: Array<BabelNode>,
+  predicate: (node: BabelNode) => boolean,
+) {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    if (predicate(ancestors[i])) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+export function findParent(
+  ancestors: Array<BabelNode>,
+  predicate: (node: BabelNode) => boolean,
+) {
+  let idx = findParentIndex(ancestors, predicate);
+  if (idx !== -1) {
+    return ancestors[idx];
+  }
+
+  return null;
+}

--- a/packages/utils/babylon-walk/src/traverse.js
+++ b/packages/utils/babylon-walk/src/traverse.js
@@ -66,8 +66,9 @@ function traverseWalk<T>(
     } else {
       let res = traverseWalk(visitors, ancestors, revisit, state, subNode);
       if (res === REMOVE) {
-        if (isNew) ancestors.pop();
-        return REMOVE;
+        // return REMOVE;
+        // $FlowFixMe
+        node[key] = null;
       } else if (res !== SKIP && res != null) {
         if (typeof res === 'function') {
           revisit.push(() => {


### PR DESCRIPTION
This is a POC to improve performance by parallelizing packaging and code generation. I open this just to show the potential – this is not finished code at all. Lots of stuff is broken. There are many open questions here, so I'm not sure how much farther I want to take this.

<img width="874" alt="image" src="https://user-images.githubusercontent.com/19409/86388109-0c1bbb80-bc49-11ea-9b29-bc6c837f5c12.png">

Currently, we run the hoist phase in parallel over each file, but the concat, link, and generate phases are single threaded. If you have multiple bundles being output, then we parallelize this at the bundle level, but if you just have one really large bundle it's not parallelized at all. These phases can be quite long: after #4826, the esbuild benchmark takes 6s to concat, 2s to link, and 4s to generate.

Most of the concat time is deserializing ASTs from the cache back to JS objects. Since JS doesn't have shared memory between threads, this is unfortunately required in the current architecture. The generate time is all spent in `@babel/generator`, printing the giant resulting AST.

The idea is to parallelize this. After #4815, the linker no longer requires scope information for the whole bundle, so it can potentially run over individual assets instead. The generator is also run over assets individually, after the linker. The linker inserts placeholders into the resulting string which we can replace easily with a find and replace back in the packager.

In order to avoid the deserialization cost, the way this parallelizes is by going back to the original worker thread that produced the AST in the first place. That AST is stored in memory in the worker between the hoist and link phases. This is made possible by a new `generateForBundle` method on Transformers which is like `generate` but also receives a Bundle and the BundleGraph. This is called through the worker farm using a new method `callWorker` which allows calling a worker from another worker by thread id. The worker farm bounces the message through the main thread to the correct worker, since direct worker to worker communication is impossible in node.

Anyway, this is all pretty convoluted and I'm not sure how much farther I want to take it. It's going to lead to significantly higher memory usage because all ASTs need to be kept in memory. Plus, when you have more than one bundle, we already do parallelize the packaging on a bundle level, so the workers would be busy anyway.

Other open questions:

* When would caching occur? Right now, I'm still writing the AST to the after the hoist phase, which is pretty expensive.
* Where should the method to generate go? I put it on the transformer right now, but maybe it should be on the packager.
* How to handle bundle imports and exports - that's commented out of the link phase. Would need to be moved because link runs over individual assets now.

Please let me know what you think!