### PR TITLE
flow typings for json-source-map

### DIFF
--- a/flow-libs/json-source-map.js.flow
+++ b/flow-libs/json-source-map.js.flow
@@ -1,0 +1,41 @@
+//@flow strict-local
+
+// Derived from the README and source of json-source-map located at
+// https://github.com/epoberezkin/json-source-map and
+// https://github.com/epoberezkin/json-source-map/blob/v0.6.1/index.js
+// Which is licensed MIT
+
+declare module 'json-source-map' {
+  declare type Position = {|
+    line: number,
+    column: number,
+    pos: number,
+  |};
+
+  declare export type Mapping = {|
+    value: Position,
+    valueEnd: Position,
+    key?: Position,
+    keyEnd?: Position,
+  |};
+
+  declare export default {|
+    parse: (
+      json: string,
+      _?: any,
+      opts?: {|bigint: boolean|},
+    ) => {|
+      data: {...},
+      pointers: {[key: string]: Mapping, ...},
+    |},
+
+    stringify: (
+      data: any,
+      _?: any,
+      space?: string | number | {|space: number, es6: boolean|},
+    ) => {|
+      json: string,
+      pointers: {[key: string]: Mapping, ...},
+    |},
+  |};
+}

--- a/flow-libs/json-source-map.js.flow
+++ b/flow-libs/json-source-map.js.flow
@@ -22,20 +22,20 @@ declare module 'json-source-map' {
   declare export default {|
     parse: (
       json: string,
-      _?: any,
+      _?: mixed,
       opts?: {|bigint: boolean|},
     ) => {|
-      data: {...},
-      pointers: {[key: string]: Mapping, ...},
+      data: mixed,
+      pointers: {|[key: string]: Mapping|},
     |},
 
     stringify: (
       data: any,
-      _?: any,
+      _?: mixed,
       space?: string | number | {|space: number, es6: boolean|},
     ) => {|
       json: string,
-      pointers: {[key: string]: Mapping, ...},
+      pointers: {|[key: string]: Mapping|},
     |},
   |};
 }

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -26,7 +26,6 @@ import createParcelConfigRequest from './ParcelConfigRequest';
 import ParcelConfig from '../ParcelConfig';
 // $FlowFixMe
 import browserslist from 'browserslist';
-// $FlowFixMe
 import jsonMap from 'json-source-map';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -2,9 +2,8 @@
 import type {FilePath} from '@parcel/types';
 
 import invariant from 'assert';
-// flowlint-next-line untyped-import:off
 import jsonMap from 'json-source-map';
-import nullthrows from 'nullthrows';
+import type {Mapping} from 'json-source-map';
 
 /** These positions are 1-based (so <code>1</code> is the first line/column) */
 export type DiagnosticHighlightLocation = {|
@@ -213,7 +212,7 @@ export function generateJSONCodeHighlights(
   // json-source-map doesn't support a tabWidth option (yet)
   let map = jsonMap.parse(code.replace(/\t/g, ' '));
   return ids.map(({key, type, message}) => {
-    let pos = nullthrows(map.pointers[key]);
+    let pos = map.pointers[key];
     return {
       ...getJSONSourceLocation(pos, type),
       message,
@@ -226,16 +225,7 @@ export function generateJSONCodeHighlights(
  * <code>result.pointers</code> array.
  */
 export function getJSONSourceLocation(
-  pos: {|
-    value: {|line: number, column: number|},
-    valueEnd: {|line: number, column: number|},
-    ...
-      | {||}
-      | {|
-          key: {|line: number, column: number|},
-          keyEnd: {|line: number, column: number|},
-        |},
-  |},
+  pos: Mapping,
   type?: ?'key' | 'value',
 ): {|
   start: DiagnosticHighlightLocation,
@@ -248,7 +238,7 @@ export function getJSONSourceLocation(
       end: {line: pos.valueEnd.line + 1, column: pos.valueEnd.column},
     };
   } else if (type == 'key' || !pos.value) {
-    invariant(pos.key);
+    invariant(pos.key && pos.keyEnd);
     return {
       start: {line: pos.key.line + 1, column: pos.key.column + 1},
       end: {line: pos.keyEnd.line + 1, column: pos.keyEnd.column},

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -2,6 +2,7 @@
 import type {FilePath} from '@parcel/types';
 
 import invariant from 'assert';
+import nullthrows from 'nullthrows';
 import jsonMap from 'json-source-map';
 import type {Mapping} from 'json-source-map';
 
@@ -212,7 +213,7 @@ export function generateJSONCodeHighlights(
   // json-source-map doesn't support a tabWidth option (yet)
   let map = jsonMap.parse(code.replace(/\t/g, ' '));
   return ids.map(({key, type, message}) => {
-    let pos = map.pointers[key];
+    let pos = nullthrows(map.pointers[key]);
     return {
       ...getJSONSourceLocation(pos, type),
       message,


### PR DESCRIPTION
**Test Plan**:
- verified that no flow errors are present

Note: Removed `nullthrows` from `packages/core/diagnostic/src/diagnostic.js` since these typings should guard against variable `pos` (line 216) from being null.
