### PR TITLE
make optimizer-data-url encode "!'()*"

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -311,7 +311,7 @@ describe('css', () => {
     assert.equal(
       css.trim(),
       `.svg-img {
-  background-image: url('data:image/svg+xml,%3Csvg%3E%0A%0A%3C%2Fsvg%3E%0A');
+  background-image: url('data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%27120%27%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%2F%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%23blur-_.%21~%2a%29%22%20%2F%3E%0A%3C%2Fsvg%3E%0A');
 }`,
     );
   });

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1620,7 +1620,7 @@ describe('html', function() {
     );
     assert.equal(
       contents.trim(),
-      `<img src="data:image/svg+xml,%3Csvg%3E%0A%0A%3C%2Fsvg%3E%0A">`,
+      `<img src="data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%27120%27%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%2F%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%23blur-_.%21~%2a%29%22%20%2F%3E%0A%3C%2Fsvg%3E%0A">`,
     );
   });
 });

--- a/packages/core/integration-tests/test/integration/data-url/img.svg
+++ b/packages/core/integration-tests/test/integration/data-url/img.svg
@@ -1,3 +1,6 @@
-<svg>
-
+<svg width="120" height='120' xmlns="http://www.w3.org/2000/svg">
+  <filter id="blur-_.!~*">
+    <feGaussianBlur stdDeviation="5"/>
+  </filter>
+  <circle cx="60" cy="60" r="50" fill="green" filter="url(#blur-_.!~*)" />
 </svg>

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2211,7 +2211,7 @@ describe('javascript', function() {
 
     assert.equal(
       (await run(b)).default,
-      'data:image/svg+xml,%3Csvg%3E%0A%0A%3C%2Fsvg%3E%0A',
+      'data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%27120%27%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%2F%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%23blur-_.%21~%2a%29%22%20%2F%3E%0A%3C%2Fsvg%3E%0A',
     );
   });
 

--- a/packages/optimizers/data-url/src/DataURLOptimizer.js
+++ b/packages/optimizers/data-url/src/DataURLOptimizer.js
@@ -5,6 +5,12 @@ import {blobToBuffer} from '@parcel/utils';
 import mime from 'mime';
 import {isBinaryFile} from 'isbinaryfile';
 
+const fixedEncodeURIComponent = (str: string): string => {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+    return '%' + c.charCodeAt(0).toString(16);
+  });
+};
+
 export default new Optimizer({
   async optimize({bundle, contents}) {
     let bufferContents = await blobToBuffer(contents);
@@ -14,7 +20,7 @@ export default new Optimizer({
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs
     let mimeType = mime.getType(bundle.filePath) ?? '';
     let encoding = hasBinaryContent ? ';base64' : '';
-    let content = encodeURIComponent(
+    let content = fixedEncodeURIComponent(
       hasBinaryContent
         ? bufferContents.toString('base64')
         : bufferContents.toString(),


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Fixies https://github.com/parcel-bundler/parcel/issues/4872

## 💻 Examples

Following svg that include characters "-_.!~*'()" that [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) does not escape can be encoded 
 to be rendered on browsers properly.
```svg
<svg width="120" height='120' xmlns="http://www.w3.org/2000/svg">
  <filter id="blur-_.!~*">
    <feGaussianBlur stdDeviation="5"/>
  </filter>
  <circle cx="60" cy="60" r="50" fill="green" filter="url(#blur-_.!~*)" />
</svg>
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
