### PR TITLE
Use TSC by default when tsconfig is present

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -4,12 +4,13 @@
     "types:*.{ts,tsx}": ["@parcel/transformer-typescript-types"],
     "bundle-text:*": ["@parcel/transformer-inline-string", "..."],
     "data-url:*": ["@parcel/transformer-inline-string", "..."],
-    "*.{js,mjs,jsm,jsx,es6,cjs,ts,tsx}": [
+    "*.{js,mjs,jsm,jsx,es6,cjs,ts-babel,tsx-babel}": [
       "@parcel/transformer-react-refresh-babel",
       "@parcel/transformer-babel",
       "@parcel/transformer-js",
       "@parcel/transformer-react-refresh-wrap"
     ],
+    "*.{ts,tsx}": ["@parcel/transformer-typescript-tsc"],
     "*.{json,json5}": ["@parcel/transformer-json"],
     "*.jsonld": ["@parcel/transformer-jsonld"],
     "*.toml": ["@parcel/transformer-toml"],

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -59,6 +59,7 @@
     "@parcel/transformer-stylus": "2.0.0-beta.1",
     "@parcel/transformer-sugarss": "2.0.0-beta.1",
     "@parcel/transformer-toml": "2.0.0-beta.1",
+    "@parcel/transformer-typescript-tsc": "2.0.0-beta.1",
     "@parcel/transformer-typescript-types": "2.0.0-beta.1",
     "@parcel/transformer-vue": "2.0.0-beta.1",
     "@parcel/transformer-yaml": "2.0.0-beta.1"

--- a/packages/core/integration-tests/test/typescript.js
+++ b/packages/core/integration-tests/test/typescript.js
@@ -10,199 +10,162 @@ import {
 } from '@parcel/test-utils';
 import {readFileSync} from 'fs';
 
-const configPath = path.join(
-  __dirname,
-  '/integration/typescript-config/.parcelrc',
-);
-
-const tscConfig = {
-  ...JSON.parse(readFileSync(configPath)),
-  filePath: configPath,
-};
-
 describe('typescript', function() {
-  // This tests both the Babel transformer implementation of typescript (which
-  // powers typescript by default in Parcel) as well as through the Typescript
-  // tsc transformer. Use a null config to indicate the default config, and the
-  // tsc config to use the tsc transformer instead.
-  //
-  // If testing details specific to either implementation, create another suite.
-  for (let config of [
-    null /* default config -- testing babel typescript */,
-    tscConfig,
-  ]) {
-    it('should produce a ts bundle using ES6 imports', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript/index.ts'),
-        {config},
-      );
+  it('should produce a ts bundle using ES6 imports', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript/index.ts'),
+    );
 
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'Local.ts'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.ts', 'Local.ts'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
+    let output = await run(b);
+    assert.equal(typeof output.count, 'function');
+    assert.equal(output.count(), 3);
+  });
+
+  it('should produce a ts bundle using commonJS require', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-require/index.ts'),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.ts', 'Local.ts'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(typeof output.count, 'function');
+    assert.equal(output.count(), 3);
+  });
+
+  it('should support json require', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-json/index.ts'),
+    );
+
+    // assert.equal(b.assets.size, 2);
+    // assert.equal(b.childBundles.size, 1);
+
+    let output = await run(b);
+    assert.equal(typeof output.count, 'function');
+    assert.equal(output.count(), 3);
+  });
+
+  it('should support env variables', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-env/index.ts'),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.ts'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(typeof output.env, 'function');
+    assert.equal(output.env(), 'test');
+  });
+
+  it('should support importing a URL to a raw asset', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-raw/index.ts'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'index.ts',
+          'JSRuntime.js',
+          'bundle-url.js',
+          'bundle-manifest.js',
+          'JSRuntime.js',
+          'relative-path.js',
+        ],
+      },
+      {
+        type: 'txt',
+        assets: ['test.txt'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(typeof output.getRaw, 'function');
+    assert(/http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()));
+    assert(
+      await outputFS.exists(
+        path.join(distDir, url.parse(output.getRaw()).pathname),
+      ),
+    );
+  });
+
+  it('should minify with minify enabled', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-require/index.ts'),
+      {
+        minify: true,
+      },
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.ts', 'Local.ts'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(typeof output.count, 'function');
+    assert.equal(output.count(), 3);
+
+    let js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
+    assert(!js.includes('local.a'));
+  });
+
+  it('should support compiling JSX', async function() {
+    await bundle(path.join(__dirname, '/integration/typescript-jsx/index.tsx'));
+
+    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
+    assert(file.includes('React.createElement("div"'));
+  });
+
+  it('should use esModuleInterop by default', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-interop/index.ts'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.ts', 'commonjs-module.js'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(typeof output.test, 'function');
+    assert.equal(output.test(), 'test passed');
+  });
+
+  it('fs.readFileSync should inline a file as a string', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/typescript-fs/index.ts'),
+    );
+
+    const text = 'export default <div>Hello</div>;';
+    let output = await run(b);
+
+    assert.deepEqual(output, {
+      fromTs: text,
+      fromTsx: text,
     });
