### PR TITLE
bump node-forge to 0.10.0 because of CVE-2020-7720

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "json5": "^1.0.1",
     "micromatch": "^3.0.4",
     "mkdirp": "^0.5.1",
-    "node-forge": "^0.7.1",
+    "node-forge": "^0.10.0",
     "node-libs-browser": "^2.0.0",
     "opn": "^5.1.0",
     "ora": "^2.1.0",


### PR DESCRIPTION
https://github.com/advisories/GHSA-92xj-mqp7-vmcj

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
