### PR TITLE
Tree shake dynamic imports

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/esm-async-chained-reexport2/index.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-async-chained-reexport2/index.js
@@ -1,4 +1,4 @@
 import { createAndFireEvent } from "./library/b.js";
 var createAndFireEventOnAtlaskit = createAndFireEvent("index");
 output = import("./library/a.js")
-    .then((m) => m.c.then(c => [createAndFireEventOnAtlaskit(), m.default(), c.c, c.createAndFireEvent("c")()]));
+    .then((m) => [createAndFireEventOnAtlaskit(), m.default(), m.a]);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/a1.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/a1.js
@@ -1,0 +1,2 @@
+shouldBeExcluded();
+export const other = "other";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/a1.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/a1.js
@@ -1,2 +1,1 @@
-shouldBeExcluded();
 export const other = "other";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/a2.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/a2.js
@@ -1,0 +1,2 @@
+export const thing = "thing";
+export const stuff = "stuff";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/async.js
@@ -1,0 +1,4 @@
+export var foo = "foo";
+export var bar = "bar";
+export * from "./a1.js";
+export {thing, stuff} from "./a2.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-assignment-error.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-assignment-error.js
@@ -1,0 +1,5 @@
+output = (async () => {
+  let missing;
+  ({missing} = await import("./async.js"));
+  return missing;
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-assignment.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-assignment.js
@@ -1,0 +1,5 @@
+output = (async () => {
+  let y, thing;
+  ({foo: y, thing} = await import("./async.js"));
+  return [y, thing];
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-error.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-error.js
@@ -1,0 +1,4 @@
+output = (async () => {
+  let {missing} = await import("./async.js");
+  return missing;
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-bailout-eval.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-bailout-eval.js
@@ -1,0 +1,6 @@
+output = (async () => {
+  let ns = await import("./async.js");
+  let other;
+  eval('other = ns.thing;');
+  return other;
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-bailout.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-bailout.js
@@ -1,0 +1,4 @@
+output = (async () => {
+  let ns = await import("./async.js");
+  return ns;
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-error.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-error.js
@@ -1,0 +1,4 @@
+output = (async () => {
+  let ns = await import("./async.js");
+  return ns.missing;
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace.js
@@ -1,0 +1,4 @@
+output = (async () => {
+  let ns = await import("./async.js");
+  return [ns.foo, ns.thing];
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration.js
@@ -1,0 +1,4 @@
+output = (async () => {
+  let {foo: y, thing} = await import("./async.js");
+  return [y, thing];
+})();

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/package.json
@@ -1,0 +1,8 @@
+{
+  "browserslist": "Chrome 80",
+  "sideEffects": [
+    "await-assignment.js",
+    "await-declaration.js",
+    "then.js"
+  ]
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/package.json
@@ -2,7 +2,7 @@
   "browserslist": "Chrome 80",
   "sideEffects": [
     "await-assignment.js",
-    "await-declaration.js",
-    "then.js"
+    "await-declaration*.js",
+    "then*.js"
   ]
 }

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-error.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-error.js
@@ -1,0 +1,1 @@
+output = import("./async.js").then(({missing}) => [missing]);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace-bailout.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace-bailout.js
@@ -1,0 +1,1 @@
+output = import("./async.js").then((ns) => ns);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace-error.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace-error.js
@@ -1,0 +1,1 @@
+output = import("./async.js").then((ns) => [ns.missing]);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace.js
@@ -1,0 +1,1 @@
+output = import("./async.js").then((ns) => [ns.foo, ns.thing]);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then.js
@@ -1,0 +1,1 @@
+output = import("./async.js").then(({foo: y, thing}) => [y, thing]);

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1120,8 +1120,8 @@ describe('scope hoisting', function() {
       });
     });
 
-    describe('tree shaking dynamic imports', function() {
-      it('supports tree shaking statically analyzable dynamic import: await assignment', async function() {
+    describe.only('tree shaking dynamic imports', function() {
+      it('supports tree shaking statically analyzable dynamic import: destructued await assignment', async function() {
         let b = await bundle(
           path.join(
             __dirname,
@@ -1152,7 +1152,7 @@ describe('scope hoisting', function() {
         assert(!contents.includes('stuff'));
       });
 
-      it('supports tree shaking statically analyzable dynamic import: await declaration', async function() {
+      it('supports tree shaking statically analyzable dynamic import: destructured await declaration', async function() {
         let b = await bundle(
           path.join(
             __dirname,
@@ -1183,7 +1183,94 @@ describe('scope hoisting', function() {
         assert(!contents.includes('stuff'));
       });
 
-      it('supports tree shaking statically analyzable dynamic import: then', async function() {
+      it('supports tree shaking statically analyzable dynamic import: namespace await declaration', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, ['foo', 'thing']);
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(b, 'await-declaration-namespace.js', './async.js'),
+            ),
+          ),
+          new Set(['foo', 'thing']),
+        );
+        assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
+
+        let contents = await outputFS.readFile(
+          b
+            .getBundles()
+            .find(b => b.getMainEntry().filePath.endsWith('async.js')).filePath,
+          'utf8',
+        );
+        assert(!contents.includes('bar'));
+        assert(!contents.includes('stuff'));
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: namespace await declaration bailout', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-bailout.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, {
+          bar: 'bar',
+          foo: 'foo',
+          other: 'other',
+          stuff: 'stuff',
+          thing: 'thing',
+        });
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(
+                b,
+                'await-declaration-namespace-bailout.js',
+                './async.js',
+              ),
+            ),
+          ),
+          new Set(['*']),
+        );
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: namespace await declaration eval bailout', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration-namespace-bailout-eval.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, 'thing');
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(
+                b,
+                'await-declaration-namespace-bailout-eval.js',
+                './async.js',
+              ),
+            ),
+          ),
+          new Set(['*']),
+        );
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: destructured then', async function() {
         let b = await bundle(
           path.join(
             __dirname,
@@ -1210,7 +1297,65 @@ describe('scope hoisting', function() {
         assert(!contents.includes('stuff'));
       });
 
-      it('supports tree shaking statically analyzable dynamic import: then (esmodule)', async function() {
+      it('supports tree shaking statically analyzable dynamic import: namespace then', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, ['foo', 'thing']);
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(b, 'then-namespace.js', './async.js'),
+            ),
+          ),
+          new Set(['foo', 'thing']),
+        );
+        assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
+
+        let contents = await outputFS.readFile(
+          b
+            .getBundles()
+            .find(b => b.getMainEntry().filePath.endsWith('async.js')).filePath,
+          'utf8',
+        );
+        assert(!contents.includes('bar'));
+        assert(!contents.includes('stuff'));
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: namespace then bailout', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then-namespace-bailout.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, {
+          bar: 'bar',
+          foo: 'foo',
+          other: 'other',
+          stuff: 'stuff',
+          thing: 'thing',
+        });
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(b, 'then-namespace-bailout.js', './async.js'),
+            ),
+          ),
+          new Set(['*']),
+        );
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: esmodule output', async function() {
         let b = await bundle(
           path.join(
             __dirname,
@@ -1245,7 +1390,7 @@ describe('scope hoisting', function() {
         assert(!contents.includes('stuff'));
       });
 
-      it('throws an error for missing exports for dynamic import: await assignment', async function() {
+      it('throws an error for missing exports for dynamic import: destructured await assignment', async function() {
         let source = 'await-assignment-error.js';
         let message = escapeMarkdown(`async.js does not export 'missing'`);
         await assert.rejects(
@@ -1286,7 +1431,7 @@ describe('scope hoisting', function() {
         );
       });
 
-      it('throws an error for missing exports for dynamic import: await declaration', async function() {
+      it('throws an error for missing exports for dynamic import: destructured await declaration', async function() {
         let source = 'await-declaration-error.js';
         let message = escapeMarkdown(`async.js does not export 'missing'`);
         await assert.rejects(
@@ -1327,7 +1472,48 @@ describe('scope hoisting', function() {
         );
       });
 
-      it('throws an error for missing exports for dynamic import: then', async function() {
+      it('throws an error for missing exports for dynamic import: namespace await declaration', async function() {
+        let source = 'await-declaration-namespace-error.js';
+        let message = escapeMarkdown(`async.js does not export 'missing'`);
+        await assert.rejects(
+          () =>
+            bundle(
+              path.join(
+                __dirname,
+                'integration/scope-hoisting/es6/tree-shaking-dynamic-import',
+                source,
+              ),
+            ),
+          {
+            name: 'BuildError',
+            message,
+            diagnostics: [
+              {
+                message,
+                origin: '@parcel/core',
+                filePath: source,
+                language: 'js',
+                codeFrame: {
+                  codeHighlights: [
+                    {
+                      start: {
+                        column: 10,
+                        line: 3,
+                      },
+                      end: {
+                        column: 19,
+                        line: 3,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        );
+      });
+
+      it('throws an error for missing exports for dynamic import: destructured then', async function() {
         let source = 'then-error.js';
         let message = escapeMarkdown(`async.js does not export 'missing'`);
         await assert.rejects(
@@ -1357,6 +1543,47 @@ describe('scope hoisting', function() {
                       },
                       end: {
                         column: 44,
+                        line: 1,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        );
+      });
+
+      it('throws an error for missing exports for dynamic import: namespace then', async function() {
+        let source = 'then-namespace-error.js';
+        let message = escapeMarkdown(`async.js does not export 'missing'`);
+        await assert.rejects(
+          () =>
+            bundle(
+              path.join(
+                __dirname,
+                'integration/scope-hoisting/es6/tree-shaking-dynamic-import',
+                source,
+              ),
+            ),
+          {
+            name: 'BuildError',
+            message,
+            diagnostics: [
+              {
+                message,
+                origin: '@parcel/core',
+                filePath: source,
+                language: 'js',
+                codeFrame: {
+                  codeHighlights: [
+                    {
+                      start: {
+                        column: 45,
+                        line: 1,
+                      },
+                      end: {
+                        column: 54,
                         line: 1,
                       },
                     },

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1046,55 +1046,78 @@ describe('scope hoisting', function() {
       assert(!contents.includes('method'));
     });
 
-    it('removes unused exports across bundles', async () => {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/scope-hoisting/es6/tree-shaking-cross-bundle/a.js',
-        ),
-      );
+    ['global', 'esmodule'].forEach(outputFormat => {
+      let targets = {
+        default: {
+          outputFormat,
+          distDir,
+        },
+      };
 
-      assert.deepEqual(await run(b), ['b1:foo', 'b2:foo']);
+      describe('cross bundle tree shaking: ' + outputFormat, () => {
+        it('removes unused exports across bundles', async () => {
+          let b = await bundle(
+            path.join(
+              __dirname,
+              '/integration/scope-hoisting/es6/tree-shaking-cross-bundle/a.js',
+            ),
+            {targets},
+          );
 
-      let contents = await outputFS.readFile(
-        b.getBundles()[0].filePath,
-        'utf8',
-      );
-      assert(!contents.includes('bar'));
-    });
+          if (outputFormat != 'esmodule') {
+            // TODO execute ESM at some point
+            assert.deepEqual(await run(b), ['b1:foo', 'b2:foo']);
+          }
 
-    it('removes unused exports with re-exports across bundles', async () => {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/scope-hoisting/es6/tree-shaking-cross-bundle-re-export/a.js',
-        ),
-      );
+          let contents = await outputFS.readFile(
+            b.getBundles()[0].filePath,
+            'utf8',
+          );
+          assert(!contents.includes('bar'));
+        });
 
-      assert.deepEqual(await run(b), ['b1:foo', 'b2:foo']);
+        it('removes unused exports with re-exports across bundles', async () => {
+          let b = await bundle(
+            path.join(
+              __dirname,
+              '/integration/scope-hoisting/es6/tree-shaking-cross-bundle-re-export/a.js',
+            ),
+            {targets},
+          );
 
-      let contents = await outputFS.readFile(
-        b.getBundles()[0].filePath,
-        'utf8',
-      );
-      assert(!contents.includes('bar'));
-    });
+          if (outputFormat != 'esmodule') {
+            // TODO execute ESM at some point
+            assert.deepEqual(await run(b), ['b1:foo', 'b2:foo']);
+          }
 
-    it('removes unused exports with wildcard re-exports across bundles', async () => {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/scope-hoisting/es6/tree-shaking-cross-bundle-re-export-wildcard/a.js',
-        ),
-      );
+          let contents = await outputFS.readFile(
+            b.getBundles()[0].filePath,
+            'utf8',
+          );
+          assert(!contents.includes('bar'));
+        });
 
-      assert.deepEqual(await run(b), ['b1:foo', 'b2:foo']);
+        it('removes unused exports with wildcard re-exports across bundles', async () => {
+          let b = await bundle(
+            path.join(
+              __dirname,
+              '/integration/scope-hoisting/es6/tree-shaking-cross-bundle-re-export-wildcard/a.js',
+            ),
+            {targets},
+          );
 
-      let contents = await outputFS.readFile(
-        b.getBundles()[0].filePath,
-        'utf8',
-      );
-      assert(!contents.includes('bar'));
+          if (outputFormat != 'esmodule') {
+            // TODO execute ESM at some point
+            assert.deepEqual(await run(b), ['b1:foo', 'b2:foo']);
+          }
+
+          let contents = await outputFS.readFile(
+            b.getBundles()[0].filePath,
+            'utf8',
+          );
+          assert(!contents.includes('bar'));
+        });
+      });
     });
 
     it('keeps member expression with computed properties that are variables', async function() {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1120,7 +1120,7 @@ describe('scope hoisting', function() {
       });
     });
 
-    describe.only('tree shaking dynamic imports', function() {
+    describe('tree shaking dynamic imports', function() {
       it('supports tree shaking statically analyzable dynamic import: destructued await assignment', async function() {
         let b = await bundle(
           path.join(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1244,6 +1244,129 @@ describe('scope hoisting', function() {
         assert(!contents.includes('bar'));
         assert(!contents.includes('stuff'));
       });
+
+      it('throws an error for missing exports for dynamic import: await assignment', async function() {
+        let source = 'await-assignment-error.js';
+        let message = escapeMarkdown(`async.js does not export 'missing'`);
+        await assert.rejects(
+          () =>
+            bundle(
+              path.join(
+                __dirname,
+                'integration/scope-hoisting/es6/tree-shaking-dynamic-import',
+                source,
+              ),
+            ),
+          {
+            name: 'BuildError',
+            message,
+            diagnostics: [
+              {
+                message,
+                origin: '@parcel/core',
+                filePath: source,
+                language: 'js',
+                codeFrame: {
+                  codeHighlights: [
+                    {
+                      start: {
+                        column: 5,
+                        line: 3,
+                      },
+                      end: {
+                        column: 11,
+                        line: 3,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        );
+      });
+
+      it('throws an error for missing exports for dynamic import: await declaration', async function() {
+        let source = 'await-declaration-error.js';
+        let message = escapeMarkdown(`async.js does not export 'missing'`);
+        await assert.rejects(
+          () =>
+            bundle(
+              path.join(
+                __dirname,
+                'integration/scope-hoisting/es6/tree-shaking-dynamic-import',
+                source,
+              ),
+            ),
+          {
+            name: 'BuildError',
+            message,
+            diagnostics: [
+              {
+                message,
+                origin: '@parcel/core',
+                filePath: source,
+                language: 'js',
+                codeFrame: {
+                  codeHighlights: [
+                    {
+                      start: {
+                        column: 8,
+                        line: 2,
+                      },
+                      end: {
+                        column: 14,
+                        line: 2,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        );
+      });
+
+      it('throws an error for missing exports for dynamic import: then', async function() {
+        let source = 'then-error.js';
+        let message = escapeMarkdown(`async.js does not export 'missing'`);
+        await assert.rejects(
+          () =>
+            bundle(
+              path.join(
+                __dirname,
+                'integration/scope-hoisting/es6/tree-shaking-dynamic-import',
+                source,
+              ),
+            ),
+          {
+            name: 'BuildError',
+            message,
+            diagnostics: [
+              {
+                message,
+                origin: '@parcel/core',
+                filePath: source,
+                language: 'js',
+                codeFrame: {
+                  codeHighlights: [
+                    {
+                      start: {
+                        column: 38,
+                        line: 1,
+                      },
+                      end: {
+                        column: 44,
+                        line: 1,
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        );
+      });
     });
 
     it('keeps member expression with computed properties that are variables', async function() {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1120,6 +1120,132 @@ describe('scope hoisting', function() {
       });
     });
 
+    describe('tree shaking dynamic imports', function() {
+      it('supports tree shaking statically analyzable dynamic import: await assignment', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-assignment.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, ['foo', 'thing']);
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(b, 'await-assignment.js', './async.js'),
+            ),
+          ),
+          new Set(['foo', 'thing']),
+        );
+        assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
+
+        let contents = await outputFS.readFile(
+          b
+            .getBundles()
+            .find(b => b.getMainEntry().filePath.endsWith('async.js')).filePath,
+          'utf8',
+        );
+        assert(!contents.includes('bar'));
+        assert(!contents.includes('stuff'));
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: await declaration', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/await-declaration.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, ['foo', 'thing']);
+
+        assert.deepStrictEqual(
+          new Set(
+            b.getUsedSymbols(
+              findDependency(b, 'await-declaration.js', './async.js'),
+            ),
+          ),
+          new Set(['foo', 'thing']),
+        );
+        assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
+
+        let contents = await outputFS.readFile(
+          b
+            .getBundles()
+            .find(b => b.getMainEntry().filePath.endsWith('async.js')).filePath,
+          'utf8',
+        );
+        assert(!contents.includes('bar'));
+        assert(!contents.includes('stuff'));
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: then', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then.js',
+          ),
+        );
+
+        let output = await run(b);
+        assert.deepEqual(output, ['foo', 'thing']);
+
+        assert.deepStrictEqual(
+          new Set(b.getUsedSymbols(findDependency(b, 'then.js', './async.js'))),
+          new Set(['foo', 'thing']),
+        );
+        assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
+
+        let contents = await outputFS.readFile(
+          b
+            .getBundles()
+            .find(b => b.getMainEntry().filePath.endsWith('async.js')).filePath,
+          'utf8',
+        );
+        assert(!contents.includes('bar'));
+        assert(!contents.includes('stuff'));
+      });
+
+      it('supports tree shaking statically analyzable dynamic import: then (esmodule)', async function() {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/tree-shaking-dynamic-import/then.js',
+          ),
+          {
+            targets: {
+              default: {
+                outputFormat: 'esmodule',
+                distDir,
+              },
+            },
+          },
+        );
+
+        // let output = await run(b);
+        // assert.deepEqual(output, 'foo');
+
+        assert.deepStrictEqual(
+          new Set(b.getUsedSymbols(findDependency(b, 'then.js', './async.js'))),
+          new Set(['foo', 'thing']),
+        );
+        assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
+
+        let contents = await outputFS.readFile(
+          b
+            .getBundles()
+            .find(b => b.getMainEntry().filePath.endsWith('async.js')).filePath,
+          'utf8',
+        );
+        assert(!contents.includes('bar'));
+        assert(!contents.includes('stuff'));
+      });
+    });
+
     it('keeps member expression with computed properties that are variables', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2338,8 +2338,8 @@ describe('scope hoisting', function() {
             '/integration/scope-hoisting/es6/side-effects-false-wrap-excluded/a.js',
           ),
         );
-        let output = await run(b);
 
+        let output = await run(b);
         assert.deepEqual(output, 4);
       });
 

--- a/packages/shared/scope-hoisting/src/formats/esmodule.js
+++ b/packages/shared/scope-hoisting/src/formats/esmodule.js
@@ -31,7 +31,7 @@ import {
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {relative} from 'path';
-import {flat, relativeBundlePath} from '@parcel/utils';
+import {relativeBundlePath} from '@parcel/utils';
 import rename from '../renamer';
 import {
   getName,

--- a/packages/shared/scope-hoisting/src/formats/esmodule.js
+++ b/packages/shared/scope-hoisting/src/formats/esmodule.js
@@ -140,9 +140,16 @@ export function generateExports(
   // let exportedIdentifiersBailout = new Map<Symbol, [Asset, Symbol]>();
   let entry = bundle.getMainEntry();
   if (entry) {
+    let usedSymbols = bundleGraph.getUsedSymbols(entry);
+    let hasNamespace = usedSymbols.has('*');
     for (let {exportAs, exportSymbol, symbol, asset, loc} of nullthrows(
       bundleGraph.getExportedSymbols(entry, bundle),
     )) {
+      if (asset === entry && !hasNamespace && !usedSymbols.has(exportAs)) {
+        // unused
+        continue;
+      }
+
       if (symbol === false) {
         // skipped
       } else if (symbol === null) {

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -53,6 +53,7 @@ import {
   getIdentifier,
   getExportIdentifier,
   dereferenceIdentifier,
+  isUnusedValue,
 } from './utils';
 
 const WRAPPER_TEMPLATE = template.statement<
@@ -1020,15 +1021,4 @@ function getCJSExportsIdentifier(asset: MutableAsset, scope) {
   } else {
     return getExportsIdentifier(asset, scope);
   }
-}
-
-function isUnusedValue(path) {
-  let {parent} = path;
-  return (
-    isExpressionStatement(parent) ||
-    (isSequenceExpression(parent) &&
-      ((Array.isArray(path.container) &&
-        path.key !== path.container.length - 1) ||
-        isUnusedValue(path.parentPath)))
-  );
 }

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -26,7 +26,6 @@ import {
   isExportNamespaceSpecifier,
   isExportSpecifier,
   isExpression,
-  isExpressionStatement,
   isFunction,
   isFunctionDeclaration,
   isIdentifier,
@@ -36,7 +35,6 @@ import {
   isMemberExpression,
   isObjectPattern,
   isObjectProperty,
-  isSequenceExpression,
   isStringLiteral,
   isUnaryExpression,
   isVariableDeclarator,
@@ -53,7 +51,6 @@ import {
   getIdentifier,
   getExportIdentifier,
   dereferenceIdentifier,
-  isUnusedValue,
 } from './utils';
 
 const WRAPPER_TEMPLATE = template.statement<
@@ -558,10 +555,10 @@ const VISITOR: Visitor<MutableAsset> = {
       }
 
       // Try to statically analyze a dynamic import() call
-      let {parent} = path;
-      let {parent: grandparent} = path.parentPath;
       let properties: ?Array<RestElement | ObjectProperty>;
-      if (!isUnusedValue(path) && dep.isAsync) {
+      if (dep.isAsync) {
+        let {parent} = path;
+        let {parent: grandparent} = path.parentPath;
         if (
           // import(xxx).then(({ default: b }) => ...);
           isMemberExpression(parent, {object: path.node}) &&

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -641,7 +641,11 @@ const VISITOR: Visitor<MutableAsset> = {
       if (memberAccesses != null) {
         // The import() return value was statically analyzable
         for (let {name, loc} of memberAccesses) {
-          dep.symbols.set(name, getName(asset, 'import', name), loc);
+          dep.symbols.set(
+            name,
+            getName(asset, 'importAsync', dep.id, name),
+            loc,
+          );
         }
       } else {
         // non-async and async fallback: everything

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -47,7 +47,6 @@ import {
   getName,
   getIdentifier,
   dereferenceIdentifier,
-  isUnusedValue,
   pathRemove,
   getThrowableDiagnosticForNode,
   verifyScopeState,
@@ -840,4 +839,15 @@ function maybeAddEsModuleFlag(scope, mod) {
       binding.path.setData('hasESModuleFlag', true);
     }
   }
+}
+
+function isUnusedValue(path: NodePath<Node>): boolean {
+  let {parent} = path;
+  return (
+    isExpressionStatement(parent) ||
+    (isSequenceExpression(parent) &&
+      ((Array.isArray(path.container) &&
+        path.key !== path.container.length - 1) ||
+        isUnusedValue(path.parentPath)))
+  );
 }

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -47,6 +47,7 @@ import {
   getName,
   getIdentifier,
   dereferenceIdentifier,
+  isUnusedValue,
   pathRemove,
   getThrowableDiagnosticForNode,
   verifyScopeState,
@@ -349,17 +350,6 @@ export function link({
 
   function getScopeBefore(path) {
     return path.isScope() ? path.parentPath.scope : path.scope;
-  }
-
-  function isUnusedValue(path) {
-    let {parent} = path;
-    return (
-      isExpressionStatement(parent) ||
-      (isSequenceExpression(parent) &&
-        ((Array.isArray(path.container) &&
-          path.key !== path.container.length - 1) ||
-          isUnusedValue(path.parentPath)))
-    );
   }
 
   function addExternalModule(path, dep) {

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -21,12 +21,7 @@ import type {Diagnostic} from '@parcel/diagnostic';
 import {simple as walkSimple} from '@parcel/babylon-walk';
 import ThrowableDiagnostic from '@parcel/diagnostic';
 import * as t from '@babel/types';
-import {
-  isExpressionStatement,
-  isSequenceExpression,
-  isVariableDeclarator,
-  isVariableDeclaration,
-} from '@babel/types';
+import {isVariableDeclarator, isVariableDeclaration} from '@babel/types';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import path from 'path';
@@ -143,17 +138,6 @@ export function hasAsyncDescendant(
   }, bundle);
 
   return _hasAsyncDescendant;
-}
-
-export function isUnusedValue(path: NodePath<Node>): boolean {
-  let {parent} = path;
-  return (
-    isExpressionStatement(parent) ||
-    (isSequenceExpression(parent) &&
-      ((Array.isArray(path.container) &&
-        path.key !== path.container.length - 1) ||
-        isUnusedValue(path.parentPath)))
-  );
 }
 
 export function assertString(v: mixed): string {

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -21,7 +21,12 @@ import type {Diagnostic} from '@parcel/diagnostic';
 import {simple as walkSimple} from '@parcel/babylon-walk';
 import ThrowableDiagnostic from '@parcel/diagnostic';
 import * as t from '@babel/types';
-import {isVariableDeclarator, isVariableDeclaration} from '@babel/types';
+import {
+  isExpressionStatement,
+  isSequenceExpression,
+  isVariableDeclarator,
+  isVariableDeclaration,
+} from '@babel/types';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import path from 'path';
@@ -138,6 +143,17 @@ export function hasAsyncDescendant(
   }, bundle);
 
   return _hasAsyncDescendant;
+}
+
+export function isUnusedValue(path: NodePath<Node>): boolean {
+  let {parent} = path;
+  return (
+    isExpressionStatement(parent) ||
+    (isSequenceExpression(parent) &&
+      ((Array.isArray(path.container) &&
+        path.key !== path.container.length - 1) ||
+        isUnusedValue(path.parentPath)))
+  );
 }
 
 export function assertString(v: mixed): string {


### PR DESCRIPTION
# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/4318

These patterns are picked up by the transformer:
```js
let { x: y } = await import("./b.js");

({ x } = await import("./b.js"));

import("./b.js").then(({ a: b }) => console.log(b));

let ns = await import("./b.js");
console.log(ns.foo);

import("./b.js").then((ns) => console.log(ns.foo));
```

This works for tree shaking as well as excluding whole subgraphs via the bundler & symbol-propagation.

<br>

This also automatically throws errors if you try to import something that is guaranteed to be missing:

<img width="576" alt="Bildschirmfoto 2020-11-19 um 23 50 07" src="https://user-images.githubusercontent.com/4586894/99733761-f4db4e80-2ac1-11eb-9028-1a19b39eaf7d.png">


### TODO:

- [x] Test for error message