### PR TITLE
Partially fix asset query handling

### DIFF
--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -151,20 +151,25 @@ export class ResolverRunner {
       filePath = dependency.moduleSpecifier;
     }
 
+    let queryPart = null;
     if (dependency.isURL) {
       let parsed = URL.parse(filePath);
       if (typeof parsed.pathname !== 'string') {
         throw new Error(`Received URL without a pathname ${filePath}.`);
       }
       filePath = decodeURIComponent(parsed.pathname);
+      if (parsed.query != null) {
+        queryPart = decodeURIComponent(parsed.query);
+      }
+    } else {
+      let matchesQuerystring = filePath.match(QUERY_PARAMS_REGEX);
+      if (matchesQuerystring && matchesQuerystring[2] != null) {
+        filePath = matchesQuerystring[1];
+        queryPart = matchesQuerystring[2].substr(1);
+      }
     }
-
-    let matchesQuerystring = filePath.match(QUERY_PARAMS_REGEX);
-    if (matchesQuerystring && matchesQuerystring.length > 2) {
-      filePath = matchesQuerystring[1];
-      query = matchesQuerystring[2]
-        ? querystring.parse(matchesQuerystring[2].substr(1))
-        : {};
+    if (queryPart != null) {
+      query = querystring.parse(queryPart);
     }
 
     let diagnostics: Array<Diagnostic> = [];

--- a/packages/core/integration-tests/test/image.js
+++ b/packages/core/integration-tests/test/image.js
@@ -29,17 +29,29 @@ describe('image', function() {
     assert.equal(image.width, 600);
   });
 
-  it('Should be able to change image format', async () => {
-    await bundle(path.join(__dirname, '/integration/image/reformat.js'));
+  describe('Should be able to change image format', () => {
+    function testCase(ext) {
+      return async () => {
+        await bundle(
+          path.join(__dirname, `/integration/image/reformat.${ext}`),
+        );
 
-    let dirContent = await outputFS.readdir(distDir);
-    let foundExtensions = [];
-    for (let filename of dirContent) {
-      foundExtensions.push(path.extname(filename));
+        let dirContent = await outputFS.readdir(distDir);
+        let foundExtensions = [];
+        for (let filename of dirContent) {
+          const foundExt = path.extname(filename);
+          if (foundExt !== '.map') {
+            foundExtensions.push(foundExt);
+          }
+        }
+        assert.deepStrictEqual(
+          foundExtensions.sort(),
+          ['.webp', `.${ext}`].sort(),
+        );
+      };
     }
-    assert.deepStrictEqual(
-      foundExtensions.sort(),
-      ['.webp', '.js', '.map'].sort(),
-    );
+    it('from JS', testCase('js'));
+    it.skip('from HTML', testCase('html'));
+    it('from CSS', testCase('css'));
   });
 });

--- a/packages/core/integration-tests/test/integration/image/reformat.css
+++ b/packages/core/integration-tests/test/integration/image/reformat.css
@@ -1,0 +1,3 @@
+.test {
+  background-image: url('url:./image.jpg?as=webp');
+}

--- a/packages/core/integration-tests/test/integration/image/reformat.html
+++ b/packages/core/integration-tests/test/integration/image/reformat.html
@@ -1,0 +1,1 @@
+<img src="url:./image.jpg?as=webp"/>


### PR DESCRIPTION
The test case for an image referenced from HTML is broken for now; there seems
to be a deeper conflict with assets in named pipelines and some aspect of the
HTML pipeline.

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

The handling of asset query strings, introduced in #4881 in support of `@parcel/transformer-image`, didn't work when the asset dependency was marked as being a URL, such as in CSS or HTML files. This PR fixes the query string handling issue, and adds test cases for transforming images from CSS and HTML. Unfortunately, there seems to be an additional issue with the HTML case; I think there's some kind of conflict between the `url:` named pipeline and some aspect of the HTML pipeline. I don't entirely know how all of this is supposed to go; should the pipeline name be stripped from the module identifier at some point in the process? If so, where? If not, how is the `replaceURLReferences` call in `HTMLPackager` supposed to deal with it?

I'd love it if someone more knowlegable could take a look at the HTML case added here and point me in the direction of a fix. I can do the implementation work if I know what ought to be happening.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
