### PR TITLE
Add globals support

### DIFF
--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -161,18 +161,20 @@ export class ResolverRunner {
           logger: new PluginLogger({origin: resolver.name}),
         });
 
-        if (result && result.isExcluded) {
-          return null;
-        }
+        if (result) {
+          if (result.isExcluded) {
+            return null;
+          }
 
-        if (result?.filePath != null) {
-          return {
-            filePath: result.filePath,
-            sideEffects: result.sideEffects,
-            code: result.code,
-            env: dependency.env,
-            pipeline: pipeline ?? dependency.pipeline,
-          };
+          if (result.filePath) {
+            return {
+              filePath: result.filePath,
+              sideEffects: result.sideEffects,
+              code: result.code,
+              env: dependency.env,
+              pipeline: pipeline ?? dependency.pipeline,
+            };
+          }
         }
       } catch (e) {
         // Add error to error map, we'll append these to the standard error if we can't resolve the asset

--- a/packages/core/integration-tests/test/globals.js
+++ b/packages/core/integration-tests/test/globals.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import path from 'path';
+import {bundle, outputFS} from '@parcel/test-utils';
+
+describe('global alias', function() {
+  it('should support all alias syntax', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/global-alias/index.js'),
+    );
+
+    let index = await outputFS.readFile(
+      b.getBundles().find(b => b.name.startsWith('index')).filePath,
+      'utf8',
+    );
+
+    assert(/module\.exports\ =\ React/.test(index));
+    assert(/module\.exports\ =\ \$/.test(index));
+    assert(/module\.exports\ =\ \_/.test(index));
+  });
+});

--- a/packages/core/integration-tests/test/globals.js
+++ b/packages/core/integration-tests/test/globals.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import path from 'path';
-import {bundle, outputFS} from '@parcel/test-utils';
+import {bundle, run} from '@parcel/test-utils';
 
 describe('global alias', function() {
   it('should support global alias syntax', async function() {
@@ -8,11 +8,15 @@ describe('global alias', function() {
       path.join(__dirname, '/integration/global-alias/index.js'),
     );
 
-    let index = await outputFS.readFile(
-      b.getBundles().find(b => b.name.startsWith('index')).filePath,
-      'utf8',
+    assert.equal(
+      await run(b, {
+        React: {
+          createElement: function() {
+            return 'ok';
+          },
+        },
+      }),
+      'ok',
     );
-
-    assert(/module\.exports\ =\ React/.test(index));
   });
 });

--- a/packages/core/integration-tests/test/integration/global-alias/index.js
+++ b/packages/core/integration-tests/test/integration/global-alias/index.js
@@ -1,3 +1,3 @@
 import React from 'react';
 
-React.createElement('div');
+module.exports = React.createElement('div');

--- a/packages/core/integration-tests/test/integration/global-alias/index.js
+++ b/packages/core/integration-tests/test/integration/global-alias/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import jQuery from 'jquery';
+import lodash from 'lodash';
+
+React.createElement('div');
+jQuery('html');
+lodash.merge({  }, {  });

--- a/packages/core/integration-tests/test/integration/global-alias/package.json
+++ b/packages/core/integration-tests/test/integration/global-alias/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "dist/index.js",
+  "alias": {
+    "react": { "global": "React" },
+    "jquery": "$",
+    "lodash": ["global", "_"]
+  }
+}

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -23,7 +23,6 @@ import builtins from './builtins';
 import nullthrows from 'nullthrows';
 // $FlowFixMe this is untyped
 import _Module from 'module';
-import {env} from 'process';
 
 const EMPTY_SHIM = require.resolve('./_empty');
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Adds support for globals using the `alias` in `package.json`.

Based off of #4846 and #4850.

Fixes #3305.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
In `package.json`:
```json
{
    "alias": {
        "react": { "global": "React" },
        "myAliasedPackageName": { "fileName": "./myPkg.js" },
        "finalPackage": "finalPackage.js"
    }
}
```
All of the above syntax forms work, for globals and normal aliases respectively. <strike>The pure string syntax works less reliably because it has to guess that it's not an alias based on whether or not the file exists.</strike> (Removed)


## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
