### PR TITLE
Fix reused sibling bundles

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -105,10 +105,14 @@ export default new Bundler({
               target: bundleGroup.target,
             });
             bundleByType.set(bundle.type, bundle);
-            bundleRoots.set(bundle, [asset]);
             bundlesByEntryAsset.set(asset, bundle);
             siblingBundlesByAsset.set(asset.id, []);
             bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
+
+            // The bundle may have already been created, and the graph gave us back the original one...
+            if (!bundleRoots.has(bundle)) {
+              bundleRoots.set(bundle, [asset]);
+            }
 
             // If the bundle is in the same bundle group as the parent, create an asset reference
             // between the dependency and the asset, and a bundle reference between the parent bundle
@@ -192,11 +196,15 @@ export default new Bundler({
             });
             bundleByType.set(bundle.type, bundle);
             siblingBundles.push(bundle);
-            bundleRoots.set(bundle, [asset]);
             bundlesByEntryAsset.set(asset, bundle);
             bundleGraph.createAssetReference(dependency, asset);
             bundleGraph.createBundleReference(parentBundle, bundle);
             bundleGraph.addBundleToBundleGroup(bundle, bundleGroup);
+
+            // The bundle may have already been created, and the graph gave us back the original one...
+            if (!bundleRoots.has(bundle)) {
+              bundleRoots.set(bundle, [asset]);
+            }
           }
 
           if (!siblings) {

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1244,10 +1244,44 @@ describe('html', function() {
   });
 
   it('should support multiple entries with shared sibling bundles', async function() {
-    await bundle(
+    let b = await bundle(
       path.join(__dirname, '/integration/shared-sibling-entries/*.html'),
       {production: true, scopeHoist: true},
     );
+
+    assertBundles(b, [
+      {
+        name: 'a.html',
+        type: 'html',
+        assets: ['a.html'],
+      },
+      {
+        name: 'b.html',
+        type: 'html',
+        assets: ['b.html'],
+      },
+      {
+        name: 'c.html',
+        type: 'html',
+        assets: ['c.html'],
+      },
+      {
+        type: 'js',
+        assets: ['a.html', 'shared.js'],
+      },
+      {
+        type: 'js',
+        assets: ['b.html', 'shared.js'],
+      },
+      {
+        type: 'js',
+        assets: ['c.html', 'shared.js'],
+      },
+      {
+        type: 'css',
+        assets: ['shared.css', 'other.css'],
+      },
+    ]);
 
     // Both HTML files should point to the sibling CSS file
     let html = await outputFS.readFile(path.join(distDir, 'a.html'), 'utf8');

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/a.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/a.html
@@ -3,6 +3,7 @@
   <body>
     <h1>a.html</h1>
     <script type="module">
+      import './other.css';
       import './shared';
     </script>
   </body>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/b.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/b.html
@@ -3,6 +3,7 @@
   <body>
     <h1>b.html</h1>
     <script type="module">
+      import './other.css';
       import './shared';
     </script>
   </body>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/c.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/c.html
@@ -3,6 +3,7 @@
   <body>
     <h1>c.html</h1>
     <script type="module">
+      import './other.css';
       import './shared';
     </script>
   </body>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries/other.css
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries/other.css
@@ -1,0 +1,3 @@
+.c {
+  color: blue;
+}


### PR DESCRIPTION
This fixes an issue introduced in #4449, now that the same bundle object can be returned when the bundle id is the same: https://github.com/parcel-bundler/parcel/pull/4449/files#diff-4c49ed02ff34648c2aae9667d844bfc1R138.

The same asset may be revisited multiple times when creating sibling bundles, e.g. CSS imported from multiple JS files. Now that the same bundle object is returned, the `bundleRoots` map was getting overwritten. The bundler now needs to check for this case.