### PR TITLE
Add flow type for json5

### DIFF
--- a/flow-libs/json5.js.flow
+++ b/flow-libs/json5.js.flow
@@ -1,0 +1,36 @@
+// @flow
+
+// Derived from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/json5/index.d.ts
+// Which is licensed MIT
+
+declare module 'json5' {
+  declare type JSONReplacer = (
+    key: string,
+    value: mixed,
+  ) => mixed | (number | string)[] | null;
+
+  declare type Reviver = (key: mixed, value: mixed) => mixed;
+  declare type replacer1 = (key: string, value: mixed) => mixed;
+  declare type replacer2 = (number | string)[] | null;
+  declare type Options = {|
+    space?: number | string,
+    quote?: string,
+    replacer?: JSONReplacer,
+  |};
+
+  declare module.exports: {
+    parse(text: string, reviver?: Reviver): any,
+    stringify(
+      value: mixed,
+      replacer?: replacer1,
+      space?: string | number,
+    ): string,
+    stringify(
+      value: mixed,
+      replacer?: replacer2,
+      space?: string | number,
+    ): string,
+    stringify(value: mixed, options?: Options): string,
+    ...
+  };
+}

--- a/flow-libs/json5.js.flow
+++ b/flow-libs/json5.js.flow
@@ -20,7 +20,7 @@ declare module 'json5' {
   |};
 
   declare module.exports: {|
-    parse(text: string, reviver?: Reviver): any,
+    parse(text: string, reviver?: Reviver): any, // Not type safe !
     stringify(
       value: mixed,
       replacer?: replacer1,

--- a/flow-libs/json5.js.flow
+++ b/flow-libs/json5.js.flow
@@ -11,8 +11,6 @@ declare module 'json5' {
   ) => mixed | (number | string)[] | null;
 
   declare type Reviver = (key: mixed, value: mixed) => mixed;
-  declare type replacer1 = (key: string, value: mixed) => mixed;
-  declare type replacer2 = (number | string)[] | null;
   declare type Options = {|
     space?: number | string,
     quote?: string,
@@ -23,12 +21,10 @@ declare module 'json5' {
     parse(text: string, reviver?: Reviver): any, // Not type safe !
     stringify(
       value: mixed,
-      replacer?: replacer1,
-      space?: string | number,
-    ): string,
-    stringify(
-      value: mixed,
-      replacer?: replacer2,
+      replacer?:
+        | (number | string)[]
+        | null
+        | ((key: string, value: mixed) => mixed),
       space?: string | number,
     ): string,
     stringify(value: mixed, options?: Options): string,

--- a/flow-libs/json5.js.flow
+++ b/flow-libs/json5.js.flow
@@ -1,6 +1,7 @@
 // @flow
 
 // Derived from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/json5/index.d.ts
+// And https://github.com/DefinitelyTyped/DefinitelyTyped#readme
 // Which is licensed MIT
 
 declare module 'json5' {
@@ -18,7 +19,7 @@ declare module 'json5' {
     replacer?: JSONReplacer,
   |};
 
-  declare module.exports: {
+  declare module.exports: {|
     parse(text: string, reviver?: Reviver): any,
     stringify(
       value: mixed,
@@ -31,6 +32,5 @@ declare module 'json5' {
       space?: string | number,
     ): string,
     stringify(value: mixed, options?: Options): string,
-    ...
-  };
+  |};
 }

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -26,7 +26,6 @@ import {
 import ThrowableDiagnostic, {
   generateJSONCodeHighlights,
 } from '@parcel/diagnostic';
-// $FlowFixMe
 import {parse} from 'json5';
 import path from 'path';
 import assert from 'assert';

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -11,7 +11,6 @@ import {
 } from '@parcel/test-utils';
 // flowlint-next-line untyped-import:off
 import WebSocket from 'ws';
-// flowlint-next-line untyped-import:off
 import json5 from 'json5';
 // flowlint-next-line untyped-import:off
 import getPort from 'get-port';


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR is for adding a flow typings file for `JSON5` 

## 🚨 Test instructions

1. Remove flow disable or `fixme` comments from `parcelConfigRequest.js` and `hmr.js`
2. Check flow is enabled
3. Run ` yarn flow check ` and confirm there are 0 errors

## 📓  Notes

❗  Not type safe return from `parse` ❗ 