### PR TITLE
Expand ReasonAsset to include res file format

### DIFF
--- a/packages/core/parcel-bundler/src/Parser.js
+++ b/packages/core/parcel-bundler/src/Parser.js
@@ -15,6 +15,7 @@ class Parser {
     this.registerExtension('mjs', './assets/JSAsset');
     this.registerExtension('ml', './assets/ReasonAsset');
     this.registerExtension('re', './assets/ReasonAsset');
+    this.registerExtension('res', './assets/ReasonAsset');
     this.registerExtension('ts', './assets/TypeScriptAsset');
     this.registerExtension('tsx', './assets/TypeScriptAsset');
     this.registerExtension('coffee', './assets/CoffeeScriptAsset');

--- a/packages/core/parcel-bundler/src/assets/ReasonAsset.js
+++ b/packages/core/parcel-bundler/src/assets/ReasonAsset.js
@@ -21,7 +21,7 @@ class ReasonAsset extends Asset {
 
     // This is a simplified use-case for Reason - it only loads the recommended
     // BuckleScript configuration to simplify the file processing.
-    const outputFile = this.name.replace(/\.(re|ml)$/, '.bs.js');
+    const outputFile = this.name.replace(/\.(re|ml|res)$/, '.bs.js');
     const outputContent = await fs.readFile(outputFile);
     return outputContent.toString();
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
ReasonML migration to Rescript included a new file format: `res`. I've tried in this PR to include the new file format in the already supported ReasonAsset. This change should be transparent to other users of legacy Reason etc as the Rescript build system will continue to support the change in syntax. https://rescript-lang.org/docs/manual/latest/migrate-from-bucklescript-reason

## 💻 Examples

TBC

## 🚨 Test instructions

TBC

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
