### PR TITLE
Fix shaking of increment expressions

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-increment-object/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-increment-object/a.js
@@ -1,0 +1,1 @@
+import "./b.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-increment-object/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-increment-object/b.js
@@ -1,0 +1,6 @@
+let counter = 1;
+function unused() {
+	return {
+		id: counter++,
+	};
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1064,6 +1064,21 @@ describe('scope hoisting', function() {
       assert.strictEqual(typeof output[3], 'undefined');
     });
 
+    it('removes functions that increment variables in object properties', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/tree-shaking-increment-object/a.js',
+        ),
+        {minify: true},
+      );
+
+      let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(!content.includes('++'));
+
+      await run(b);
+    });
+
     it('support exporting a ES6 module exported as CommonJS', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -169,7 +169,6 @@ function dereferenceIdentifier(node, scope) {
     if (i >= 0) {
       binding.dereference();
       binding.referencePaths.splice(i, 1);
-      return;
     }
 
     let j = binding.constantViolations.findIndex(v =>
@@ -180,7 +179,6 @@ function dereferenceIdentifier(node, scope) {
       if (binding.constantViolations.length == 0) {
         binding.constant = true;
       }
-      return;
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3736,9 +3736,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001030:
-  version "1.0.30001032"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001032.tgz#b8d224914e2cd7f507085583d4e38144c652bce4"
-  integrity sha512-8joOm7BwcpEN4BfVHtfh0hBXSAPVYk+eUIcNntGtMkUWy/6AKRCDZINCLe3kB1vHhT2vBxBF85Hh9VlPXi/qjA==
+  version "1.0.30001117"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001117.tgz#69a9fae5d480eaa9589f7641a83842ad396d17c4"
+  integrity sha512-4tY0Fatzdx59kYjQs+bNxUwZB03ZEBgVmJ1UkFPz/Q8OLiUUbjct2EdpnXj0fvFTPej2EkbPIG0w8BWsjAyk1Q==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
# ↪️ Pull Request

Closes #5025

`UpdateExpressions` (e.g. `counter++`) are listed in both `referencePaths` and `constantViolations`, remove `return` to check for their existence in both lists