### PR TITLE
Windows 32 bit support

### DIFF
--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -17,6 +17,7 @@ jobs:
       - task: NodeTool@0
         inputs:
           versionSpec: $(node_version)
+          force32bit: ${{ eq(parameters.name, 'Windows-32bit') }}
         displayName: 'Install Node.js'
 
       # Install Rust
@@ -32,6 +33,15 @@ jobs:
           - script: |
               curl -sSf -o rustup-init.exe https://win.rustup.rs
               rustup-init.exe -y --default-toolchain stable --default-host x86_64-pc-windows-msvc
+              set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+              echo "##vso[task.setvariable variable=PATH]%PATH%;%USERPROFILE%\.cargo\bin"
+              rustc -Vv
+              cargo -V
+            displayName: Install Rust
+
+      - ${{ if eq(parameters.name, 'Windows-32bit') }}:
+          - script: |
+              curl -sSf -o rustup-init.exe https://win.rustup.rs
               set PATH=%PATH%;%USERPROFILE%\.cargo\bin
               echo "##vso[task.setvariable variable=PATH]%PATH%;%USERPROFILE%\.cargo\bin"
               rustc -Vv

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -17,7 +17,7 @@ jobs:
       - task: NodeTool@0
         inputs:
           versionSpec: $(node_version)
-          force32bit: ${{ eq(parameters.name, 'Windows-32bit') }}
+          force32bit: ${{ eq(parameters.name, 'Windows_32bit') }}
         displayName: 'Install Node.js'
 
       # Install Rust
@@ -39,7 +39,7 @@ jobs:
               cargo -V
             displayName: Install Rust
 
-      - ${{ if eq(parameters.name, 'Windows-32bit') }}:
+      - ${{ if eq(parameters.name, 'Windows_32bit') }}:
           - script: |
               curl -sSf -o rustup-init.exe https://win.rustup.rs
               set PATH=%PATH%;%USERPROFILE%\.cargo\bin

--- a/azure-pipelines-template.yml
+++ b/azure-pipelines-template.yml
@@ -39,15 +39,6 @@ jobs:
               cargo -V
             displayName: Install Rust
 
-      - ${{ if eq(parameters.name, 'Windows_32bit') }}:
-          - script: |
-              curl -sSf -o rustup-init.exe https://win.rustup.rs
-              set PATH=%PATH%;%USERPROFILE%\.cargo\bin
-              echo "##vso[task.setvariable variable=PATH]%PATH%;%USERPROFILE%\.cargo\bin"
-              rustc -Vv
-              cargo -V
-            displayName: Install Rust
-
       - ${{ if eq(parameters.name, 'Linux') }}:
           - script: |
               echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,5 +16,5 @@ jobs:
 
 - template: azure-pipelines-template.yml
   parameters:
-   name: Windows-32bit
+   name: Windows_32bit
    vmImage: vs2017-win2016

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,3 +13,8 @@ jobs:
   parameters:
    name: Windows
    vmImage: windows-latest
+
+- template: azure-pipelines-template.yml
+  parameters:
+   name: Windows-32bit
+   vmImage: vs2017-win2016


### PR DESCRIPTION
This runs the CI on Windows 32 bit. 

Fixes https://github.com/parcel-bundler/parcel/issues/5597


[fs-search](https://github.com/parcel-bundler/parcel/pull/5481) broke Parcel on Windows 32bit. This PR is adding Win 32bit to CI to prevent this kind of breakage.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

The CI itself runs the tests.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
