### PR TITLE
Reduce linux binary size for fs-search package

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Link native packages
         run: node scripts/link-native.js
       - uses: bahmutov/npm-install@v1.1.0
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: strip *.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -59,6 +62,8 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
         env:
           RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip *.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -107,6 +112,8 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
         env:
           RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip *.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: strip *.node
+        run: strip native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -63,7 +63,7 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.target }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: strip *.node
+        run: strip native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -113,7 +113,7 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.target }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: strip *.node
+        run: strip native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: strip native-packages/*/*.node
+      - name: Strip debug symbols
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: strip -x native-packages/*/*.node # Must use -x on macOS. This produces larger results on linux.
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -142,6 +145,8 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
         env:
           RUST_TARGET: aarch64-apple-darwin
+      - name: Strip debug symbols
+        run: strip -x native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: strip native-packages/*/*.node
+      - name: Strip debug symbols
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: strip -x native-packages/*/*.node # Must use -x on macOS. This produces larger results on linux.
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -141,6 +144,8 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
         env:
           RUST_TARGET: aarch64-apple-darwin
+      - name: Strip debug symbols
+        run: strip -x native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Link native packages
         run: node scripts/link-native.js
       - uses: bahmutov/npm-install@v1.1.0
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: strip *.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -58,6 +61,8 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
         env:
           RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip *.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -106,6 +111,8 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
         env:
           RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip *.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: bahmutov/npm-install@v1.1.0
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: strip *.node
+        run: strip native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -62,7 +62,7 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.target }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: strip *.node
+        run: strip native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -112,7 +112,7 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.target }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: strip *.node
+        run: strip native-packages/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Strips debug symbols. Due to https://github.com/rust-lang/rust/issues/46034