### PR TITLE
Reduce number of concurrent open file handles

### DIFF
--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -24,6 +24,7 @@
     "@parcel/utils": "2.0.0-beta.1",
     "@parcel/watcher": "2.0.0-alpha.8",
     "@parcel/workers": "2.0.0-beta.1",
+    "graceful-fs": "^4.2.4",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
     "nullthrows": "^1.1.1",

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -9,7 +9,7 @@ import type {
   AsyncSubscription,
 } from '@parcel/watcher';
 
-import fs from 'fs';
+import fs from 'graceful-fs';
 import ncp from 'ncp';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -6,7 +6,12 @@ import type {AnsiDiagnosticResult} from '@parcel/utils';
 import type {ServerError, HMRServerOptions} from './types.js.flow';
 
 import WebSocket from 'ws';
-import {md5FromObject, prettyDiagnostic, ansiHtml} from '@parcel/utils';
+import {
+  ansiHtml,
+  md5FromObject,
+  prettyDiagnostic,
+  PromiseQueue,
+} from '@parcel/utils';
 
 type HMRAsset = {|
   id: string,
@@ -28,6 +33,8 @@ type HMRMessage =
         html: Array<AnsiDiagnosticResult>,
       |},
     |};
+
+const FS_CONCURRENCY = 64;
 
 export default class HMRServer {
   wss: typeof WebSocket.Server;
@@ -102,8 +109,9 @@ export default class HMRServer {
     let changedAssets = Array.from(event.changedAssets.values());
     if (changedAssets.length === 0) return;
 
-    let assets = await Promise.all(
-      changedAssets.map(async asset => {
+    let queue = new PromiseQueue({maxConcurrent: FS_CONCURRENCY});
+    for (let asset of changedAssets) {
+      queue.add(async () => {
         let dependencies = event.bundleGraph.getDependencies(asset);
         let depsByBundle = {};
         for (let bundle of event.bundleGraph.findBundlesWithAsset(asset)) {
@@ -129,9 +137,10 @@ export default class HMRServer {
           envHash: md5FromObject(asset.env),
           depsByBundle,
         };
-      }),
-    );
+      });
+    }
 
+    let assets = await queue.run();
     this.broadcast({
       type: 'update',
       assets: assets,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6913,6 +6913,11 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
+graceful-fs@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
 grapheme-breaker@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/grapheme-breaker/-/grapheme-breaker-0.3.2.tgz#5b9e6b78c3832452d2ba2bb1cb830f96276410ac"


### PR DESCRIPTION
This:

* Uses the graceful-fs package in place of the built-in fs module in `NodeFS`. graceful-fs queues calls and retries on EMFILE.
* Throttles the number of concurrent `asset.getCode()` calls in the HMRServer by using a PromiseQueue with a maximum concurrency limit, currently limited to 64 (macOS currently has a fairly low per-process fd limit of 256). `asset.getCode()` internally uses `fs.createReadStream()` through `Cache.getStream()`. 
  * **Note**: In my testing, graceful-fs was not sufficient to address excessive file handles and this queue in the HMRServer was necessary, as Node `require`'s own file reading threw an EMFILE.
  * **Question**: Should this happen in the Cache or even NodeFS instead?

