### PR TITLE
srcset value should be joined by ', ' rather than ','

### DIFF
--- a/src/assets/HTMLAsset.js
+++ b/src/assets/HTMLAsset.js
@@ -111,7 +111,7 @@ class HTMLAsset extends Asset {
       pair[0] = this.processSingleDependency(pair[0], opts);
       newSources.push(pair.join(' '));
     }
-    return newSources.join(',');
+    return newSources.join(', ');
   }
 
   getAttrDepHandler(attr) {

--- a/test/html.js
+++ b/test/html.js
@@ -537,6 +537,12 @@ describe('html', function() {
         }
       ]
     });
+
+    // ensure space after comma
+    const {html} = b.entryAsset.generated;
+    assert(
+      html.match(/srcset="\/200x200.[^.]+.png 250w, \/300x300.[^.]+.png 500w"/)
+    );
   });
 
   it('should detect srcset attribute of source element', async function() {


### PR DESCRIPTION
Given this pug (or similar HTML):

```pug
picture
    source(srcset="./static/img/hero-home-page.avif, ./static/img/hero-home-page@2x.avif 2x, ./static/img/hero-home-page@3x.avif 3x" type="image/avif")
    source(srcset="./static/img/hero-home-page.webp, ./static/img/hero-home-page@2x.webp 2x, ./static/img/hero-home-page@3x.webp 3x" type="image/webp")
    img(decoding="async" alt="Mobile-Friendly Solution" src="./static/img/hero-home-page.png" width="360" height="187")
```

Parcel outputs the following:

```html
<picture>
    <source srcset="/hero-home-page.a98f0083.avif,/hero-home-page@2x.fd57322d.avif 2x,/hero-home-page@3x.a817c73e.avif 3x" type="image/avif">
    <source srcset="/hero-home-page.511098e0.webp,/hero-home-page@2x.1bde44b9.webp 2x,/hero-home-page@3x.649c5cc8.webp 3x" type="image/webp">
    <img decoding="async" alt="Mobile-Friendly Solution" src="/hero-home-page.5a1e4e46.png" width="360" height="187">
</picture>
```

Which causes the browser to request `/hero-home-page.a98f0083.avif,/hero-home-page@2x.fd57322d.avif` incorrectly.

> A srcset attribute is an attribute with requirements defined in this section.
>
> If present, its value must consist of one or more image candidate strings, each separated from the next by a U+002C COMMA character (,). If an image candidate string contains no descriptors and no ASCII whitespace after the URL, **the following image candidate string, if there is one, must begin with one or more ASCII whitespace.**

-- https://html.spec.whatwg.org/multipage/images.html#srcset-attributes

## TODO

- [ ] a couple azure pipelines are failing... not sure why (got `ReferenceError: internalBinding is not defined` locally as well and just ignored it and tests still passed)
- [ ] port to v2?