### PR TITLE
Document more of the BundleGraph class

### DIFF
--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -267,6 +267,7 @@ export default class BundleGraph<TBundle: IBundle>
     );
   }
 
+  /** @returns the bundles in the graph that contain the asset */
   findBundlesWithAsset(asset: IAsset): Array<TBundle> {
     return this.#graph
       .findBundlesWithAsset(assetToAssetValue(asset))
@@ -275,6 +276,7 @@ export default class BundleGraph<TBundle: IBundle>
       );
   }
 
+  /** @returns the bundles in the graph that contain the dependency */
   findBundlesWithDependency(dependency: IDependency): Array<TBundle> {
     return this.#graph
       .findBundlesWithDependency(dependencyToInternalDependency(dependency))

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -119,6 +119,11 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
     return bundleGroup;
   }
 
+  /**
+   * Remove a bundle group from the graph. For each bundle currently in the
+   * group, if this is the only group it belongs to, remove the bundle from
+   * the graph as well.
+   */
   removeBundleGroup(bundleGroup: BundleGroup): void {
     this.#graph.removeBundleGroup(bundleGroup);
   }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -924,7 +924,7 @@ export interface MutableBundleGraph extends BundleGraph<Bundle> {
   getDependencyAssets(Dependency): Array<Asset>;
   /** Get Bundles that load this bundle asynchronously. */
   getParentBundlesOfBundleGroup(BundleGroup): Array<Bundle>;
-  /** @returns the total size of an asset along with its subgraph */
+  /** @returns the size of an asset and all assets in its subgraph */
   getTotalSize(Asset): number;
   /**
    * Recursively remove an asset and its dependencies to a bundle. Stops at
@@ -996,12 +996,13 @@ export interface BundleGraph<TBundle: Bundle> {
     | {|type: 'asset', value: Asset|}
   );
   /**
-   * @returns whether the dependency is deferred or not. Dependencies are deferred
-   *         if
+   * A dependency caused by a re-export can be deferred (skipped) if there is no
+   * incoming dependency that uses the re-exported value.
+   * @returns Whether the dependency was deferred.
    */
   isDependencyDeferred(dependency: Dependency): boolean;
   /**
-   * Get the resolved an asset for a dependency. This may or may not exist in
+   * Get the resolved asset for a dependency. This may or may not exist in
    * the current bundle.
    *
    * @param dep The dependency to resolve


### PR DESCRIPTION
This adds more docblocks to the public `BundleGraph` and `MutableBundleGraph` interfaces, as well as some methods of the internal `BundleGraph` class.