### PR TITLE
fix: typescript createProgram doesn't support incremental mode

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/composite/add.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/composite/add.ts
@@ -1,0 +1,1 @@
+export const add = (a: number, b: number) => a + b;

--- a/packages/core/integration-tests/test/integration/ts-types/composite/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/composite/expected.d.ts
@@ -1,0 +1,3 @@
+export const add: (a: number, b: number) => number;
+
+//# sourceMappingURL=index.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/composite/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/composite/index.ts
@@ -1,0 +1,1 @@
+export * from './add';

--- a/packages/core/integration-tests/test/integration/ts-types/composite/package.json
+++ b/packages/core/integration-tests/test/integration/ts-types/composite/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ts-composite",
+  "private": true,
+  "main": "dist/main.js",
+  "types": "dist/index.d.ts"
+}

--- a/packages/core/integration-tests/test/integration/ts-types/composite/tsconfig.json
+++ b/packages/core/integration-tests/test/integration/ts-types/composite/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+  },
+  "files": [
+    "index.ts",
+    "add.ts"
+  ],
+  "references": []
+}

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -194,4 +194,22 @@ describe('typescript types', function() {
 
     assert(/import\s*{\s*B\s*}\s*from\s*"b";/.test(dist));
   });
+
+  it('should generate a typescript declaration file even when composite is true', async function() {
+    await bundle(
+      path.join(__dirname, '/integration/ts-types/composite/index.ts'),
+    );
+
+    let dist = (
+      await outputFS.readFile(
+        path.join(__dirname, '/integration/ts-types/composite/dist/index.d.ts'),
+        'utf8',
+      )
+    ).replace(/\r\n/g, '\n');
+    let expected = await inputFS.readFile(
+      path.join(__dirname, '/integration/ts-types/composite/expected.d.ts'),
+      'utf8',
+    );
+    assert.equal(dist, expected);
+  });
 });

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -39,6 +39,8 @@ export default (new Transformer({
       emitDeclarationOnly: true,
       outFile: 'index.d.ts',
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      // createProgram doesn't support incremental mode
+      composite: false,
     };
 
     let host = new CompilerHost(options.inputFS, ts, logger);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR solves https://github.com/parcel-bundler/parcel/issues/5344

`transformer-typescript-types` uses the typescript API through the `ts.createProgram` function. But this function is not meant to be used with [composite](https://www.typescriptlang.org/docs/handbook/project-references.html#composite). Indeed, the typescript's team provide another API specifically for this case: [`createIncrementalProgram`](https://github.com/microsoft/TypeScript/pull/31432).

Incremental build is irrelevant for Parcel here, but on the other hand the user could have a `tsconfig.json` with composite enabled, for instance to enable some `vscode` features (ie. project references). So we should make sure that `composite` is set to false.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
I provided an example repository to test the fix: https://github.com/paeolo/parcel-issue-5344. But the idea is juste to set `composite: true` in the `compilerOptions` and have a non-empty `index.d.ts` when you build.

## ✔️ PR Todo

- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
