### PR TITLE
Output format name collision with global

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/conflict-global/index.js
+++ b/packages/core/integration-tests/test/integration/formats/conflict-global/index.js
@@ -1,0 +1,3 @@
+const Foo = 2;
+foo([...(new Map([['a', 10]]))]);
+export { Foo as Map };

--- a/packages/core/integration-tests/test/integration/formats/conflict-global/package.json
+++ b/packages/core/integration-tests/test/integration/formats/conflict-global/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "conflict-global",
+  "private": true,
+  "module": "dist/esm.js",
+  "main": "dist/cjs.js"
+}

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1025,7 +1025,7 @@ describe('output formats', function() {
     });
   });
 
-  it.only("doesn't overwrite used global variables", async function() {
+  it("doesn't overwrite used global variables", async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/formats/conflict-global/index.js'),
     );

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import path from 'path';
 import nullthrows from 'nullthrows';
-import {bundle as _bundle, outputFS, run} from '@parcel/test-utils';
+import {bundle as _bundle, outputFS, run, runBundle} from '@parcel/test-utils';
 
 const bundle = (name, opts = {}) =>
   _bundle(name, Object.assign({scopeHoist: true}, opts));
@@ -1023,6 +1023,38 @@ describe('output formats', function() {
         ],
       });
     });
+  });
+
+  it.only("doesn't overwrite used global variables", async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/formats/conflict-global/index.js'),
+    );
+
+    let cjs = b
+      .getBundles()
+      .find(b => b.type === 'js' && b.env.outputFormat === 'commonjs');
+
+    let calls = [];
+    assert.deepEqual(
+      await runBundle(b, cjs, {
+        foo(v) {
+          calls.push(v);
+        },
+      }),
+      {Map: 2},
+    );
+    assert.deepEqual(calls, [[['a', 10]]]);
+
+    let esmContents = await outputFS.readFile(
+      b
+        .getBundles()
+        .find(b => b.type === 'js' && b.env.outputFormat === 'esmodule')
+        .filePath,
+      'utf8',
+    );
+    assert(esmContents.includes('const _Map'));
+    assert(esmContents.includes('_Map as Map'));
+    assert(esmContents.includes('new Map'));
   });
 
   describe('global', function() {

--- a/packages/shared/scope-hoisting/src/formats/commonjs.js
+++ b/packages/shared/scope-hoisting/src/formats/commonjs.js
@@ -437,15 +437,17 @@ export function generateExports(
 
           // If there is an existing binding with the exported name (e.g. an import),
           // rename it so we can use the name for the export instead.
-          if (path.scope.hasBinding(exportAs) && exportAs !== symbol) {
+          if (path.scope.hasBinding(exportAs, true) && exportAs !== symbol) {
             rename(path.scope, exportAs, path.scope.generateUid(exportAs));
           }
 
           let binding = nullthrows(path.scope.getBinding(symbol));
           if (!hasReplacement) {
-            let id = !t.isValidIdentifier(exportAs)
-              ? path.scope.generateUid(exportAs)
-              : exportAs;
+            let id =
+              // We cannot use the name if it's already used as global (e.g. `Map`).
+              !t.isValidIdentifier(exportAs) || path.scope.hasGlobal(exportAs)
+                ? path.scope.generateUid(exportAs)
+                : exportAs;
             // rename only once, avoid having to update `replacements` transitively
             rename(path.scope, symbol, id);
             replacements.set(symbol, id);


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/4849

Previously, 
```js
const Foo = 2;
console.log(Map);
export { Foo as Map };
```

was failing because it tried to rename the `Map` binding (because `scope.hasBinding()` returned true).

After fixing that, the output was 
```js
export const Map = 2;
console.log(Map);
```

We now pick a different name instead if `scope.hasGlobal(...)` is true (both for esm and cjs).

```js
const _Map = 2;
export { _Map as Map };
console.log(Map);
```