### PR TITLE
Tests and improvements to babel config invalidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "release": "lerna publish -y from-package --dist-tag=next --no-git-tag-version --no-push"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.7",
+    "@babel/core": "^7.12.0",
     "cross-env": "^7.0.0",
     "doctoc": "^1.4.0",
     "eslint": "^6.0.0",

--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -110,9 +110,7 @@ export default {
     },
     bundler: {
       type: 'string',
-      __validate: (validatePluginName('bundler', 'bundler'): (
-        val: string,
-      ) => void),
+      __validate: (validatePluginName('bundler', 'bundler'): string => void),
     },
     resolvers: (pipelineSchema('resolver', 'resolvers'): SchemaEntity),
     transformers: (mapPipelineSchema(

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -12,7 +12,7 @@
     "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.4",
+    "@babel/core": "^7.12.0",
     "@babel/plugin-syntax-export-default-from": "^7.2.0",
     "@babel/plugin-syntax-export-namespace-from": "^7.2.0",
     "@babel/plugin-syntax-module-attributes": "^7.10.4",

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -10,6 +10,7 @@ import {
   inputFS,
   ncp,
   workerFarm,
+  symlinkPrivilegeWarning,
 } from '@parcel/test-utils';
 import fs from 'fs';
 
@@ -863,80 +864,89 @@ describe('cache', function() {
       });
 
       it('should invalidate on startup when there are symlinked plugins', async function() {
-        let b = await testBabelCache({
-          // Babel's config loader only works with the node filesystem
-          inputFS,
-          outputFS: inputFS,
-          async setup() {
-            await inputFS.mkdirp(inputDir);
-            await inputFS.ncp(
-              path.join(__dirname, '/integration/cache'),
-              inputDir,
-            );
-            await inputFS.mkdirp(
-              path.join(inputDir, 'packages/babel-plugin-dummy'),
-            );
-            await inputFS.mkdirp(path.join(inputDir, 'node_modules'));
-            fs.symlinkSync(
-              path.join(inputDir, 'packages/babel-plugin-dummy'),
-              path.join(inputDir, 'node_modules/babel-plugin-dummy'),
-            );
-            await inputFS.writeFile(
-              path.join(inputDir, 'packages/babel-plugin-dummy/package.json'),
-              JSON.stringify({
-                name: 'babel-plugin-dummy',
-                version: '1.0.0',
-              }),
-            );
-            await inputFS.copyFile(
-              path.join(
-                __dirname,
-                '/integration/babelrc-custom/babel-plugin-dummy.js',
-              ),
-              path.join(inputDir, 'packages/babel-plugin-dummy/index.js'),
-            );
-            await inputFS.writeFile(
-              path.join(inputDir, '.babelrc'),
-              JSON.stringify({
-                plugins: ['babel-plugin-dummy'],
-              }),
-            );
-            await inputFS.writeFile(
-              path.join(inputDir, 'src/index.js'),
-              'console.log("REPLACE_ME")',
-            );
-          },
-          async update(b) {
-            let contents = await overlayFS.readFile(
-              b.bundleGraph.getBundles()[0].filePath,
-              'utf8',
-            );
-            assert(
-              contents.includes('hello there'),
-              'string should be replaced',
-            );
+        try {
+          let b = await testBabelCache({
+            // Babel's config loader only works with the node filesystem
+            inputFS,
+            outputFS: inputFS,
+            async setup() {
+              await inputFS.mkdirp(inputDir);
+              await inputFS.ncp(
+                path.join(__dirname, '/integration/cache'),
+                inputDir,
+              );
+              await inputFS.mkdirp(
+                path.join(inputDir, 'packages/babel-plugin-dummy'),
+              );
+              await inputFS.mkdirp(path.join(inputDir, 'node_modules'));
+              fs.symlinkSync(
+                path.join(inputDir, 'packages/babel-plugin-dummy'),
+                path.join(inputDir, 'node_modules/babel-plugin-dummy'),
+              );
+              await inputFS.writeFile(
+                path.join(inputDir, 'packages/babel-plugin-dummy/package.json'),
+                JSON.stringify({
+                  name: 'babel-plugin-dummy',
+                  version: '1.0.0',
+                }),
+              );
+              await inputFS.copyFile(
+                path.join(
+                  __dirname,
+                  '/integration/babelrc-custom/babel-plugin-dummy.js',
+                ),
+                path.join(inputDir, 'packages/babel-plugin-dummy/index.js'),
+              );
+              await inputFS.writeFile(
+                path.join(inputDir, '.babelrc'),
+                JSON.stringify({
+                  plugins: ['babel-plugin-dummy'],
+                }),
+              );
+              await inputFS.writeFile(
+                path.join(inputDir, 'src/index.js'),
+                'console.log("REPLACE_ME")',
+              );
+            },
+            async update(b) {
+              let contents = await overlayFS.readFile(
+                b.bundleGraph.getBundles()[0].filePath,
+                'utf8',
+              );
+              assert(
+                contents.includes('hello there'),
+                'string should be replaced',
+              );
 
-            let plugin = path.join(
-              inputDir,
-              'packages/babel-plugin-dummy/index.js',
-            );
-            let source = await inputFS.readFile(plugin, 'utf8');
-            await inputFS.writeFile(
-              plugin,
-              source.replace('hello there', 'replaced'),
-            );
+              let plugin = path.join(
+                inputDir,
+                'packages/babel-plugin-dummy/index.js',
+              );
+              let source = await inputFS.readFile(plugin, 'utf8');
+              await inputFS.writeFile(
+                plugin,
+                source.replace('hello there', 'replaced'),
+              );
 
-            await workerFarm.callAllWorkers('invalidateRequireCache', [
-              path.join(inputDir, 'packages/babel-plugin-dummy/index.js'),
-            ]);
-          },
-        });
+              await workerFarm.callAllWorkers('invalidateRequireCache', [
+                path.join(inputDir, 'packages/babel-plugin-dummy/index.js'),
+              ]);
+            },
+          });
 
-        let contents = await overlayFS.readFile(
-          b.bundleGraph.getBundles()[0].filePath,
-          'utf8',
-        );
-        assert(contents.includes('replaced'), 'string should be replaced');
+          let contents = await overlayFS.readFile(
+            b.bundleGraph.getBundles()[0].filePath,
+            'utf8',
+          );
+          assert(contents.includes('replaced'), 'string should be replaced');
+        } catch (e) {
+          if (e.code == 'EPERM') {
+            symlinkPrivilegeWarning();
+            this.skip();
+          } else {
+            throw e;
+          }
+        }
       });
     });
   });

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -50,6 +50,7 @@ async function deleteInputDir() {
 
 async function testCache(update: UpdateFn | TestConfig, integration) {
   // Delete cache from previous test and perform initial build
+  await deleteInputDir();
   await overlayFS.rimraf(path.join(__dirname, '/input'));
   await ncp(
     path.join(__dirname, '/integration', integration ?? 'cache'),
@@ -81,8 +82,6 @@ async function testCache(update: UpdateFn | TestConfig, integration) {
 }
 
 describe('cache', function() {
-  before(deleteInputDir);
-
   it('should support updating a JS file', async function() {
     let b = await testCache(async b => {
       assert.equal(await run(b.bundleGraph), 4);
@@ -161,8 +160,6 @@ describe('cache', function() {
       {name: 'babel.config.cjs', formatter: cjs, nesting: false},
       // {name: 'babel.config.mjs', formatter: mjs, nesting: false}
     ];
-
-    beforeEach(deleteInputDir);
 
     let testBabelCache = async (opts: TestConfig) => {
       await workerFarm.callAllWorkers('invalidateRequireCache', [

--- a/packages/core/integration-tests/test/integration/cache/src/index.js
+++ b/packages/core/integration-tests/test/integration/cache/src/index.js
@@ -1,3 +1,9 @@
 import test from './nested/test';
 
-module.exports = test + 2;
+class Result {
+  constructor(value) {
+    this.value = value;
+  }
+}
+
+module.exports = new Result(test + 2).value;

--- a/packages/core/integration-tests/test/integration/runtime-update/node_modules/parcel-runtime-mock/index.js
+++ b/packages/core/integration-tests/test/integration/runtime-update/node_modules/parcel-runtime-mock/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = new Runtime({
   apply() {
     return [{
-      filePath: path.resolve(__dirname, '../../../input/MockRuntime.js'),
+      filePath: path.resolve(__dirname, '../../MockRuntime.js'),
       code: `let x = require('./dynamic-runtime'); console.log(x);`,
       isEntry: true
     }]

--- a/packages/core/is-v2-ready-yet/package.json
+++ b/packages/core/is-v2-ready-yet/package.json
@@ -19,7 +19,7 @@
     "victory": "^31.0.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.0",
+    "@babel/core": "^7.12.0",
     "@babel/plugin-proposal-class-properties": "^7.2.1",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0"

--- a/packages/core/register/example/package.json
+++ b/packages/core/register/example/package.json
@@ -7,7 +7,7 @@
     "start": "node ./index.js"
   },
   "dependencies": {
-    "@babel/core": "^7.2.0",
+    "@babel/core": "^7.12.0",
     "something": "1.0.0"
   }
 }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -9,6 +9,7 @@ import type {
   InitialParcelOptions,
   NamedBundle,
 } from '@parcel/types';
+import type WorkerFarm from '@parcel/workers';
 
 import invariant from 'assert';
 import util from 'util';
@@ -29,7 +30,7 @@ import _chalk from 'chalk';
 import resolve from 'resolve';
 import {NodePackageManager} from '@parcel/package-manager';
 
-const workerFarm = createWorkerFarm();
+export const workerFarm = (createWorkerFarm(): WorkerFarm);
 export const inputFS: NodeFS = new NodeFS();
 export let outputFS: MemoryFS = new MemoryFS(workerFarm);
 export let overlayFS: OverlayFS = new OverlayFS(outputFS, inputFS);

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -493,6 +493,26 @@ export default class WorkerFarm extends EventEmitter {
     });
   }
 
+  async callAllWorkers(method: string, args: Array<any>) {
+    let promises = [];
+    for (let worker of this.workers.values()) {
+      promises.push(
+        new Promise((resolve, reject) => {
+          worker.call({
+            method,
+            args,
+            resolve,
+            reject,
+            retries: 0,
+          });
+        }),
+      );
+    }
+
+    promises.push(this.localWorker[method](this.workerApi, ...args));
+    await Promise.all(promises);
+  }
+
   async takeHeapSnapshot() {
     let snapshotId = getTimeId();
 

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -16,6 +16,6 @@
     "read-pkg-up": "^4.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.7.0"
+    "@babel/core": "^7.12.0"
   }
 }

--- a/packages/dev/eslint-config-browser/index.js
+++ b/packages/dev/eslint-config-browser/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: '@parcel/eslint-config',
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {
     ecmaVersion: 5,
   },

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -8,7 +8,7 @@ module.exports = {
     'prettier/flowtype',
     'prettier/react',
   ],
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   plugins: ['@parcel', 'flowtype', 'import', 'monorepo', 'react', 'mocha'],
   parserOptions: {
     ecmaVersion: 2018,

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "2.0.0-beta.1",
   "dependencies": {
+    "@babel/eslint-parser": "^7.12.1",
     "@parcel/eslint-plugin": "2.0.0-beta.1",
-    "babel-eslint": "^10.0.1",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-flowtype": "^3.1.1",
     "eslint-plugin-import": "^2.16.0",

--- a/packages/dev/eslint-plugin/package.json
+++ b/packages/dev/eslint-plugin/package.json
@@ -8,7 +8,7 @@
     "read-pkg-up": "^5.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^10.0.1",
+    "@babel/eslint-parser": "^7.12.1",
     "eslint": "^5.16.0"
   }
 }

--- a/packages/dev/eslint-plugin/test/rules/no-self-package-imports.test.js
+++ b/packages/dev/eslint-plugin/test/rules/no-self-package-imports.test.js
@@ -9,7 +9,7 @@ const message =
 const filename = __filename;
 
 new RuleTester({
-  parser: 'babel-eslint',
+  parser: '@babel/eslint-parser',
   parserOptions: {ecmaVersion: 2018, sourceType: 'module'},
 }).run('no-self-package-imports', rule, {
   valid: [

--- a/packages/dev/eslint-plugin/test/utils.test.js
+++ b/packages/dev/eslint-plugin/test/utils.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const path = require('path');
-const {parse} = require('babel-eslint');
+const {parse} = require('@babel/eslint-parser');
 const readPkgUp = require('read-pkg-up');
 
 const {

--- a/packages/reporters/cli/test/CLIReporter.test.js
+++ b/packages/reporters/cli/test/CLIReporter.test.js
@@ -39,7 +39,7 @@ describe('CLIReporter', () => {
   let stdoutOutput;
   let stderrOutput;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Stub these out to avoid writing noise to real stdio and to read from these
     // otherwise only writable streams
     originalStdout = process.stdout;
@@ -53,6 +53,13 @@ describe('CLIReporter', () => {
     let mockStderr = new PassThrough();
     mockStderr.on('data', d => (stderrOutput += stripAnsi(d.toString())));
     _setStdio(mockStdout, mockStderr);
+
+    await _report(
+      {
+        type: 'buildStart',
+      },
+      EMPTY_OPTIONS,
+    );
   });
 
   afterEach(() => {

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -23,6 +23,6 @@
     "@parcel/plugin": "2.0.0-beta.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.2.2"
+    "@babel/core": "^7.12.2"
   }
 }

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -20,7 +20,7 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.12.0",
     "@babel/generator": "^7.0.0",
     "@babel/helper-compilation-targets": "^7.8.4",
     "@babel/plugin-transform-flow-strip-types": "^7.0.0",

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -20,7 +20,7 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.12.0",
     "@babel/generator": "^7.0.0",
     "@babel/parser": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.0.0",

--- a/packages/transformers/postcss/src/PostCSSTransformer.js
+++ b/packages/transformers/postcss/src/PostCSSTransformer.js
@@ -123,13 +123,6 @@ export default (new Transformer({
     });
     for (let msg of messages) {
       if (msg.type === 'dependency') {
-        msg = (msg: {|
-          type: 'dependency',
-          plugin: string,
-          file: string,
-          parent: string,
-        |});
-
         asset.addIncludedFile(msg.file);
       }
     }

--- a/packages/utils/babel-plugin-transform-runtime/package.json
+++ b/packages/utils/babel-plugin-transform-runtime/package.json
@@ -22,7 +22,7 @@
     "semver": "^5.4.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.4",
+    "@babel/core": "^7.12.0",
     "@parcel/babel-preset-env": "2.0.0-beta.1"
   }
 }

--- a/packages/utils/babel-preset-env/package.json
+++ b/packages/utils/babel-preset-env/package.json
@@ -22,9 +22,9 @@
     "semver": "^5.4.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.4"
+    "@babel/core": "^7.12.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.12.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,6 +99,15 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/eslint-parser@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.12.1.tgz#b3ae38e6174d2d0d2d00d2dcd919b4086b6bb8f0"
+  integrity sha512-cc7WQHnHQY3++/bghgbDtPx+5bf6xTsokyGzV6Qzh65NLz/unv+mPQuACkQ9GFhIhcTFv6yqwNaEcfX7EkOEsg==
+  dependencies:
+    eslint-scope "5.1.0"
+    eslint-visitor-keys "^1.3.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.3.3", "@babel/generator@^7.4.4", "@babel/generator@^7.8.0":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
@@ -2851,18 +2860,6 @@ babel-code-frame@^6.26.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
-
-babel-eslint@^10.0.1:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"
-  integrity sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.0.0"
-    "@babel/traverse" "^7.0.0"
-    "@babel/types" "^7.0.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
 
 babel-generator@^6.18.0:
   version "6.26.1"
@@ -5707,6 +5704,14 @@ eslint-plugin-react@^7.12.0:
     prop-types "^15.7.2"
     resolve "^1.14.2"
 
+eslint-scope@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
+  integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -5734,6 +5739,11 @@ eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint@^5.16.0:
   version "5.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,29 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.2.0", "@babel/core@^7.2.2", "@babel/core@^7.4.4", "@babel/core@^7.7.0", "@babel/core@^7.8.7":
+"@babel/core@^7.12.0", "@babel/core@^7.12.2":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
+  integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.1"
+    "@babel/parser" "^7.12.3"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.4.4":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -77,7 +99,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.3.3", "@babel/generator@^7.4.4", "@babel/generator@^7.8.0", "@babel/generator@^7.9.0", "@babel/generator@^7.9.5":
+"@babel/generator@^7.0.0", "@babel/generator@^7.3.3", "@babel/generator@^7.4.4", "@babel/generator@^7.8.0":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
   integrity sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
@@ -85,6 +107,15 @@
     "@babel/types" "^7.9.5"
     jsesc "^2.5.1"
     lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.12.1", "@babel/generator@^7.9.0", "@babel/generator@^7.9.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.1.tgz#0d70be32bdaa03d7c51c8597dda76e0df1f15468"
+  integrity sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==
+  dependencies:
+    "@babel/types" "^7.12.1"
+    jsesc "^2.5.1"
     source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.8.3":
@@ -168,7 +199,16 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-function-name@^7.8.3", "@babel/helper-function-name@^7.9.5":
+"@babel/helper-function-name@^7.10.4", "@babel/helper-function-name@^7.9.5":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
+"@babel/helper-function-name@^7.8.3":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
   integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
@@ -177,12 +217,12 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.9.5"
 
-"@babel/helper-get-function-arity@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
-  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+"@babel/helper-get-function-arity@^7.10.4", "@babel/helper-get-function-arity@^7.8.3":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-hoist-variables@^7.8.3":
   version "7.8.3"
@@ -191,39 +231,41 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-member-expression-to-functions@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
-  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+"@babel/helper-member-expression-to-functions@^7.12.1", "@babel/helper-member-expression-to-functions@^7.8.3":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz#fba0f2fcff3fba00e6ecb664bb5e6e26e2d6165c"
+  integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-module-imports@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
-  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+"@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.8.3":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz#1644c01591a15a2f084dd6d092d9430eb1d1216c"
+  integrity sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-module-transforms@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
-  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.9.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
+  integrity sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
   dependencies:
-    "@babel/helper-module-imports" "^7.8.3"
-    "@babel/helper-replace-supers" "^7.8.6"
-    "@babel/helper-simple-access" "^7.8.3"
-    "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/template" "^7.8.6"
-    "@babel/types" "^7.9.0"
-    lodash "^4.17.13"
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-simple-access" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    lodash "^4.17.19"
 
-"@babel/helper-optimise-call-expression@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
-  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+"@babel/helper-optimise-call-expression@^7.10.4", "@babel/helper-optimise-call-expression@^7.8.3":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
+  integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-plugin-utils@7.8.0":
   version "7.8.0"
@@ -258,7 +300,17 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-replace-supers@^7.8.3", "@babel/helper-replace-supers@^7.8.6":
+"@babel/helper-replace-supers@^7.12.1", "@babel/helper-replace-supers@^7.8.6":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz#f15c9cc897439281891e11d5ce12562ac0cf3fa9"
+  integrity sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
+    "@babel/helper-optimise-call-expression" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+
+"@babel/helper-replace-supers@^7.8.3":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
   integrity sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
@@ -268,20 +320,19 @@
     "@babel/traverse" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/helper-simple-access@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
-  integrity sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
+"@babel/helper-simple-access@^7.12.1", "@babel/helper-simple-access@^7.8.3":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
+  integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
   dependencies:
-    "@babel/template" "^7.8.3"
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-split-export-declaration@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
-  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+"@babel/helper-split-export-declaration@^7.11.0", "@babel/helper-split-export-declaration@^7.8.3":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
+  integrity sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.11.0"
 
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
@@ -298,7 +349,16 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helpers@^7.8.0", "@babel/helpers@^7.9.0":
+"@babel/helpers@^7.12.1", "@babel/helpers@^7.9.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.1.tgz#8a8261c1d438ec18cb890434df4ec768734c1e79"
+  integrity sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==
+  dependencies:
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+
+"@babel/helpers@^7.8.0":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
   integrity sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
@@ -316,10 +376,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.10.4", "@babel/parser@^7.4.4", "@babel/parser@^7.8.0", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.4.4", "@babel/parser@^7.8.0", "@babel/parser@^7.8.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
+
+"@babel/parser@^7.10.4", "@babel/parser@^7.12.1", "@babel/parser@^7.12.3", "@babel/parser@^7.9.0":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
+  integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -966,7 +1031,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.8.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
+"@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.8.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
   integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
@@ -975,7 +1040,7 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.2.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.8.0", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.2.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.8.0", "@babel/traverse@^7.8.3":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.5.tgz#6e7c56b44e2ac7011a948c21e283ddd9d9db97a2"
   integrity sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==
@@ -990,10 +1055,34 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.8.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
+  integrity sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/types@^7.0.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.8.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
+  integrity sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -4906,7 +4995,7 @@ debug-log@^1.0.1:
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
   integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
-debug@*, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@*, debug@^4.0.1, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -4933,6 +5022,13 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -9488,7 +9584,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -12175,10 +12271,17 @@ resolve@^0.6.1:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
   integrity sha1-3ZV5gufnNt699TtYpN2RdUV13UY=
 
-resolve@^1.0.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
+resolve@^1.0.0, resolve@^1.1.5, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
   integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.3.2:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
Fixes #1359. Closes T-652.

This improves babel config invalidation and adds cache tests. Most of this depends on https://github.com/babel/babel/pull/11907 which was released in Babel v7.12. This gives us a full list of all files that affected a babel config, including extended configs and ignore files. If we detect an earlier version of babel core, we invalidate on startup and log a warning to let the user know to upgrade. This also implements invalidation on startup for symlinked babel plugins.

The warnings we previously had in the babel transformer weren't really visible to most users because they were logged as verbose. I've changed these to actual warnings so people will be more likely to see them. I've also implemented warning deduplication in the CLI reporter so that the same warning won't be logged for every single file in a build. I think this is probably ok because the number of distinct warnings we actually emit is pretty low.