### PR TITLE
Correctly bailout for static member accesses on namespace

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-namespace-static-member/b.js
@@ -1,0 +1,4 @@
+import * as b from "./library/index.js";
+
+let val = "foo";
+output = b[val];

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -930,6 +930,31 @@ describe('scope hoisting', function() {
       assert.deepEqual(calls, ['c1', 'c3']);
     });
 
+    it('should bailout with a non-static member access on a namespace', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-namespace-static-member/b.js',
+        ),
+      );
+
+      assert.deepStrictEqual(
+        new Set(
+          b.getUsedSymbols(findDependency(b, 'b.js', './library/index.js')),
+        ),
+        new Set(['*']),
+      );
+
+      let calls = [];
+      let output = await run(b, {
+        sideEffect: v => {
+          calls.push(v);
+        },
+      });
+      assert.deepEqual(output, 'foo');
+      assert.deepEqual(calls, ['c1', 'c2', 'c3']);
+    });
+
     it('supports importing a namespace from a wrapped module', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -651,8 +651,8 @@ const VISITOR: Visitor<MutableAsset> = {
             if (
               isIdentifier(node) &&
               isMemberExpression(parent, {object: node}) &&
-              (isIdentifier(parent.property) ||
-                (parent.computed && isStringLiteral(parent.property)))
+              ((!parent.computed && isIdentifier(parent.property)) ||
+                isStringLiteral(parent.property))
             ) {
               let imported: string =
                 // $FlowFixMe


### PR DESCRIPTION
Previously, this might have thrown with `does not export 'val'` 😬 

Fixup for #5362

```js
import * as b from "./library/index.js";

let val = "foo";
output = b[val];
```

The atlaskit-editor benchmark even failed with a build error, but I didn't notice that at the time...