### PR TITLE
Also replace this for top-level arrow functions

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/this-arrow-function/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/this-arrow-function/a.js
@@ -1,0 +1,3 @@
+const b = require('./b');
+
+output = b.run();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/this-arrow-function/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/this-arrow-function/b.js
@@ -1,0 +1,3 @@
+module.exports.other = () => 'other';
+
+module.exports.run = () => `Say ${this.other()}`;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/this-arrow-function/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/this-arrow-function/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": "Chrome 80"
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1716,6 +1716,21 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'foo');
     });
 
+    it('supports using this in arrow functions', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/this-arrow-function/a.js',
+        ),
+      );
+
+      let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(content.includes('=>'));
+
+      let output = await run(b);
+      assert.strictEqual(output, 'Say other');
+    });
+
     it('supports assigning to this as exports object', async function() {
       let b = await bundle(
         path.join(
@@ -1725,7 +1740,7 @@ describe('scope hoisting', function() {
       );
 
       let output = await run(b);
-      assert.equal(output, 2);
+      assert.strictEqual(output, 2);
     });
 
     it('supports assigning to this as exports object in wrapped module', async function() {
@@ -1737,7 +1752,7 @@ describe('scope hoisting', function() {
       );
 
       let output = await run(b);
-      assert.equal(output, 6);
+      assert.strictEqual(output, 6);
     });
 
     it('support url imports in wrapped modules with interop', async function() {

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -292,7 +292,23 @@ const VISITOR: Visitor<MutableAsset> = {
   },
 
   ThisExpression(path, asset: MutableAsset) {
-    if (!path.scope.parent && !path.scope.getData('shouldWrap')) {
+    if (!path.scope.getData('shouldWrap')) {
+      let retainThis = false;
+      let scope = path.scope;
+      while (scope?.parent) {
+        if (
+          scope.path.isFunction() &&
+          !scope.path.isArrowFunctionExpression()
+        ) {
+          retainThis = true;
+          break;
+        }
+        scope = scope.parent.getFunctionParent();
+      }
+      if (retainThis) {
+        return;
+      }
+
       if (asset.meta.isES6Module) {
         path.replaceWith(t.identifier('undefined'));
       } else {


### PR DESCRIPTION
# ↪️ Pull Request

Closes #4851

Testing `!path.scope.parent` when determining whether to replace `this` in the hoist transformer isn't adequate because arrow function have a scope but still use the parent scope's `this`, so instead check whether there is a non-arrow function in the scope's ancestry.