### PR TITLE
Print original port

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -362,7 +362,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     port = await getPort({port, host});
 
     if (port !== originalPort) {
-      let errorMessage = `Port "${port}" could not be used`;
+      let errorMessage = `Port "${originalPort}" could not be used`;
       if (command.port != null) {
         // Throw the error if the user defined a custom port
         throw new Error(errorMessage);


### PR DESCRIPTION
Prevent this:

```
$ parcel2 index.html
Port "60178" could not be used
ℹ️ Server running at http://localhost:60178
````

Instead, the original port should be printed in the warning.