### PR TITLE
Create heap snapshots with ctrl-y

### DIFF
--- a/flow-libs/inspector.js.flow
+++ b/flow-libs/inspector.js.flow
@@ -2,9 +2,13 @@
 
 // based on https://nodejs.org/api/inspector.html
 declare module 'inspector' {
-  declare export class Session {
+  declare export class Session extends events$EventEmitter {
     connect(): void;
     disconnect(): void;
-    post(method: string, params?: mixed, callback?: (err: Error, result: any) => void): void;
+    post(
+      method: string,
+      params?: mixed,
+      callback?: (err: Error, result: any) => void,
+    ): void;
   }
 }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -426,6 +426,11 @@ export default class Parcel {
     this.isProfiling = false;
     return this.#farm.endProfile();
   }
+
+  takeHeapSnapshot(): Promise<void> {
+    logger.info({origin: '@parcel/core', message: 'Taking heap snapshot...'});
+    return this.#farm.takeHeapSnapshot();
+  }
 }
 
 export class BuildError extends ThrowableDiagnostic {

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -258,6 +258,9 @@ async function run(entries: Array<string>, command: any) {
             ? parcel.stopProfiling()
             : parcel.startProfiling());
           break;
+        case 'y':
+          await parcel.takeHeapSnapshot();
+          break;
       }
     });
 

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -21,6 +21,7 @@ import {
   serialize,
 } from '@parcel/core';
 import ThrowableDiagnostic, {anyToDiagnostic} from '@parcel/diagnostic';
+import {escapeMarkdown} from '@parcel/utils';
 import Worker, {type WorkerCall} from './Worker';
 import cpuCount from './cpuCount';
 import Handle from './Handle';
@@ -31,7 +32,6 @@ import Trace from './Trace';
 import fs from 'fs';
 import logger from '@parcel/logger';
 
-let profileId = 1;
 let referenceId = 1;
 
 export opaque type SharedReference = number;
@@ -474,7 +474,7 @@ export default class WorkerFarm extends EventEmitter {
 
     var profiles = await Promise.all(promises);
     let trace = new Trace();
-    let filename = `profile-${profileId++}.trace`;
+    let filename = `profile-${getTimeId()}.trace`;
     let stream = trace.pipe(fs.createWriteStream(filename));
 
     for (let profile of profiles) {
@@ -488,8 +488,42 @@ export default class WorkerFarm extends EventEmitter {
 
     logger.info({
       origin: '@parcel/workers',
-      message: `Wrote profile to ${filename}`,
+      message: escapeMarkdown(`Wrote profile to ${filename}`),
     });
+  }
+
+  async takeHeapSnapshot() {
+    let snapshotId = getTimeId();
+
+    try {
+      let snapshotPaths = await Promise.all(
+        [...this.workers.values()].map(
+          worker =>
+            new Promise((resolve, reject) => {
+              worker.call({
+                method: 'takeHeapSnapshot',
+                args: [snapshotId],
+                resolve,
+                reject,
+                retries: 0,
+              });
+            }),
+        ),
+      );
+
+      logger.info({
+        origin: '@parcel/workers',
+        message: escapeMarkdown(
+          'Wrote heap snapshots to the following paths:\n' +
+            snapshotPaths.join('\n'),
+        ),
+      });
+    } catch {
+      logger.error({
+        origin: '@parcel/workers',
+        message: 'Unable to take heap snapshots. Note: requires Node 11.13.0+',
+      });
+    }
   }
 
   static getNumWorkers(): number {
@@ -522,4 +556,17 @@ export default class WorkerFarm extends EventEmitter {
   static getConcurrentCallsPerWorker(): number {
     return parseInt(process.env.PARCEL_MAX_CONCURRENT_CALLS, 10) || 5;
   }
+}
+
+function getTimeId() {
+  let now = new Date();
+  return (
+    String(now.getFullYear()) +
+    String(now.getMonth() + 1).padStart(2, '0') +
+    String(now.getDate()).padStart(2, '0') +
+    '-' +
+    String(now.getHours()).padStart(2, '0') +
+    String(now.getMinutes()).padStart(2, '0') +
+    String(now.getSeconds()).padStart(2, '0')
+  );
 }

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -150,6 +150,22 @@ export class Child {
       } catch (e) {
         result = errorResponseFromError(e);
       }
+    } else if (method === 'takeHeapSnapshot') {
+      try {
+        let v8 = require('v8');
+        result = responseFromContent(
+          // $FlowFixMe
+          v8.writeHeapSnapshot(
+            'heap-' +
+              args[0] +
+              '-' +
+              (this.childId ? 'worker' + this.childId : 'main') +
+              '.heapsnapshot',
+          ),
+        );
+      } catch (e) {
+        result = errorResponseFromError(e);
+      }
     } else if (method === 'createSharedReference') {
       let [ref, value] = args;
       this.sharedReferences.set(ref, value);

--- a/packages/examples/kitchen-sink/src/async.js
+++ b/packages/examples/kitchen-sink/src/async.js
@@ -4,6 +4,3 @@ console.log(require('react'));
 require('lodash');
 
 class Foo {}
-
-import('./preloaded', {preload: true});
-import('./prefetched', {prefetch: true});


### PR DESCRIPTION
This adds the capability of taking a heap snapshot while Parcel is running by using the ctrl-y keybinding. It asks each worker to do so using Node's `v8.writeHeapSnapshot()` [0] and produces files in pwd like `heap-20201027-184546-main.heapsnapshot` for the main thread and `heap-20201027-184546-worker1.heapsnapshot` for workers. This also updates cpu profiles to use time-based ids. Identifying this way avoids overwriting prior profiles or heap snapshots and is what `v8.writeHeapSnapshot()` uses by default — `yyyymmdd-hhmmss` [0].

Requires Node 11.13.0 (see [0]).

Test Plan: 
* Press ctrl-y while running the kitchen sink and verify heap snapshot files are produced. Load some in Chrome DevTools to confirm they are valid.
* Using Node 10, press ctrl-y while running the kitchen sink example. Verify an error is shown.

[0] https://nodejs.org/api/v8.html#v8_v8_writeheapsnapshot_filename