### PR TITLE
fix: svg use referencing local symbol via id

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -703,6 +703,19 @@ describe('html', function() {
     ]);
   });
 
+  it('should ignore svgs referencing local symbols via <use xlink:href="#">', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/html-svg-local-symbol/index.html'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html'],
+      },
+    ]);
+  });
+
   it('should bundle svg files using <image xlink:href=""> correctly', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-svg-image/index.html'),

--- a/packages/core/integration-tests/test/integration/html-svg-local-symbol/index.html
+++ b/packages/core/integration-tests/test/integration/html-svg-local-symbol/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<svg xmlns:xlink="http://www.w3.org/1999/xlink">
+	<use xlink:href="#all" href="#all"/>
+</svg>
+<svg xmlns:xlink="http://www.w3.org/1999/xlink">
+	<symbol id="all">
+		<rect width="100" height="100" x="0" y="0"/>
+	</symbol>
+</svg>

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -160,6 +160,11 @@ export default function collectDependencies(asset: MutableAsset, ast: AST) {
         continue;
       }
 
+      // Check for id references
+      if (attrs[attr][0] === '#') {
+        continue;
+      }
+
       let elements = ATTRS[attr];
       if (elements && elements.includes(node.tag)) {
         let depHandler = getAttrDepHandler(attr);


### PR DESCRIPTION
add test case to cover case of local symbols

# ↪️ Pull Request

Parcel have failed when referenced local SVG symbols via `<use xlink:href="#sth"></use>` (more explanation in the bug report - #5175).

**Added only integration test, please give me a sign, if it's needed from me to add anything else to this PR** (ping @mischnic)

## 💻 Examples

Now the bundler correctly ignores paths starting with a hash (id references), for example:
```html
<svg xmlns:xlink="http://www.w3.org/1999/xlink">
   <use xlink:href="#logotype" href="#logotype"></use>
</svg>
```

## 🚨 Test instructions

In the examples.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
