### PR TITLE
Exit with better status codes in watch modes

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -16,6 +16,11 @@ import {version} from '../package.json';
 
 require('v8-compile-cache');
 
+// Exit codes in response to signals are traditionally
+// 128 + signal value
+// https://tldp.org/LDP/abs/html/exitcodes.html
+const SIGINT_EXIT_CODE = 130;
+
 async function logUncaughtError(e: mixed) {
   if (e instanceof ThrowableDiagnostic) {
     for (let diagnostic of e.diagnostics) {
@@ -202,6 +207,7 @@ async function run(entries: Array<string>, command: any) {
     process.exit(exitCode);
   }
 
+  const isWatching = command.name() === 'watch' || command.name() === 'serve';
   if (process.stdin.isTTY) {
     // $FlowFixMe
     process.stdin.setRawMode(true);
@@ -223,6 +229,9 @@ async function run(entries: Array<string>, command: any) {
           // We don't use the SIGINT event for this because when run inside yarn, the parent
           // yarn process ends before Parcel and it appears that Parcel has ended while it may still
           // be cleaning up. Handling events from stdin prevents this impression.
+
+          // Enqueue a busy message to be shown if Parcel doesn't shut down
+          // within the timeout.
           setTimeout(
             () =>
               INTERNAL_ORIGINAL_CONSOLE.log(
@@ -230,7 +239,9 @@ async function run(entries: Array<string>, command: any) {
               ),
             500,
           );
-          await exit(1);
+          // When watching, a 0 success code is acceptable when Parcel is interrupted with ctrl-c.
+          // When building, fail with a code as if we received a SIGINT.
+          await exit(isWatching ? 0 : SIGINT_EXIT_CODE);
           break;
         case 'e':
           await (parcel.isProfiling
@@ -245,7 +256,7 @@ async function run(entries: Array<string>, command: any) {
     });
   }
 
-  if (command.name() === 'watch' || command.name() === 'serve') {
+  if (isWatching) {
     ({unsubscribe} = await parcel.watch(err => {
       if (err) {
         throw err;
@@ -269,7 +280,8 @@ async function run(entries: Array<string>, command: any) {
       process.stdin.resume();
     }
 
-    // In non-tty cases, respond to SIGINT by cleaning up.
+    // In non-tty cases, respond to SIGINT by cleaning up. Since we're watching,
+    // a 0 success code is acceptable.
     process.on('SIGINT', exit);
     process.on('SIGTERM', exit);
   } else {


### PR DESCRIPTION
This implements better exit status codes when using watch-type development modes (watch, serve). It:

* In watch modes, causes Parcel to exit with a success (0) code when a SIGINT-style ctrl-c is detected
* In build mode, causes Parcel to exit with a code (130) that is normally used when SIGINT is received [0]
* Notes in a comment why we exit with 0 when receiving SIGINT and SIGTERM in watch modes
* Notes in a comment why we enqueue the shutdown message in a timeout

Test Plan:
* Add a timeout sleep to Parcel.js to suspend the app for easier testing
* Run `parcel build`, press ctrl-c, and verify it exits with a code of 130.
* Run `parcel build`, send a SIGINT to the process, and verify it exits with a code of 130.
* Run `parcel build`, send a SIGTERM to the process, and verify it exits with a code of 143.
* Run `parcel serve`, press ctrl-c, and verify it exits with a code of 0.
* Run `parcel serve`, send a SIGINT to the process, and verify it exits with a code of 0.
* Run `parcel serve`, send a SIGTERM to the process, and verify it exits with a code of 0.

Closes #5128 

[0] https://tldp.org/LDP/abs/html/exitcodes.html