### PR TITLE
Change cli autoinstall default to false (not properly tested)

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -56,7 +56,7 @@ if (typeof process.env.PARCEL_BUILD_ENV === 'string') {
 
 program.version(version);
 
-// --no-cache, --cache-dir, --no-source-maps, --no-autoinstall, --global?, --public-url, --log-level
+// --no-cache, --cache-dir, --no-source-maps, --autoinstall, --global?, --public-url, --log-level
 // --no-content-hash, --experimental-scope-hoisting, --detailed-report
 
 const commonOptions = {
@@ -97,7 +97,7 @@ var hmrOptions = {
   '--https': 'serves files over HTTPS',
   '--cert <path>': 'path to certificate to use with HTTPS',
   '--key <path>': 'path to private key to use with HTTPS',
-  '--no-autoinstall': 'disable autoinstall',
+  '--autoinstall': 'enable autoinstall, no effect in production modes',
   '--hmr-port <port>': 'hot module replacement port',
 };
 
@@ -366,7 +366,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     contentHash: hmr ? false : command.contentHash,
     serve,
     targets: command.target.length > 0 ? command.target : null,
-    autoinstall: command.autoinstall ?? true,
+    autoinstall: command.autoinstall ?? false,
     logLevel: command.logLevel,
     profile: command.profile,
     detailedReport: command.detailedReport,


### PR DESCRIPTION
# ↪️ Pull Request

#4298 and #2081.

Reverses the default for autoinstall in the cli to be disabled by default, and enabled for non-production builds with `--autoinstall`.

Changes are not properly tested, and were made naively. But maybe enough to get the ball rolling.

There are also some documentation changes which should go along with this.

## 💻 Examples

`parcel index.html` Now never autoinstalls

`parcel index.html --autoinstall` now autoinstalls

## 🚨 Test instructions

I was unfortunately... not able to get autoinstall to work at all? Neither following the example instructions in CONTRIBUTING.md nor just installing parcel@2.0.0-beta.1 in completely separate project lead to a successful autoinstall.

That would actually put the cli doing what I'd want already, but this PR (blindly) makes that an official change.

I unfortunately ran out of time to continue attempting to get some solidly tested working stuff. The existing tests seem to pass locally fwiw though.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
