### PR TITLE
Include pipeline in cache key

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -381,6 +381,7 @@ export default class Transformation {
   getCacheKey(assets: Array<UncommittedAsset>, configs: ConfigMap): string {
     let assetsKeyInfo = assets.map(a => ({
       filePath: a.value.filePath,
+      pipeline: a.value.pipeline,
       hash: a.value.hash,
       uniqueKey: a.value.uniqueKey,
     }));


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Fixes #4929 
Includes the pipeline specifier (i.e. `types:`, `template:`, etc.) in the cache key for a transformer so that the results aren't mixed up.

Apparently, Parcel thought that `template:App.vue` could reuse the asset from `App.vue` because they had the same cache key. This caused a circular dependency and therefore a broken build in the Vue transformer. This didn't fail in tests because caching was disabled. I think that tests should use caching to prevent bugs like this in the future.

## ✔️ PR Todo

- [x] Included links to related issues/PRs
