### PR TITLE
Serialize the BundleGraph as a raw value

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -56,6 +56,7 @@ type InternalExportSymbolResolution = {|
 |};
 
 type SerializedBundleGraph = {|
+  $$raw: true,
   graph: GraphOpts<BundleGraphNode, BundleGraphEdgeTypes>,
   bundleContentHashes: Map<string, string>,
   assetPublicIds: Set<string>,
@@ -167,6 +168,7 @@ export default class BundleGraph {
 
   serialize(): SerializedBundleGraph {
     return {
+      $$raw: true,
       graph: this._graph.serialize(),
       assetPublicIds: this._assetPublicIds,
       bundleContentHashes: this._bundleContentHashes,

--- a/packages/core/core/src/serializer.js
+++ b/packages/core/core/src/serializer.js
@@ -57,6 +57,10 @@ function isBuffer(object) {
   );
 }
 
+function shouldContinueMapping(value) {
+  return value && typeof value === 'object' && value.$$raw !== true;
+}
+
 function mapObject(object: any, fn: (val: any) => any, preOrder = false): any {
   let cache = new Map();
   let memo = new Map();
@@ -90,7 +94,13 @@ function mapObject(object: any, fn: (val: any) => any, preOrder = false): any {
       }
 
       // Recursively walk the children
-      if (newValue && typeof newValue === 'object' && newValue.$$raw !== true) {
+      if (
+        preOrder
+          ? shouldContinueMapping(newValue)
+          : newValue &&
+            typeof newValue === 'object' &&
+            shouldContinueMapping(object)
+      ) {
         newValue = walk(newValue, newValue === value);
       }
 
@@ -137,7 +147,11 @@ function mapObject(object: any, fn: (val: any) => any, preOrder = false): any {
   };
 
   let mapped = memoizedFn(object);
-  if (mapped && typeof mapped === 'object' && mapped.$$raw !== true) {
+  if (
+    preOrder
+      ? shouldContinueMapping(mapped)
+      : mapped && typeof mapped === 'object' && shouldContinueMapping(object)
+  ) {
     return walk(mapped, mapped === object);
   }
 


### PR DESCRIPTION
The BundleGraph does not need to be recursively traversed when being serialized or deserialized. Instead, mark it as a raw value to skip this step of the serializer.

This also required a change to the serializer to skip recursively deserializing values when the input value was a raw value. Previously, it recursed unconditionally.

Test Plan:
* Perform a trace and verify that `restoreDeserializedObject` called on the BundleGraph at the beginning of packaging has minimal impact on performance as it ends once it encounters the raw value.