### PR TITLE
Disables stdin raw mode on exit #5291

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -208,6 +208,11 @@ async function run(entries: Array<string>, command: any) {
       await parcel.stopProfiling();
     }
 
+    if (process.stdin.isTTY && process.stdin.isRaw) {
+      // $FlowFixMe
+      process.stdin.setRawMode(false);
+    }
+
     disposable.dispose();
     process.exit(exitCode);
   }


### PR DESCRIPTION
# ↪️ Pull Request
Fix #5291 

Since stdin [switched into raw mode](https://github.com/parcel-bundler/parcel/blob/v2/packages/core/parcel/src/cli.js#L218) it is necessary to switch it back on exit, otherwise it creates terminal side effects, etc

## 💻 Examples

## 🚨 Test instructions

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs