### PR TITLE
lineCounter with empty string

### DIFF
--- a/packages/core/parcel-bundler/src/utils/lineCounter.js
+++ b/packages/core/parcel-bundler/src/utils/lineCounter.js
@@ -1,5 +1,6 @@
 function lineCounter(string) {
   let lines = 1;
+  if (string == null) return 0;
   for (let i = 0; i < string.length; i++) {
     if (string.charAt(i) === '\n') {
       lines++;


### PR DESCRIPTION
# ↪️ Pull Request

npm build throws error with empty string in lineCounter 

similar to #4691

## 💻 Examples

Cannot read property 'length' of undefined
    at lineCounter (..\node_modules\parcel-bundler\src\utils\lineCounter.js:4:30)
    at JSPackager.writeModule (..\node_modules\parcel-bundler\src\packagers\JSPackager.js:127:60)
    at async JSPackager.addAsset (..\node_modules\parcel-bundler\src\packagers\JSPackager.js:88:5)
    at async Bundle._addDeps (..\node_modules\parcel-bundler\src\Bundle.js:250:5)
    at async Bundle._package (..\node_modules\parcel-bundler\src\Bundle.js:219:7)
    at async Promise.all (index 0)
    at async Bundle.package (..\node_modules\parcel-bundler\src\Bundle.js:202:5)
    at async Bundler.bundle (..\node_modules\parcel-bundler\src\Bundler.js:325:27)

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
