### PR TITLE
Don't retransform when unset env vars remain unchanged

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -2,13 +2,12 @@
 
 import type {
   AsyncSubscription,
-  BundleGraph as IBundleGraph,
   BuildEvent,
+  BuildSuccessEvent,
   EnvironmentOpts,
   FilePath,
   InitialParcelOptions,
   ModuleSpecifier,
-  NamedBundle as INamedBundle,
 } from '@parcel/types';
 import type {AssetRequestResult, ParcelOptions} from './types';
 import type {FarmOptions} from '@parcel/workers';
@@ -163,7 +162,7 @@ export default class Parcel {
     this.#initialized = true;
   }
 
-  async run(): Promise<IBundleGraph<INamedBundle>> {
+  async run(): Promise<BuildSuccessEvent> {
     let startTime = Date.now();
     if (!this.#initialized) {
       await this.init();
@@ -184,7 +183,7 @@ export default class Parcel {
       throw new BuildError(result.diagnostics);
     }
 
-    return result.bundleGraph;
+    return result;
   }
 
   async startNextBuild() {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -26,7 +26,7 @@ type GlobNode = {|id: string, +type: 'glob', value: Glob|};
 type EnvNode = {|
   id: string,
   +type: 'env',
-  value: {|key: string, value: string|},
+  value: {|key: string, value: string | void|},
 |};
 
 type Request<TInput, TResult> = {|
@@ -93,7 +93,7 @@ const nodeFromRequest = (request: StoredRequest) => ({
   value: request,
 });
 
-const nodeFromEnv = (env: string, value: string) => ({
+const nodeFromEnv = (env: string, value: string | void) => ({
   id: 'env:' + env,
   type: 'env',
   value: {
@@ -272,7 +272,7 @@ export class RequestGraph extends Graph<
     this.unpredicatableNodeIds.add(requestNode.id);
   }
 
-  invalidateOnEnvChange(requestId: string, env: string, value: string) {
+  invalidateOnEnvChange(requestId: string, env: string, value: string | void) {
     let requestNode = this.getRequestNode(requestId);
     let envNode = nodeFromEnv(env, value);
     if (!this.hasNode(envNode.id)) {
@@ -507,11 +507,7 @@ export default class RequestTracker {
         this.graph.invalidateOnFileUpdate(requestId, filePath),
       invalidateOnStartup: () => this.graph.invalidateOnStartup(requestId),
       invalidateOnEnvChange: env =>
-        this.graph.invalidateOnEnvChange(
-          requestId,
-          env,
-          this.options.env[env] || '',
-        ),
+        this.graph.invalidateOnEnvChange(requestId, env, this.options.env[env]),
       getInvalidations: () => this.graph.getInvalidations(requestId),
       storeResult: result => {
         this.storeResult(requestId, result);

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -1,12 +1,12 @@
 import assert from 'assert';
 import path from 'path';
-import {bundle, run, overlayFS, ncp} from '@parcel/test-utils';
+import {bundler, run, overlayFS, ncp} from '@parcel/test-utils';
 
 function runBundle() {
-  return bundle(path.join(__dirname, '/input/src/index.js'), {
+  return bundler(path.join(__dirname, '/input/src/index.js'), {
     inputFS: overlayFS,
     disableCache: false,
-  });
+  }).run();
 }
 
 async function testCache(update, integration) {
@@ -38,19 +38,19 @@ async function testCache(update, integration) {
 describe('cache', function() {
   it('should support updating a JS file', async function() {
     let b = await testCache(async b => {
-      assert.equal(await run(b), 4);
+      assert.equal(await run(b.bundleGraph), 4);
       await overlayFS.writeFile(
         path.join(__dirname, '/input/src/nested/test.js'),
         'export default 4',
       );
     });
 
-    assert.equal(await run(b), 6);
+    assert.equal(await run(b.bundleGraph), 6);
   });
 
   it('should support adding a dependency', async function() {
     let b = await testCache(async b => {
-      assert.equal(await run(b), 4);
+      assert.equal(await run(b.bundleGraph), 4);
       await overlayFS.writeFile(
         path.join(__dirname, '/input/src/nested/foo.js'),
         'export default 6',
@@ -61,7 +61,7 @@ describe('cache', function() {
       );
     });
 
-    assert.equal(await run(b), 8);
+    assert.equal(await run(b.bundleGraph), 8);
   });
 
   it('should error when deleting a file', async function() {
@@ -114,10 +114,10 @@ describe('cache', function() {
   describe('parcel config', function() {
     it('should support adding a .parcelrc', async function() {
       let b = await testCache(async b => {
-        assert.equal(await run(b), 4);
+        assert.equal(await run(b.bundleGraph), 4);
 
         let contents = await overlayFS.readFile(
-          b.getBundles()[0].filePath,
+          b.bundleGraph.getBundles()[0].filePath,
           'utf8',
         );
         assert(!contents.includes('TRANSFORMED CODE'));
@@ -134,7 +134,7 @@ describe('cache', function() {
       });
 
       let contents = await overlayFS.readFile(
-        b.getBundles()[0].filePath,
+        b.bundleGraph.getBundles()[0].filePath,
         'utf8',
       );
       assert(contents.includes('TRANSFORMED CODE'));
@@ -155,7 +155,7 @@ describe('cache', function() {
         },
         async update(b) {
           let contents = await overlayFS.readFile(
-            b.getBundles()[0].filePath,
+            b.bundleGraph.getBundles()[0].filePath,
             'utf8',
           );
           assert(contents.includes('TRANSFORMED CODE'));
@@ -170,12 +170,12 @@ describe('cache', function() {
       });
 
       let contents = await overlayFS.readFile(
-        b.getBundles()[0].filePath,
+        b.bundleGraph.getBundles()[0].filePath,
         'utf8',
       );
       assert(!contents.includes('TRANSFORMED CODE'));
 
-      assert.equal(await run(b), 4);
+      assert.equal(await run(b.bundleGraph), 4);
     });
 
     it('should support updating an extended .parcelrc', async function() {
@@ -200,7 +200,7 @@ describe('cache', function() {
         },
         async update(b) {
           let contents = await overlayFS.readFile(
-            b.getBundles()[0].filePath,
+            b.bundleGraph.getBundles()[0].filePath,
             'utf8',
           );
           assert(contents.includes('TRANSFORMED CODE'));
@@ -215,12 +215,12 @@ describe('cache', function() {
       });
 
       let contents = await overlayFS.readFile(
-        b.getBundles()[0].filePath,
+        b.bundleGraph.getBundles()[0].filePath,
         'utf8',
       );
       assert(!contents.includes('TRANSFORMED CODE'));
 
-      assert.equal(await run(b), 4);
+      assert.equal(await run(b.bundleGraph), 4);
     });
 
     it('should error when deleting an extended parcelrc', async function() {
@@ -247,7 +247,7 @@ describe('cache', function() {
             },
             async update(b) {
               let contents = await overlayFS.readFile(
-                b.getBundles()[0].filePath,
+                b.bundleGraph.getBundles()[0].filePath,
                 'utf8',
               );
               assert(contents.includes('TRANSFORMED CODE'));
@@ -277,7 +277,7 @@ describe('cache', function() {
         },
         async update(b) {
           let contents = await overlayFS.readFile(
-            b.getBundles()[0].filePath,
+            b.bundleGraph.getBundles()[0].filePath,
             'utf8',
           );
           assert(contents.includes('TRANSFORMED CODE'));
@@ -287,12 +287,12 @@ describe('cache', function() {
       });
 
       let contents = await overlayFS.readFile(
-        b.getBundles()[0].filePath,
+        b.bundleGraph.getBundles()[0].filePath,
         'utf8',
       );
       assert(!contents.includes('TRANSFORMED CODE'));
 
-      assert.equal(await run(b), 4);
+      assert.equal(await run(b.bundleGraph), 4);
     });
   });
 
@@ -311,7 +311,7 @@ describe('cache', function() {
           );
         },
         async update(b) {
-          assert.equal(await run(b), 'hi');
+          assert.equal(await run(b.bundleGraph), 'hi');
 
           await overlayFS.writeFile(
             path.join(__dirname, '/input/src/test.txt'),
@@ -320,7 +320,92 @@ describe('cache', function() {
         },
       });
 
-      assert.equal(await run(b), 'updated');
+      assert.equal(await run(b.bundleGraph), 'updated');
+    });
+
+    it('should not invalidate when a set environment variable does not change', async () => {
+      let b = await testCache({
+        async setup() {
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/.env'),
+            'TEST=hi',
+          );
+
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/src/index.js'),
+            'module.exports = process.env.TEST',
+          );
+        },
+        async update(b) {
+          assert.equal(await run(b.bundleGraph), 'hi');
+
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/.env'),
+            'TEST=hi',
+          );
+        },
+      });
+
+      assert.equal(await run(b.bundleGraph), 'hi');
+      assert.equal(b.changedAssets.size, 0);
+    });
+
+    it('should not invalidate when an environment variable remains unset', async () => {
+      let b = await testCache({
+        async setup() {
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/src/index.js'),
+            'module.exports = process.env.TEST',
+          );
+        },
+        async update(b) {
+          assert.equal(await run(b.bundleGraph), undefined);
+        },
+      });
+
+      assert.equal(await run(b.bundleGraph), undefined);
+      assert.equal(b.changedAssets.size, 0);
+    });
+
+    it('should invalidate when an environment variable becomes set', async () => {
+      let b = await testCache({
+        async setup() {
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/src/index.js'),
+            'module.exports = process.env.TEST',
+          );
+        },
+        async update(b) {
+          assert.equal(await run(b.bundleGraph), undefined);
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/.env'),
+            'TEST=hi',
+          );
+        },
+      });
+
+      assert.equal(await run(b.bundleGraph), 'hi');
+    });
+
+    it('should invalidate when an environment variable becomes unset', async () => {
+      let b = await testCache({
+        async setup() {
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/src/index.js'),
+            'module.exports = process.env.TEST',
+          );
+          await overlayFS.writeFile(
+            path.join(__dirname, '/input/.env'),
+            'TEST=hi',
+          );
+        },
+        async update(b) {
+          assert.equal(await run(b.bundleGraph), 'hi');
+          await overlayFS.writeFile(path.join(__dirname, '/input/.env'), '');
+        },
+      });
+
+      assert.equal(await run(b.bundleGraph), undefined);
     });
 
     it('should invalidate when environment variables change', async function() {
@@ -337,7 +422,7 @@ describe('cache', function() {
           );
         },
         async update(b) {
-          assert.equal(await run(b), 'hi');
+          assert.equal(await run(b.bundleGraph), 'hi');
 
           await overlayFS.writeFile(
             path.join(__dirname, '/input/.env'),
@@ -346,7 +431,7 @@ describe('cache', function() {
         },
       });
 
-      assert.equal(await run(b), 'updated');
+      assert.equal(await run(b.bundleGraph), 'updated');
     });
   });
 
@@ -410,7 +495,7 @@ describe('cache', function() {
     it('should support updating files added by runtimes', async function() {
       let b = await testCache(async b => {
         let contents = await overlayFS.readFile(
-          b.getBundles()[0].filePath,
+          b.bundleGraph.getBundles()[0].filePath,
           'utf8',
         );
         assert(contents.includes('INITIAL CODE'));
@@ -421,7 +506,7 @@ describe('cache', function() {
       }, 'runtime-update');
 
       let contents = await overlayFS.readFile(
-        b.getBundles()[0].filePath,
+        b.bundleGraph.getBundles()[0].filePath,
         'utf8',
       );
       assert(contents.includes('UPDATED CODE'));

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -2,6 +2,7 @@
 
 import type {
   BuildEvent,
+  BuildSuccessEvent,
   BundleGraph,
   FilePath,
   InitialParcelOptions,
@@ -118,7 +119,7 @@ export async function bundle(
   entries: FilePath | Array<FilePath>,
   opts?: InitialParcelOptions,
 ): Promise<BundleGraph<NamedBundle>> {
-  return nullthrows(await bundler(entries, opts).run());
+  return (await bundler(entries, opts).run()).bundleGraph;
 }
 
 export function getNextBuild(b: Parcel): Promise<BuildEvent> {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -2,7 +2,6 @@
 
 import type {
   BuildEvent,
-  BuildSuccessEvent,
   BundleGraph,
   FilePath,
   InitialParcelOptions,


### PR DESCRIPTION
Previously we defaulted to storing an empty string in the graph when an environment variable was not set, compared it against it being `undefined` on rebuild, and invalidated it.

This allows for `undefined` to be stored in the graph to represent an environment variable being unset (which is different from being set to the empty string).

This adds tests for this case, as well as for cases when environment variables change from being unset to set, and set to unset.

**Note**: To be able to test that no assets were transformed, `Parcel#run()` has been changed to return a `Promise<BuildSuccessEvent>`, which includes `changedAssets`. This is probably useful for users of Parcel's JS API as well.

Test Plan: `yarn test`