### PR TITLE
Make sure default imports are also live

### DIFF
--- a/packages/core/integration-tests/test/integration/js-import-default-live/index.js
+++ b/packages/core/integration-tests/test/integration/js-import-default-live/index.js
@@ -1,0 +1,7 @@
+import a, { set } from "./other.js";
+
+let oldValue = a;
+set(789);
+let newValue = a;
+
+export default [oldValue, newValue]

--- a/packages/core/integration-tests/test/integration/js-import-default-live/other.js
+++ b/packages/core/integration-tests/test/integration/js-import-default-live/other.js
@@ -1,0 +1,5 @@
+let a = 123;
+function set(v) {
+	a = v;
+}
+export { a as default, set };

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3095,8 +3095,8 @@ describe('javascript', function() {
     );
     let res = await run(b);
     assert.deepEqual(Object.keys(res), ['foo', 'bar']);
-    assert.equal(res.foo('test'), 'foo:test');
-    assert.equal(res.bar('test'), 'bar:test');
+    assert.strictEqual(res.foo('test'), 'foo:test');
+    assert.strictEqual(res.bar('test'), 'bar:test');
   });
 
   it('should handle exports of imports', async function() {
@@ -3120,6 +3120,14 @@ describe('javascript', function() {
       path.join(__dirname, 'integration/js-import-shadow/index.js'),
     );
     let res = await run(b);
-    assert.equal(res.baz(), 'foo');
+    assert.strictEqual(res.baz(), 'foo');
+  });
+
+  it('should not freeze live default imports', async function() {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-import-default-live/index.js'),
+    );
+    let res = await run(b);
+    assert.deepEqual(res.default, [123, 789]);
   });
 });

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -22,6 +22,6 @@ describe('svg', function() {
 
     let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf-8');
     assert(file.includes('function SvgIcon'));
-    assert(file.includes('_reactDefault.createElement("svg"'));
+    assert(file.includes('_reactDefault.default.createElement("svg"'));
   });
 });

--- a/packages/transformers/js/src/esmodule-helpers.js
+++ b/packages/transformers/js/src/esmodule-helpers.js
@@ -1,5 +1,5 @@
 exports.interopDefault = function(a) {
-  return a && a.__esModule ? a.default : a;
+  return a && a.__esModule ? a : {default: a};
 };
 
 exports.defineInteropFlag = function(a) {

--- a/packages/transformers/js/src/visitors/modules.js
+++ b/packages/transformers/js/src/visitors/modules.js
@@ -228,7 +228,10 @@ function getDefault(state, source) {
   if (!names.default) {
     names.default = state.scope.generateUid(names.name + 'Default');
   }
-  return t.identifier(names.default);
+  return t.memberExpression(
+    t.identifier(names.default),
+    t.identifier('default'),
+  );
 }
 
 function getNamespace(state, source) {


### PR DESCRIPTION
# ↪️ Pull Request

Closes https://github.com/parcel-bundler/parcel/issues/5502

Do this instead:
```js
var _bJs = require("./b.js");

var _parcelHelpers = require("@parcel/transformer-js/src/esmodule-helpers.js");

var _bJsDefault = _parcelHelpers.interopDefault(_bJs);

console.log(_bJsDefault.default);

_bJs.set(789);
```
This is similar to Babel