### PR TITLE
Replace asset.setEnvironment with transformer.getEnvironment

### DIFF
--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -14,6 +14,7 @@ import type {
   Asset,
   RequestInvalidation,
   Dependency,
+  Environment,
   ParcelOptions,
 } from './types';
 
@@ -342,6 +343,7 @@ export default class UncommittedAsset {
     plugin: PackageName,
     configPath: FilePath,
     configKeyPath: string,
+    env: Environment,
   ): UncommittedAsset {
     let content = result.content ?? null;
 
@@ -356,7 +358,7 @@ export default class UncommittedAsset {
         isInline: result.isInline ?? this.value.isInline,
         isSplittable: result.isSplittable ?? this.value.isSplittable,
         isSource: result.isSource ?? this.value.isSource,
-        env: mergeEnvironments(this.value.env, result.env),
+        env,
         dependencies:
           this.value.type === result.type
             ? new Map(this.value.dependencies)

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -12,7 +12,6 @@ import type {
   Dependency as IDependency,
   DependencyOptions,
   Environment as IEnvironment,
-  EnvironmentOpts,
   FilePath,
   Meta,
   MutableAsset as IMutableAsset,
@@ -30,7 +29,6 @@ import Dependency from './Dependency';
 import {AssetSymbols, MutableAssetSymbols} from './Symbols';
 import UncommittedAsset from '../UncommittedAsset';
 import CommittedAsset from '../CommittedAsset';
-import {createEnvironment} from '../Environment';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
@@ -309,9 +307,5 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
       isAsync: true, // The browser has native loaders for url dependencies
       ...opts,
     });
-  }
-
-  setEnvironment(env: EnvironmentOpts): void {
-    this.#asset.value.env = createEnvironment(env);
   }
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -562,7 +562,6 @@ export interface MutableAsset extends BaseAsset {
   setCode(string): void;
   /** Throws if the AST is dirty (meaning: this won't implicity stringify the AST). */
   getCode(): Promise<string>;
-  setEnvironment(opts: EnvironmentOpts): void;
   setMap(?SourceMap): void;
   setStream(Readable): void;
 }
@@ -662,9 +661,7 @@ export type ResolveFn = (from: FilePath, to: string) => Promise<FilePath>;
 /**
  * @section validator
  */
-type ResolveConfigFn = (
-  configNames: Array<FilePath>,
-) => Promise<?FilePath>;
+type ResolveConfigFn = (configNames: Array<FilePath>) => Promise<?FilePath>;
 
 /**
  * @section validator
@@ -722,6 +719,9 @@ export type Validator = DedicatedThreadValidator | MultiThreadValidator;
  * @section transformer
  */
 export type Transformer = {|
+  getEnvironment?: ({|
+    env: Environment,
+  |}) => EnvironmentOpts,
   loadConfig?: ({|
     config: Config,
     options: PluginOptions,


### PR DESCRIPTION
asset.setEnvironment was problematic because it replaced the environment but did not affect the id of the asset which had already been computed. Instead, this PR replaces it with an optional transformer method which does the same thing but is run before the asset is even loaded, and again for each pipeline (if the asset changes types or new assets are added). This allows the environment in the cache key to be correct as well so hopefully we'll see more cache hits as opposed to unnecessary re-transformations.

Closes T-885