### PR TITLE
Use exact versions for @parcel dependencies and update engines to beta

### DIFF
--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -17,7 +17,7 @@
   "source": "src/DefaultBundler.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-beta.1",

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -20,7 +20,7 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
-    "@parcel/diagnostic": "^2.0.0-beta.1",
+    "@parcel/diagnostic": "2.0.0-beta.1",
     "@parcel/plugin": "2.0.0-beta.1",
     "@parcel/utils": "2.0.0-beta.1",
     "nullthrows": "^1.1.1"

--- a/packages/core/register/example/package.json
+++ b/packages/core/register/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "register-example",
-  "version": "2.0.0-alpha.1.1",
+  "version": "2.0.0-beta.1",
   "main": "./index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -17,7 +17,7 @@
   "source": "src/DefaultNamer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-beta.1",

--- a/packages/optimizers/blob-url/package.json
+++ b/packages/optimizers/blob-url/package.json
@@ -17,7 +17,7 @@
   "source": "src/BlobURLOptimizer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -17,7 +17,7 @@
   "source": "src/CSSNanoOptimizer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/optimizers/data-url/package.json
+++ b/packages/optimizers/data-url/package.json
@@ -17,7 +17,7 @@
   "source": "src/DataURLOptimizer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/optimizers/htmlnano/package.json
+++ b/packages/optimizers/htmlnano/package.json
@@ -17,7 +17,7 @@
   "source": "src/HTMLNanoOptimizer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/optimizers/terser/package.json
+++ b/packages/optimizers/terser/package.json
@@ -17,7 +17,7 @@
   "source": "src/TerserOptimizer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-beta.1",

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -17,7 +17,7 @@
   "source": "src/CSSPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -17,7 +17,7 @@
   "source": "src/HTMLPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -17,7 +17,7 @@
   "source": "src/JSPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@babel/traverse": "^7.2.3",

--- a/packages/packagers/raw-url/package.json
+++ b/packages/packagers/raw-url/package.json
@@ -17,7 +17,7 @@
   "source": "src/RawUrlPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/packagers/raw/package.json
+++ b/packages/packagers/raw/package.json
@@ -17,7 +17,7 @@
   "source": "src/RawPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/packagers/ts/package.json
+++ b/packages/packagers/ts/package.json
@@ -17,7 +17,7 @@
   "source": "src/TSPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/reporters/build-metrics/package.json
+++ b/packages/reporters/build-metrics/package.json
@@ -17,7 +17,7 @@
   "source": "src/BuildMetricsReporter.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/reporters/bundle-buddy/package.json
+++ b/packages/reporters/bundle-buddy/package.json
@@ -17,7 +17,7 @@
   "source": "src/BundleBuddyReporter.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -17,7 +17,7 @@
   "source": "src/CLIReporter.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -18,7 +18,7 @@
   "source": "src/ServerReporter.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -17,7 +17,7 @@
   "source": "src/JSONReporter.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -17,7 +17,7 @@
   "source": "src/DefaultResolver.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/node-resolver-core": "2.0.0-beta.1",

--- a/packages/runtimes/hmr/package.json
+++ b/packages/runtimes/hmr/package.json
@@ -17,7 +17,7 @@
   "source": "src/HMRRuntime.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -17,7 +17,7 @@
   "source": "src/JSRuntime.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/runtimes/react-refresh/package.json
+++ b/packages/runtimes/react-refresh/package.json
@@ -17,7 +17,7 @@
   "source": "src/ReactRefreshRuntime.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -17,7 +17,7 @@
   "source": "src/BabelTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@babel/core": "^7.12.0",

--- a/packages/transformers/coffeescript/package.json
+++ b/packages/transformers/coffeescript/package.json
@@ -17,7 +17,7 @@
   "source": "src/CoffeeScriptTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -17,7 +17,7 @@
   "source": "src/CSSTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/elm/package.json
