### PR TITLE
Don't error after ctrl-c

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -230,7 +230,7 @@ async function run(entries: Array<string>, command: any) {
               ),
             500,
           );
-          await exit(1);
+          await exit();
           break;
         case 'e':
           await (parcel.isProfiling


### PR DESCRIPTION
# ↪️ Pull Request

This pull request stops error messages from being shown when a server is interrupted with Ctrl-C. It fixes #5030.

The problem was introduced in #4971. Before that PR the call to `exit()` on line 247 had no argument, now the argument is `1` which causes `npm` & `yarn` to show an error.

## 🚨 Test instructions

You can test this with the examples in this repo. Before:
```
> yarn parcel server packages/examples/simple/index.html
yarn run v1.22.4
$ /workspaces/parcel/node_modules/.bin/parcel server packages/examples/simple/index.html
[press ctrl c here]
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

> echo $?
1
```

After:
```
> yarn parcel server packages/examples/simple/index.html
yarn run v1.22.4
$ /workspaces/parcel/node_modules/.bin/parcel server packages/examples/simple/index.html
[press ctrl c here]
Done in 29.55s.
> echo $?
0
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
