### PR TITLE
Devserver port search fix

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -349,8 +349,9 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
         chalk.bold.yellowBright(`⚠️  Port ${command.port} could not be used.`),
       );
       // If port was provided using -p or --port flag then throw an Error
-      if (isCustomPort && nodeEnv === 'development')
+      if (isCustomPort && nodeEnv === 'development') {
         throw new Error(`port ${command.port} taken`);
+      }
     }
   }
 

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -183,7 +183,7 @@ async function run(entries: Array<string>, command: any) {
   try {
     options = await normalizeOptions(command);
   } catch (e) {
-    return process.exit(-1);
+    return process.exit(1);
   }
   let fs = new NodeFS();
   let packageManager = new NodePackageManager(fs);
@@ -349,8 +349,8 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
         chalk.bold.yellowBright(`⚠️  Port ${command.port} could not be used.`),
       );
       // If port was provided using -p or --port flag then throw an Error
-      if (isCustomPort && nodeEnv === 'development') {
-        throw new Error(`port ${command.port} taken`);
+      if (isCustomPort) {
+        throw new Error(`Port ${command.port} could not be used`);
       }
     }
   }

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -349,7 +349,8 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
         chalk.bold.yellowBright(`⚠️  Port ${command.port} could not be used.`),
       );
       // If port was provided using -p or --port flag then throw an Error
-      if (isCustomPort) throw new Error(`port ${command.port} taken`);
+      if (isCustomPort && nodeEnv === 'development')
+        throw new Error(`port ${command.port} taken`);
     }
   }
 

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -179,7 +179,13 @@ async function run(entries: Array<string>, command: any) {
     return;
   }
   let Parcel = require('@parcel/core').default;
-  let options = await normalizeOptions(command);
+  let optionsError;
+  let options;
+  try {
+    options = await normalizeOptions(command);
+  } catch (e) {
+    optionsError = true;
+  }
   let fs = new NodeFS();
   let packageManager = new NodePackageManager(fs);
   let parcel = new Parcel({
@@ -216,7 +222,7 @@ async function run(entries: Array<string>, command: any) {
     disposable.dispose();
     process.exit(exitCode);
   }
-  if (!options) {
+  if (optionsError) {
     await exit(-1);
   }
 
@@ -316,9 +322,7 @@ async function run(entries: Array<string>, command: any) {
   }
 }
 
-async function normalizeOptions(
-  command,
-): Promise<InitialParcelOptions | boolean> {
+async function normalizeOptions(command): Promise<InitialParcelOptions> {
   let nodeEnv;
   if (command.name() === 'build') {
     nodeEnv = initialNodeEnv || 'production';
@@ -348,8 +352,8 @@ async function normalizeOptions(
       INTERNAL_ORIGINAL_CONSOLE.warn(
         chalk.bold.yellowBright(`⚠️  Port ${command.port} could not be used.`),
       );
-      // If port was provided using -p or --port flag then return -1
-      if (isCustomPort) return false;
+      // If port was provided using -p or --port flag then throw an Error
+      if (isCustomPort) throw new Error(`port ${command.port} taken`);
     }
   }
 

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -183,7 +183,7 @@ async function run(entries: Array<string>, command: any) {
   try {
     options = await normalizeOptions(command);
   } catch (e) {
-    process.exit(-1);
+    return process.exit(-1);
   }
   let fs = new NodeFS();
   let packageManager = new NodePackageManager(fs);

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -191,12 +191,7 @@ async function run(entries: Array<string>, command: any) {
     return;
   }
   let Parcel = require('@parcel/core').default;
-  let options;
-  try {
-    options = await normalizeOptions(command);
-  } catch (e) {
-    return process.exit(1);
-  }
+  let options = await normalizeOptions(command);
   let fs = new NodeFS();
   let packageManager = new NodePackageManager(fs);
   let parcel = new Parcel({

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -179,12 +179,11 @@ async function run(entries: Array<string>, command: any) {
     return;
   }
   let Parcel = require('@parcel/core').default;
-  let optionsError;
   let options;
   try {
     options = await normalizeOptions(command);
   } catch (e) {
-    optionsError = true;
+    process.exit(-1);
   }
   let fs = new NodeFS();
   let packageManager = new NodePackageManager(fs);
@@ -221,9 +220,6 @@ async function run(entries: Array<string>, command: any) {
 
     disposable.dispose();
     process.exit(exitCode);
-  }
-  if (optionsError) {
-    await exit(-1);
   }
 
   const isWatching = command.name() === 'watch' || command.name() === 'serve';


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Added a change after which devserver is not searching for a new port if a specific one was requested

Closes #5495

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
If a user has explicitly wanted to serve on a specific port, then if that port is taken it won't search for a new one.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
