### PR TITLE
Make sure Handle is registered with the serializer

### DIFF
--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -18,7 +18,10 @@ import Logger, {patchConsole, unpatchConsole} from '@parcel/logger';
 import ThrowableDiagnostic, {anyToDiagnostic} from '@parcel/diagnostic';
 import bus from './bus';
 import Profiler from './Profiler';
-import Handle from './Handle';
+import _Handle from './Handle';
+
+// The import of './Handle' should really be imported eagerly (with @babel/plugin-transform-modules-commonjs's lazy mode).
+const Handle = _Handle;
 
 type ChildCall = WorkerRequest & {|
   resolve: (result: Promise<any> | any) => void,


### PR DESCRIPTION
Regression from https://github.com/parcel-bundler/parcel/pull/5109.

Outputting to a MemoryFS was broken because this wasn't called in time in the worker child: https://github.com/parcel-bundler/parcel/blob/a2dc60f2d204bbba1237a8524821338e0cde9e83/packages/core/workers/src/Handle.js#L48

I couldn't find a better way of opting out of lazy mode for a single import.