### PR TITLE
Don't remove subgraphs that are still needed for other dependencies in the bundle

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -860,7 +860,8 @@ export default class BundleGraph {
     }
 
     return this._graph
-      .findAncestors(node, node => node.type === 'dependency')
+      .getNodesConnectedTo(node)
+      .filter(node => node.type === 'dependency')
       .map(node => {
         invariant(node.type === 'dependency');
         return node.value;


### PR DESCRIPTION
This has `removeAssetGraphFromBundle` stop if it encounters an asset where it and its subgraph are still needed by other dependencies in the bundle. Thanks to @devongovett for the idea of using a first pass for identifying subgraph dependency nodes.

This is described by this scenario drawn by @mischnic, where either asset 2 or asset 3 is removed, removing asset 1 along with it, which is necessary for the other:

<img width="489" alt="1" src="https://user-images.githubusercontent.com/755844/88439349-d38e7e00-cdbf-11ea-8052-508fd3abe4bd.png">
<img width="367" alt="2" src="https://user-images.githubusercontent.com/755844/88439356-d8533200-cdbf-11ea-8807-7ee5b8deeebc.png">
