### PR TITLE
Use a unique parcelRequire global per project

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1155,7 +1155,7 @@ export default class BundleGraph {
     this.traverseBundles((childBundle, _, traversal) => {
       if (childBundle.isInline) {
         bundles.push(childBundle);
-      } else {
+      } else if (childBundle.id !== bundle.id) {
         traversal.skipChildren();
       }
     }, bundle);

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1131,10 +1131,8 @@ export default class BundleGraph {
     return hashHex;
   }
 
-  getHash(bundle: Bundle): string {
-    let hash = crypto.createHash('md5');
-    hash.update(bundle.id);
-
+  getInlineBundles(bundle: Bundle): Array<Bundle> {
+    let bundles = [];
     let seen = new Set();
     let addReferencedBundles = bundle => {
       if (seen.has(bundle.id)) {
@@ -1146,7 +1144,7 @@ export default class BundleGraph {
       let referencedBundles = this.getReferencedBundles(bundle);
       for (let referenced of referencedBundles) {
         if (referenced.isInline) {
-          hash.update(this.getContentHash(referenced));
+          bundles.push(referenced);
           addReferencedBundles(referenced);
         }
       }
@@ -1154,13 +1152,30 @@ export default class BundleGraph {
 
     addReferencedBundles(bundle);
 
-    this.traverseBundles((childBundle, ctx, traversal) => {
-      if (childBundle.id === bundle.id || childBundle.isInline) {
-        hash.update(this.getContentHash(childBundle));
+    this.traverseBundles((childBundle, _, traversal) => {
+      if (childBundle.isInline) {
+        bundles.push(childBundle);
       } else {
-        hash.update(childBundle.id);
         traversal.skipChildren();
       }
+    }, bundle);
+
+    return bundles;
+  }
+
+  getHash(bundle: Bundle): string {
+    let hash = crypto.createHash('md5');
+    hash.update(bundle.id);
+    hash.update(this.getContentHash(bundle));
+
+    let inlineBundles = this.getInlineBundles(bundle);
+    for (let inlineBundle of inlineBundles) {
+      hash.update(this.getContentHash(inlineBundle));
+    }
+
+    this.traverseBundles((childBundle, _, traversal) => {
+      hash.update(childBundle.id);
+      traversal.skipChildren();
     }, bundle);
 
     hash.update(JSON.stringify(objectSortedEntriesDeep(bundle.env)));

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1173,10 +1173,11 @@ export default class BundleGraph {
       hash.update(this.getContentHash(inlineBundle));
     }
 
-    this.traverseBundles((childBundle, _, traversal) => {
-      hash.update(childBundle.id);
-      traversal.skipChildren();
-    }, bundle);
+    for (let childBundle of this.getChildBundles(bundle)) {
+      if (!childBundle.isInline) {
+        hash.update(childBundle.id);
+      }
+    }
 
     hash.update(JSON.stringify(objectSortedEntriesDeep(bundle.env)));
     return hash.digest('hex');

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -9,7 +9,6 @@ import type {
   NamedBundle as NamedBundleType,
   Async,
   ConfigOutput,
-  ConfigResult,
 } from '@parcel/types';
 import type SourceMap from '@parcel/source-map';
 import type WorkerFarm, {SharedReference} from '@parcel/workers';
@@ -168,6 +167,20 @@ export default class PackagerRunner {
     };
   }
 
+  async loadConfigs(
+    bundleGraph: InternalBundleGraph,
+    bundle: InternalBundle,
+  ): Promise<Map<string, ?ConfigOutput>> {
+    let configs = new Map();
+
+    configs.set(bundle.id, await this.loadConfig(bundleGraph, bundle));
+    for (let inlineBundle of bundleGraph.getInlineBundles(bundle)) {
+      configs.set(inlineBundle.id, await this.loadConfig(bundleGraph, inlineBundle));
+    }
+
+    return configs;
+  }
+
   async loadConfig(
     bundleGraph: InternalBundleGraph,
     bundle: InternalBundle,
@@ -204,12 +217,12 @@ export default class PackagerRunner {
     bundle: InternalBundle,
     bundleGraph: InternalBundleGraph,
     cacheKeys: CacheKeyMap,
-    config: ConfigResult,
+    configs: Map<string, ?ConfigOutput>,
   ): Promise<BundleInfo> {
     let {type, contents, map} = await this.getBundleResult(
       bundle,
       bundleGraph,
-      config,
+      configs,
     );
 
     return this.writeToCache(cacheKeys, type, contents, map);
@@ -218,7 +231,7 @@ export default class PackagerRunner {
   async getBundleResult(
     bundle: InternalBundle,
     bundleGraph: InternalBundleGraph,
-    config: ConfigResult,
+    configs: Map<string, ?ConfigOutput>,
   ): Promise<{|
     type: string,
     contents: Blob,
@@ -226,7 +239,7 @@ export default class PackagerRunner {
   |}> {
     await initSourcemaps;
 
-    let packaged = await this.package(bundle, bundleGraph, config);
+    let packaged = await this.package(bundle, bundleGraph, configs);
     let type = packaged.type ?? bundle.type;
     let res = await this.optimize(
       bundle,
@@ -260,7 +273,7 @@ export default class PackagerRunner {
   async package(
     internalBundle: InternalBundle,
     bundleGraph: InternalBundleGraph,
-    config: ConfigResult,
+    configs: Map<string, ?ConfigOutput>,
   ): Promise<BundleResult> {
     let bundle = NamedBundle.get(internalBundle, bundleGraph, this.options);
     this.report({
@@ -272,7 +285,7 @@ export default class PackagerRunner {
     let {name, plugin} = await this.config.getPackager(bundle.filePath);
     try {
       return await plugin.package({
-        config,
+        config: configs.get(bundle.id)?.config,
         bundle,
         bundleGraph: new BundleGraph<NamedBundleType>(
           bundleGraph,
@@ -298,6 +311,7 @@ export default class PackagerRunner {
             bundleToInternalBundle(bundle),
             // $FlowFixMe
             bundleGraphToInternalBundleGraph(bundleGraph),
+            configs,
           );
 
           return {contents: res.contents};
@@ -432,7 +446,7 @@ export default class PackagerRunner {
   async getCacheKey(
     bundle: InternalBundle,
     bundleGraph: InternalBundleGraph,
-    configResult: ?ConfigResult,
+    configs: Map<string, ?ConfigOutput>
   ): Promise<string> {
     let filePath = nullthrows(bundle.filePath);
     // TODO: include packagers and optimizers used in inline bundles as well
@@ -440,6 +454,11 @@ export default class PackagerRunner {
     let optimizers = (
       await this.config.getOptimizers(filePath)
     ).map(({name, version}) => [name, version]);
+
+    let configResults = {};
+    for (let [id, config] of configs) {
+      configResults[id] = config?.config;
+    }
 
     // TODO: add third party configs to the cache key
     let {sourceMaps} = this.options;
@@ -449,7 +468,7 @@ export default class PackagerRunner {
       optimizers,
       opts: {sourceMaps},
       hash: bundleGraph.getHash(bundle),
-      configResult,
+      configResults,
     });
   }
 

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -175,7 +175,10 @@ export default class PackagerRunner {
 
     configs.set(bundle.id, await this.loadConfig(bundleGraph, bundle));
     for (let inlineBundle of bundleGraph.getInlineBundles(bundle)) {
-      configs.set(inlineBundle.id, await this.loadConfig(bundleGraph, inlineBundle));
+      configs.set(
+        inlineBundle.id,
+        await this.loadConfig(bundleGraph, inlineBundle),
+      );
     }
 
     return configs;
@@ -446,7 +449,7 @@ export default class PackagerRunner {
   async getCacheKey(
     bundle: InternalBundle,
     bundleGraph: InternalBundleGraph,
-    configs: Map<string, ?ConfigOutput>
+    configs: Map<string, ?ConfigOutput>,
   ): Promise<string> {
     let filePath = nullthrows(bundle.filePath);
     // TODO: include packagers and optimizers used in inline bundles as well

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -135,10 +135,10 @@ export async function runPackage(
     report: reportWorker.bind(null, workerApi),
   });
 
-  let config = await runner.loadConfig(bundleGraph, bundle);
+  let configs = await runner.loadConfigs(bundleGraph, bundle);
   // TODO: add invalidations in `config?.files` once packaging is a request
 
-  let cacheKey = await runner.getCacheKey(bundle, bundleGraph, config?.config);
+  let cacheKey = await runner.getCacheKey(bundle, bundleGraph, configs);
   let cacheKeys = {
     content: PackagerRunner.getContentKey(cacheKey),
     map: PackagerRunner.getMapKey(cacheKey),
@@ -147,6 +147,6 @@ export async function runPackage(
 
   return (
     (await runner.getBundleInfoFromCache(cacheKeys.info)) ??
-    runner.getBundleInfo(bundle, bundleGraph, cacheKeys, config?.config)
+    runner.getBundleInfo(bundle, bundleGraph, cacheKeys, configs)
   );
 }

--- a/packages/core/integration-tests/test/integration/hash-distDir/b/package.json
+++ b/packages/core/integration-tests/test/integration/hash-distDir/b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "b",
+  "name": "a",
   "app": "dist/index.html",
   "targets": {
     "app": {}

--- a/packages/core/integration-tests/test/react-refresh.js
+++ b/packages/core/integration-tests/test/react-refresh.js
@@ -207,12 +207,13 @@ async function setup(entry) {
   let bundle = nullthrows(
     bundleEvent.bundleGraph.getBundles().find(b => b.type === 'js'),
   );
+  let parcelRequire = Object.keys(window).find(k =>
+    k.startsWith('parcelRequire'),
+  );
   // ReactDOM.render
-  await window
-    .parcelRequire(
-      bundleEvent.bundleGraph.getAssetPublicId(bundle.getEntryAssets().pop()),
-    )
-    .default();
+  await window[parcelRequire](
+    bundleEvent.bundleGraph.getAssetPublicId(bundle.getEntryAssets().pop()),
+  ).default();
   await sleep(100);
 
   let [, indexNum, appNum, fooText, fooNum] = root.textContent.match(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2435,7 +2435,7 @@ describe('scope hoisting', function() {
       .getBundles()
       .sort((a, b) => b.stats.size - a.stats.size)[0];
     let contents = await outputFS.readFile(sharedBundle.filePath, 'utf8');
-    assert(contents.includes(`parcelRequire =`));
+    assert(contents.includes(`$parcel$global[parcelRequireName] = `));
   });
 
   it('does not include prelude if child bundles are isolated', async function() {
@@ -2445,7 +2445,7 @@ describe('scope hoisting', function() {
 
     let mainBundle = b.getBundles().find(b => b.name === 'index.js');
     let contents = await outputFS.readFile(mainBundle.filePath, 'utf8');
-    assert(!contents.includes(`parcelRequire =`));
+    assert(!contents.includes(`$parcel$global[parcelRequireName] = `));
   });
 
   it('should include prelude in shared worker bundles', async function() {
@@ -2458,7 +2458,7 @@ describe('scope hoisting', function() {
       .sort((a, b) => b.stats.size - a.stats.size)
       .find(b => b.name !== 'index.js');
     let contents = await outputFS.readFile(sharedBundle.filePath, 'utf8');
-    assert(contents.includes(`parcelRequire =`));
+    assert(contents.includes(`$parcel$global[parcelRequireName] = `));
 
     let workerBundle = b.getBundles().find(b => b.name.startsWith('worker-b'));
     contents = await outputFS.readFile(workerBundle.filePath, 'utf8');

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -207,9 +207,13 @@ export async function runBundles(
       case 'global':
         if (env.scopeHoist) {
           return typeof ctx.output !== 'undefined' ? ctx.output : undefined;
-        } else if (ctx.parcelRequire) {
-          // $FlowFixMe
-          return ctx.parcelRequire(bundleGraph.getAssetPublicId(entryAsset));
+        } else {
+          for (let key in ctx) {
+            if (key.startsWith('parcelRequire')) {
+              // $FlowFixMe
+              return ctx[key](bundleGraph.getAssetPublicId(entryAsset));
+            }
+          }
         }
         return;
       case 'commonjs':

--- a/packages/packagers/js/src/JSPackager.js
+++ b/packages/packagers/js/src/JSPackager.js
@@ -28,13 +28,17 @@ export default (new Packager({
   async loadConfig({options}) {
     // Generate a name for the global parcelRequire function that is unique to this project.
     // This allows multiple parcel builds to coexist on the same page.
-    let pkg = await loadConfig(options.inputFS, path.join(options.entryRoot, 'index'), ['package.json']);
+    let pkg = await loadConfig(
+      options.inputFS,
+      path.join(options.entryRoot, 'index'),
+      ['package.json'],
+    );
     let name = pkg?.config.name ?? '';
     return {
       config: {
-        parcelRequireName: 'parcelRequire' + md5FromString(name).slice(-4)
+        parcelRequireName: 'parcelRequire' + md5FromString(name).slice(-4),
       },
-      files: pkg?.files ?? []
+      files: pkg?.files ?? [],
     };
   },
   async package({

--- a/packages/packagers/js/src/prelude.js
+++ b/packages/packagers/js/src/prelude.js
@@ -6,7 +6,7 @@
 // anything defined in a previous bundle is accessed via the
 // orig method which is the require for previous bundles
 
-(function(modules, cache, entry, mainEntry, globalName) {
+(function(modules, cache, entry, mainEntry, parcelRequireName, globalName) {
   /* eslint-disable no-undef */
   var globalObject =
     typeof globalThis !== 'undefined'
@@ -22,8 +22,8 @@
 
   // Save the require from previous bundle to this closure if any
   var previousRequire =
-    typeof globalObject.parcelRequire === 'function' &&
-    globalObject.parcelRequire;
+    typeof globalObject[parcelRequireName] === 'function' &&
+    globalObject[parcelRequireName];
   // Do not use `require` to prevent Webpack from trying to bundle this call
   var nodeRequire =
     typeof module !== 'undefined' &&
@@ -37,7 +37,8 @@
         // cache jump to the current global require ie. the last bundle
         // that was added to the page.
         var currentRequire =
-          typeof parcelRequire === 'function' && parcelRequire;
+          typeof globalObject[parcelRequireName] === 'function' &&
+          globalObject[parcelRequireName];
         if (!jumped && currentRequire) {
           return currentRequire(name, true);
         }
@@ -105,7 +106,13 @@
     ];
   };
 
-  globalObject.parcelRequire = newRequire;
+  Object.defineProperty(newRequire, 'root', {
+    get: function() {
+      return globalObject[parcelRequireName];
+    },
+  });
+
+  globalObject[parcelRequireName] = newRequire;
 
   for (var i = 0; i < entry.length; i++) {
     newRequire(entry[i]);

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -61,8 +61,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
       var handled = false;
       assets.forEach(asset => {
         var didAccept =
-          asset.type === 'css' ||
-          hmrAcceptCheck(global.parcelRequire, asset.id);
+          asset.type === 'css' || hmrAcceptCheck(module.bundle.root, asset.id);
         if (didAccept) {
           handled = true;
         }
@@ -72,7 +71,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
         console.clear();
 
         assets.forEach(function(asset) {
-          hmrApply(global.parcelRequire, asset);
+          hmrApply(module.bundle.root, asset);
         });
 
         for (var i = 0; i < assetsToAccept.length; i++) {
@@ -270,7 +269,7 @@ function hmrAcceptCheck(bundle, id) {
     return true;
   }
 
-  return getParents(global.parcelRequire, id).some(function(v) {
+  return getParents(module.bundle.root, id).some(function(v) {
     return hmrAcceptCheck(v[0], v[1]);
   });
 }
@@ -295,7 +294,7 @@ function hmrAcceptRun(bundle, id) {
   if (cached && cached.hot && cached.hot._acceptCallbacks.length) {
     cached.hot._acceptCallbacks.forEach(function(cb) {
       var assetsToAlsoAccept = cb(function() {
-        return getParents(global.parcelRequire, id);
+        return getParents(module.bundle.root, id);
       });
       if (assetsToAlsoAccept && assetsToAccept.length) {
         assetsToAccept.push.apply(assetsToAccept, assetsToAlsoAccept);

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -321,7 +321,7 @@ function getLoaderRuntime({
   }
 
   if (bundle.env.outputFormat === 'global') {
-    loaderCode += `.then(() => parcelRequire('${bundleGraph.getAssetPublicId(
+    loaderCode += `.then(() => module.bundle.root('${bundleGraph.getAssetPublicId(
       bundleGraph.getAssetById(bundleGroup.entryAssetId),
     )}')${
       // In global output with scope hoisting, functions return exports are

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -9,6 +9,7 @@ import type {
 import type {
   ArrayExpression,
   ExpressionStatement,
+  Identifier,
   File,
   Statement,
 } from '@babel/types';
@@ -24,6 +25,7 @@ const REGISTER_TEMPLATE = template.statement<
   {|
     REFERENCED_IDS: ArrayExpression,
     STATEMENTS: Array<Statement>,
+    PARCEL_REQUIRE: Identifier,
   |},
   ExpressionStatement,
 >(`(function() {
@@ -34,7 +36,7 @@ const REGISTER_TEMPLATE = template.statement<
   }
   var $parcel$referencedAssets = REFERENCED_IDS;
   for (var $parcel$i = 0; $parcel$i < $parcel$referencedAssets.length; $parcel$i++) {
-    parcelRequire.registerBundle($parcel$referencedAssets[$parcel$i], $parcel$bundleWrapper);
+    PARCEL_REQUIRE.registerBundle($parcel$referencedAssets[$parcel$i], $parcel$bundleWrapper);
   }
 })()`);
 const WRAPPER_TEMPLATE = template.statement<
@@ -47,6 +49,7 @@ export function generate({
   bundle,
   ast,
   referencedAssets,
+  parcelRequireName,
   options,
 }: {|
   bundleGraph: BundleGraph<NamedBundle>,
@@ -54,6 +57,7 @@ export function generate({
   ast: File,
   options: PluginOptions,
   referencedAssets: Set<Asset>,
+  parcelRequireName: string,
 |}): {|contents: string, map: ?SourceMap|} {
   let interpreter;
   let mainEntry = bundle.getMainEntry();
@@ -80,6 +84,7 @@ export function generate({
                   t.stringLiteral(bundleGraph.getAssetPublicId(asset)),
                 ),
             ),
+            PARCEL_REQUIRE: t.identifier(parcelRequireName),
           }),
         ]
       : [WRAPPER_TEMPLATE({STATEMENTS: statements})];

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -271,7 +271,10 @@ const VISITOR: Visitor<MutableAsset> = {
       path.replaceWith(t.identifier('null'));
     }
 
-    if (t.matchesPattern(path.node, 'module.bundle')) {
+    if (
+      t.matchesPattern(path.node, 'module.bundle.root') ||
+      t.matchesPattern(path.node, 'module.bundle')
+    ) {
       path.replaceWith(t.identifier('parcelRequire'));
     }
   },

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -424,9 +424,20 @@ export function link({
       let program = path.scope.getProgramParent().path;
       if (!program.scope.hasOwnBinding(initIdentifier.name)) {
         // add binding so we can track the scope
-        let [decl] = program.unshiftContainer('body', [
-          t.variableDeclaration('var', [t.variableDeclarator(initIdentifier)]),
+        // If parcelRequire exists in scope, be sure to insert after that so the global outputFormat
+        // can add the rhs later and reference it properly.
+        let declNode = t.variableDeclaration('var', [
+          t.variableDeclarator(initIdentifier),
         ]);
+        let parcelRequire = program.scope.getBinding('parcelRequire');
+        let decl;
+        if (parcelRequire) {
+          [decl] = parcelRequire.path
+            .getStatementParent()
+            .insertAfter(declNode);
+        } else {
+          [decl] = program.unshiftContainer('body', [declNode]);
+        }
         program.scope.registerDeclaration(decl);
       }
 

--- a/packages/shared/scope-hoisting/src/prelude.js
+++ b/packages/shared/scope-hoisting/src/prelude.js
@@ -1,19 +1,8 @@
 var $parcel$modules = {};
 var $parcel$bundles = {};
 
-var globalObject =
-  typeof globalThis !== 'undefined'
-    ? globalThis
-    : typeof self !== 'undefined'
-    ? self
-    : typeof window !== 'undefined'
-    ? window
-    : typeof global !== 'undefined'
-    ? global
-    : {};
-
-if (globalObject.parcelRequire == null) {
-  globalObject.parcelRequire = function(name) {
+if (parcelRequire == null) {
+  parcelRequire = function(name) {
     // Execute the bundle wrapper function if there is one registered.
     if (name in $parcel$bundles) {
       $parcel$bundles[name]();
@@ -35,12 +24,14 @@ if (globalObject.parcelRequire == null) {
     throw err;
   };
 
-  globalObject.parcelRequire.register = function register(id, exports) {
+  parcelRequire.register = function register(id, exports) {
     $parcel$modules[id] = exports;
   };
 
-  globalObject.parcelRequire.registerBundle = function registerBundle(id, fn) {
+  parcelRequire.registerBundle = function registerBundle(id, fn) {
     $parcel$bundles[id] = fn;
     $parcel$modules[id] = {};
   };
+
+  $parcel$global[parcelRequireName] = parcelRequire;
 }

--- a/packages/shared/scope-hoisting/src/shake.js
+++ b/packages/shared/scope-hoisting/src/shake.js
@@ -101,7 +101,9 @@ function isPure(binding) {
       init.isIdentifier() ||
       init.isThisExpression() ||
       (isVariableDeclarator(node) &&
-        isIdentifier(node.id, {name: '$parcel$global'}))
+        isIdentifier(node.id, {name: '$parcel$global'})) ||
+      (isVariableDeclarator(node) &&
+        isIdentifier(node.id, {name: 'parcelRequire'}))
     );
   }
 


### PR DESCRIPTION
Fixes #4953.

This changes the global `parcelRequire` function to use a unique generated name per project. This should make it possible to have multiple parcel builds on the same page at once. It's generated by hashing the ~~projectRoot~~ package.json#name. Probably not perfect but better than nothing. 🤷 If anyone has a better idea on how to generate a unique id for a project that's stable over time let me know. 😄 