### PR TITLE
Add bundle id to bundle hash

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1133,6 +1133,7 @@ export default class BundleGraph {
 
   getHash(bundle: Bundle): string {
     let hash = crypto.createHash('md5');
+    hash.update(bundle.id);
 
     let seen = new Set();
     let addReferencedBundles = bundle => {


### PR DESCRIPTION
# ↪️ Pull Request
Currently `BundleGraph.getHash(bundle)` does not incorporate the input bundle's name or id so bundles with different ids/names can end up using the same cache entries if they contain the same assets. This becomes a problem when the cache entries contain a sourcemap url which only applies to one of the bundles. If the bundle that created the cache entry no longer exists in a subsequent build or in a completely separate build and the sourcemap url contains a hashReference, then the build will fail with `Cannot read property 'hashReferences' of undefined` because it is trying to look up the final bundle hash of a bundle that doesn't exist in the build.

A quick and safe fix is to add the bundle id to the cache key, which I've done in this PR. This may be more aggressive than necessary in some cases. We could probably introduce the notion of a `SOURCE_REF` similar to a `HASH_REF`, which to refer to the bundle's own source map and the ref would be replaced when writing to dist. I've created a follow up task for this optimization in height (T-777).

Fixes T-776

## 🚨 Test instructions
Manually confirmed it resolves `Cannot read property 'hashReferences' of undefined` in a previously broken build.