-
-    it('should produce a ts bundle using commonJS require', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-require/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'Local.ts'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-    });
-
-    it('should support json require', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-json/index.ts'),
-      );
-
-      // assert.equal(b.assets.size, 2);
-      // assert.equal(b.childBundles.size, 1);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-    });
-
-    it('should support env variables', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-env/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.env, 'function');
-      assert.equal(output.env(), 'test');
-    });
-
-    it('should support importing a URL to a raw asset', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-raw/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: [
-            'index.ts',
-            'JSRuntime.js',
-            'bundle-url.js',
-            'bundle-manifest.js',
-            'JSRuntime.js',
-            'relative-path.js',
-          ],
-        },
-        {
-          type: 'txt',
-          assets: ['test.txt'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.getRaw, 'function');
-      assert(/http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()));
-      assert(
-        await outputFS.exists(
-          path.join(distDir, url.parse(output.getRaw()).pathname),
-        ),
-      );
-    });
-
-    it('should minify with minify enabled', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-require/index.ts'),
-        {
-          config,
-          minify: true,
-        },
-      );
-
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'Local.ts'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-
-      let js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-      assert(!js.includes('local.a'));
-    });
-
-    it('should support compiling JSX', async function() {
-      await bundle(
-        path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
-        {config},
-      );
-
-      let file = await outputFS.readFile(
-        path.join(distDir, 'index.js'),
-        'utf8',
-      );
-      assert(file.includes('React.createElement("div"'));
-    });
-
-    it('should use esModuleInterop by default', async function() {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-interop/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['index.ts', 'commonjs-module.js'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.test, 'function');
-      assert.equal(output.test(), 'test passed');
-    });
-
-    it('fs.readFileSync should inline a file as a string', async function() {
-      if (config != null) {
-        return;
-      }
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-fs/index.ts'),
-        {config},
-      );
-
-      const text = 'export default <div>Hello</div>;';
-      let output = await run(b);
-
-      assert.deepEqual(output, {
-        fromTs: text,
-        fromTsx: text,
-      });
-    });
-  }
+  });
 });

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -16,7 +16,7 @@ import getTypescriptOptions from './typescript';
 import {enginesToBabelTargets} from './utils';
 import {BABEL_RANGE} from './constants';
 
-const TYPESCRIPT_EXTNAME_RE = /^\.tsx?/;
+const TYPESCRIPT_EXTNAME_RE = /^\.tsx?-babel/;
 const BABEL_TRANSFORMER_DIR = path.dirname(__dirname);
 
 export async function load(

--- a/packages/transformers/babel/src/jsx.js
+++ b/packages/transformers/babel/src/jsx.js
@@ -7,7 +7,7 @@ import path from 'path';
 
 const JSX_EXTENSIONS = {
   '.jsx': true,
-  '.tsx': true,
+  '.tsx-babel': true,
 };
 
 const JSX_PRAGMA = {

--- a/packages/transformers/babel/src/typescript.js
+++ b/packages/transformers/babel/src/typescript.js
@@ -9,7 +9,7 @@ export default function getTypescriptOptions(config: Config): BabelConfig {
     plugins: [
       [
         '@babel/plugin-transform-typescript',
-        {isTSX: path.extname(config.searchPath) === '.tsx'},
+        {isTSX: path.extname(config.searchPath) === '.tsx-babel'},
       ],
     ],
   };

--- a/packages/transformers/typescript-tsc/src/TSCTransformer.js
+++ b/packages/transformers/typescript-tsc/src/TSCTransformer.js
@@ -12,6 +12,15 @@ export default (new Transformer({
   },
 
   async transform({asset, config, options}) {
+    // Allow other transformers to force TSC
+    if (!config && !asset.meta.forceTSC) {
+      return [
+        {
+          type: asset.type + '-babel',
+          content: await asset.getCode(),
+        },
+      ];
+    }
     asset.type = 'js';
 
     let [typescript, code]: [TypeScriptModule, string] = await Promise.all([


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

(NOT COMPLETE) Typechecks and compiles with `tsc` for compiling when `tsconfig.json` present, and babel otherwise. This allows for rapid builds out of the box (and for benchmarks) but safer, typechecking builds otherwise.

I think this is as close to a middle ground as is possible - Those who want zero-config and high speed can use babel, and those who want little config with high safety can have that too with `tsc`.

Note that the test cases were cut down quite a bit.
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->


## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
