### PR TITLE
P2 x 323 flow types for ansi html

### DIFF
--- a/flow-libs/ansi-html.js.flow
+++ b/flow-libs/ansi-html.js.flow
@@ -1,0 +1,5 @@
+//@flow
+
+declare module 'ansi-html' {
+  declare module.exports: (input: string) => string;
+}

--- a/flow-libs/ansi-html.js.flow
+++ b/flow-libs/ansi-html.js.flow
@@ -1,4 +1,4 @@
-//@flow
+// @flow
 
 declare module 'ansi-html' {
   declare module.exports: (input: string) => string;

--- a/packages/core/utils/src/ansi-html.js
+++ b/packages/core/utils/src/ansi-html.js
@@ -1,6 +1,5 @@
 // @flow strict-local
 import ansiHTML from 'ansi-html';
-// flowlint-next-line untyped-import:off
 import {escapeHTML} from './escape-html';
 
 export function ansiHtml(ansi: string): string {

--- a/packages/core/utils/src/ansi-html.js
+++ b/packages/core/utils/src/ansi-html.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict enable
 import ansiHTML from 'ansi-html';
 import {escapeHTML} from './escape-html';
 

--- a/packages/core/utils/src/ansi-html.js
+++ b/packages/core/utils/src/ansi-html.js
@@ -1,5 +1,6 @@
-// @flow strict enable
+// @flow strict-local
 import ansiHTML from 'ansi-html';
+// flowlint-next-line untyped-import:off
 import {escapeHTML} from './escape-html';
 
 export function ansiHtml(ansi: string): string {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR is for adding a flow type for ansi-html

Sources: I looked at `strip-ansi`[ flow type ](https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/strip-ansi_v3.x.x/flow_v0.104.x-/strip-ansi_v3.x.x.js) as well as the `ansi-html.js` file[ within the parcel repo](https://github.com/parcel-bundler/parcel/blob/a5e234877e42ce98eb2bd38665edf6937af5733a/packages/core/utils/src/ansi-html.js)

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

1. Added `flow strict enable` to `ansi-html.js` file without errors
2. Ran `yarn flow check` with 0 errros
3. Try flow function `s({input:string}) {} `, `s({obj: []})` doesn't work since it's not a string

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
