### PR TITLE
Access asset publicId via the bundle graph

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -81,18 +81,17 @@ export default class BundleGraph {
     let assetGroupIds = new Set();
     for (let [, node] of assetGraph.nodes) {
       if (node.type === 'asset') {
-        let asset = node.value;
+        let {id: assetId} = node.value;
         // Generate a new, short public id for this asset to use.
         // If one already exists, use it.
-        let publicId = publicIdByAssetId.get(asset.id);
+        let publicId = publicIdByAssetId.get(assetId);
         if (publicId == null) {
-          publicId = getPublicId(asset.id, existing =>
+          publicId = getPublicId(assetId, existing =>
             assetPublicIds.has(existing),
           );
-          publicIdByAssetId.set(asset.id, publicId);
+          publicIdByAssetId.set(assetId, publicId);
           assetPublicIds.add(publicId);
         }
-        asset.publicId = publicId;
       }
 
       // Don't copy over asset groups into the bundle graph.
@@ -984,6 +983,15 @@ export default class BundleGraph {
     return node.value;
   }
 
+  getAssetPublicId(asset: Asset): string {
+    let publicId = this._publicIdByAssetId.get(asset.id);
+    if (publicId == null) {
+      throw new Error("Asset or it's public id not found");
+    }
+
+    return publicId;
+  }
+
   getExportedSymbols(asset: Asset) {
     if (!asset.symbols) {
       return [];
@@ -1021,7 +1029,7 @@ export default class BundleGraph {
     this.traverseAssets(bundle, asset => {
       hash.update(
         [
-          asset.publicId,
+          this.getAssetPublicId(asset),
           asset.outputHash,
           asset.filePath,
           asset.type,

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -84,7 +84,6 @@ export function createAsset(options: AssetOptions): Asset {
     includedFiles: options.includedFiles || new Map(),
     isSource: options.isSource,
     outputHash: options.outputHash,
-    publicId: null,
     pipeline: options.pipeline,
     env: options.env,
     meta: options.meta || {},

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -209,10 +209,6 @@ export class Asset extends BaseAsset implements IAsset {
   get stats(): Stats {
     return this.#asset.value.stats;
   }
-
-  get publicId(): string {
-    return nullthrows(this.#asset.value.publicId);
-  }
 }
 
 export class MutableAsset extends BaseAsset implements IMutableAsset {

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -65,6 +65,10 @@ export default class BundleGraph<TBundle: IBundle>
     return assetFromValue(this.#graph.getAssetById(id), this.#options);
   }
 
+  getAssetPublicId(asset: IAsset): string {
+    return this.#graph.getAssetPublicId(assetToAssetValue(asset));
+  }
+
   isDependencyDeferred(dep: IDependency): boolean {
     return this.#graph.isDependencyDeferred(
       dependencyToInternalDependency(dep),

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -121,7 +121,6 @@ export type Asset = {|
   mapKey: ?string,
   outputHash: ?string,
   pipeline: ?string,
-  publicId: ?string,
   astKey: ?string,
   astGenerator: ?ASTGenerator,
   symbols: ?Map<Symbol, {|local: Symbol, loc: ?SourceLocation|}>,

--- a/packages/core/core/test/BundleGraph.test.js
+++ b/packages/core/core/test/BundleGraph.test.js
@@ -16,7 +16,7 @@ describe('BundleGraph', () => {
       createMockAssetGraph([id1, id2]),
     );
     assert.deepEqual(
-      getAssets(bundleGraph).map(a => a.publicId),
+      getAssets(bundleGraph).map(a => bundleGraph.getAssetPublicId(a)),
       ['296TI', '4DGUq'],
     );
   });
@@ -26,7 +26,7 @@ describe('BundleGraph', () => {
       createMockAssetGraph([id1, id1.slice(0, 16) + '7' + id1.slice(17)]),
     );
     assert.deepEqual(
-      getAssets(bundleGraph).map(a => a.publicId),
+      getAssets(bundleGraph).map(a => bundleGraph.getAssetPublicId(a)),
       ['296TI', '296TII'],
     );
   });

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2527,8 +2527,12 @@ describe('javascript', function() {
     let sameBundle = bundles.find(b => b.name === 'same-bundle.js');
     let getDep = bundles.find(b => b.name === 'get-dep.js');
 
-    assert.deepEqual(await (await runBundle(sameBundle)).default, [42, 42, 42]);
-    assert.deepEqual(await (await runBundle(getDep)).default, 42);
+    assert.deepEqual(await (await runBundle(b, sameBundle)).default, [
+      42,
+      42,
+      42,
+    ]);
+    assert.deepEqual(await (await runBundle(b, getDep)).default, 42);
   });
 
   it("can share dependencies between a shared bundle and its sibling's descendants", async () => {

--- a/packages/core/integration-tests/test/react-refresh.js
+++ b/packages/core/integration-tests/test/react-refresh.js
@@ -209,7 +209,11 @@ async function setup(entry) {
     bundleEvent.bundleGraph.getBundles().find(b => b.type === 'js'),
   );
   // ReactDOM.render
-  await window.parcelRequire(bundle.getEntryAssets().pop().publicId).default();
+  await window
+    .parcelRequire(
+      bundleEvent.bundleGraph.getAssetPublicId(bundle.getEntryAssets().pop()),
+    )
+    .default();
   await sleep(100);
 
   let [, indexNum, appNum, fooText, fooNum] = root.textContent.match(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2411,8 +2411,8 @@ describe('scope hoisting', function() {
     );
     let getDep = bundles.find(b => b.name === 'get-dep-scope-hoisting.js');
 
-    assert.deepEqual(await runBundle(sameBundle), [42, 42, 42]);
-    assert.deepEqual(await runBundle(getDep), 42);
+    assert.deepEqual(await runBundle(b, sameBundle), [42, 42, 42]);
+    assert.deepEqual(await runBundle(b, getDep), 42);
   });
 
   it("can share dependencies between a shared bundle and its sibling's descendants", async () => {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -157,6 +157,7 @@ export function getNextBuild(b: Parcel): Promise<BuildEvent> {
 type RunOpts = {require?: boolean, ...};
 
 export async function runBundles(
+  bundleGraph: BundleGraph<NamedBundle>,
   parent: NamedBundle,
   bundles: Array<NamedBundle>,
   globals: mixed,
@@ -215,7 +216,7 @@ export async function runBundles(
           return typeof ctx.output !== 'undefined' ? ctx.output : undefined;
         } else if (ctx.parcelRequire) {
           // $FlowFixMe
-          return ctx.parcelRequire(entryAsset.publicId);
+          return ctx.parcelRequire(bundleGraph.getAssetPublicId(entryAsset));
         }
         return;
       case 'commonjs':
@@ -232,11 +233,12 @@ export async function runBundles(
 }
 
 export function runBundle(
+  bundleGraph: BundleGraph<NamedBundle>,
   bundle: NamedBundle,
   globals: mixed,
   opts: RunOpts = {},
 ): Promise<mixed> {
-  return runBundles(bundle, [bundle], globals, opts);
+  return runBundles(bundleGraph, bundle, [bundle], globals, opts);
 }
 
 export async function run(
@@ -265,13 +267,14 @@ export async function run(
       return node;
     });
     return runBundles(
+      bundleGraph,
       bundle,
       scripts.map(p => nullthrows(bundles.find(b => b.filePath === p))),
       globals,
       opts,
     );
   } else {
-    return runBundle(bundle, globals, opts);
+    return runBundle(bundleGraph, bundle, globals, opts);
   }
 }
 

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -527,7 +527,6 @@ export interface Asset extends BaseAsset {
   /** Throws if there is no AST.*/
   getAST(): Promise<?AST>;
 
-  +publicId: string;
   +stats: Stats;
 }
 
@@ -932,6 +931,7 @@ export interface MutableBundleGraph extends BundleGraph<Bundle> {
  */
 export interface BundleGraph<TBundle: Bundle> {
   getAssetById(id: string): Asset;
+  getAssetPublicId(asset: Asset): string;
   getBundles(): Array<TBundle>;
   getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
   getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<TBundle>;

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -113,7 +113,9 @@ export default new Packager({
           // if this is a reference to another javascript asset, we should not include
           // its output, as its contents should already be loaded.
           invariant(!bundle.hasAsset(resolved));
-          wrapped += JSON.stringify(resolved.publicId) + ':[function() {},{}]';
+          wrapped +=
+            JSON.stringify(bundleGraph.getAssetPublicId(resolved)) +
+            ':[function() {},{}]';
         } else {
           return;
         }
@@ -131,14 +133,14 @@ export default new Packager({
         for (let dep of dependencies) {
           let resolved = bundleGraph.getDependencyResolution(dep, bundle);
           if (resolved) {
-            deps[dep.moduleSpecifier] = resolved.publicId;
+            deps[dep.moduleSpecifier] = bundleGraph.getAssetPublicId(resolved);
           }
         }
 
         let {code, mapBuffer} = results[i];
         let output = code || '';
         wrapped +=
-          JSON.stringify(asset.publicId) +
+          JSON.stringify(bundleGraph.getAssetPublicId(asset)) +
           ':[function(require,module,exports) {\n' +
           output +
           '\n},';
@@ -182,9 +184,13 @@ export default new Packager({
         '({' +
         assets +
         '},{},' +
-        JSON.stringify(entries.map(asset => asset.publicId)) +
+        JSON.stringify(
+          entries.map(asset => bundleGraph.getAssetPublicId(asset)),
+        ) +
         ', ' +
-        JSON.stringify(mainEntry?.publicId ?? null) +
+        JSON.stringify(
+          mainEntry ? bundleGraph.getAssetPublicId(mainEntry) : null,
+        ) +
         ', ' +
         'null' +
         ')' +

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -114,14 +114,16 @@ export default class HMRServer {
               bundle,
             );
             if (resolved) {
-              deps[dep.moduleSpecifier] = resolved.publicId;
+              deps[dep.moduleSpecifier] = event.bundleGraph.getAssetPublicId(
+                resolved,
+              );
             }
           }
           depsByBundle[bundle.id] = deps;
         }
 
         return {
-          id: asset.publicId,
+          id: event.bundleGraph.getAssetPublicId(asset),
           type: asset.type,
           output: await asset.getCode(),
           envHash: md5FromObject(asset.env),

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -267,9 +267,9 @@ function getLoaderRuntimes({
     }
 
     if (bundle.env.outputFormat === 'global') {
-      loaders += `.then(() => parcelRequire('${
-        bundleGraph.getAssetById(bundleGroup.entryAssetId).publicId
-      }')${
+      loaders += `.then(() => parcelRequire('${bundleGraph.getAssetPublicId(
+        bundleGraph.getAssetById(bundleGroup.entryAssetId),
+      )}')${
         // In global output with scope hoisting, functions return exports are
         // always returned. Otherwise, the exports are returned.
         bundle.env.scopeHoist ? '()' : ''

--- a/packages/shared/scope-hoisting/src/formats/global.js
+++ b/packages/shared/scope-hoisting/src/formats/global.js
@@ -53,6 +53,7 @@ export function generateBundleImports(
   from: NamedBundle,
   {bundle, assets}: ExternalBundle,
   path: NodePath<Program>,
+  bundleGraph: BundleGraph<NamedBundle>,
 ) {
   let statements = [];
   if (from.env.isWorker()) {
@@ -69,7 +70,9 @@ export function generateBundleImports(
     nullthrows(path.scope.getBinding(getName(asset, 'init')))
       .path.get('init')
       .replaceWith(
-        IMPORT_TEMPLATE({ASSET_ID: t.stringLiteral(asset.publicId)}),
+        IMPORT_TEMPLATE({
+          ASSET_ID: t.stringLiteral(bundleGraph.getAssetPublicId(asset)),
+        }),
       );
   }
 }
@@ -97,7 +100,7 @@ export function generateExports(
 
     statements.push(
       EXPORT_TEMPLATE({
-        ASSET_ID: t.stringLiteral(asset.publicId),
+        ASSET_ID: t.stringLiteral(bundleGraph.getAssetPublicId(asset)),
         IDENTIFIER: t.identifier(exportsId),
       }),
     );
@@ -116,7 +119,7 @@ export function generateExports(
       // Export a function returning the exports, as other cases of global output
       // register init functions.
       EXPORT_FN_TEMPLATE({
-        ASSET_ID: t.stringLiteral(entry.publicId),
+        ASSET_ID: t.stringLiteral(bundleGraph.getAssetPublicId(entry)),
         IDENTIFIER: t.identifier(assertString(entry.meta.exportsIdentifier)),
       }),
     );

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -76,7 +76,9 @@ export function generate({
             REFERENCED_IDS: t.arrayExpression(
               [mainEntry, ...referencedAssets]
                 .filter(Boolean)
-                .map(asset => t.stringLiteral(asset.publicId)),
+                .map(asset =>
+                  t.stringLiteral(bundleGraph.getAssetPublicId(asset)),
+                ),
             ),
           }),
         ]

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -666,7 +666,7 @@ export function link({
 
         for (let file of importedFiles.values()) {
           if (file.bundle) {
-            format.generateBundleImports(bundle, file, path);
+            format.generateBundleImports(bundle, file, path, bundleGraph);
           } else {
             format.generateExternalImport(bundle, file, path);
           }

--- a/packages/shared/scope-hoisting/src/types.js
+++ b/packages/shared/scope-hoisting/src/types.js
@@ -29,6 +29,7 @@ export type OutputFormat = {|
     from: NamedBundle,
     external: ExternalBundle,
     path: NodePath<Program>,
+    bundleGraph: BundleGraph<NamedBundle>,
   ): void,
   generateExternalImport(
     bundle: NamedBundle,


### PR DESCRIPTION
# ↪️ Pull Request

The BundlerRunner (calling `InternalBundleGraph.fromAssetGraph`) mutated the asset value objects by setting their `publicId`. When a cached bundle graph was used, the assets weren't mutated and the `publicId` was null.
https://github.com/parcel-bundler/parcel/blob/131e9296aa1fdebdb4cccbf90d3ab0ae82934674/packages/core/core/src/BundlerRunner.js#L83-L94

This manifested in the HMR reporter crashing because every other component also used a cached result (e.g. packager) and so `asset.publicId` was never actually accessed.

Instead use the existing map in the bundle graph to get an assets's public id.


Fixes https://github.com/parcel-bundler/parcel/issues/4860
Related: #4449
