### PR TITLE
@babel/preset-env flow typings

### DIFF
--- a/flow-libs/babel-preset-env.js.flow
+++ b/flow-libs/babel-preset-env.js.flow
@@ -1,8 +1,6 @@
 // @flow strict-local
 
 declare module '@babel/preset-env' {
-  declare type assertVersionCb = () => boolean;
-
   declare export type Targets = {
     browsers?: string | Array<string>,
     esmodules?: boolean,
@@ -13,7 +11,7 @@ declare module '@babel/preset-env' {
   declare export type PresetEnvPlugin = [mixed, mixed];
 
   declare export default (
-    {assertVersion: assertVersionCb, ...},
+    {assertVersion: () => boolean, ...},
     {targets: Targets, ...},
   ) => {plugins: Array<PresetEnvPlugin>, ...};
 }

--- a/flow-libs/babel-preset-env.js.flow
+++ b/flow-libs/babel-preset-env.js.flow
@@ -3,7 +3,7 @@
 declare module '@babel/preset-env' {
   declare type assertVersionCb = () => boolean;
 
-  declare type BabelTargets = {
+  declare export type BabelTargets = {
     browsers?: string | Array<string>,
     esmodules?: boolean,
     [string]: string,

--- a/flow-libs/babel-preset-env.js.flow
+++ b/flow-libs/babel-preset-env.js.flow
@@ -10,10 +10,10 @@ declare module '@babel/preset-env' {
     ...
   };
 
-  declare export type PresetEnvPlugins = [PresetEnvPlugin, PresetOpts];
+  declare export type PresetEnvPlugin = [mixed, mixed];
 
   declare export default (
     {assertVersion: assertVersionCb, ...},
     {targets: Targets, ...},
-  ) => {plugins: Array<PresetEnvPlugins>, ...};
+  ) => {plugins: Array<PresetEnvPlugin>, ...};
 }

--- a/flow-libs/babel-preset-env.js.flow
+++ b/flow-libs/babel-preset-env.js.flow
@@ -1,0 +1,17 @@
+// @flow strict-local
+
+declare module '@babel/preset-env' {
+  declare type assertVersionCb = () => boolean;
+
+  declare type BabelTargets = {
+    browsers?: string | Array<string>,
+    esmodules?: boolean,
+    [string]: string,
+    ...
+  };
+
+  declare export default (
+    {assertVersion: assertVersionCb, ...},
+    {targets: BabelTargets, ...},
+  ) => {plugins: Array<any>, ...};
+}

--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -1545,3 +1545,7 @@ export default new Validator({
 ```
 
 If your plugin implements `validateAll`, Parcel will make sure to always invoke this method on the same thread (so that your cache state is accessible).
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/parcel-bundler/parcel/blob/v2/LICENSE) file for details

--- a/packages/transformers/babel/src/env.js
+++ b/packages/transformers/babel/src/env.js
@@ -1,9 +1,8 @@
 // @flow strict-local
 
 import type {Config} from '@parcel/types';
-import type {BabelTargets} from './types';
-
 import presetEnv from '@babel/preset-env';
+import type {BabelTargets} from '@babel/preset-env';
 
 import getBabelTargets from './getBabelTargets';
 import {enginesToBabelTargets} from './utils';

--- a/packages/transformers/babel/src/env.js
+++ b/packages/transformers/babel/src/env.js
@@ -2,10 +2,7 @@
 
 import type {Config} from '@parcel/types';
 import presetEnv from '@babel/preset-env';
-import type {
-  Targets as BabelTargets,
-  PresetEnvPlugins,
-} from '@babel/preset-env';
+import type {Targets as BabelTargets, PresetEnvPlugin} from '@babel/preset-env';
 
 import getBabelTargets from './getBabelTargets';
 import {enginesToBabelTargets} from './utils';
@@ -65,7 +62,7 @@ export default async function getEnvOptions(
   };
 }
 
-function getNeededPlugins(targets: BabelTargets): Array<PresetEnvPlugins> {
+function getNeededPlugins(targets: BabelTargets): Array<PresetEnvPlugin> {
   return presetEnv(
     {assertVersion: () => true},
     {targets: targets},

--- a/packages/transformers/babel/src/env.js
+++ b/packages/transformers/babel/src/env.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict-local
 
 import type {Config} from '@parcel/types';
 import type {BabelTargets} from './types';

--- a/packages/transformers/babel/src/getBabelTargets.js
+++ b/packages/transformers/babel/src/getBabelTargets.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Config} from '@parcel/types';
-import type {BabelTargets} from './types';
+import type {BabelTargets} from '@babel/preset-env';
 
 import browserslist from 'browserslist';
 import semver from 'semver';

--- a/packages/transformers/babel/src/types.js
+++ b/packages/transformers/babel/src/types.js
@@ -4,10 +4,3 @@ export type BabelConfig = {|
   plugins?: Array<any>,
   presets?: Array<any>,
 |};
-
-export type BabelTargets = {
-  browsers?: string | Array<string>,
-  esmodules?: boolean,
-  [string]: string,
-  ...
-};

--- a/packages/transformers/babel/src/utils.js
+++ b/packages/transformers/babel/src/utils.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Environment} from '@parcel/types';
-import type {BabelTargets} from './types';
+import type {BabelTargets} from '@babel/preset-env';
 
 import invariant from 'assert';
 import semver from 'semver';


### PR DESCRIPTION
Test Plan:
- Ran `yarn flow` to verify there are no flow errors

Question: 

packages/utils/babel-preset-transform-runtime/test/babel-plugin-transform-runtime.test.js (in ticket) seems to use @parcel/babel-preset-env instead of @babel/preset-env. Not sure if I should do the same for this file?