### PR TITLE
Cache invalidation for parcel options

### DIFF
--- a/packages/core/core/src/AssetGraphBuilder.js
+++ b/packages/core/core/src/AssetGraphBuilder.js
@@ -87,13 +87,9 @@ export default class AssetGraphBuilder extends EventEmitter {
     this.workerFarm = workerFarm;
     this.assetRequests = [];
 
-    // TODO: changing these should not throw away the entire graph.
-    // We just need to re-run target resolution.
-    let {hot, publicUrl, distDir, minify, scopeHoist} = options;
     this.cacheKey = md5FromObject({
       parcelVersion: PARCEL_VERSION,
       name,
-      options: {hot, publicUrl, distDir, minify, scopeHoist},
       entries,
     });
 
@@ -120,6 +116,7 @@ export default class AssetGraphBuilder extends EventEmitter {
     if (changes) {
       this.requestGraph.invalidateUnpredictableNodes();
       this.requestGraph.invalidateEnvNodes(options.env);
+      this.requestGraph.invalidateOptionNodes(options);
       this.requestTracker.respondToFSEvents(changes);
     } else {
       this.assetGraph.initialize({

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -170,6 +170,8 @@ export default class BundlerRunner {
       version,
       hash: assetGraph.getHash(),
       config: configResult?.config,
+      // TODO: remove once bundling is a request and we track options as invalidations.
+      hot: this.options.hot,
     });
   }
 

--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -16,6 +16,7 @@ export function createEnvironment({
   minify = false,
   isLibrary = false,
   scopeHoist = false,
+  sourceMap,
 }: EnvironmentOpts = {}): Environment {
   if (context == null) {
     if (engines?.node) {
@@ -85,6 +86,7 @@ export function createEnvironment({
     isLibrary,
     minify,
     scopeHoist,
+    sourceMap,
   };
 }
 
@@ -111,5 +113,6 @@ export function getEnvironmentHash(env: Environment): string {
     includeNodeModules: env.includeNodeModules,
     outputFormat: env.outputFormat,
     isLibrary: env.isLibrary,
+    sourceMap: env.sourceMap,
   });
 }

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -121,7 +121,12 @@ export default class PackagerRunner {
         let info = await this.processBundle(bundle, bundleGraph, ref);
         bundleInfoMap[bundle.id] = info;
         if (!info.hashReferences.length) {
-          hashRefToNameHash.set(bundle.hashReference, info.hash.slice(-8));
+          hashRefToNameHash.set(
+            bundle.hashReference,
+            this.options.contentHash
+              ? info.hash.slice(-8)
+              : bundle.id.slice(-8),
+          );
           writeEarlyPromises[bundle.id] = this.writeToDist({
             bundle,
             info,
@@ -131,7 +136,12 @@ export default class PackagerRunner {
         }
       }),
     );
-    assignComplexNameHashes(hashRefToNameHash, bundles, bundleInfoMap);
+    assignComplexNameHashes(
+      hashRefToNameHash,
+      bundles,
+      bundleInfoMap,
+      this.options,
+    );
     await Promise.all(
       bundles.map(
         bundle =>
@@ -246,8 +256,8 @@ export default class PackagerRunner {
   }
 
   getSourceMapReference(bundle: NamedBundle, map: ?SourceMap): Async<?string> {
-    if (map && this.options.sourceMaps && !bundle.isInline) {
-      if (bundle.target.sourceMap && bundle.target.sourceMap.inline) {
+    if (map && bundle.env.sourceMap && !bundle.isInline) {
+      if (bundle.env.sourceMap && bundle.env.sourceMap.inline) {
         return this.generateSourceMap(bundleToInternalBundle(bundle), map);
       } else {
         return path.basename(bundle.filePath) + '.map';
@@ -388,10 +398,10 @@ export default class PackagerRunner {
 
     if (bundle.target) {
       if (
-        bundle.target.sourceMap &&
-        bundle.target.sourceMap.sourceRoot !== undefined
+        bundle.env.sourceMap &&
+        bundle.env.sourceMap.sourceRoot !== undefined
       ) {
-        sourceRoot = bundle.target.sourceMap.sourceRoot;
+        sourceRoot = bundle.env.sourceMap.sourceRoot;
       } else if (
         this.options.serve &&
         bundle.target.env.context === 'browser'
@@ -400,10 +410,10 @@ export default class PackagerRunner {
       }
 
       if (
-        bundle.target.sourceMap &&
-        bundle.target.sourceMap.inlineSources !== undefined
+        bundle.env.sourceMap &&
+        bundle.env.sourceMap.inlineSources !== undefined
       ) {
-        inlineSources = bundle.target.sourceMap.inlineSources;
+        inlineSources = bundle.env.sourceMap.inlineSources;
       } else if (bundle.target.env.context !== 'node') {
         // inlining should only happen in production for browser targets by default
         inlineSources = this.options.mode === 'production';
@@ -411,7 +421,7 @@ export default class PackagerRunner {
     }
 
     let mapFilename = filePath + '.map';
-    let isInlineMap = bundle.target.sourceMap && bundle.target.sourceMap.inline;
+    let isInlineMap = bundle.env.sourceMap && bundle.env.sourceMap.inline;
 
     let stringified = await map.stringify({
       file: path.basename(mapFilename),
@@ -442,12 +452,12 @@ export default class PackagerRunner {
     ).map(({name, version}) => [name, version]);
 
     // TODO: add third party configs to the cache key
-    let {sourceMap, publicUrl} = bundle.target;
+    let {publicUrl} = bundle.target;
     return md5FromObject({
       parcelVersion: PARCEL_VERSION,
       packager,
       optimizers,
-      target: {sourceMap, publicUrl},
+      target: {publicUrl},
       hash: bundleGraph.getHash(bundle),
       configResult,
     });
@@ -498,8 +508,7 @@ export default class PackagerRunner {
       bundle.type = info.type;
     }
 
-    // Without content hashing, the hash reference is already the correct id
-    if (this.options.contentHash && filePath.includes(thisHashReference)) {
+    if (filePath.includes(thisHashReference)) {
       let thisNameHash = nullthrows(hashRefToNameHash.get(thisHashReference));
       filePath = filePath.replace(thisHashReference, thisNameHash);
       name = name.replace(thisHashReference, thisNameHash);
@@ -538,9 +547,8 @@ export default class PackagerRunner {
 
     let mapKey = cacheKeys.map;
     if (
-      (typeof bundle.target.sourceMap === 'object'
-        ? !bundle.target.sourceMap.inline
-        : bundle.target.sourceMap) &&
+      bundle.env.sourceMap &&
+      !bundle.env.sourceMap.inline &&
       (await this.options.cache.blobExists(mapKey))
     ) {
       let mapStream = this.options.cache.getStream(mapKey);
@@ -657,7 +665,12 @@ function replaceStream(hashRefToNameHash) {
   });
 }
 
-function assignComplexNameHashes(hashRefToNameHash, bundles, bundleInfoMap) {
+function assignComplexNameHashes(
+  hashRefToNameHash,
+  bundles,
+  bundleInfoMap,
+  options,
+) {
   for (let bundle of bundles) {
     if (hashRefToNameHash.get(bundle.hashReference) != null) {
       continue;
@@ -669,9 +682,13 @@ function assignComplexNameHashes(hashRefToNameHash, bundles, bundleInfoMap) {
 
     hashRefToNameHash.set(
       bundle.hashReference,
-      md5FromString(
-        includedBundles.map(bundleId => bundleInfoMap[bundleId].hash).join(':'),
-      ).slice(-8),
+      options.contentHash
+        ? md5FromString(
+            includedBundles
+              .map(bundleId => bundleInfoMap[bundleId].hash)
+              .join(':'),
+          ).slice(-8)
+        : bundle.id.slice(-8),
     );
   }
 }

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -10,7 +10,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {isGlobMatch} from '@parcel/utils';
 import Graph, {type GraphOpts} from './Graph';
-import {assertSignalNotAborted} from './utils';
+import {assertSignalNotAborted, hashFromOption} from './utils';
 
 type SerializedRequestGraph = {|
   ...GraphOpts<RequestGraphNode, RequestGraphEdgeType>,
@@ -18,6 +18,7 @@ type SerializedRequestGraph = {|
   incompleteNodeIds: Set<NodeId>,
   globNodeIds: Set<NodeId>,
   envNodeIds: Set<NodeId>,
+  optionNodeIds: Set<NodeId>,
   unpredicatableNodeIds: Set<NodeId>,
 |};
 
@@ -27,6 +28,12 @@ type EnvNode = {|
   id: string,
   +type: 'env',
   value: {|key: string, value: string|},
+|};
+
+type OptionNode = {|
+  id: string,
+  +type: 'option',
+  value: {|key: string, hash: string|},
 |};
 
 type Request<TInput, TResult> = {|
@@ -48,7 +55,12 @@ type RequestNode = {|
   +type: 'request',
   value: StoredRequest,
 |};
-type RequestGraphNode = RequestNode | FileNode | GlobNode | EnvNode;
+type RequestGraphNode =
+  | RequestNode
+  | FileNode
+  | GlobNode
+  | EnvNode
+  | OptionNode;
 
 type RequestGraphEdgeType =
   | 'subrequest'
@@ -62,6 +74,7 @@ export type RunAPI = {|
   invalidateOnFileUpdate: FilePath => void,
   invalidateOnStartup: () => void,
   invalidateOnEnvChange: string => void,
+  invalidateOnOptionChange: string => void,
   getInvalidations(): Array<RequestInvalidation>,
   storeResult: (result: mixed) => void,
   runRequest: <TInput, TResult>(
@@ -102,6 +115,15 @@ const nodeFromEnv = (env: string, value: string) => ({
   },
 });
 
+const nodeFromOption = (option: string, value: mixed) => ({
+  id: 'option:' + option,
+  type: 'option',
+  value: {
+    key: option,
+    hash: hashFromOption(value),
+  },
+});
+
 export class RequestGraph extends Graph<
   RequestGraphNode,
   RequestGraphEdgeType,
@@ -110,6 +132,7 @@ export class RequestGraph extends Graph<
   incompleteNodeIds: Set<NodeId> = new Set();
   globNodeIds: Set<NodeId> = new Set();
   envNodeIds: Set<NodeId> = new Set();
+  optionNodeIds: Set<NodeId> = new Set();
   // Unpredictable nodes are requests that cannot be predicted whether they should rerun based on
   // filesystem changes alone. They should rerun on each startup of Parcel.
   unpredicatableNodeIds: Set<NodeId> = new Set();
@@ -122,6 +145,7 @@ export class RequestGraph extends Graph<
     deserialized.incompleteNodeIds = opts.incompleteNodeIds;
     deserialized.globNodeIds = opts.globNodeIds;
     deserialized.envNodeIds = opts.envNodeIds;
+    deserialized.optionNodeIds = opts.optionNodeIds;
     deserialized.unpredicatableNodeIds = opts.unpredicatableNodeIds;
     // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381 (Windows only)
     return deserialized;
@@ -135,6 +159,7 @@ export class RequestGraph extends Graph<
       incompleteNodeIds: this.incompleteNodeIds,
       globNodeIds: this.globNodeIds,
       envNodeIds: this.envNodeIds,
+      optionNodeIds: this.optionNodeIds,
       unpredicatableNodeIds: this.unpredicatableNodeIds,
     };
   }
@@ -147,6 +172,10 @@ export class RequestGraph extends Graph<
 
       if (node.type === 'env') {
         this.envNodeIds.add(node.id);
+      }
+
+      if (node.type === 'option') {
+        this.optionNodeIds.add(node.id);
       }
     }
 
@@ -161,6 +190,9 @@ export class RequestGraph extends Graph<
     }
     if (node.type === 'env') {
       this.envNodeIds.delete(node.id);
+    }
+    if (node.type === 'option') {
+      this.optionNodeIds.delete(node.id);
     }
     return super.removeNode(node);
   }
@@ -231,6 +263,22 @@ export class RequestGraph extends Graph<
     }
   }
 
+  invalidateOptionNodes(options: ParcelOptions) {
+    for (let nodeId of this.optionNodeIds) {
+      let node = nullthrows(this.getNode(nodeId));
+      invariant(node.type === 'option');
+      if (hashFromOption(options[node.value.key]) !== node.value.hash) {
+        let parentNodes = this.getNodesConnectedTo(
+          node,
+          'invalidated_by_update',
+        );
+        for (let parentNode of parentNodes) {
+          this.invalidateNode(parentNode);
+        }
+      }
+    }
+  }
+
   invalidateOnFileUpdate(requestId: string, filePath: FilePath) {
     let requestNode = this.getRequestNode(requestId);
     let fileNode = nodeFromFilePath(filePath);
@@ -281,6 +329,18 @@ export class RequestGraph extends Graph<
 
     if (!this.hasEdge(requestNode.id, envNode.id, 'invalidated_by_update')) {
       this.addEdge(requestNode.id, envNode.id, 'invalidated_by_update');
+    }
+  }
+
+  invalidateOnOptionChange(requestId: string, option: string, value: mixed) {
+    let requestNode = this.getRequestNode(requestId);
+    let optionNode = nodeFromOption(option, value);
+    if (!this.hasNode(optionNode.id)) {
+      this.addNode(optionNode);
+    }
+
+    if (!this.hasEdge(requestNode.id, optionNode.id, 'invalidated_by_update')) {
+      this.addEdge(requestNode.id, optionNode.id, 'invalidated_by_update');
     }
   }
 
@@ -511,6 +571,12 @@ export default class RequestTracker {
           requestId,
           env,
           this.options.env[env] || '',
+        ),
+      invalidateOnOptionChange: option =>
+        this.graph.invalidateOnOptionChange(
+          requestId,
+          option,
+          this.options[option],
         ),
       getInvalidations: () => this.graph.getInvalidations(requestId),
       storeResult: result => {

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -37,6 +37,7 @@ import {
   md5FromFilePath,
 } from '@parcel/utils';
 import {getEnvironmentHash} from './Environment';
+import {hashFromOption} from './utils';
 
 type AssetOptions = {|
   id?: string,
@@ -210,6 +211,8 @@ export function getInvalidationId(invalidation: RequestInvalidation): string {
       return 'file:' + invalidation.filePath;
     case 'env':
       return 'env:' + invalidation.key;
+    case 'option':
+      return 'option:' + invalidation.key;
     default:
       throw new Error('Unknown invalidation type: ' + invalidation.type);
   }
@@ -236,6 +239,13 @@ export async function getInvalidationHash(
           invalidation.key + ':' + (options.env[invalidation.key] || ''),
         );
         break;
+      case 'option':
+        hash.update(
+          invalidation.key + ':' + hashFromOption(options[invalidation.key]),
+        );
+        break;
+      default:
+        throw new Error('Unknown invalidation type: ' + invalidation.type);
     }
   }
 

--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -6,6 +6,7 @@ import type {
   OutputFormat,
   PackageName,
   VersionMap,
+  TargetSourceMapOptions,
 } from '@parcel/types';
 import type {Environment as InternalEnvironment} from '../types';
 import nullthrows from 'nullthrows';
@@ -115,6 +116,10 @@ export default class Environment implements IEnvironment {
 
   get scopeHoist(): boolean {
     return this.#environment.scopeHoist;
+  }
+
+  get sourceMap(): ?TargetSourceMapOptions {
+    return this.#environment.sourceMap;
   }
 
   isBrowser(): boolean {

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -158,9 +158,7 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
       id: bundleId,
       value: {
         id: bundleId,
-        hashReference: this.#options.contentHash
-          ? HASH_REF_PREFIX + bundleId
-          : bundleId.slice(0, 8),
+        hashReference: HASH_REF_PREFIX + bundleId,
         type: opts.type ?? nullthrows(entryAsset).type,
         env: opts.env
           ? environmentToInternalEnvironment(opts.env)

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -39,10 +39,6 @@ export default class PluginOptions implements IPluginOptions {
     return this.#options.mode;
   }
 
-  get sourceMaps(): boolean {
-    return this.#options.sourceMaps;
-  }
-
   get env(): EnvMap {
     return this.#options.env;
   }
@@ -65,10 +61,6 @@ export default class PluginOptions implements IPluginOptions {
 
   get entryRoot(): FilePath {
     return this.#options.entryRoot;
-  }
-
-  get distDir(): ?FilePath {
-    return this.#options.distDir;
   }
 
   get cacheDir(): FilePath {

--- a/packages/core/core/src/public/Target.js
+++ b/packages/core/core/src/public/Target.js
@@ -2,7 +2,6 @@
 import type {
   FilePath,
   Target as ITarget,
-  TargetSourceMapOptions,
   Environment as IEnvironment,
   SourceLocation,
 } from '@parcel/types';
@@ -41,10 +40,6 @@ export default class Target implements ITarget {
 
   get env(): IEnvironment {
     return new Environment(this.#target.env);
-  }
-
-  get sourceMap(): ?TargetSourceMapOptions {
-    return this.#target.sourceMap;
   }
 
   get name(): string {

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -84,6 +84,11 @@ async function run({input, api, options, farm}: RunInput) {
       case 'env':
         api.invalidateOnEnvChange(invalidation.key);
         break;
+      case 'option':
+        api.invalidateOnOptionChange(invalidation.key);
+        break;
+      default:
+        throw new Error(`Unknown invalidation type: ${invalidation.type}`);
     }
   }
 

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -32,6 +32,7 @@ import path from 'path';
 import assert from 'assert';
 
 import ParcelConfigSchema from '../ParcelConfig.schema';
+import {optionsProxy} from '../utils';
 
 const NAMED_PIPELINE_REGEX = /^[\w-.+]+:/;
 
@@ -67,7 +68,7 @@ export default function createParcelConfigRequest(): ParcelConfigRequest {
     type,
     async run({api, options}: RunOpts): Promise<ConfigAndCachePath> {
       let {config, extendedFiles, usedDefault} = await loadParcelConfig(
-        options,
+        optionsProxy(options, api.invalidateOnOptionChange),
       );
 
       api.invalidateOnFileUpdate(config.filePath);

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -40,6 +40,7 @@ import {
   ENGINES_SCHEMA,
 } from '../TargetDescriptor.schema';
 import {BROWSER_ENVS} from '../public/Environment';
+import {optionsProxy} from '../utils';
 
 type RunOpts = {|
   input: Entry,
@@ -83,7 +84,10 @@ export default function createTargetRequest(input: Entry): TargetRequest {
 }
 
 async function run({input, api, options}: RunOpts) {
-  let targetResolver = new TargetResolver(api, options);
+  let targetResolver = new TargetResolver(
+    api,
+    optionsProxy(options, api.invalidateOnOptionChange),
+  );
   let targets = await targetResolver.resolve(input.packagePath);
 
   let {config} = nullthrows(
@@ -193,8 +197,8 @@ export class TargetResolver {
               minify: this.options.minify && descriptor.minify !== false,
               scopeHoist:
                 this.options.scopeHoist && descriptor.scopeHoist !== false,
+              sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
             }),
-            sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           };
         });
       }
@@ -232,7 +236,6 @@ export class TargetResolver {
             name: 'default',
             distDir: this.options.serve.distDir,
             publicUrl: this.options.publicUrl ?? '/',
-            sourceMap: this.options.sourceMaps ? {} : undefined,
             env: createEnvironment({
               context: 'browser',
               engines: {
@@ -240,6 +243,7 @@ export class TargetResolver {
               },
               minify: this.options.minify,
               scopeHoist: this.options.scopeHoist,
+              sourceMap: this.options.sourceMaps ? {} : undefined,
             }),
           },
         ];
@@ -444,8 +448,8 @@ export class TargetResolver {
             minify: this.options.minify && descriptor.minify !== false,
             scopeHoist:
               this.options.scopeHoist && descriptor.scopeHoist !== false,
+            sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           }),
-          sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           loc,
         });
       }
@@ -529,8 +533,8 @@ export class TargetResolver {
             minify: this.options.minify && descriptor.minify !== false,
             scopeHoist:
               this.options.scopeHoist && descriptor.scopeHoist !== false,
+            sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           }),
-          sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
           loc,
         });
       }
@@ -548,8 +552,8 @@ export class TargetResolver {
           context,
           minify: this.options.minify,
           scopeHoist: this.options.scopeHoist,
+          sourceMap: this.options.sourceMaps ? {} : undefined,
         }),
-        sourceMap: this.options.sourceMaps ? {} : undefined,
       });
     }
 

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -70,13 +70,13 @@ export type Environment = {|
   isLibrary: boolean,
   minify: boolean,
   scopeHoist: boolean,
+  sourceMap: ?TargetSourceMapOptions,
 |};
 
 export type Target = {|
   distEntry?: ?FilePath,
   distDir: FilePath,
   env: Environment,
-  sourceMap?: TargetSourceMapOptions,
   name: string,
   publicUrl: string,
   loc?: ?SourceLocation,
@@ -141,7 +141,15 @@ export type EnvInvalidation = {|
   key: string,
 |};
 
-export type RequestInvalidation = FileInvalidation | EnvInvalidation;
+export type OptionInvalidation = {|
+  type: 'option',
+  key: string,
+|};
+
+export type RequestInvalidation =
+  | FileInvalidation
+  | EnvInvalidation
+  | OptionInvalidation;
 
 export type ParcelOptions = {|
   entries: Array<FilePath>,

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -2,9 +2,11 @@
 
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import type {BundleGroup} from '@parcel/types';
+import type {ParcelOptions} from './types';
 
 import assert from 'assert';
 import baseX from 'base-x';
+import {md5FromObject} from '@parcel/utils';
 import {registerSerializableClass} from './serializer';
 import AssetGraph from './AssetGraph';
 import BundleGraph from './BundleGraph';
@@ -77,4 +79,45 @@ export function getPublicId(
   }
 
   throw new Error('Original id was not unique');
+}
+
+// These options don't affect compilation and should cause invalidations
+const ignoreOptions = new Set([
+  'env', // handled by separate invalidateOnEnvChange
+  'inputFS',
+  'outputFS',
+  'workerFarm',
+  'killWorkers',
+  'packageManager',
+  'detailedReport',
+  'disableCache',
+  'cacheDir',
+  'autoinstall',
+  'logLevel',
+  'profile',
+  'patchConsole',
+  'projectRoot',
+]);
+
+export function optionsProxy(
+  options: ParcelOptions,
+  invalidateOnOptionChange: string => void,
+): ParcelOptions {
+  return new Proxy(options, {
+    get(target, prop) {
+      if (!ignoreOptions.has(prop)) {
+        invalidateOnOptionChange(prop);
+      }
+
+      return target[prop];
+    },
+  });
+}
+
+export function hashFromOption(value: mixed): string {
+  if (typeof value === 'object' && value != null) {
+    return md5FromObject(value);
+  }
+
+  return String(value);
 }

--- a/packages/core/core/test/Environment.test.js
+++ b/packages/core/core/test/Environment.test.js
@@ -15,6 +15,7 @@ describe('Environment', () => {
       isLibrary: false,
       minify: false,
       scopeHoist: false,
+      sourceMap: undefined,
     });
   });
 
@@ -29,6 +30,7 @@ describe('Environment', () => {
       isLibrary: false,
       minify: false,
       scopeHoist: false,
+      sourceMap: undefined,
     });
   });
 
@@ -45,6 +47,7 @@ describe('Environment', () => {
         isLibrary: false,
         minify: false,
         scopeHoist: false,
+        sourceMap: undefined,
       },
     );
   });
@@ -60,6 +63,7 @@ describe('Environment', () => {
       isLibrary: false,
       minify: false,
       scopeHoist: false,
+      sourceMap: undefined,
     });
   });
 
@@ -74,6 +78,7 @@ describe('Environment', () => {
       isLibrary: false,
       minify: false,
       scopeHoist: false,
+      sourceMap: undefined,
     });
   });
 });

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -67,6 +67,7 @@ describe('TargetResolver', () => {
     invalidateOnFileUpdate() {},
     invalidateOnFileDelete() {},
     invalidateOnEnvChange() {},
+    invalidateOnOptionChange() {},
     invalidateOnStartup() {},
     getInvalidations() {
       return [];
@@ -111,8 +112,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
         },
         {
           name: 'customB',
@@ -128,8 +129,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
         },
       ],
     );
@@ -156,8 +157,8 @@ describe('TargetResolver', () => {
             isLibrary: true,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -185,9 +186,9 @@ describe('TargetResolver', () => {
             isLibrary: true,
             minify: false,
             scopeHoist: false,
-          },
-          sourceMap: {
-            inlineSources: true,
+            sourceMap: {
+              inlineSources: true,
+            },
           },
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -216,8 +217,8 @@ describe('TargetResolver', () => {
             isLibrary: true,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -255,8 +256,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: undefined,
           },
-          sourceMap: undefined,
           loc: {
             filePath: path.join(
               COMMON_TARGETS_IGNORE_FIXTURE_PATH,
@@ -296,8 +297,8 @@ describe('TargetResolver', () => {
             isLibrary: true,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -328,8 +329,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -360,8 +361,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -398,8 +399,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: undefined,
         },
       ],
@@ -429,8 +430,8 @@ describe('TargetResolver', () => {
           outputFormat: 'commonjs',
           minify: false,
           scopeHoist: false,
+          sourceMap: {},
         },
-        sourceMap: {},
         loc: {
           filePath: path.join(CONTEXT_FIXTURE_PATH, 'package.json'),
           start: {
@@ -470,8 +471,8 @@ describe('TargetResolver', () => {
           outputFormat: 'global',
           minify: false,
           scopeHoist: false,
+          sourceMap: {},
         },
-        sourceMap: {},
         loc: {
           filePath: path.join(fixture, 'package.json'),
           start: {
@@ -511,8 +512,8 @@ describe('TargetResolver', () => {
             isLibrary: true,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -540,8 +541,8 @@ describe('TargetResolver', () => {
             isLibrary: true,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
             start: {
@@ -588,8 +589,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
         },
       ],
     );
@@ -615,8 +616,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
         },
       ],
     );
@@ -643,8 +644,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: undefined,
         },
       ],
@@ -676,8 +677,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: undefined,
         },
         {
@@ -699,8 +700,8 @@ describe('TargetResolver', () => {
             isLibrary: false,
             minify: false,
             scopeHoist: false,
+            sourceMap: {},
           },
-          sourceMap: {},
           loc: undefined,
         },
       ],

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -96,7 +96,6 @@ export interface Target {
   /** The output folder */
   +distDir: FilePath;
   +env: Environment;
-  +sourceMap: ?TargetSourceMapOptions;
   +name: string;
   +publicUrl: string;
   /** The location that created this Target, e.g. `package.json#main`*/
@@ -160,6 +159,7 @@ export type EnvironmentOpts = {|
   +isLibrary?: boolean,
   +minify?: boolean,
   +scopeHoist?: boolean,
+  +sourceMap?: ?TargetSourceMapOptions
 |};
 
 /**
@@ -200,6 +200,7 @@ export interface Environment {
   +minify: boolean;
   /** Whether scope hoisting is enabled. */
   +scopeHoist: boolean;
+  +sourceMap: ?TargetSourceMapOptions;
 
   /** Whether <code>context</code> specifies a browser context. */
   isBrowser(): boolean;
@@ -292,7 +293,6 @@ export type InitialServerOptions = {|
 
 export interface PluginOptions {
   +mode: BuildMode;
-  +sourceMaps: boolean;
   +env: EnvMap;
   +hot: ?HMROptions;
   +serve: ServerOptions | false;

--- a/packages/optimizers/cssnano/src/CSSNanoOptimizer.js
+++ b/packages/optimizers/cssnano/src/CSSNanoOptimizer.js
@@ -42,7 +42,7 @@ export default (new Optimizer({
     }
 
     let contents = result.css;
-    if (options.sourceMaps) {
+    if (bundle.env.sourceMap) {
       let reference = await getSourceMapReference(map);
       if (reference != null) {
         contents += '\n' + '/*# sourceMappingURL=' + reference + ' */\n';

--- a/packages/optimizers/terser/src/TerserOptimizer.js
+++ b/packages/optimizers/terser/src/TerserOptimizer.js
@@ -26,7 +26,7 @@ export default (new Optimizer({
     let originalMap = map ? await map.stringify({}) : null;
     let config = {
       ...userConfig?.config,
-      sourceMap: options.sourceMaps
+      sourceMap: bundle.env.sourceMap
         ? {
             filename: path.relative(options.projectRoot, bundle.filePath),
             asObject: true,

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -43,7 +43,7 @@ export default (new Packager({
 
               return css;
             }),
-            options.sourceMaps && asset.getMapBuffer(),
+            bundle.env.sourceMap && asset.getMapBuffer(),
           ]),
         );
       },
@@ -55,7 +55,7 @@ export default (new Packager({
     let lineOffset = 0;
     for (let [asset, code, mapBuffer] of outputs) {
       contents += code + '\n';
-      if (options.sourceMaps) {
+      if (bundle.env.sourceMap) {
         if (mapBuffer) {
           map.addBufferMappings(mapBuffer, lineOffset);
         } else {
@@ -72,7 +72,7 @@ export default (new Packager({
       }
     }
 
-    if (options.sourceMaps) {
+    if (bundle.env.sourceMap) {
       let reference = await getSourceMapReference(map);
       if (reference != null) {
         contents += '/*# sourceMappingURL=' + reference + ' */\n';

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -87,7 +87,7 @@ export default (new Packager({
         queue.add(async () => {
           let [code, mapBuffer] = await Promise.all([
             node.value.getCode(),
-            bundle.target.sourceMap && node.value.getMapBuffer(),
+            bundle.env.sourceMap && node.value.getMapBuffer(),
           ]);
           return {code, mapBuffer};
         });
@@ -147,7 +147,7 @@ export default (new Packager({
         wrapped += JSON.stringify(deps);
         wrapped += ']';
 
-        if (options.sourceMaps) {
+        if (bundle.env.sourceMap) {
           if (mapBuffer) {
             map.addBufferMappings(mapBuffer, lineOffset);
           } else {

--- a/packages/shared/babel-ast-utils/src/index.js
+++ b/packages/shared/babel-ast-utils/src/index.js
@@ -56,7 +56,7 @@ export async function generate({
   let generated;
   try {
     generated = babelGenerate(ast.program, {
-      sourceMaps: options.sourceMaps,
+      sourceMaps: !!asset.env.sourceMap,
       sourceFileName: sourceFileName,
     });
   } catch (e) {

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -95,13 +95,13 @@ export function generate({
   );
 
   let {code, rawMappings} = babelGenerate(ast, {
-    sourceMaps: options.sourceMaps,
+    sourceMaps: !!bundle.env.sourceMap,
     minified: bundle.env.minify,
     comments: true, // retain /*@__PURE__*/ comments for terser
   });
 
   let map = null;
-  if (options.sourceMaps && rawMappings != null) {
+  if (bundle.env.sourceMap && rawMappings != null) {
     map = new SourceMap(options.projectRoot);
     map.addIndexedMappings(rawMappings);
   }

--- a/packages/transformers/coffeescript/src/CoffeeScriptTransformer.js
+++ b/packages/transformers/coffeescript/src/CoffeeScriptTransformer.js
@@ -14,11 +14,11 @@ export default (new Transformer({
     asset.type = 'js';
     let output = coffee.compile(await asset.getCode(), {
       filename: sourceFileName,
-      sourceMap: options.sourceMaps,
+      sourceMap: !!asset.env.sourceMap,
     });
 
-    // return from compile is based on sourceMaps option
-    if (options.sourceMaps) {
+    // return from compile is based on sourceMap option
+    if (asset.env.sourceMap) {
       let map = null;
       if (output.v3SourceMap) {
         map = new SourceMap(options.projectRoot);

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -56,6 +56,7 @@ export default (new Transformer({
         browsers: asset.env.engines.browsers,
       },
       minify: asset.env.minify,
+      sourceMap: asset.env.sourceMap,
     });
 
     // When this asset is an bundle entry, allow that bundle to be split to load shared assets separately.

--- a/packages/transformers/less/src/LessTransformer.js
+++ b/packages/transformers/less/src/LessTransformer.js
@@ -37,7 +37,7 @@ export default (new Transformer({
     try {
       let lessConfig: LessConfig = config ? {...config.config} : {};
 
-      if (options.sourceMaps) {
+      if (asset.env.sourceMap) {
         lessConfig.sourceMap = {};
       }
 

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -268,7 +268,7 @@ async function processPipeline({
         type: 'js',
         uniqueKey: asset.id + '-template',
         ...(!template.src &&
-          options.sourceMaps && {
+          asset.env.sourceMap && {
             map: createMap(templateComp.map, options.projectRoot),
           }),
         content:
@@ -323,7 +323,7 @@ ${
         uniqueKey: asset.id + '-script',
         content: script.content,
         ...(!script.src &&
-          options.sourceMaps && {
+          asset.env.sourceMap && {
             map: createMap(script.map, options.projectRoot),
           }),
       };
@@ -396,7 +396,7 @@ ${
             content: styleComp.code,
             sideEffects: !style.module,
             ...(!style.src &&
-              options.sourceMaps && {
+              asset.env.sourceMap && {
                 map: createMap(style.map, options.projectRoot),
               }),
             uniqueKey: asset.id + '-style' + i,


### PR DESCRIPTION
Fixes #5210. Fixes #3694. Fixes #5231. Closes T-365.

This adds tests for cache invalidation when parcel options passed via the API or CLI change, and implements several fixes. In addition, the entire asset/request graph is no longer thrown away when certain options change, likely leading to improved rebuild perf (untested).

* Adds an option node to the request graph, and an `invalidateOnOptionChange` method to the request API. On startup, requests connected to option nodes in the graph are invalidated if the option's value changes.
* We automatically track which options are read by transformer plugins and add invalidations for them via a Proxy. We also do this in the TargetRequest (for many things) and ParcelConfigRequest (for the config and defaultConfig options). **Should we do this automatically for all requests?** We could also take a similar approach for environment variables rather than needing to manually call an API...
* Source map options are moved into the environment rather than the target since transformers need access to them. Previously transformers just looked at the global option to turn on or off source maps, but this would not be enough in case different targets had different values. We still need to only include the environment options that a transformer actually uses in its id/cache key, but this can be done separately.
* Hash references are now always replaced in bundle content so that the `contentHash` option invalidates properly without needing to rebuild the whole bundle.