### PR TITLE
Avoid crash when "--max-old-space-size" is present

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -46,7 +46,7 @@ export default class Worker extends EventEmitter {
 
   async fork(forkModule: FilePath) {
     let filteredArgs = process.execArgv.filter(
-      v => !/^--(debug|inspect)/.test(v),
+      v => !/^--(debug|inspect|max-old-space-size=)/.test(v),
     );
 
     for (let i = 0; i < filteredArgs.length; i++) {


### PR DESCRIPTION
# ↪️ Pull Request

This is a fix for issue #4795. Parcel 2 runs out of memory building large code bases. Normally you can pass the `--max-old-space-size=...` flag to node to increase the memory ceiling for node programs, but this doesn't work with Parcel because passing this flag causes Parcel to crash.

## 💻 Examples

The crash looks like this:

```
$ npm install parcel
$ touch empty.js
$ node --max-old-space-size=8192 node_modules/.bin/parcel empty.js
Error [ERR_WORKER_INVALID_EXEC_ARGV] Initiated Worker with invalid execArgv flags: --max-old-space-size=8192
    at new Worker (internal/worker.js:134:13)
    ...
```

This change prevents the crash.

## 🚨 Test instructions

I ran this command inside the Parcel repo to test this change:

```
yarn build && NODE_ENV=test node --max-old-space-size=8192 node_modules/.bin/mocha
```

This command fails without my change and passes with my change.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
