### PR TITLE
Strip empty export named

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-named-empty/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-named-empty/a.js
@@ -1,0 +1,2 @@
+output = 2;
+export {};

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -484,6 +484,21 @@ describe('scope hoisting', function() {
       assert.strictEqual(output, Test);
     });
 
+    it('should remove export named declaration without specifiers', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/export-named-empty/a.js',
+        ),
+      );
+
+      let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(!/export\s*{\s*}\s*;/.test(content));
+
+      let output = await run(b);
+      assert.strictEqual(output, 2);
+    });
+
     it('throws a meaningful error on undefined exports', async function() {
       let threw = false;
       try {

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -663,12 +663,11 @@ const VISITOR: Visitor<MutableAsset> = {
           addExport(asset, path, identifiers[id], identifiers[id]);
         }
       }
-    } else if (specifiers.length > 0) {
+    } else {
       for (let specifier of specifiers) {
         invariant(isExportSpecifier(specifier)); // because source is empty
         addExport(asset, path, specifier.local, specifier.exported);
       }
-
       path.remove();
     }
   },


### PR DESCRIPTION
Previously, `export {};` wasn't removed in the hoist transformer and left inside the IIFE in the output bundle....

```
@parcel/optimizer-terser: "Export" statement may only appear at the top level
  4235 | resolve(i18nProvider.changeLocale(newLocale))}).then(function(){stopLoading();setLocale(newLocale)}).catch(function(error){stopLoading();notify("ra.notification.i18n
> 4236 | export{};$ec2d257ced52b65e7a10db54dcc6764c$init();var $f9a9e0598a100fcf59a6afbb1230d76c$export$default=function(records){return records.reduce(function(values,record
>      | ^ "Export" statement may only appear at the top level
```