### PR TITLE
Unsubscribe ReporterRunner from Bus

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -163,6 +163,7 @@ export default class Parcel {
       options: resolvedOptions,
       workerFarm: this.#farm,
     });
+    this.#disposable.add(this.#reporterRunner);
 
     this.#packagerRunner = new PackagerRunner({
       config: this.#config,
@@ -200,7 +201,6 @@ export default class Parcel {
       this.#assetGraphBuilder.writeToCache(),
       this.#runtimesAssetGraphBuilder.writeToCache(),
     ]);
-    this.#reporterRunner.destroy();
   }
 
   async _startNextBuild() {

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -200,6 +200,7 @@ export default class Parcel {
       this.#assetGraphBuilder.writeToCache(),
       this.#runtimesAssetGraphBuilder.writeToCache(),
     ]);
+    this.#reporterRunner.destroy();
   }
 
   async _startNextBuild() {

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -36,6 +36,7 @@ export default class ReporterRunner {
   constructor(opts: Opts) {
     this.config = opts.config;
     this.options = opts.options;
+    this.workerFarm = opts.workerFarm;
     this.pluginOptions = new PluginOptions(this.options);
 
     logger.onLog(event => this.report(event));

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -2,7 +2,7 @@
 
 import type {ReporterEvent} from '@parcel/types';
 import type {WorkerApi} from '@parcel/workers';
-import type {ParcelOptions} from './types';
+import type {Bundle as InternalBundle, ParcelOptions} from './types';
 
 import invariant from 'assert';
 import {
@@ -28,6 +28,7 @@ type Opts = {|
 |};
 
 export default class ReporterRunner {
+  workerFarm: WorkerFarm;
   config: ParcelConfig;
   options: ParcelOptions;
   pluginOptions: PluginOptions;
@@ -39,27 +40,7 @@ export default class ReporterRunner {
 
     logger.onLog(event => this.report(event));
 
-    bus.on('reporterEvent', event => {
-      if (
-        event.type === 'buildProgress' &&
-        (event.phase === 'optimizing' || event.phase === 'packaging') &&
-        !(event.bundle instanceof NamedBundle)
-      ) {
-        // Convert any internal bundles back to their public equivalents as reporting
-        // is public api
-        let bundleGraph = opts.workerFarm.workerApi.getSharedReference(
-          event.bundleGraphRef,
-        );
-        invariant(bundleGraph instanceof BundleGraph);
-        this.report({
-          ...event,
-          bundle: NamedBundle.get(event.bundle, bundleGraph, this.options),
-        });
-        return;
-      }
-
-      this.report(event);
-    });
+    bus.on('reporterEvent', this.eventHandler);
 
     if (this.options.patchConsole) {
       patchConsole();
@@ -67,6 +48,34 @@ export default class ReporterRunner {
       unpatchConsole();
     }
   }
+
+  eventHandler: ReporterEvent => void = (event): void => {
+    if (
+      event.type === 'buildProgress' &&
+      (event.phase === 'optimizing' || event.phase === 'packaging') &&
+      !(event.bundle instanceof NamedBundle)
+    ) {
+      // $FlowFixMe[prop-missing]
+      let bundleGraphRef = event.bundleGraphRef;
+      // $FlowFixMe[incompatible-exact]
+      let bundle: InternalBundle = event.bundle;
+      // Convert any internal bundles back to their public equivalents as reporting
+      // is public api
+      let bundleGraph = this.workerFarm.workerApi.getSharedReference(
+        // $FlowFixMe
+        bundleGraphRef,
+      );
+      invariant(bundleGraph instanceof BundleGraph);
+      // $FlowFixMe[incompatible-call]
+      this.report({
+        ...event,
+        bundle: NamedBundle.get(bundle, bundleGraph, this.options),
+      });
+      return;
+    }
+
+    this.report(event);
+  };
 
   async report(event: ReporterEvent) {
     let reporters = await this.config.getReporters();
@@ -83,6 +92,10 @@ export default class ReporterRunner {
         INTERNAL_ORIGINAL_CONSOLE.error(e);
       }
     }
+  }
+
+  destroy() {
+    bus.off('reporterEvent', this.eventHandler);
   }
 }
 

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -94,7 +94,7 @@ export default class ReporterRunner {
     }
   }
 
-  destroy() {
+  dispose() {
     bus.off('reporterEvent', this.eventHandler);
   }
 }


### PR DESCRIPTION
# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/4135

Fixes T-385

Fixes a memory leak if the JS API was used repeatedly without restarting the process.

## 🚨 Test instructions

Run the integration tests. Previously, this warning was printed after the 10th test:
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 reporterEvent listeners added to [Bus] 
```

