### PR TITLE
Forward extra properties from pug config to pug

### DIFF
--- a/packages/transformers/pug/src/PugTransformer.js
+++ b/packages/transformers/pug/src/PugTransformer.js
@@ -44,11 +44,8 @@ export default (new Transformer({
       compileDebug: false,
       basedir: path.dirname(asset.filePath),
       filename: asset.filePath,
+      ...pugConfig,
       pretty: pugConfig.pretty || false,
-      doctype: pugConfig.doctype,
-      filters: pugConfig.filters,
-      filterOptions: pugConfig.filterOptions,
-      filterAliases: pugConfig.filterAliases,
     });
 
     for (let filePath of render.dependencies) {


### PR DESCRIPTION
# ↪️ Pull Request

Pretty self-explanatory: this lets users pass arbitrary options from `.pugrc`, etc., to Pug, instead of only whitelisting a subset of them.

## 💻 Examples

###### .pugrc.js
```js
module.exports = {
  plugins: [require('my-custom-pug-plugin')],
};
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
