### PR TITLE
rename SASS → Sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and Parcel adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- CSS/SASS/LESS sourcemaps [Details](https://github.com/parcel-bundler/parcel/pull/2489)
+- CSS/Sass/LESS sourcemaps [Details](https://github.com/parcel-bundler/parcel/pull/2489)
 - Add Markdown support [Details](https://github.com/parcel-bundler/parcel/pull/2538)
 - Unhandled HMR updates should cause a page reload [Details](https://github.com/parcel-bundler/parcel/pull/2676)
 - Enables jsx plugin in case jsx syntax is used in js files [Details](https://github.com/parcel-bundler/parcel/pull/2530)

--- a/packages/core/integration-tests/data/lastTestRun.json
+++ b/packages/core/integration-tests/data/lastTestRun.json
@@ -2559,13 +2559,13 @@
     {
       "fileName": "sourcemaps",
       "link": "https://github.com/parcel-bundler/parcel/tree/v2/packages/core/integration-tests/test/sourcemaps.js",
-      "title": "should create a valid sourcemap for a SASS asset",
+      "title": "should create a valid sourcemap for a Sass asset",
       "status": "pending"
     },
     {
       "fileName": "sourcemaps",
       "link": "https://github.com/parcel-bundler/parcel/tree/v2/packages/core/integration-tests/test/sourcemaps.js",
-      "title": "should create a valid sourcemap when for a CSS asset importing SASS",
+      "title": "should create a valid sourcemap when for a CSS asset importing Sass",
       "status": "pending"
     },
     {

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -683,7 +683,7 @@ describe('sourcemaps', function() {
     await test(true);
   });
 
-  it('should create a valid sourcemap for a SASS asset', async function() {
+  it('should create a valid sourcemap for a Sass asset', async function() {
     async function test(minify) {
       let inputFilePath = path.join(
         __dirname,
@@ -738,7 +738,7 @@ describe('sourcemaps', function() {
     await test(true);
   });
 
-  it('should create a valid sourcemap when for a CSS asset importing SASS', async function() {
+  it('should create a valid sourcemap when for a CSS asset importing Sass', async function() {
     async function test(minify) {
       let inputFilePath = path.join(
         __dirname,

--- a/packages/core/parcel-bundler/src/Parser.js
+++ b/packages/core/parcel-bundler/src/Parser.js
@@ -37,8 +37,8 @@ class Parser {
     this.registerExtension('styl', './assets/StylusAsset');
     this.registerExtension('stylus', './assets/StylusAsset');
     this.registerExtension('less', './assets/LESSAsset');
-    this.registerExtension('sass', './assets/SASSAsset');
-    this.registerExtension('scss', './assets/SASSAsset');
+    this.registerExtension('sass', './assets/SassAsset');
+    this.registerExtension('scss', './assets/SassAsset');
 
     this.registerExtension('html', './assets/HTMLAsset');
     this.registerExtension('htm', './assets/HTMLAsset');

--- a/packages/core/parcel-bundler/src/assets/SASSAsset.js
+++ b/packages/core/parcel-bundler/src/assets/SASSAsset.js
@@ -6,7 +6,7 @@ const os = require('os');
 const Resolver = require('../Resolver');
 const parseCSSImport = require('../utils/parseCSSImport');
 
-class SASSAsset extends Asset {
+class SassAsset extends Asset {
   constructor(name, options) {
     super(name, options);
     this.type = 'css';
@@ -95,7 +95,7 @@ class SASSAsset extends Asset {
   }
 }
 
-module.exports = SASSAsset;
+module.exports = SassAsset;
 
 async function getSassRuntime(searchPath) {
   try {


### PR DESCRIPTION
Fixes #5147 

Some places this was already correct, but not all. Now it's consistently "Sass".