+++ b/packages/transformers/elm/package.json
@@ -20,8 +20,8 @@
     "parcel": "^2.0.0-alpha.3.1"
   },
   "dependencies": {
-    "@parcel/diagnostic": "^2.0.0-beta.1",
-    "@parcel/plugin": "^2.0.0-beta.1",
+    "@parcel/diagnostic": "2.0.0-beta.1",
+    "@parcel/plugin": "2.0.0-beta.1",
     "command-exists": "^1.2.8",
     "cross-spawn": "^7.0.3",
     "nullthrows": "^1.1.1",

--- a/packages/transformers/glsl/package.json
+++ b/packages/transformers/glsl/package.json
@@ -17,7 +17,7 @@
   "source": "src/GLSLTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/graphql/package.json
+++ b/packages/transformers/graphql/package.json
@@ -17,7 +17,7 @@
   "source": "src/GraphQLTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -17,7 +17,7 @@
   "source": "src/HTMLTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -16,7 +16,7 @@
     "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
-    "@parcel/plugin": "^2.0.0-beta.1"
+    "@parcel/plugin": "2.0.0-beta.1"
   },
   "devDependencies": {
     "sharp": "^0.24.1"

--- a/packages/transformers/inline-string/package.json
+++ b/packages/transformers/inline-string/package.json
@@ -17,7 +17,7 @@
   "source": "src/InlineStringTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/inline/package.json
+++ b/packages/transformers/inline/package.json
@@ -17,7 +17,7 @@
   "source": "src/InlineTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -17,7 +17,7 @@
   "source": "src/JSTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@babel/core": "^7.12.0",

--- a/packages/transformers/json/package.json
+++ b/packages/transformers/json/package.json
@@ -17,7 +17,7 @@
   "source": "src/JSONTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/jsonld/package.json
+++ b/packages/transformers/jsonld/package.json
@@ -17,7 +17,7 @@
   "source": "src/JSONLDTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "scripts": {
     "test": "yarn workspace @parcel/integration-tests test -g jsonld"

--- a/packages/transformers/less/package.json
+++ b/packages/transformers/less/package.json
@@ -17,7 +17,7 @@
   "source": "src/LessTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/mdx/package.json
+++ b/packages/transformers/mdx/package.json
@@ -17,7 +17,7 @@
   "source": "src/MDXTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -17,7 +17,7 @@
   "source": "src/PostCSSTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/posthtml/package.json
+++ b/packages/transformers/posthtml/package.json
@@ -17,7 +17,7 @@
   "source": "src/PostHTMLTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/pug/package.json
+++ b/packages/transformers/pug/package.json
@@ -17,7 +17,7 @@
   "source": "src/PugTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/raw/package.json
+++ b/packages/transformers/raw/package.json
@@ -17,7 +17,7 @@
   "source": "src/RawTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/react-refresh-babel/package.json
+++ b/packages/transformers/react-refresh-babel/package.json
@@ -17,7 +17,7 @@
   "source": "src/ReactRefreshBabelTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/react-refresh-wrap/package.json
+++ b/packages/transformers/react-refresh-wrap/package.json
@@ -17,7 +17,7 @@
   "source": "src/ReactRefreshWrapTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@babel/generator": "^7.0.0",

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -17,7 +17,7 @@
   "source": "src/SassTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/fs": "2.0.0-beta.1",

--- a/packages/transformers/stylus/package.json
+++ b/packages/transformers/stylus/package.json
@@ -17,7 +17,7 @@
   "source": "src/StylusTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/sugarss/package.json
+++ b/packages/transformers/sugarss/package.json
@@ -17,7 +17,7 @@
   "source": "src/SugarssTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/svg-react/package.json
+++ b/packages/transformers/svg-react/package.json
@@ -17,7 +17,7 @@
   "source": "src/SvgReactTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/svgo/package.json
+++ b/packages/transformers/svgo/package.json
@@ -17,7 +17,7 @@
   "source": "src/SVGOTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/toml/package.json
+++ b/packages/transformers/toml/package.json
@@ -17,7 +17,7 @@
   "source": "src/TOMLTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/transformers/typescript-tsc/package.json
+++ b/packages/transformers/typescript-tsc/package.json
@@ -17,7 +17,7 @@
   "source": "src/TSCTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -17,7 +17,7 @@
   "source": "src/TSTypesTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/transformers/vue/package.json
+++ b/packages/transformers/vue/package.json
@@ -17,7 +17,7 @@
   "source": "src/VueTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-beta.1",

--- a/packages/transformers/vue/package.json
+++ b/packages/transformers/vue/package.json
@@ -20,10 +20,10 @@
     "parcel": "^2.0.0-alpha.1.1"
   },
   "dependencies": {
-    "@parcel/diagnostic": "^2.0.0-beta.1",
+    "@parcel/diagnostic": "2.0.0-beta.1",
     "@parcel/plugin": "2.0.0-beta.1",
     "@parcel/source-map": "2.0.0-alpha.4.19",
-    "@parcel/utils": "^2.0.0-beta.1",
+    "@parcel/utils": "2.0.0-beta.1",
     "nullthrows": "^1.1.1",
     "semver": "^5.4.1"
   },

--- a/packages/transformers/yaml/package.json
+++ b/packages/transformers/yaml/package.json
@@ -17,7 +17,7 @@
   "source": "src/YAMLTransformer.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1"

--- a/packages/validators/eslint/package.json
+++ b/packages/validators/eslint/package.json
@@ -17,7 +17,7 @@
   "source": "src/EslintValidator.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",

--- a/packages/validators/typescript/package.json
+++ b/packages/validators/typescript/package.json
@@ -17,7 +17,7 @@
   "source": "src/TypeScriptValidator.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-alpha.1.1"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.1",


### PR DESCRIPTION
This:

* Updates remaining references to `^` semver requirements on `@parcel` packages to reference exact versions
* Updates engines fields to reference the beta prerelease. These remain `^` (should they be exact for now?)

Test Plan: `yarn clean`