### PR TITLE
Resolve static member accesses on namespace imports

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/commonjs-external/multiple.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-external/multiple.js
@@ -1,4 +1,4 @@
 import _, {add} from 'lodash';
 import * as lodash from 'lodash';
 
-export const bar = _.add(add(1, 2), lodash.add(1, 2));
+export const bar = _.add(add(1, 2), lodash['ad'+'d'](1, 2));

--- a/packages/core/integration-tests/test/integration/formats/commonjs-external/namespace.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-external/namespace.js
@@ -1,3 +1,3 @@
 import * as _ from 'lodash';
 
-export const bar = _.add(1, 2);
+export const bar = _['ad'+'d'](1, 2);

--- a/packages/core/integration-tests/test/integration/formats/esm-external/multiple.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-external/multiple.js
@@ -1,4 +1,4 @@
 import _, {add} from 'lodash';
 import * as lodash from 'lodash';
 
-export const bar = _.add(add(1, 2), lodash.add(1, 2));
+export const bar = _.add(add(1, 2), lodash['ad'+'d'](1, 2));

--- a/packages/core/integration-tests/test/integration/formats/esm-external/namespace.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-external/namespace.js
@@ -1,3 +1,3 @@
 import * as _ from 'lodash';
 
-export const bar = _.add(1, 2);
+export const bar = _['ad'+'d'](1, 2);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-external/a.js
@@ -1,3 +1,5 @@
 import * as lodash from "./b";
 
-export default lodash.add(10,2);
+let x = lodash;
+
+export default x.add(10,2);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/a.js
@@ -1,3 +1,3 @@
-import * as test from './library';
+import * as test from './library/index.js';
 
-output = test.foo;
+output = test.foo + test['foobar'];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/a.js
@@ -1,0 +1,3 @@
+import * as test from './library';
+
+output = test.foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/c1.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/c1.js
@@ -1,0 +1,2 @@
+sideEffect("c1");
+export const foo = "foo";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/c2.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/c2.js
@@ -1,0 +1,2 @@
+sideEffect("c2");
+export const bar = "bar";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/c3.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/c3.js
@@ -1,0 +1,2 @@
+sideEffect("c3");
+export const foobar = "foobar";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/index.js
@@ -1,0 +1,2 @@
+export * from "./c1.js";
+export * from "./c2.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/index.js
@@ -1,2 +1,3 @@
 export * from "./c1.js";
 export * from "./c2.js";
+export * from "./c3.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/library/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace/a.js
@@ -1,3 +1,5 @@
 import * as test from './b';
 
-output = test.foo;
+let x = test;
+
+output = x.foo;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -913,14 +913,21 @@ describe('scope hoisting', function() {
         ),
       );
 
+      assert.deepStrictEqual(
+        new Set(
+          b.getUsedSymbols(findDependency(b, 'a.js', './library/index.js')),
+        ),
+        new Set(['foo', 'foobar']),
+      );
+
       let calls = [];
       let output = await run(b, {
         sideEffect: v => {
           calls.push(v);
         },
       });
-      assert.deepEqual(output, 'foo');
-      assert.deepEqual(calls, ['c1']);
+      assert.deepEqual(output, 'foofoobar');
+      assert.deepEqual(calls, ['c1', 'c3']);
     });
 
     it('supports importing a namespace from a wrapped module', async function() {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -905,6 +905,24 @@ describe('scope hoisting', function() {
       assert.deepEqual(await run(b), 4);
     });
 
+    it('supports resolving a static member access on a namespace', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-namespace-static-member/a.js',
+        ),
+      );
+
+      let calls = [];
+      let output = await run(b, {
+        sideEffect: v => {
+          calls.push(v);
+        },
+      });
+      assert.deepEqual(output, 'foo');
+      assert.deepEqual(calls, ['c1']);
+    });
+
     it('supports importing a namespace from a wrapped module', async function() {
       let b = await bundle(
         path.join(
@@ -920,7 +938,7 @@ describe('scope hoisting', function() {
       assert(!contents.includes('$parcel$exportWildcard'));
 
       let output = await run(b);
-      assert.deepEqual(await output, 1);
+      assert.deepEqual(output, 1);
     });
 
     it('supports importing a namespace from a transpiled CommonJS module', async function() {
@@ -932,7 +950,7 @@ describe('scope hoisting', function() {
       );
 
       let output = await run(b);
-      assert.deepEqual(await output, {
+      assert.deepEqual(output, {
         bar: 3,
         foo: 1,
       });


### PR DESCRIPTION
# ↪️ Pull Request

Depends on https://github.com/parcel-bundler/parcel/pull/4861

This is needed for my next PR and also excludes "c2" in this case:
```js
import * as test from './library';
console.log(test.foo);

// library/index.js ("sideEffects": false)
export * from "./c1.js";
export * from "./c2.js";

// library/c1.js ("sideEffects": false)
export const foo = "foo";

// library/c2.js ("sideEffects": false)
export const bar = "bar";
```

Works by actually resolving `test.foo` in the transformer, so the asset c2 can be excluded by symbol propagation.
`$index$exports.foo` was already being resolved previously in the linker, but this way, even more can be excluded up front, meaning less memory usage and faster builds.