### PR TITLE
Don't swallow resolver error

### DIFF
--- a/packages/core/utils/src/resolve.js
+++ b/packages/core/utils/src/resolve.js
@@ -176,7 +176,7 @@ export function resolveSync(
 
     // $FlowFixMe
     opts.packageFilter = pkg => {
-      if (pkg.name.startsWith('@parcel/') && pkg.name !== '@parcel/watcher') {
+      if (pkg.name?.startsWith('@parcel/') && pkg.name !== '@parcel/watcher') {
         if (pkg.source) {
           pkg.main = pkg.source;
         }

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -163,6 +163,8 @@ export default class NodeResolver {
         return {
           diagnostics: err.diagnostics,
         };
+      } else {
+        throw err;
       }
     }
 


### PR DESCRIPTION
Previously, if some error in the node resolver occurred (e.g. something like `The "path" argument must be of type string. Received null`, so an actual bug), the error would be swallowed and the message would instead just be `Cannot resolve dependency ...`