### PR TITLE
Solves error #2636

### DIFF
--- a/src/assets/SASSAsset.js
+++ b/src/assets/SASSAsset.js
@@ -22,7 +22,7 @@ class SASSAsset extends Asset {
     });
 
     let opts =
-      (await this.getConfig(['.sassrc', '.sassrc.js'], {packageKey: 'sass'})) ||
+      (await this.getConfig(['.sassrc', '.sassrc.js'])) ||
       {};
     opts.includePaths = (opts.includePaths
       ? opts.includePaths.map(includePath => path.resolve(includePath))


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
This pull request solves error `"Cannot create property 'includePaths' on string 'index.scss'"` when importing primer/css and also twbs/bootstrap scss files. Also should fix error reported in #2636.
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples
In javascript file import `@primer/css/core/index.scss` then run parcel and error will pop up
<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions
Do the same as the example provided then the only error received will be `images\spinners\octocat-spinner-16px.gif: ENOENT: no such file or directory` but it's not related to parcel.
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
