### PR TITLE
Encapsulate AdjacencyList in class

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -125,20 +125,15 @@ export default class BundleGraph {
     for (let edge of assetGraph.getAllEdges()) {
       let fromIds;
       if (assetGroupIds.has(edge.from)) {
-        fromIds = [
-          ...(assetGraph.inboundEdges.get(edge.from)?.get(null) ?? []),
-        ];
+        fromIds = [...assetGraph.inboundEdges.getEdges(edge.from, null)];
       } else {
         fromIds = [edge.from];
       }
 
       for (let from of fromIds) {
         if (assetGroupIds.has(edge.to)) {
-          let outbound = assetGraph.outboundEdges.get(edge.to)?.get(null);
-          if (outbound != null) {
-            for (let to of outbound) {
-              graph.addEdge(from, to);
-            }
+          for (let to of assetGraph.outboundEdges.getEdges(edge.to, null)) {
+            graph.addEdge(from, to);
           }
         } else {
           graph.addEdge(from, edge.to);


### PR DESCRIPTION
This encapsulates the AdjacencyList structure and functionality in a class. This removes (or rather centralizes) a lot of the null checking introduced by #4906 and exposes more purpose-oriented methods rather than having the user understand how it is internally structured.

Some of the methods still return Maps and Sets. `getListMap` returns the underlying structure, which is needed for serialization, but all other methods return read-only structures which are enforced by flow but not are read-only at runtime.

Test Plan: `yarn test`