### PR TITLE
Limit the number of threads (fix memory usage)

### DIFF
--- a/packages/core/workers/src/cpuCount.js
+++ b/packages/core/workers/src/cpuCount.js
@@ -41,7 +41,10 @@ export function detectRealCores(): number {
 }
 
 let cores;
-export default function getCores(bypassCache?: boolean = false): number {
+export default function getCores(
+  bypassCache?: boolean = false,
+  limit: number = 4,
+): number {
   // Do not re-run commands if we already have the count...
   if (cores && !bypassCache) {
     return cores;
@@ -61,6 +64,9 @@ export default function getCores(bypassCache?: boolean = false): number {
   if (!cores) {
     cores = 1;
   }
+
+  // limit the number of cores
+  cores = Math.max(Math.min(cores, limit), 1);
 
   return cores;
 }


### PR DESCRIPTION
# ↪️ Pull Request

See [this comment](https://github.com/parcel-bundler/parcel/issues/5072#issuecomment-757090390) for the analysis behind this PR.

Fixes https://github.com/parcel-bundler/parcel/issues/5072
Fixes https://github.com/parcel-bundler/parcel/issues/4628

## 💻 Examples
Parcel does not utilize all the threads it spawns so there is no point in using long-lived workers when they do not do anything. This results in huge memory usage and slow-down.

For example, here as you see, other than workers 0 and 1, the others almost do nothing. 
![image](https://user-images.githubusercontent.com/16418197/104778139-807bff00-5742-11eb-91ec-ca9cc7220bb4.png)


<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
