### PR TITLE
Fix concat order of namespace reexports and named reexports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/index.js
@@ -1,0 +1,5 @@
+import { b } from "./library/index.js";
+
+if(false){
+  b();
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/a.js
@@ -1,0 +1,5 @@
+import { ForwardRef } from "../other.js";
+
+export function a() {
+	return ForwardRef;
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/b.js
@@ -1,0 +1,7 @@
+import { ForwardRef } from "../other.js";
+
+output = ForwardRef;
+
+export function b() {
+	return ForwardRef;
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/index.js
@@ -1,0 +1,2 @@
+export * from "./a";
+export { b } from "./b";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/library/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/other.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-namespace-order/other.js
@@ -1,0 +1,1 @@
+export const ForwardRef = Symbol.for('abc');

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -329,6 +329,18 @@ describe('scope hoisting', function() {
       });
     });
 
+    it('has the correct order with namespace re-exports', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-namespace-order/index.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, Symbol.for('abc'));
+    });
+
     it('excludes default when re-exporting a module', async function() {
       let source = path.normalize(
         'integration/scope-hoisting/es6/re-export-exclude-default/a.js',

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -99,7 +99,7 @@ export async function concat({
 
   let usedExports = getUsedExports(bundle, bundleGraph);
 
-  // Node: for each asset, the order of `$parcel$require` calls and the corresponding
+  // Note: for each asset, the order of `$parcel$require` calls and the corresponding
   // `asset.getDependencies()` must be the same!
   bundle.traverseAssets<TraversalContext>({
     enter(asset, context) {


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/4667

```js
// entry
import {b} from "./lib
```

```js
// lib.js
export * from "./a";
export { b } from "./b";
```

The order of `$parcel$require` calls in `lib.js` was reversed compared to the order in the graph (and the original order).
The concat order in the postorder traversal is based on these require calls and the result was:
```
entry
 |- b
 |- a
    |- shared dependency of a & b
```

instead of 
```
entry
 |- a
    |- shared dependency of a & b
 |- b
```

Using a value exported by a shared dependency of `a` and `b` would throw or just be undefined.