### PR TITLE
Extend test utils to execute ESM bundles

### DIFF
--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "scripts": {
-    "test": "cross-env NODE_ENV=test PARCEL_BUILD_ENV=test mocha",
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules NODE_ENV=test PARCEL_BUILD_ENV=test mocha",
     "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json"
   },
   "devDependencies": {

--- a/packages/core/integration-tests/test/integration/formats/esm-async-chained-reexport2/index.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-async-chained-reexport2/index.js
@@ -1,4 +1,4 @@
 import { createAndFireEvent } from "./library/b.js";
 var createAndFireEventOnAtlaskit = createAndFireEvent("index");
-output = import("./library/a.js")
-    .then((m) => [createAndFireEventOnAtlaskit(), m.default(), m.a]);
+
+export default import("./library/a.js").then((m) => [createAndFireEventOnAtlaskit(), m.default(), m.a]);

--- a/packages/core/integration-tests/test/integration/formats/esm-async/index.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-async/index.js
@@ -1,1 +1,1 @@
-output = import('./async').then(a => a.foo + 2);
+export default import('./async').then(a => a.foo + 2);

--- a/packages/core/integration-tests/test/integration/formats/esm-bundle-import-reexport/index.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-bundle-import-reexport/index.js
@@ -1,8 +1,5 @@
-import {T} from "./i18n";
+import {T} from './i18n/index.js';
 
-const version = import("./version.js");
+const version = import('./version.js');
 
-console.log(
-	T("index"),
-	version.then(v => "Diagram" + v.default())
-);
+export default version.then((v) => [T('index'), 'Diagram' + v.default()]);

--- a/packages/core/integration-tests/test/integration/formats/esm-bundle-import-reexport/version.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-bundle-import-reexport/version.js
@@ -1,4 +1,4 @@
-import {T} from "./i18n";
+import {T} from "./i18n/index.js";
 
 export default function() {
 	return "Version: " + T("some name");

--- a/packages/core/integration-tests/test/integration/formats/esm-split/async1.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-split/async1.js
@@ -1,6 +1,4 @@
 import _ from 'lodash';
 import react from 'react';
 
-console.log('async1');
-console.log(_);
-console.log(react);
+export default ['async1', _, react];

--- a/packages/core/integration-tests/test/integration/formats/esm-split/async2.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-split/async2.js
@@ -1,6 +1,4 @@
 import _ from 'lodash';
 import react from 'react';
 
-console.log('async2');
-console.log(_);
-console.log(react);
+export default ['async2', _, react];

--- a/packages/core/integration-tests/test/integration/formats/esm-split/index.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-split/index.js
@@ -1,2 +1,4 @@
-import('./async1');
-import('./async2');
+export default Promise.all([import('./async1'), import('./async2')]).then(
+	([{default: [a, b, c]}, {default: [x, y, z]}]) =>
+		a === 'async1' && x === 'async2' && b === y && c === z,
+);

--- a/packages/core/integration-tests/test/integration/formats/esm-wrap-codesplit/a.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-wrap-codesplit/a.js
@@ -2,4 +2,4 @@ if (Date.now() < 0) {
 	let x = require("./c.js");
 }
 
-output = import("./b.js");
+export default import("./b.js");

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -3,14 +3,17 @@ import path from 'path';
 import nullthrows from 'nullthrows';
 import {
   assertBundles,
+  assertESMExports,
   bundle as _bundle,
   outputFS,
   run,
   runBundle,
 } from '@parcel/test-utils';
+import * as react from 'react';
+import * as lodash from 'lodash';
+import * as lodashFP from 'lodash/fp';
 
-const bundle = (name, opts = {}) =>
-  _bundle(name, Object.assign({scopeHoist: true}, opts));
+const bundle = (name, opts) => _bundle(name, {scopeHoist: true, ...opts});
 
 describe('output formats', function() {
   describe('commonjs', function() {
@@ -526,7 +529,7 @@ describe('output formats', function() {
         path.join(__dirname, '/integration/formats/esm/named.js'),
       );
 
-      assert.deepEqual({...(await run(b))}, {bar: 5, foo: 2});
+      await assertESMExports(b, {bar: 5, foo: 2});
     });
 
     it('should support esmodule output (default identifier)', async function() {
@@ -538,6 +541,7 @@ describe('output formats', function() {
       assert(!dist.includes('function')); // no iife
       assert(dist.includes('var _default = $'));
       assert(dist.includes('export default _default'));
+      await assertESMExports(b, {default: 4});
     });
 
     it('should support esmodule output (default function)', async function() {
@@ -547,6 +551,7 @@ describe('output formats', function() {
 
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export default function'));
+      assert.strictEqual((await run(b)).default(), 2);
     });
 
     it('should support esmodule output (multiple)', async function() {
@@ -557,6 +562,7 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export {a, c}'));
       assert(dist.includes('export default'));
+      await assertESMExports(b, {a: 2, c: 5, default: 3});
     });
 
     it('should support esmodule output (exporting symbol multiple times)', async function() {
@@ -567,6 +573,7 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export {test, test as other, foo};'));
       assert(dist.includes('export default test;'));
+      await assertESMExports(b, {default: 1, foo: 2, other: 1, test: 1});
     });
 
     it('should support esmodule output (re-export)', async function() {
@@ -577,6 +584,7 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export {a, c}'));
       assert(!dist.includes('export default'));
+      await assertESMExports(b, {a: 2, c: 5});
     });
 
     it.skip('should support esmodule output (re-export namespace as)', async function() {
@@ -589,6 +597,7 @@ describe('output formats', function() {
 
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export var ns'));
+      await assertESMExports(b, {ns: {a: 2, c: 5}});
     });
 
     it('should support esmodule output (renaming re-export)', async function() {
@@ -599,6 +608,7 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export var foo'));
       assert(!dist.includes('export default'));
+      await assertESMExports(b, {foo: 4});
     });
 
     it('should support esmodule output with external modules (named import)', async function() {
@@ -609,6 +619,11 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export const bar'));
       assert(dist.includes('import {add} from "lodash"'));
+      await assertESMExports(
+        b,
+        {bar: 3},
+        {lodash: () => ({add: (a, b) => a + b})},
+      );
     });
 
     it('should support esmodule output with external modules (named import with same name)', async function() {
@@ -621,6 +636,14 @@ describe('output formats', function() {
       assert(dist.includes('import {assign} from "lodash/fp"'));
       assert(dist.includes('import {assign as _assign} from "lodash"'));
       assert(dist.includes('assign !== _assign'));
+      await assertESMExports(
+        b,
+        {bar: true},
+        {
+          lodash: () => lodash,
+          'lodash/fp': () => lodashFP,
+        },
+      );
     });
 
     it('should support esmodule output with external modules (namespace import)', async function() {
@@ -641,6 +664,13 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('export const bar'));
       assert(dist.includes('import _lodash from "lodash"'));
+      await assertESMExports(
+        b,
+        {bar: 3},
+        {
+          lodash: () => lodash,
+        },
+      );
     });
 
     it('should support esmodule output with external modules (multiple specifiers)', async function() {
@@ -652,6 +682,13 @@ describe('output formats', function() {
       assert(dist.includes('export const bar'));
       assert(dist.includes('import _lodash, * as _lodash2 from "lodash"'));
       assert(dist.includes('import {add} from "lodash"'));
+      await assertESMExports(
+        b,
+        {bar: 6},
+        {
+          lodash: () => lodash,
+        },
+      );
     });
 
     it('should support esmodule output with external modules (export)', async function() {
@@ -662,6 +699,14 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('import {add} from "lodash"'));
       assert(dist.includes('export {add}'));
+      await assertESMExports(
+        b,
+        3,
+        {
+          lodash: () => lodash,
+        },
+        ns => ns.add(1, 2),
+      );
     });
 
     it('should support esmodule output with external modules (re-export)', async function() {
@@ -672,6 +717,14 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('import {add} from "lodash"'));
       assert(dist.includes('export {add}'));
+      await assertESMExports(
+        b,
+        3,
+        {
+          lodash: () => lodash,
+        },
+        ns => ns.add(1, 2),
+      );
     });
 
     it('should support importing sibling bundles in library mode', async function() {
@@ -726,6 +779,8 @@ describe('output formats', function() {
         'utf8',
       );
       assert(dist.includes('$parcel$interopDefault'));
+      let ns = await run(b);
+      assert.deepEqual(await ns.default, [123, 123]);
     });
 
     it('should rename imports that conflict with exports', async function() {
@@ -736,6 +791,7 @@ describe('output formats', function() {
       let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
       assert(dist.includes('import {foo as _foo} from "foo";'));
       assert(dist.includes('export const foo = _foo + 3;'));
+      await assertESMExports(b, {foo: 13}, {foo: () => ({foo: 10})});
     });
 
     it('should support async imports', async function() {
@@ -754,6 +810,7 @@ describe('output formats', function() {
         'utf8',
       );
       assert(async.includes('export const foo'));
+      await assertESMExports(b, 4, {}, ns => ns.default);
     });
 
     // This is currently not possible, it would have to do something like this:
@@ -786,6 +843,7 @@ describe('output formats', function() {
         'utf8',
       );
       assert(!async.includes('$import$'));
+      await assertESMExports(b, ['index', 'a', 1], {}, ns => ns.default);
     });
 
     it('should throw an error on missing export with esmodule output and sideEffects: false', async function() {
@@ -866,6 +924,13 @@ describe('output formats', function() {
           async2,
         ),
       );
+
+      await assertESMExports(
+        b,
+        true,
+        {lodash: () => lodash, react: () => react},
+        ns => ns.default,
+      );
     });
 
     it('should call init for wrapped modules when codesplitting to esmodules', async function() {
@@ -891,6 +956,8 @@ describe('output formats', function() {
           childBundleContents,
         ),
       );
+      let ns = await run(b);
+      assert.deepStrictEqual({...(await ns.default)}, {default: 2});
     });
 
     it('should support async split bundles for workers', async function() {
@@ -1124,6 +1191,13 @@ describe('output formats', function() {
         dist2.match(/import {([a-z0-9$]+)} from "\.\/index\.js";/)[1],
         exportName,
       );
+
+      await assertESMExports(
+        b,
+        ['!!!index!!!', 'DiagramVersion: !!!some name!!!'],
+        {},
+        ns => ns.default,
+      );
     });
 
     it('should support generating ESM from CommonJS', async function() {
@@ -1138,6 +1212,9 @@ describe('output formats', function() {
       assert(dist.includes('import {add} from "lodash"'));
       assert(dist.includes('add(a, b)'));
       assert(dist.includes('export default'));
+
+      let ns = await run(b, {}, {}, {lodash: () => lodash});
+      assert.strictEqual(ns.default(1, 2), 3);
     });
 
     it('should support re-assigning to module.exports', async function() {
@@ -1156,6 +1233,9 @@ describe('output formats', function() {
         lines[lines.length - 3].startsWith('export default'),
       );
       assert.equal(dist.match(/export default/g).length, 1);
+
+      let ns = await run(b);
+      assert.deepStrictEqual({...ns}, {default: 'xyz'});
     });
 
     it("doesn't support require.resolve calls for excluded assets without commonjs", async function() {
@@ -1207,6 +1287,9 @@ describe('output formats', function() {
       assert(contents.includes('var exports = {}'));
       assert(contents.includes('export default exports'));
       assert(contents.includes('exports.default ='));
+
+      let ns = await run(b);
+      assert.deepEqual({...ns}, {default: {default: 'default'}});
     });
   });
 

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -526,10 +526,7 @@ describe('output formats', function() {
         path.join(__dirname, '/integration/formats/esm/named.js'),
       );
 
-      let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-      assert(!dist.includes('function')); // no iife
-      assert(dist.includes('export const foo = 2'));
-      assert(/export const bar = .+ \+ 3/.test(dist));
+      assert.deepEqual({...(await run(b))}, {bar: 5, foo: 2});
     });
 
     it('should support esmodule output (default identifier)', async function() {


### PR DESCRIPTION
1. Execute the ESM build output and compares it with the expected result
2. Where possible (= if there's no CJS interop problem), compare the exports of the build output with the exports of the build input

Depends on https://github.com/parcel-bundler/parcel/pull/5664

Close T-461

TODO:
- [x] update assertions
- [x] Not include `require` in the context for Node with esm