### PR TITLE
Tweak autoinstall behaviour

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -103,7 +103,7 @@ export default async function resolveOptions(
     },
     mode,
     minify,
-    autoinstall: initialOptions.autoinstall ?? true,
+    autoinstall: initialOptions.autoinstall ?? false,
     hot: initialOptions.hot ?? null,
     contentHash:
       initialOptions.contentHash ?? initialOptions.mode === 'production',

--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -393,6 +393,7 @@ describe('babel', function() {
           distDir,
         },
       },
+      autoinstall: true,
     });
     let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
     assert(file.includes('function Foo'));
@@ -415,6 +416,7 @@ describe('babel', function() {
           distDir,
         },
       },
+      autoinstall: true,
     });
     let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
     assert(!file.includes('REPLACE_ME'));

--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -549,6 +549,7 @@ describe('babel', function() {
 
       let b = bundler(path.join(inputDir, 'index.js'), {
         outputFS: fs,
+        autoinstall: true,
       });
 
       subscription = await b.watch();

--- a/packages/core/integration-tests/test/postcss.js
+++ b/packages/core/integration-tests/test/postcss.js
@@ -260,6 +260,7 @@ describe('postcss', () => {
       inputFS: outputFS,
       packageManager,
       distDir,
+      autoinstall: true,
     });
 
     // cssnext was installed

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -125,7 +125,7 @@ export class NodePackageManager implements PackageManager {
           extensions: Object.keys(Module._extensions),
         });
       } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND' || options?.autoinstall === false) {
+        if (e.code !== 'MODULE_NOT_FOUND' || options?.autoinstall !== true) {
           throw e;
         }
 
@@ -139,6 +139,7 @@ export class NodePackageManager implements PackageManager {
           await this.install([{name, range: options?.range}], from, {
             saveDev: options?.saveDev ?? true,
           });
+
           return this.resolve(name, from, {
             ...options,
             autoinstall: false,
@@ -175,7 +176,7 @@ export class NodePackageManager implements PackageManager {
             from,
           );
 
-          if (conflicts == null && options?.autoinstall !== false) {
+          if (conflicts == null && options?.autoinstall === true) {
             await this.install([{name, range}], from);
             return this.resolve(name, from, {
               ...options,

--- a/packages/core/package-manager/test/NodePackageManager.test.js
+++ b/packages/core/package-manager/test/NodePackageManager.test.js
@@ -65,6 +65,7 @@ describe('NodePackageManager', function() {
       await packageManager.resolve(
         'a',
         path.join(FIXTURES_DIR, 'has-foo/index.js'),
+        {autoinstall: true},
       ),
       {
         pkg: {
@@ -84,6 +85,7 @@ describe('NodePackageManager', function() {
         packageManager.resolve(
           'a',
           path.join(FIXTURES_DIR, 'has-a-not-yet-installed/index.js'),
+          {autoinstall: true},
         ),
       err => {
         invariant(err instanceof ThrowableDiagnostic);
@@ -104,6 +106,7 @@ describe('NodePackageManager', function() {
     await packageManager.resolve(
       'peers',
       path.join(FIXTURES_DIR, 'has-foo/index.js'),
+      {autoinstall: true},
     );
     assert.deepEqual(spy.args, [
       [
@@ -134,6 +137,7 @@ describe('NodePackageManager', function() {
     await packageManager.resolve(
       'peers',
       path.join(FIXTURES_DIR, 'empty/index.js'),
+      {autoinstall: true},
     );
     assert.deepEqual(spy.args, [
       [
@@ -194,6 +198,7 @@ describe('NodePackageManager', function() {
           path.join(FIXTURES_DIR, 'has-foo/subpackage/index.js'),
           {
             range: '^2.0.0',
+            autoinstall: true,
           },
         ),
         {
@@ -244,6 +249,7 @@ describe('NodePackageManager', function() {
             path.join(FIXTURES_DIR, 'has-foo/index.js'),
             {
               range: '^2.0.0',
+              autoinstall: true,
             },
           ),
         err => {

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -58,7 +58,6 @@ const commonOptions = {
   '--no-cache': 'disable the filesystem cache',
   '--cache-dir <path>': 'set the cache directory. defaults to ".parcel-cache"',
   '--no-source-maps': 'disable sourcemaps',
-  '--no-autoinstall': 'disable autoinstall',
   '--no-content-hash': 'disable content hashing',
   '--target [name]': [
     'only build given target(s)',
@@ -91,6 +90,7 @@ var hmrOptions = {
   '--https': 'serves files over HTTPS',
   '--cert <path>': 'path to certificate to use with HTTPS',
   '--key <path>': 'path to private key to use with HTTPS',
+  '--no-autoinstall': 'disable autoinstall',
 };
 
 function applyOptions(cmd, options) {
@@ -270,6 +270,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
   let nodeEnv;
   if (command.name() === 'build') {
     nodeEnv = initialNodeEnv || 'production';
+    command.autoinstall = false;
   } else {
     nodeEnv = initialNodeEnv || 'development';
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Only enable autoinstall when explicitly enabled when using `packageManager.resolve`, currently when passing undefined and null it also autoinstalls, which might be a problem with third party plugins.

This PR also disabled autoinstall completely when using the build command as this command should probably be reliable across machines (especially build pipelines and CI/CD)

Slightly related to #2978 

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
