### PR TITLE
Fix non-top-level module.exports assignments

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/commonjs-esm/universal-library.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-esm/universal-library.js
@@ -1,0 +1,11 @@
+!(function (name, definition) {
+  if (typeof module != "undefined") {
+    module.exports = definition();
+  } else if (typeof define == "function" && typeof define.amd == "object") {
+    define(definition);
+  } else {
+    this[name] = definition();
+  }
+})("some-pkg-name", function () {
+  return { a: 2 };
+});

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1122,6 +1122,21 @@ describe('output formats', function() {
     });
   });
 
+  it('should support generating ESM from universal module wrappers', async function() {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/formats/commonjs-esm/universal-library.js',
+      ),
+    );
+
+    let dist = (
+      await outputFS.readFile(b.getBundles()[0].filePath, 'utf8')
+    ).trim();
+    assert.strictEqual(dist.match(/export default/g).length, 1);
+    assert(/export default \$\w+\$\w+;(\n+\/\/.*)?$/.test(dist));
+  });
+
   it("doesn't overwrite used global variables", async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/formats/conflict-global/index.js'),

--- a/packages/shared/scope-hoisting/src/formats/esmodule.js
+++ b/packages/shared/scope-hoisting/src/formats/esmodule.js
@@ -321,9 +321,13 @@ export function generateExports(
               binding.constantViolations[binding.constantViolations.length - 1];
           }
 
-          let [decl] = insertPath.insertAfter(
-            t.exportDefaultDeclaration(t.identifier(defaultExport)),
-          );
+          let node = t.exportDefaultDeclaration(t.identifier(defaultExport));
+          let decl;
+          if (insertPath.parentPath.isProgram()) {
+            [decl] = insertPath.insertAfter(node);
+          } else {
+            [decl] = programPath.pushContainer('body', node);
+          }
           binding?.reference(decl.get<NodePath<Identifier>>('declaration'));
         }
 


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/5230

Previously:

```js
!(function (name, definition) {
  if (typeof module != "undefined") {
    module.exports = definition();
  } else if (typeof define == "function" && typeof define.amd == "object") {
    define(definition);
  } else {
    this[name] = definition();
  }
})("some-pkg-name", function () {
  return { a: 2 };
});
```


```js
// ASSET: lib.js
var $d32bcf3d24482056cb8353653e5e805e$exports = {};
var $d32bcf3d24482056cb8353653e5e805e$var$define;
!function (name, definition) {
  if ("object" != "undefined") {
    $d32bcf3d24482056cb8353653e5e805e$exports = definition();
    export default $d32bcf3d24482056cb8353653e5e805e$exports; // <------
  } else if (typeof $d32bcf3d24482056cb8353653e5e805e$var$define == "function" && typeof $d32bcf3d24482056cb8353653e5e805e$var$define.amd == "object") {
    $d32bcf3d24482056cb8353653e5e805e$var$define(definition);
  } else {
    this[name] = definition();
  }
}("some-pkg-name", function () {
  return {
    a: 2
  };
});
```