### PR TITLE
Distinguish between module and classic scripts

### DIFF
--- a/flow-libs/posthtml.js.flow
+++ b/flow-libs/posthtml.js.flow
@@ -11,6 +11,11 @@ declare module 'posthtml' {
     tag: string,
     attrs?: {[string]: string, ...},
     content?: Array<string>,
+    loc?: {
+      start: {|line: number, column: number|},
+      end: {|line: number, column: number|},
+      ...
+    },
     ...
   };
 
@@ -26,7 +31,7 @@ declare module 'posthtml' {
     ...
   };
 
-  declare var walk: (fn: (node: PostHTMLNode) => PostHTMLNode) => void;
+  declare var walk: (fn: (node: PostHTMLNode) => PostHTMLNode | PostHTMLNode[]) => void;
   declare var process: (
     tree: PostHTMLTree | string,
     options: ?PostHTMLOptions,

--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -37,18 +37,11 @@
     "url:*": ["@parcel/transformer-raw"]
   },
   "namers": ["@parcel/namer-default"],
-  "runtimes": {
-    "browser": [
-      "@parcel/runtime-js",
-      "@parcel/runtime-browser-hmr",
-      "@parcel/runtime-react-refresh"
-    ],
-    "service-worker": ["@parcel/runtime-js"],
-    "web-worker": ["@parcel/runtime-js"],
-    "node": ["@parcel/runtime-js"],
-    "electron-renderer": ["@parcel/runtime-js"],
-    "electron-main": ["@parcel/runtime-js"]
-  },
+  "runtimes": [
+    "@parcel/runtime-js",
+    "@parcel/runtime-browser-hmr",
+    "@parcel/runtime-react-refresh"
+  ],
   "optimizers": {
     "data-url:*": ["...", "@parcel/optimizer-data-url"],
     "*.css": ["@parcel/optimizer-cssnano"],

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -21,6 +21,7 @@ import {md5FromObject} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 import Graph, {type GraphOpts} from './Graph';
 import {createDependency} from './Dependency';
+import {getAssetGroupId} from './assetUtils';
 
 type AssetGraphOpts = {|
   ...GraphOpts<AssetGraphNode>,
@@ -55,13 +56,7 @@ export function nodeFromDep(dep: Dependency): DependencyNode {
 
 export function nodeFromAssetGroup(assetGroup: AssetGroup): AssetGroupNode {
   return {
-    id: md5FromObject({
-      ...assetGroup,
-      // only influences building the asset graph
-      canDefer: undefined,
-      // if only the isURL property is different, no need to re-run transformation.
-      isURL: undefined,
-    }),
+    id: getAssetGroupId(assetGroup),
     type: 'asset_group',
     value: assetGroup,
     usedSymbolsDownDirty: true,

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -23,7 +23,12 @@ import assert from 'assert';
 import invariant from 'assert';
 import crypto from 'crypto';
 import nullthrows from 'nullthrows';
-import {flatMap, objectSortedEntriesDeep, unique} from '@parcel/utils';
+import {
+  flatMap,
+  objectSortedEntriesDeep,
+  unique,
+  isSubset,
+} from '@parcel/utils';
 
 import {getBundleGroupId, getPublicId} from './utils';
 import Graph, {ALL_EDGE_TYPES, mapVisitor, type GraphOpts} from './Graph';
@@ -615,7 +620,7 @@ export default class BundleGraph {
       visitedBundles.add(descendant);
       if (
         descendant.type !== bundle.type ||
-        descendant.env.context !== bundle.env.context
+        !isSubset(descendant.env.context, bundle.env.context)
       ) {
         actions.skipChildren();
         return;
@@ -630,7 +635,7 @@ export default class BundleGraph {
       let similarSiblings = this.getSiblingBundles(descendant).filter(
         sibling =>
           sibling.type === bundle.type &&
-          sibling.env.context === bundle.env.context,
+          isSubset(sibling.env.context, bundle.env.context),
       );
       if (
         similarSiblings.some(
@@ -713,7 +718,7 @@ export default class BundleGraph {
             // Don't deduplicate when context changes
             if (
               node.type === 'bundle' &&
-              node.value.env.context !== bundle.env.context
+              !isSubset(node.value.env.context, bundle.env.context)
             ) {
               actions.skipChildren();
             }
@@ -766,7 +771,7 @@ export default class BundleGraph {
             // Stop when context changes
             if (
               node.type === 'bundle' &&
-              node.value.env.context !== bundle.env.context
+              !isSubset(node.value.env.context, bundle.env.context)
             ) {
               actions.skipChildren();
             }

--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -17,6 +17,7 @@ export function createEnvironment({
   isLibrary = false,
   scopeHoist = false,
   sourceMap,
+  loc,
 }: EnvironmentOpts = {}): Environment {
   if (context == null) {
     if (engines?.node) {
@@ -28,58 +29,63 @@ export function createEnvironment({
     }
   }
 
+  let ctx = new Set(typeof context === 'string' ? [context] : context);
+
   if (engines == null) {
-    switch (context) {
-      case 'node':
-      case 'electron-main':
-        engines = {
-          node: DEFAULT_ENGINES.node,
-        };
-        break;
-      case 'browser':
-      case 'web-worker':
-      case 'service-worker':
-      case 'electron-renderer':
-        engines = {
-          browsers: DEFAULT_ENGINES.browsers,
-        };
-        break;
-      default:
-        engines = {};
+    engines = {};
+    for (let context of ctx) {
+      switch (context) {
+        case 'node':
+        case 'electron-main':
+          engines.node = DEFAULT_ENGINES.node;
+          break;
+        case 'browser':
+        case 'web-worker':
+        case 'service-worker':
+        case 'electron-renderer':
+          engines.browsers = DEFAULT_ENGINES.browsers;
+          break;
+      }
     }
   }
 
   if (includeNodeModules == null) {
-    switch (context) {
-      case 'node':
-      case 'electron-main':
-      case 'electron-renderer':
-        includeNodeModules = false;
-        break;
-      case 'browser':
-      case 'web-worker':
-      case 'service-worker':
-      default:
-        includeNodeModules = true;
-        break;
+    includeNodeModules = true;
+    for (let context of ctx) {
+      switch (context) {
+        case 'node':
+        case 'electron-main':
+        case 'electron-renderer':
+          includeNodeModules = false;
+          break;
+        case 'browser':
+        case 'web-worker':
+        case 'service-worker':
+        default:
+          includeNodeModules = true;
+          break;
+      }
     }
   }
 
   if (outputFormat == null) {
-    switch (context) {
-      case 'node':
-      case 'electron-main':
-      case 'electron-renderer':
-        outputFormat = 'commonjs';
-        break;
-      default:
-        outputFormat = 'global';
-        break;
+    outputFormat = 'global';
+    for (let context of ctx) {
+      switch (context) {
+        case 'node':
+        case 'electron-main':
+        case 'electron-renderer':
+          outputFormat = 'commonjs';
+          break;
+        default:
+          outputFormat = 'global';
+          break;
+      }
     }
   }
 
   return {
-    context,
+    context: ctx,
     engines,
     includeNodeModules,
     outputFormat,
@@ -87,6 +93,7 @@ export function createEnvironment({
     minify,
     scopeHoist,
     sourceMap,
+    loc,
   };
 }
 

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -421,7 +421,7 @@ export default class PackagerRunner {
         sourceRoot = bundle.env.sourceMap.sourceRoot;
       } else if (
         this.options.serve &&
-        bundle.target.env.context === 'browser'
+        bundle.target.env.context.has('browser')
       ) {
         sourceRoot = '/__parcel_source_root';
       }
@@ -431,7 +431,7 @@ export default class PackagerRunner {
         bundle.env.sourceMap.inlineSources !== undefined
       ) {
         inlineSources = bundle.env.sourceMap.inlineSources;
-      } else if (bundle.target.env.context !== 'node') {
+      } else if (!bundle.target.env.context.has('node')) {
         // inlining should only happen in production for browser targets by default
         inlineSources = this.options.mode === 'production';
       }

--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -7,7 +7,6 @@ import type {
   Bundler,
   Namer,
   Runtime,
-  EnvironmentContext,
   PackageName,
   Optimizer,
   Packager,
@@ -52,7 +51,7 @@ export default class ParcelConfig {
   transformers: GlobMap<ExtendableParcelConfigPipeline>;
   bundler: ?ParcelPluginNode;
   namers: PureParcelConfigPipeline;
-  runtimes: {[EnvironmentContext]: PureParcelConfigPipeline, ...};
+  runtimes: PureParcelConfigPipeline;
   packagers: GlobMap<ParcelPluginNode>;
   validators: GlobMap<ExtendableParcelConfigPipeline>;
   optimizers: GlobMap<ExtendableParcelConfigPipeline>;
@@ -71,7 +70,7 @@ export default class ParcelConfig {
     this.filePath = config.filePath;
     this.resolvers = config.resolvers || [];
     this.transformers = config.transformers || {};
-    this.runtimes = config.runtimes || {};
+    this.runtimes = config.runtimes || [];
     this.bundler = config.bundler;
     this.namers = config.namers || [];
     this.packagers = config.packagers || {};
@@ -266,10 +265,8 @@ export default class ParcelConfig {
     return this.loadPlugins<Namer>(this.namers);
   }
 
-  getRuntimes(
-    context: EnvironmentContext,
-  ): Promise<Array<LoadedPlugin<Runtime>>> {
-    let runtimes = this.runtimes[context];
+  getRuntimes(): Promise<Array<LoadedPlugin<Runtime>>> {
+    let runtimes = this.runtimes;
     if (!runtimes) {
       return Promise.resolve([]);
     }

--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -122,7 +122,7 @@ export default {
     packagers: (mapStringSchema('packager', 'packagers'): SchemaEntity),
     optimizers: (mapPipelineSchema('optimizer', 'optimizers'): SchemaEntity),
     reporters: (pipelineSchema('reporter', 'reporters'): SchemaEntity),
-    runtimes: (mapPipelineSchema('runtime', 'runtimes'): SchemaEntity),
+    runtimes: (pipelineSchema('runtime', 'runtimes'): SchemaEntity),
     filePath: {
       type: 'string',
     },

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -402,7 +402,17 @@ export default class Transformation {
           .filter(
             asset =>
               asset.ast != null &&
-              !(asset.value.type === 'js' && asset.value.env.scopeHoist),
+              !(
+                asset.value.type === 'js' &&
+                asset.value.env.scopeHoist &&
+                // HACK: also handle global scripts with no dependencies.
+                // JSPackager calls getCode() for these even with scope hoisting, so we
+                // need to generate here until we find a way to make generate happen on demand.
+                !(
+                  asset.value.env.context.has('script') &&
+                  asset.value.dependencies.size === 0
+                )
+              ),
           )
           .map(async asset => {
             if (asset.isASTDirty) {

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -14,6 +14,7 @@ import type {
 } from '@parcel/types';
 import type {
   Asset,
+  AssetGroup,
   RequestInvalidation,
   Dependency,
   Environment,
@@ -24,6 +25,7 @@ import type {ConfigOutput} from '@parcel/utils';
 import {Readable} from 'stream';
 import crypto from 'crypto';
 import {PluginLogger} from '@parcel/logger';
+import {md5FromObject} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 import CommittedAsset from './CommittedAsset';
 import UncommittedAsset from './UncommittedAsset';
@@ -250,4 +252,15 @@ export async function getInvalidationHash(
   }
 
   return hash.digest('hex');
+}
+
+export function getAssetGroupId(assetGroup: AssetGroup): string {
+  return md5FromObject({
+    ...assetGroup,
+    env: getEnvironmentHash(assetGroup.env),
+    // only influences building the asset graph
+    canDefer: undefined,
+    // if only the isURL property is different, no need to re-run transformation.
+    isURL: undefined,
+  });
 }

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -138,10 +138,11 @@ export default async function dumpGraphToGraphViz(
 
 function getEnvDescription(env: Environment) {
   let description;
+  let context = [...env.context].join(', ');
   if (typeof env.engines.browsers === 'string') {
-    description = `${env.context}: ${env.engines.browsers}`;
+    description = `${context}: ${env.engines.browsers}`;
   } else if (Array.isArray(env.engines.browsers)) {
-    description = `${env.context}: ${env.engines.browsers.join(', ')}`;
+    description = `${context}: ${env.engines.browsers.join(', ')}`;
   } else if (env.engines.node) {
     description = `node: ${env.engines.node}`;
   } else if (env.engines.electron) {

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -9,6 +9,7 @@ import type {TransformationResult} from '../Transformation';
 import {md5FromObject} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 import createParcelConfigRequest from './ParcelConfigRequest';
+import {getAssetGroupId} from '../assetUtils';
 
 type RunInput = {|
   input: AssetRequestInput,
@@ -42,7 +43,7 @@ const type = 'asset_request';
 function getId(input: AssetRequestInput) {
   // eslint-disable-next-line no-unused-vars
   let {optionsRef, ...hashInput} = input;
-  return `${type}:${md5FromObject(hashInput)}`;
+  return `${type}:${getAssetGroupId(hashInput)}`;
 }
 
 async function run({input, api, options, farm}: RunInput) {

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -269,7 +269,11 @@ export function processConfig(
           }
         : undefined,
     namers: processPipeline(configFile.namers, '/namers', configFile.filePath),
-    runtimes: processMap(configFile.runtimes, '/runtimes', configFile.filePath),
+    runtimes: processPipeline(
+      configFile.runtimes,
+      '/runtimes',
+      configFile.filePath,
+    ),
     packagers: processMap(
       configFile.packagers,
       '/packagers',
@@ -491,7 +495,7 @@ export function mergeConfigs(
     validators: mergeMaps(base.validators, ext.validators, mergePipelines),
     bundler: ext.bundler || base.bundler,
     namers: mergePipelines(base.namers, ext.namers),
-    runtimes: mergeMaps(base.runtimes, ext.runtimes, mergePipelines),
+    runtimes: mergePipelines(base.runtimes, ext.runtimes),
     packagers: mergeMaps(base.packagers, ext.packagers),
     optimizers: mergeMaps(base.optimizers, ext.optimizers, mergePipelines),
     reporters: mergePipelines(base.reporters, ext.reporters),

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -24,6 +24,7 @@ import {
   resolveConfig,
   md5FromObject,
   validateSchema,
+  setIntersects,
 } from '@parcel/utils';
 import {createEnvironment} from '../Environment';
 import createParcelConfigRequest from './ParcelConfigRequest';
@@ -199,7 +200,7 @@ export class TargetResolver {
             },
           });
         }
-        if (!BROWSER_ENVS.has(targets[0].env.context)) {
+        if (!setIntersects(BROWSER_ENVS, targets[0].env.context)) {
           throw new ThrowableDiagnostic({
             diagnostic: {
               message: `Only browser targets are supported in serve mode`,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -50,7 +50,7 @@ export type ProcessedParcelConfig = {|
   transformers?: {[Glob]: ExtendableParcelConfigPipeline, ...},
   bundler: ?ParcelPluginNode,
   namers?: PureParcelConfigPipeline,
-  runtimes?: {[EnvironmentContext]: PureParcelConfigPipeline, ...},
+  runtimes?: PureParcelConfigPipeline,
   packagers?: {[Glob]: ParcelPluginNode, ...},
   optimizers?: {[Glob]: ExtendableParcelConfigPipeline, ...},
   reporters?: PureParcelConfigPipeline,
@@ -60,7 +60,7 @@ export type ProcessedParcelConfig = {|
 |};
 
 export type Environment = {|
-  context: EnvironmentContext,
+  context: Set<EnvironmentContext>,
   engines: Engines,
   includeNodeModules:
     | boolean
@@ -71,6 +71,7 @@ export type Environment = {|
   minify: boolean,
   scopeHoist: boolean,
   sourceMap: ?TargetSourceMapOptions,
+  loc: ?SourceLocation,
 |};
 
 export type Target = {|

--- a/packages/core/core/test/Environment.test.js
+++ b/packages/core/core/test/Environment.test.js
@@ -6,7 +6,7 @@ import {createEnvironment} from '../src/Environment';
 describe('Environment', () => {
   it('assigns a default environment with nothing passed', () => {
     assert.deepEqual(createEnvironment(), {
-      context: 'browser',
+      context: new Set(['browser']),
       engines: {
         browsers: ['> 0.25%'],
       },
@@ -16,12 +16,13 @@ describe('Environment', () => {
       minify: false,
       scopeHoist: false,
       sourceMap: undefined,
+      loc: undefined,
     });
   });
 
   it('assigns a node context if a node engine is given', () => {
     assert.deepEqual(createEnvironment({engines: {node: '>= 10.0.0'}}), {
-      context: 'node',
+      context: new Set(['node']),
       engines: {
         node: '>= 10.0.0',
       },
@@ -31,6 +32,7 @@ describe('Environment', () => {
       minify: false,
       scopeHoist: false,
       sourceMap: undefined,
+      loc: undefined,
     });
   });
 
@@ -38,7 +40,7 @@ describe('Environment', () => {
     assert.deepEqual(
       createEnvironment({engines: {browsers: ['last 1 version']}}),
       {
-        context: 'browser',
+        context: new Set(['browser']),
         engines: {
           browsers: ['last 1 version'],
         },
@@ -48,13 +50,14 @@ describe('Environment', () => {
         minify: false,
         scopeHoist: false,
         sourceMap: undefined,
+        loc: undefined,
       },
     );
   });
 
   it('assigns default engines for node', () => {
     assert.deepEqual(createEnvironment({context: 'node'}), {
-      context: 'node',
+      context: new Set(['node']),
       engines: {
         node: '>= 8.0.0',
       },
@@ -64,12 +67,13 @@ describe('Environment', () => {
       minify: false,
       scopeHoist: false,
       sourceMap: undefined,
+      loc: undefined,
     });
   });
 
   it('assigns default engines for browsers', () => {
     assert.deepEqual(createEnvironment({context: 'browser'}), {
-      context: 'browser',
+      context: new Set(['browser']),
       engines: {
         browsers: ['> 0.25%'],
       },
@@ -79,6 +83,7 @@ describe('Environment', () => {
       minify: false,
       scopeHoist: false,
       sourceMap: undefined,
+      loc: undefined,
     });
   });
 });

--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -568,7 +568,7 @@ describe('loadParcelConfig', () => {
           resolveFrom: '.parcelrc',
           keyPath: '/bundler',
         },
-        runtimes: {},
+        runtimes: [],
         namers: [],
         optimizers: {},
         packagers: {},

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -103,7 +103,7 @@ describe('TargetResolver', () => {
           publicUrl: '/',
           distDir: path.resolve('customA'),
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             includeNodeModules: true,
             engines: {
               browsers: ['> 0.25%'],
@@ -113,6 +113,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
         },
         {
@@ -120,7 +121,7 @@ describe('TargetResolver', () => {
           publicUrl: '/',
           distDir: path.resolve('customB'),
           env: {
-            context: 'node',
+            context: new Set(['node']),
             includeNodeModules: false,
             engines: {
               node: '>= 8.0.0',
@@ -130,6 +131,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
         },
       ],
@@ -148,7 +150,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'node',
+            context: new Set(['node']),
             engines: {
               node: '>= 8.0.0',
             },
@@ -158,6 +160,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -177,7 +180,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['last 1 version'],
             },
@@ -189,6 +192,7 @@ describe('TargetResolver', () => {
             sourceMap: {
               inlineSources: true,
             },
+            loc: undefined,
           },
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -208,7 +212,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/assets',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['last 1 version'],
             },
@@ -218,6 +222,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -247,7 +252,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'node',
+            context: new Set(['node']),
             engines: {
               node: '>= 8.0.0',
             },
@@ -257,6 +262,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: undefined,
+            loc: undefined,
           },
           loc: {
             filePath: path.join(
@@ -288,7 +294,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'node',
+            context: new Set(['node']),
             engines: {
               node: '>= 8.0.0',
             },
@@ -298,6 +304,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -320,7 +327,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['last 1 version'],
             },
@@ -330,6 +337,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -352,7 +360,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['ie11'],
             },
@@ -362,6 +370,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(CUSTOM_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -390,7 +399,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: 'www',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: '> 0.25%',
             },
@@ -400,6 +409,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: undefined,
         },
@@ -416,7 +426,7 @@ describe('TargetResolver', () => {
         distEntry: 'index.js',
         publicUrl: '/',
         env: {
-          context: 'node',
+          context: new Set(['node']),
           engines: {},
           includeNodeModules: false,
           isLibrary: true,
@@ -424,6 +434,7 @@ describe('TargetResolver', () => {
           minify: false,
           scopeHoist: false,
           sourceMap: {},
+          loc: undefined,
         },
         loc: {
           filePath: path.join(CONTEXT_FIXTURE_PATH, 'package.json'),
@@ -450,7 +461,7 @@ describe('TargetResolver', () => {
         distEntry: 'index.html',
         publicUrl: '/',
         env: {
-          context: 'browser',
+          context: new Set(['browser']),
           engines: {},
           includeNodeModules: true,
           isLibrary: false,
@@ -458,6 +469,7 @@ describe('TargetResolver', () => {
           minify: false,
           scopeHoist: false,
           sourceMap: {},
+          loc: undefined,
         },
         loc: {
           filePath: path.join(fixture, 'package.json'),
@@ -489,7 +501,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            context: 'node',
+            context: new Set(['node']),
             engines: {
               node: '>= 8.0.0',
             },
@@ -499,6 +511,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -518,7 +531,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/assets',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['last 1 version'],
             },
@@ -528,6 +541,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: {
             filePath: path.join(COMMON_TARGETS_FIXTURE_PATH, 'package.json'),
@@ -561,7 +575,7 @@ describe('TargetResolver', () => {
           distDir: serveDistDir,
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {},
             includeNodeModules: true,
             outputFormat: 'global',
@@ -569,6 +583,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
         },
       ],
@@ -586,7 +601,7 @@ describe('TargetResolver', () => {
           distDir: path.join(DEFAULT_DISTPATH_FIXTURE_PATHS.none, 'dist'),
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['Chrome 80'],
             },
@@ -596,6 +611,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
         },
       ],
@@ -614,7 +630,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['Chrome 80'],
             },
@@ -624,6 +640,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: undefined,
         },
@@ -647,7 +664,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['last 1 version'],
             },
@@ -657,6 +674,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: undefined,
         },
@@ -670,7 +688,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: '/',
           env: {
-            context: 'browser',
+            context: new Set(['browser']),
             engines: {
               browsers: ['IE 11'],
             },
@@ -680,6 +698,7 @@ describe('TargetResolver', () => {
             minify: false,
             scopeHoist: false,
             sourceMap: {},
+            loc: undefined,
           },
           loc: undefined,
         },

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -1808,7 +1808,7 @@ describe('cache', function() {
             'utf8',
           );
           assert(
-            contents.includes('<script src="http://example.com'),
+            contents.includes('<script type="module" src="http://example.com'),
             'should include example.com',
           );
 
@@ -1832,7 +1832,9 @@ describe('cache', function() {
         'utf8',
       );
       assert(
-        contents.includes('<script src="http://mygreatwebsite.com'),
+        contents.includes(
+          '<script type="module" src="http://mygreatwebsite.com',
+        ),
         'should include example.com',
       );
     });
@@ -2146,7 +2148,7 @@ describe('cache', function() {
             'utf8',
           );
           assert(
-            contents.includes('<script src="http://example.com'),
+            contents.includes('<script type="module" src="http://example.com'),
             'should include example.com',
           );
 
@@ -2161,7 +2163,9 @@ describe('cache', function() {
         'utf8',
       );
       assert(
-        contents.includes('<script src="http://mygreatwebsite.com'),
+        contents.includes(
+          '<script type="module" src="http://mygreatwebsite.com',
+        ),
         'should include example.com',
       );
     });

--- a/packages/core/integration-tests/test/integration/blob-url/index.js
+++ b/packages/core/integration-tests/test/integration/blob-url/index.js
@@ -1,2 +1,2 @@
-let worker = new Worker('blob-url:./worker');
+let worker = new Worker('blob-url:./worker', {type: 'module'});
 worker.postMessage('test');

--- a/packages/core/integration-tests/test/integration/cache/src/index.html
+++ b/packages/core/integration-tests/test/integration/cache/src/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
   <body>
-    <script src="index.js"></script>
+    <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/packages/core/integration-tests/test/integration/child-bundle-different-types/index.html
+++ b/packages/core/integration-tests/test/integration/child-bundle-different-types/index.html
@@ -11,7 +11,7 @@
   <div id="main1">
     Hello World Main1
   </div>
-  <script src="./main.js"></script>
+  <script type="module" src="./main.js"></script>
   <a href="./other.html">GOOO</a>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/child-bundle-different-types/other.html
+++ b/packages/core/integration-tests/test/integration/child-bundle-different-types/other.html
@@ -12,6 +12,6 @@
   <div id="main1">
     Heelo
   </div>
-  <script src="./index.js"></script>
+  <script type="module" src="./index.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/config-merging/node_modules/parcel-config-test1/index.json
+++ b/packages/core/integration-tests/test/integration/config-merging/node_modules/parcel-config-test1/index.json
@@ -1,5 +1,3 @@
 {
-  "runtimes": {
-    "node": ["parcel-runtime-nothing"]
-  }
+  "runtimes": ["parcel-runtime-nothing"]
 }

--- a/packages/core/integration-tests/test/integration/formats/esm-split-worker/index.html
+++ b/packages/core/integration-tests/test/integration/formats/esm-split-worker/index.html
@@ -1,1 +1,1 @@
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/formats/global-split-worker/index.js
+++ b/packages/core/integration-tests/test/integration/formats/global-split-worker/index.js
@@ -1,1 +1,1 @@
-new Worker("./main-worker");
+new Worker("./main-worker", {type: 'module'});

--- a/packages/core/integration-tests/test/integration/hmr-css/index.html
+++ b/packages/core/integration-tests/test/integration/hmr-css/index.html
@@ -6,6 +6,6 @@
 </head>
 <body>
   <h1>Hello world</h1>
-  <script src="index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-css-doctype/index.html
+++ b/packages/core/integration-tests/test/integration/html-css-doctype/index.html
@@ -1,2 +1,2 @@
 <!DOCTYPE html>
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-css-head/index.html
+++ b/packages/core/integration-tests/test/integration/html-css-head/index.html
@@ -2,6 +2,6 @@
 <html>
 <body>
   <h1>Hello world</h1>
-  <script src="index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-css-multi/index.html
+++ b/packages/core/integration-tests/test/integration/html-css-multi/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <h1>Hello world</h1>
-  <script src="a.js"></script>
-  <script src="b.js"></script>
+  <script type="module" src="a.js"></script>
+  <script type="module" src="b.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-css-optional-elements/index.html
+++ b/packages/core/integration-tests/test/integration/html-css-optional-elements/index.html
@@ -1,3 +1,3 @@
-<script src="other.js"></script>
+<script type="module" src="other.js"></script>
 <h1>Hello world</h1>
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-css/index.html
+++ b/packages/core/integration-tests/test/integration/html-css/index.html
@@ -5,6 +5,6 @@
 </head>
 <body>
   <h1>Hello world</h1>
-  <script src="index.js"></script>
+  <script type="module" src="index.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-inline-js-nested/index.html
+++ b/packages/core/integration-tests/test/integration/html-inline-js-nested/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-  <script>
+  <script type="module">
     require('./test');
   </script>
 </body>

--- a/packages/core/integration-tests/test/integration/html-inline-js-require/index.html
+++ b/packages/core/integration-tests/test/integration/html-inline-js-require/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-  <script>
+  <script type="module">
     require('./test');
   </script>
 </body>

--- a/packages/core/integration-tests/test/integration/html-inline-js-script/error.html
+++ b/packages/core/integration-tests/test/integration/html-inline-js-script/error.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      import './module';
+    </script>
+  </body>
+</html>

--- a/packages/core/integration-tests/test/integration/html-inline-js-script/globals-dependencies.html
+++ b/packages/core/integration-tests/test/integration/html-inline-js-script/globals-dependencies.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      log(typeof bar, typeof baz);
+      let x = 2;
+      if (true) {
+        log(typeof bar, typeof baz);
+        let y = 3;
+        var z = 4;
+        function bar() {}
+        class Test {}
+      }
+
+      log(typeof bar, typeof baz);
+
+      class Foo {}
+      function baz() {}
+
+      import('./module');
+    </script>
+    <script>
+      output = {
+        x,
+        y: typeof y,
+        z,
+        bar,
+        Test: typeof Test,
+        Foo,
+        baz
+      };
+    </script>
+  </body>
+</html>

--- a/packages/core/integration-tests/test/integration/html-inline-js-script/globals.html
+++ b/packages/core/integration-tests/test/integration/html-inline-js-script/globals.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <body>
+    <script>
+      log(typeof bar, typeof baz);
+      let x = 2;
+      if (true) {
+        log(typeof bar, typeof baz);
+        let y = 3;
+        var z = 4;
+        function bar() {}
+        class Test {}
+      }
+
+      log(typeof bar, typeof baz);
+
+      class Foo {}
+      function baz() {}
+    </script>
+    <script>
+      output = {
+        x,
+        y: typeof y,
+        z,
+        bar,
+        Test: typeof Test,
+        Foo,
+        baz
+      };
+    </script>
+  </body>
+</html>

--- a/packages/core/integration-tests/test/integration/html-inline-js-script/module.js
+++ b/packages/core/integration-tests/test/integration/html-inline-js-script/module.js
@@ -1,0 +1,1 @@
+export function bar() {}

--- a/packages/core/integration-tests/test/integration/html-js-dedup/index.html
+++ b/packages/core/integration-tests/test/integration/html-js-dedup/index.html
@@ -1,3 +1,3 @@
 <!DOCTYPE html>
-<script src="component-1.js"></script>
-<script src="component-2.js"></script>
+<script type="module" src="component-1.js"></script>
+<script type="module" src="component-2.js"></script>

--- a/packages/core/integration-tests/test/integration/html-js-dynamic/index.html
+++ b/packages/core/integration-tests/test/integration/html-js-dynamic/index.html
@@ -1,1 +1,1 @@
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-js-shared-dynamic-nested/index.html
+++ b/packages/core/integration-tests/test/integration/html-js-shared-dynamic-nested/index.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-js-shared-head/index.html
+++ b/packages/core/integration-tests/test/integration/html-js-shared-head/index.html
@@ -1,5 +1,5 @@
 <html>
   <head>
-    <script type="text/javascript" src="index.js"></script>
+    <script type="module" src="index.js"></script>
   </head>
 </html>

--- a/packages/core/integration-tests/test/integration/html-js-shared-head/index.js
+++ b/packages/core/integration-tests/test/integration/html-js-shared-head/index.js
@@ -1,3 +1,3 @@
 console.log(require("lodash").add(1, 2));
 import("./async.js");
-new Worker("./worker.js");
+new Worker("./worker.js", {type: 'module'});

--- a/packages/core/integration-tests/test/integration/html-js-shared/index.html
+++ b/packages/core/integration-tests/test/integration/html-js-shared/index.html
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-js-shared/index.js
+++ b/packages/core/integration-tests/test/integration/html-js-shared/index.js
@@ -1,3 +1,3 @@
 console.log(require("lodash").add(1, 2));
 import("./async.js");
-new Worker("./worker.js");
+new Worker("./worker.js", {type: 'module'});

--- a/packages/core/integration-tests/test/integration/html-js/error.html
+++ b/packages/core/integration-tests/test/integration/html-js/error.html
@@ -1,0 +1,1 @@
+<script src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-js/index.html
+++ b/packages/core/integration-tests/test/integration/html-js/index.html
@@ -1,1 +1,1 @@
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/html-multi-entry/a.html
+++ b/packages/core/integration-tests/test/integration/html-multi-entry/a.html
@@ -3,5 +3,5 @@
 </head>
 
 <body>
-	<script src="./index.js"></script>
+	<script type="module" src="./index.js"></script>
 </body>

--- a/packages/core/integration-tests/test/integration/html-multi-entry/b.html
+++ b/packages/core/integration-tests/test/integration/html-multi-entry/b.html
@@ -3,5 +3,5 @@
 </head>
 
 <body>
-	<script src="./index.js"></script>
+	<script type="module" src="./index.js"></script>
 </body>

--- a/packages/core/integration-tests/test/integration/html-root/index.html
+++ b/packages/core/integration-tests/test/integration/html-root/index.html
@@ -5,6 +5,6 @@
 </head>
 <body>
   <a href="./other.html">goto page2</a>
-  <script type="text/javascript" src="./main.js"></script>
+  <script type="module" src="./main.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-root/other.html
+++ b/packages/core/integration-tests/test/integration/html-root/other.html
@@ -5,6 +5,6 @@
 </head>
 <body>
   <a href="./index.html">goto page1</a>
-  <script type="text/javascript" src="./index2.js"></script>
+  <script type="module" src="./index2.js"></script>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-shared-worker/index.html
+++ b/packages/core/integration-tests/test/integration/html-shared-worker/index.html
@@ -2,6 +2,6 @@
 <html>
   <body>
     <h1>Hello!</h1>
-    <script src="./index.js"></script>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-shared-worker/index.js
+++ b/packages/core/integration-tests/test/integration/html-shared-worker/index.js
@@ -2,4 +2,4 @@ import _ from 'lodash';
 
 output("main", _.add(1, 2));
 
-new Worker('worker.js');
+new Worker('worker.js', {type: 'module'});

--- a/packages/core/integration-tests/test/integration/html-shared/iframe.html
+++ b/packages/core/integration-tests/test/integration/html-shared/iframe.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html>
   <body>
-    <script src="iframe.js"></script>
+    <script type="module" src="iframe.js"></script>
   </body>
 </html>

--- a/packages/core/integration-tests/test/integration/html-shared/index.html
+++ b/packages/core/integration-tests/test/integration/html-shared/index.html
@@ -3,6 +3,6 @@
   <body>
     <h1>Hello!</h1>
     <iframe src="iframe.html"></iframe>
-    <script src="./index.js"></script>
+    <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/packages/core/integration-tests/test/integration/react-refresh-lazy-child/index.html
+++ b/packages/core/integration-tests/test/integration/react-refresh-lazy-child/index.html
@@ -1,2 +1,2 @@
 <div id="root"></div>
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/react-refresh/index.html
+++ b/packages/core/integration-tests/test/integration/react-refresh/index.html
@@ -1,2 +1,2 @@
 <div id="root"></div>
-<script src="index.js"></script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/resolver-dependency-meta/.parcelrc
+++ b/packages/core/integration-tests/test/integration/resolver-dependency-meta/.parcelrc
@@ -1,7 +1,5 @@
 {
   "extends": "@parcel/config-default",
   "resolvers": ["parcel-resolver-meta", "..."],
-  "runtimes": {
-    "browser": ["parcel-runtime-meta", "..."]
-  }
+  "runtimes": ["parcel-runtime-meta", "..."]
 }

--- a/packages/core/integration-tests/test/integration/runtime-symbol-merging/.parcelrc
+++ b/packages/core/integration-tests/test/integration/runtime-symbol-merging/.parcelrc
@@ -1,8 +1,6 @@
 {
   "extends": "@parcel/config-default",
-  "runtimes": {
-    "browser": [
-      "parcel-runtime-mock"
-    ]
-  }
+  "runtimes": [
+    "parcel-runtime-mock"
+  ]
 }

--- a/packages/core/integration-tests/test/integration/runtime-update/.parcelrc
+++ b/packages/core/integration-tests/test/integration/runtime-update/.parcelrc
@@ -1,8 +1,6 @@
 {
   "extends": "@parcel/config-default",
-  "runtimes": {
-    "browser": [
-      "parcel-runtime-mock",
-    ],
-  }
+  "runtimes": [
+    "parcel-runtime-mock",
+  ]
 }

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-async/index.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-async/index.html
@@ -1,1 +1,1 @@
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/live-bindings-cross-bundle/a.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/live-bindings-cross-bundle/a.html
@@ -1,1 +1,1 @@
-<script src="a.js"></script>
+<script type="module" src="a.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/live-bindings-cross-bundle/b.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/live-bindings-cross-bundle/b.html
@@ -1,1 +1,1 @@
-<script src="b.js"></script>
+<script type="module" src="b.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/shared-bundle-reexport/index1.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/shared-bundle-reexport/index1.html
@@ -1,1 +1,1 @@
-<script src="index1.js"></script>
+<script type="module" src="index1.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/shared-bundle-reexport/index2.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/shared-bundle-reexport/index2.html
@@ -1,1 +1,1 @@
-<script src="index2.js"></script>
+<script type="module" src="index2.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/shared-bundle-reexport/index3.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/shared-bundle-reexport/index3.html
@@ -1,1 +1,1 @@
-<script src="index3.js"></script>
+<script type="module" src="index3.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-css/index.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-css/index.html
@@ -1,2 +1,2 @@
 <div id="react-root"></div>
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-no-new-bundle/index.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-no-new-bundle/index.html
@@ -1,2 +1,2 @@
 <div id="react-root"></div>
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/update-used-symbols-dependency-add-namespace/index.html
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/update-used-symbols-dependency-add-namespace/index.html
@@ -1,2 +1,2 @@
 <div id="react-root"></div>
-<script src="./index.js"></script>
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/service-worker/error.js
+++ b/packages/core/integration-tests/test/integration/service-worker/error.js
@@ -1,0 +1,1 @@
+navigator.serviceWorker.register('module-worker.js');

--- a/packages/core/integration-tests/test/integration/service-worker/module-worker.js
+++ b/packages/core/integration-tests/test/integration/service-worker/module-worker.js
@@ -1,0 +1,1 @@
+export var foo = 2;

--- a/packages/core/integration-tests/test/integration/service-worker/module.js
+++ b/packages/core/integration-tests/test/integration/service-worker/module.js
@@ -1,0 +1,1 @@
+navigator.serviceWorker.register('module-worker.js', {type: 'module'});

--- a/packages/core/integration-tests/test/integration/service-worker/scope.js
+++ b/packages/core/integration-tests/test/integration/service-worker/scope.js
@@ -1,0 +1,1 @@
+navigator.serviceWorker.register('module-worker.js', {scope: 'foo', type: 'module'});

--- a/packages/core/integration-tests/test/integration/shared-many/a.html
+++ b/packages/core/integration-tests/test/integration/shared-many/a.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="a.js"></script>
+<script type="module" src="a.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many/b.html
+++ b/packages/core/integration-tests/test/integration/shared-many/b.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="b.js"></script>
+<script type="module" src="b.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many/c.html
+++ b/packages/core/integration-tests/test/integration/shared-many/c.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="c.js"></script>
+<script type="module" src="c.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many/d.html
+++ b/packages/core/integration-tests/test/integration/shared-many/d.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="d.js"></script>
+<script type="module" src="d.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many/e.html
+++ b/packages/core/integration-tests/test/integration/shared-many/e.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="e.js"></script>
+<script type="module" src="e.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many/f.html
+++ b/packages/core/integration-tests/test/integration/shared-many/f.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="f.js"></script>
+<script type="module" src="f.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-many/g.html
+++ b/packages/core/integration-tests/test/integration/shared-many/g.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="g.js"></script>
+<script type="module" src="g.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-sibling-duplicate/a.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-duplicate/a.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="a.js"></script>
+<script type="module" src="a.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-sibling-duplicate/b.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-duplicate/b.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="b.js"></script>
+<script type="module" src="b.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-sibling-duplicate/c.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-duplicate/c.html
@@ -1,2 +1,2 @@
 <!doctype html>
-<script src="c.js"></script>
+<script type="module" src="c.js"></script>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries-multiple/a.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries-multiple/a.html
@@ -2,6 +2,6 @@
 <html>
   <body>
     <h1>a.html</h1>
-    <script src="./a.js"></script>
+    <script type="module" src="./a.js"></script>
   </body>
 </html>

--- a/packages/core/integration-tests/test/integration/shared-sibling-entries-multiple/b.html
+++ b/packages/core/integration-tests/test/integration/shared-sibling-entries-multiple/b.html
@@ -2,6 +2,6 @@
 <html>
   <body>
     <h1>b.html</h1>
-    <script src="./b.js"></script>
+    <script type="module" src="./b.js"></script>
   </body>
 </html>

--- a/packages/core/integration-tests/test/integration/worker-circular/index.js
+++ b/packages/core/integration-tests/test/integration/worker-circular/index.js
@@ -1,1 +1,1 @@
-new Worker('worker.js');
+new Worker('worker.js', {type: 'module'});

--- a/packages/core/integration-tests/test/integration/worker-shared/index.js
+++ b/packages/core/integration-tests/test/integration/worker-shared/index.js
@@ -1,3 +1,3 @@
 import _ from 'lodash';
 
-new Worker('worker-a.js');
+new Worker('worker-a.js', {type: 'module'});

--- a/packages/core/integration-tests/test/integration/worker-shared/worker-a.js
+++ b/packages/core/integration-tests/test/integration/worker-shared/worker-a.js
@@ -1,4 +1,4 @@
 import _ from 'lodash'
 
 console.log(_);
-new Worker('worker-b.js')
+new Worker('worker-b.js', {type: 'module'})

--- a/packages/core/integration-tests/test/integration/workers-module/dedicated-worker.js
+++ b/packages/core/integration-tests/test/integration/workers-module/dedicated-worker.js
@@ -1,3 +1,4 @@
 import foo from "foo";
 
 console.log("DedicatedWorker", foo);
+export {foo};

--- a/packages/core/integration-tests/test/integration/workers-module/error.js
+++ b/packages/core/integration-tests/test/integration/workers-module/error.js
@@ -1,0 +1,1 @@
+new Worker("dedicated-worker.js");

--- a/packages/core/integration-tests/test/integration/workers-module/named.js
+++ b/packages/core/integration-tests/test/integration/workers-module/named.js
@@ -1,0 +1,2 @@
+new Worker("dedicated-worker.js", {name: 'worker', type: 'module'});
+new SharedWorker("shared-worker.js", {name: 'shared', type: 'module'});

--- a/packages/core/integration-tests/test/integration/workers-module/package.json
+++ b/packages/core/integration-tests/test/integration/workers-module/package.json
@@ -1,7 +1,0 @@
-{
-    "targets": {
-        "default": {
-            "includeNodeModules": false
-        }
-    }
-}

--- a/packages/core/integration-tests/test/integration/workers-module/shared-worker.js
+++ b/packages/core/integration-tests/test/integration/workers-module/shared-worker.js
@@ -1,3 +1,4 @@
 import foo from "foo";
 
 console.log("SharedWorker", foo);
+export {foo};

--- a/packages/core/integration-tests/test/integration/workers/worker-client.js
+++ b/packages/core/integration-tests/test/integration/workers/worker-client.js
@@ -3,12 +3,12 @@ const commonText = require('./common').commonFunction('Index');
 navigator.serviceWorker.register('service-worker.js', { scope: './' });
 
 exports.startWorker = function() {
-  const worker = new Worker('worker.js', {name: 'myName'});
+  const worker = new Worker('worker.js', {type: 'module', name: 'myName'});
   worker.postMessage(commonText);
 };
 
 exports.startSharedWorker = function() {
-  const worker = new SharedWorker('shared-worker.js');
+  const worker = new SharedWorker('shared-worker.js', {type: 'module'});
 };
 
 

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -832,7 +832,7 @@ describe('output formats', function() {
       );
 
       let workerBundle = nullthrows(
-        b.getBundles().find(b => b.env.context === 'web-worker'),
+        b.getBundles().find(b => b.env.context.has('web-worker')),
       );
       let workerBundleContents = await outputFS.readFile(
         workerBundle.filePath,

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -502,6 +502,11 @@ describe('scope hoisting', function() {
             f,
           ),
         ),
+        {
+          defaultEngines: {
+            browsers: '>= 0.25%',
+          },
+        },
       );
 
       let output = await runBundle(
@@ -824,6 +829,11 @@ describe('scope hoisting', function() {
           __dirname,
           '/integration/scope-hoisting/es6/shared-bundle-reexport/*.html',
         ),
+        {
+          defaultEngines: {
+            browsers: '>= 0.25%',
+          },
+        },
       );
 
       assertBundles(b, [
@@ -836,8 +846,16 @@ describe('scope hoisting', function() {
           assets: ['index1.js'],
         },
         {
+          type: 'js',
+          assets: ['index1.js'],
+        },
+        {
           type: 'html',
           assets: ['index2.html'],
+        },
+        {
+          type: 'js',
+          assets: ['index2.js'],
         },
         {
           type: 'js',
@@ -853,7 +871,19 @@ describe('scope hoisting', function() {
         },
         {
           type: 'js',
+          assets: ['index3.js'],
+        },
+        {
+          type: 'js',
           assets: ['a.js'],
+        },
+        {
+          type: 'js',
+          assets: ['a.js'],
+        },
+        {
+          type: 'js',
+          assets: ['b.js'],
         },
         {
           type: 'js',
@@ -1681,6 +1711,11 @@ describe('scope hoisting', function() {
           __dirname,
           '/integration/scope-hoisting/es6/interop-async/index.html',
         ),
+        {
+          defaultEngines: {
+            browsers: '>= 0.25%',
+          },
+        },
       );
 
       let output = await run(b);
@@ -2033,6 +2068,9 @@ describe('scope hoisting', function() {
         let b = bundler(path.join(testDir, 'index.html'), {
           inputFS: overlayFS,
           outputFS: overlayFS,
+          defaultEngines: {
+            browsers: '>= 0.25%',
+          },
         });
 
         await overlayFS.mkdirp(testDir);
@@ -2148,12 +2186,21 @@ describe('scope hoisting', function() {
             __dirname,
             '/integration/scope-hoisting/es6/side-effects-css/index.html',
           ),
+          {
+            defaultEngines: {
+              browsers: '>= 0.25%',
+            },
+          },
         );
 
         assertBundles(b, [
           {
             name: 'index.html',
             assets: ['index.html'],
+          },
+          {
+            type: 'js',
+            assets: ['index.js', 'a.js', 'b1.js'],
           },
           {
             type: 'js',
@@ -2187,12 +2234,17 @@ describe('scope hoisting', function() {
             __dirname,
             '/integration/scope-hoisting/es6/side-effects-no-new-bundle/index.html',
           ),
+          {defaultEngines: {browsers: '>= 0.25%'}},
         );
 
         assertBundles(b, [
           {
             name: 'index.html',
             assets: ['index.html'],
+          },
+          {
+            type: 'js',
+            assets: ['index.js', 'a.js', 'b1.js'],
           },
           {
             type: 'js',
@@ -4133,12 +4185,21 @@ describe('scope hoisting', function() {
   it('should not throw with JS included from HTML', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-js/index.html'),
+      {
+        defaultEngines: {
+          browsers: '>= 0.25%',
+        },
+      },
     );
 
     assertBundles(b, [
       {
         name: 'index.html',
         assets: ['index.html'],
+      },
+      {
+        type: 'js',
+        assets: ['index.js', 'other.js'],
       },
       {
         type: 'js',
@@ -4162,6 +4223,11 @@ describe('scope hoisting', function() {
   it('should not throw with JS dynamic imports included from HTML', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-js-dynamic/index.html'),
+      {
+        defaultEngines: {
+          browsers: '>= 0.25%',
+        },
+      },
     );
 
     assertBundles(b, [
@@ -4184,6 +4250,20 @@ describe('scope hoisting', function() {
       },
       {
         type: 'js',
+        assets: [
+          'bundle-url.js',
+          'cacheLoader.js',
+          'import-polyfill.js',
+          'index.js',
+          'JSRuntime.js',
+        ],
+      },
+      {
+        type: 'js',
+        assets: ['local.js'],
+      },
+      {
+        type: 'js',
         assets: ['local.js'],
       },
     ]);
@@ -4196,6 +4276,11 @@ describe('scope hoisting', function() {
   it('should include the prelude in shared entry bundles', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-shared/index.html'),
+      {
+        defaultEngines: {
+          browsers: '>= 0.25%',
+        },
+      },
     );
 
     assertBundles(b, [
@@ -4208,12 +4293,24 @@ describe('scope hoisting', function() {
         assets: ['index.js'],
       },
       {
+        type: 'js',
+        assets: ['index.js'],
+      },
+      {
         name: 'iframe.html',
         assets: ['iframe.html'],
       },
       {
         type: 'js',
         assets: ['iframe.js'],
+      },
+      {
+        type: 'js',
+        assets: ['iframe.js'],
+      },
+      {
+        type: 'js',
+        assets: ['lodash.js'],
       },
       {
         type: 'js',
@@ -4241,6 +4338,11 @@ describe('scope hoisting', function() {
   it('should include prelude in shared worker bundles', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/worker-shared/index.js'),
+      {
+        defaultEngines: {
+          browsers: '>= 0.25%',
+        },
+      },
     );
 
     let sharedBundle = b

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -13,6 +13,8 @@
     "node": ">= 10.0.0"
   },
   "dependencies": {
+    "@babel/core": "^7.12.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.0.0",
     "@parcel/config-default": "2.0.0-beta.1",
     "@parcel/core": "2.0.0-beta.1",
     "@parcel/fs": "2.0.0-beta.1",

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -76,3 +76,4 @@ export {
   loadSourceMapUrl,
   loadSourceMap,
 } from './sourcemap';
+export {setIntersects, isSetEqual, isSubset} from './set';

--- a/packages/core/utils/src/set.js
+++ b/packages/core/utils/src/set.js
@@ -1,0 +1,50 @@
+// @flow
+
+export function setIntersects<T>(a: Set<T>, b: Set<T>): boolean {
+  for (let item of a) {
+    if (b.has(item)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isSetEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) {
+    return false;
+  }
+
+  for (let item of a) {
+    if (!b.has(item)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Returns true if either set is a subset of the other.
+ */
+export function isSubset<T>(a: Set<T>, b: Set<T>): boolean {
+  let res = true;
+  for (let item of b) {
+    if (!a.has(item)) {
+      res = false;
+      break;
+    }
+  }
+
+  if (!res) {
+    res = true;
+    for (let item of a) {
+      if (!b.has(item)) {
+        res = false;
+        break;
+      }
+    }
+  }
+
+  return res;
+}

--- a/packages/shared/babel-ast-utils/src/index.js
+++ b/packages/shared/babel-ast-utils/src/index.js
@@ -36,6 +36,8 @@ export async function parse({
         strictMode: false,
         sourceType: 'module',
         plugins: ['exportDefaultFrom', 'exportNamespaceFrom', 'dynamicImport'],
+        // $FlowFixMe
+        startLine: asset.meta.loc?.start.line,
       }),
     };
   } catch (e) {

--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -90,6 +90,27 @@ export function generate({
       : [WRAPPER_TEMPLATE({STATEMENTS: statements})];
   }
 
+  let topLevelVars = mainEntry?.meta.topLevelVars;
+  if (
+    topLevelVars &&
+    typeof topLevelVars === 'object' &&
+    !Array.isArray(topLevelVars)
+  ) {
+    let vars = {};
+    for (let key in topLevelVars) {
+      let type = topLevelVars[key];
+      invariant(typeof type === 'string');
+      let decl = t.variableDeclarator(t.identifier(key));
+      if (vars[type]) {
+        vars[type].declarations.push(decl);
+      } else {
+        // $FlowFixMe
+        vars[type] = t.variableDeclaration(type, [decl]);
+        statements.unshift(vars[type]);
+      }
+    }
+  }
+
   ast = t.file(
     t.program(
       statements,

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -25,6 +25,7 @@ import {isVariableDeclarator, isVariableDeclaration} from '@babel/types';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import path from 'path';
+import {isSubset} from '@parcel/utils';
 
 export function getName(
   asset: Asset | MutableAsset,
@@ -125,7 +126,7 @@ export function hasAsyncDescendant(
       return;
     }
 
-    if (b.env.context !== bundle.env.context || b.type !== 'js') {
+    if (!isSubset(b.env.context, bundle.env.context) || b.type !== 'js') {
       actions.skipChildren();
       return;
     }

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -42,6 +42,8 @@ export default async function babel7(
       strictMode: false,
       sourceType: 'module',
       plugins: ['dynamicImport'],
+      // $FlowFixMe
+      startLine: asset.meta.loc?.start.line,
     },
     caller: {
       name: 'parcel',

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",
+    "@parcel/posthtml-parser": "^0.6.0",
     "@parcel/utils": "2.0.0-beta.1",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.11.3",
-    "posthtml-parser": "^0.4.1",
     "posthtml-render": "^1.1.5",
     "semver": "^5.4.1"
   }

--- a/packages/transformers/html/src/HTMLTransformer.js
+++ b/packages/transformers/html/src/HTMLTransformer.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Transformer} from '@parcel/plugin';
-import parse from 'posthtml-parser';
+import parse from '@parcel/posthtml-parser';
 import nullthrows from 'nullthrows';
 import render from 'posthtml-render';
 import semver from 'semver';

--- a/packages/transformers/js/src/visitors/script-globals.js
+++ b/packages/transformers/js/src/visitors/script-globals.js
@@ -1,0 +1,146 @@
+// @flow
+
+import type {AST, MutableAsset, PluginOptions} from '@parcel/types';
+
+import * as types from '@babel/types';
+import {
+  isFunctionDeclaration,
+  isVariableDeclaration,
+  isClassDeclaration,
+  isProgram,
+  isDirective,
+} from '@babel/types';
+import {traverse} from '@parcel/babylon-walk';
+import invariant from 'assert';
+import nullthrows from 'nullthrows';
+
+let scriptGlobalsVisitor = {
+  Function(path) {
+    path.skip();
+  },
+  Block: {
+    enter(path, context) {
+      if (!isProgram(path.node)) {
+        context.isInBlock = true;
+      }
+
+      context.blockStack.push([]);
+    },
+    exit(path, context) {
+      context.isInBlock = false;
+
+      let functionAssignments = context.blockStack.pop();
+      if (functionAssignments.length > 0) {
+        // $FlowFixMe
+        path.node.body.unshift(...functionAssignments);
+        context.asset.setAST(context.ast);
+      }
+    },
+  },
+  Directive(path, context) {
+    if (isDirective(path.node) && path.node.value.value === 'use strict') {
+      context.isStrictMode = true;
+    }
+  },
+  VariableDeclaration(path, {asset, ast, isInBlock}) {
+    let node = path.node;
+    invariant(isVariableDeclaration(node));
+
+    if (isInBlock && node.kind !== 'var') {
+      return;
+    }
+
+    let ids = types.getBindingIdentifiers(node);
+    for (let id in ids) {
+      // $FlowFixMe
+      asset.meta.topLevelVars[id] = node.kind;
+    }
+
+    path.replaceWith(
+      types.expressionStatement(
+        types.sequenceExpression(
+          node.declarations
+            .filter(decl => decl.init)
+            .map(decl =>
+              types.assignmentExpression('=', decl.id, nullthrows(decl.init)),
+            ),
+        ),
+      ),
+    );
+
+    asset.setAST(ast);
+  },
+  FunctionDeclaration(path, {asset, isInBlock, isStrictMode, blockStack}) {
+    let node = path.node;
+    invariant(isFunctionDeclaration(node));
+
+    // In strict mode, function declarations inside blocks are not hoisted to the global scope.
+    if (isInBlock && isStrictMode) {
+      return;
+    }
+
+    let id = node.id;
+    if (!id) {
+      return;
+    }
+
+    let name = id.name;
+    id.name = types.toIdentifier('$' + asset.id) + '$var$' + name;
+    // $FlowFixMe
+    asset.meta.topLevelVars[name] = 'var';
+
+    let assignment = types.expressionStatement(
+      types.assignmentExpression(
+        '=',
+        types.identifier(name),
+        types.identifier(id.name),
+      ),
+    );
+
+    // Follow Annex B.3.3 rules. Function declarations should be hoisted to the top
+    // of the nearest block, or the program if not inside a block. Safari does not
+    // currently implement this rule for globals, but it would be hard to replicate this.
+    // https://tc39.es/ecma262/#sec-block-level-function-declarations-web-legacy-compatibility-semantics
+    blockStack[blockStack.length - 1].push(assignment);
+  },
+  ClassDeclaration(path, {asset, ast, isInBlock}) {
+    let node = path.node;
+    invariant(isClassDeclaration(node));
+    if (isInBlock || !node.id) {
+      return;
+    }
+
+    let name = node.id.name;
+
+    // $FlowFixMe
+    asset.meta.topLevelVars[name] = 'let';
+
+    path.replaceWith(
+      types.expressionStatement(
+        types.assignmentExpression(
+          '=',
+          types.identifier(name),
+          types.toExpression(node),
+        ),
+      ),
+    );
+
+    asset.setAST(ast);
+  },
+};
+
+export function assignScriptGlobals(
+  asset: MutableAsset,
+  ast: AST,
+  options: PluginOptions,
+) {
+  asset.meta.topLevelVars = {};
+  traverse(ast.program, scriptGlobalsVisitor, {
+    asset,
+    ast,
+    options,
+    isStrictMode: false,
+    isInBlock: false,
+    blockStack: [],
+  });
+}

--- a/packages/transformers/posthtml/package.json
+++ b/packages/transformers/posthtml/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",
+    "@parcel/posthtml-parser": "^0.6.0",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.11.3",
-    "posthtml-parser": "^0.4.1",
     "posthtml-render": "^1.1.5",
     "semver": "^5.4.1"
   }

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -4,7 +4,7 @@ import {Transformer} from '@parcel/plugin';
 
 import path from 'path';
 import posthtml from 'posthtml';
-import parse from 'posthtml-parser';
+import parse from '@parcel/posthtml-parser';
 import render from 'posthtml-render';
 import nullthrows from 'nullthrows';
 import semver from 'semver';

--- a/packages/utils/babylon-walk/src/traverse.js
+++ b/packages/utils/babylon-walk/src/traverse.js
@@ -42,6 +42,11 @@ class Path {
     // $FlowFixMe
     this.parent[this.listkey].splice(this.key, 1);
   }
+  insertAfter(...n: Node[]) {
+    invariant(this.listkey && typeof this.key === 'number');
+    // $FlowFixMe
+    this.parent[this.listkey].splice(this.key + 1, 0, ...n);
+  }
 }
 
 export default function traverse<T>(

--- a/packages/utils/posthtml-parser/LICENSE
+++ b/packages/utils/posthtml-parser/LICENSE
@@ -1,0 +1,22 @@
+(The MIT License)
+
+Copyright (c) 2015 Ivan Voischev <voischev.ivan@ya.ru>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/utils/posthtml-parser/index.js
+++ b/packages/utils/posthtml-parser/index.js
@@ -1,0 +1,198 @@
+const {Parser} = require('htmlparser2');
+
+/**
+ * @see https://github.com/fb55/htmlparser2/wiki/Parser-options
+ */
+const defaultOptions = {lowerCaseTags: false, lowerCaseAttributeNames: false, decodeEntities: false};
+
+const defaultDirectives = [{name: '!doctype', start: '<', end: '>'}];
+
+/**
+ * Parse html to PostHTMLTree
+ * @param  {String} html
+ * @param  {Object} [options=defaultOptions]
+ * @return {PostHTMLTree}
+ */
+function postHTMLParser(html, options) {
+  const bufArray = [];
+  const results = [];
+
+  bufArray.last = function () {
+    return this[this.length - 1];
+  };
+
+  function isDirective({name}, tag) {
+    if (name instanceof RegExp) {
+      const regex = new RegExp(name.source, 'i');
+
+      return regex.test(tag);
+    }
+
+    if (tag !== name) {
+      return false;
+    }
+
+    return true;
+  }
+
+  function parserDirective(name, data) {
+    const directives = [].concat(defaultDirectives, options.directives || []);
+    const last = bufArray.last();
+
+    for (const directive of directives) {
+      const directiveText = directive.start + data + directive.end;
+
+      name = name.toLowerCase();
+      if (isDirective(directive, name)) {
+        if (!last) {
+          results.push(directiveText);
+          return;
+        }
+
+        if (last.content === undefined) {
+          last.content = [];
+        }
+
+        last.content.push(directiveText);
+      }
+    }
+  }
+
+  function normalizeArributes(attrs) {
+    const result = {};
+    Object.keys(attrs).forEach(key => {
+      const object = {};
+      object[key] = attrs[key].replace(/&quot;/g, '"');
+      Object.assign(result, object);
+    });
+
+    return result;
+  }
+
+  let lastLoc = {
+    line: 1,
+    column: 1
+  };
+
+  let lastIndex = 0;
+  function getLoc(index) {
+    if (index < lastIndex) {
+      throw new Error('Source indices must be monotonic');
+    }
+
+    while (lastIndex < index) {
+      if (html.charCodeAt(lastIndex) === /* \n */ 10) {
+        lastLoc.line++;
+        lastLoc.column = 1;
+      } else {
+        lastLoc.column++;
+      }
+
+      lastIndex++;
+    }
+
+    return {
+      line: lastLoc.line,
+      column: lastLoc.column
+    };
+  }
+
+  const parser = new Parser({
+    onprocessinginstruction: parserDirective,
+    oncomment(data) {
+      const comment = `<!--${data}-->`;
+      const last = bufArray.last();
+
+      if (!last) {
+        results.push(comment);
+        return;
+      }
+
+      if (last.content === undefined) {
+        last.content = [];
+      }
+
+      last.content.push(comment);
+    },
+    onopentag(tag, attrs) {
+      const buf = {
+        tag,
+        loc: {
+          start: getLoc(parser.startIndex),
+          end: null
+        }
+      };
+
+      if (Object.keys(attrs).length > 0) {
+        buf.attrs = normalizeArributes(attrs);
+      }
+
+      bufArray.push(buf);
+    },
+    onclosetag() {
+      const buf = bufArray.pop();
+      buf.loc.end = getLoc(parser.endIndex);
+
+      if (!bufArray.length > 0) {
+        results.push(buf);
+        return;
+      }
+
+      const last = bufArray.last();
+      if (!Array.isArray(last.content)) {
+        last.content = [];
+      }
+
+      last.content.push(buf);
+    },
+    ontext(text) {
+      const last = bufArray.last();
+
+      if (!last) {
+        results.push(text);
+        return;
+      }
+
+      if (last.content && last.content.length > 0 && typeof last.content[last.content.length - 1] === 'string') {
+        last.content[last.content.length - 1] = `${last.content[last.content.length - 1]}${text}`;
+        return;
+      }
+
+      if (last.content === undefined) {
+        last.content = [];
+      }
+
+      last.content.push(text);
+    }
+  }, options || defaultOptions);
+
+  parser.write(html);
+  parser.end();
+
+  return results;
+}
+
+function parserWrapper(...args) {
+  let option;
+
+  function parser(html) {
+    const opt = {...defaultOptions, ...option};
+    return postHTMLParser(html, opt);
+  }
+
+  if (
+    args.length === 1 &&
+    Boolean(args[0]) &&
+    args[0].constructor.name === 'Object'
+  ) {
+    option = args[0];
+    return parser;
+  }
+
+  option = args[1];
+  return parser(args[0]);
+}
+
+module.exports = parserWrapper;
+module.exports.defaultOptions = defaultOptions;
+module.exports.defaultDirectives = defaultDirectives;

--- a/packages/utils/posthtml-parser/package.json
+++ b/packages/utils/posthtml-parser/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@parcel/posthtml-parser",
+  "version": "0.6.0",
+  "description": "Parse HTML/XML to PostHTMLTree",
+  "keywords": [
+    "html",
+    "xml",
+    "parser",
+    "posthtml",
+    "posthtmltree"
+  ],
+  "main": "index.js",
+  "types": "index.d.ts",
+  "engines": {
+    "node": ">=10.0.0"
+  },
+  "repository": "posthtml/posthtml-parser",
+  "author": "Ivan Voischev <voischev.ivan@ya.ru>",
+  "contributors": [
+    {
+      "name": "Ivan Voischev",
+      "email": "voischev.ivan@ya.ru"
+    },
+    {
+      "name": "Ivan Demidov",
+      "email": "scrum@list.ru"
+    }
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/posthtml/posthtml-parser/issues"
+  },
+  "homepage": "https://github.com/posthtml/posthtml-parser#readme",
+  "dependencies": {
+    "htmlparser2": "^5.0.1"
+  },
+  "funding": {
+    "type": "patreon",
+    "url": "https://opencollective.com/posthtml"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/posthtml"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5265,6 +5265,15 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.1.0.tgz#5f7c828f1bfc44887dc2a315ab5c45691d544b58"
+  integrity sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    entities "^2.0.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -5299,6 +5308,13 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+domhandler@^3.0.0, domhandler@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.3.0.tgz#6db7ea46e4617eb15cf875df68b2b8524ce0037a"
+  integrity sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==
+  dependencies:
+    domelementtype "^2.0.1"
+
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -5306,6 +5322,15 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.4.2.tgz#7ee5be261944e1ad487d9aa0616720010123922b"
+  integrity sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -7395,6 +7420,16 @@ htmlparser2@^3.9.2:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
+
+htmlparser2@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-5.0.1.tgz#7daa6fc3e35d6107ac95a4fc08781f091664f6e7"
+  integrity sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.3.0"
+    domutils "^2.4.2"
+    entities "^2.0.0"
 
 htmlparser2@~3.9.2:
   version "3.9.2"


### PR DESCRIPTION
Whew, this turned out way bigger than I expected... 😂 

This changes the way script tags are treated in HTML to distinguish between classic scripts and ES modules, improves Parcel's web compatibility, and introduces automatic modern-by-default optimizations for production builds.

* `import`, `export`, `require`, and all Node polyfill features are now only allowed in `<script type="module">` contexts (both inline and linked). Classic `<script>` elements can still have dynamic `import()`, `Worker`, `SharedWorker`, and `navigator.serviceWorker.register` dependencies. This matches what browsers support more closely, and allows better interoperability with legacy scripts where e.g. `require` being processed by Parcel was unexpected.
* Classic `<script>` now works just like the browser - global variables are truly global. The bundle is not wrapped in a function, so top-level variables are accessible between scripts on the page, in HTML event handler attributes, etc. See e.g. #5378. By default, when there are no dependencies, the script is not processed at all by Parcel. However, when an async dependency is seen that may require us to inject a runtime, we do wrap the bundle in a function to avoid unintended globals, but the globals seen in the original source are hoisted for compatibility.
* In addition, `<script type="module">` is now automatically compiled to both a modern ES module version and also a legacy `<script nomodule>` version if the browser targets do not all support ES modules natively. If no browserslist or target config is specified, then only a modern ES module version is output. For inline scripts, only a single script is output in order to avoid duplicating content - a modern version if all targets support it, otherwise legacy.
* The same rules also apply in other scenarios, including web workers and service workers. These now require the `type: 'module'` option just like in the browser to use ES modules, otherwise they will behave just like as described above for classic scripts. Workers are compiled to ES modules natively if all browser targets support them, otherwise they are compiled to a classic script instead.

When an import or export is found in a classic script, we show an error message that indicates both where the dependency is, as well as where the environment was originally instantiated.

<img width="983" alt="image" src="https://user-images.githubusercontent.com/19409/100533217-d535db80-31cf-11eb-9eb2-1bc11cf94670.png">

This also resulted in adding support for multiple contexts at once in an environment. For example, an asset may have both "browser" and "script" as its environment. This may have other uses later on. I also added a method to the environment object to allow easier checking if it supports a particular feature. There's basic data for things like esmodules, dynamic imports, etc. so far, but ideally we'd get this data from somewhere else that we don't need to maintain ourselves. Finally, environments also now support a `loc` property to track the source location where they were originally created, mostly for error messaging purposes.

One other change due to the multi-environment support is that I changed the config format to no longer configure runtimes per context, and instead just have a single pipeline. The reality was that all of the contexts used the same runtime plugin anyway, and if the runtimes are context specific, they can check internally themselves.

Close T-554, Close T-136