### PR TITLE
update readme to include dist-dir documentation

### DIFF
--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -139,6 +139,7 @@ console.log("Hello World");
     - [`--https`](#--https)
       - [`--cert <path>`](#--cert-path)
       - [`--key <path>`](#--key-path)
+    - [`--dist-dir <dir>`](#--dist-dir-dir)
     - [`--cache-dir <dir>`, `--no-cache`](#--cache-dir-dir---no-cache)
     - [`--hot`, `--no-hot`](#--hot---no-hot)
       - [`--hot-host <hostname>`](#--hot-host-hostname)
@@ -323,6 +324,10 @@ Specify the filepath to your SSL certificate when using `--https`.
 ##### `--key <path>`
 
 Specify the filepath to your SSL key when using `--https`.
+
+#### `--dist-dir <dir>`
+
+Configure the directory where compiled assets are output. Default is `./dist`.
 
 #### `--cache-dir <dir>`, `--no-cache`
 


### PR DESCRIPTION
It looks like the `--dist-dir` CLI option is not documented in the README, and since this option changed from `out-dir` in V1 I think it makes sense to add this to the README in V2.