### PR TITLE
Fix sourcemap generation with comments

### DIFF
--- a/packages/core/integration-tests/test/integration/sourcemap-comments/index.js
+++ b/packages/core/integration-tests/test/integration/sourcemap-comments/index.js
@@ -1,0 +1,9 @@
+console.log('foo');
+// comment
+console.log('bar');
+/* block comment line */
+console.log('baz');
+/* multi line
+  block comment 
+ */
+console.log('idhf');

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -1197,4 +1197,62 @@ describe('sourcemaps', function() {
     await test(false);
     await test(true);
   });
+
+  it('should handle comments correctly in sourcemaps', async function() {
+    let sourceFilename = path.join(
+      __dirname,
+      '/integration/sourcemap-comments/index.js',
+    );
+    let b = await bundle(sourceFilename, {
+      scopeHoist: true,
+    });
+
+    let filename = b.getBundles()[0].filePath;
+    let raw = await outputFS.readFile(filename, 'utf8');
+    let mapUrlData = await loadSourceMapUrl(outputFS, filename, raw);
+    if (!mapUrlData) {
+      throw new Error('Could not load map');
+    }
+    let map = mapUrlData.map;
+
+    let sourceMap = new SourceMap('/');
+    sourceMap.addRawMappings(map);
+    let input = await inputFS.readFile(
+      path.join(path.dirname(filename), map.sourceRoot, map.sources[0]),
+      'utf8',
+    );
+    let sourcePath = './index.js';
+
+    checkSourceMapping({
+      map: sourceMap,
+      source: input,
+      generated: raw,
+      str: "console.log('foo')",
+      sourcePath,
+    });
+
+    checkSourceMapping({
+      map: sourceMap,
+      source: input,
+      generated: raw,
+      str: "console.log('bar')",
+      sourcePath,
+    });
+
+    checkSourceMapping({
+      map: sourceMap,
+      source: input,
+      generated: raw,
+      str: "console.log('baz')",
+      sourcePath,
+    });
+
+    checkSourceMapping({
+      map: sourceMap,
+      source: input,
+      generated: raw,
+      str: "console.log('idhf')",
+      sourcePath,
+    });
+  });
 });

--- a/packages/shared/babel-ast-utils/src/generator.js
+++ b/packages/shared/babel-ast-utils/src/generator.js
@@ -257,7 +257,8 @@ function formatComments(state, comments) {
     const comment = comments[i];
     if (comment.type === 'CommentLine') {
       // Line comment
-      state.write('// ' + comment.value.trim() + state.lineEnd + indent);
+      state.write('// ' + comment.value.trim() + state.lineEnd);
+      state.write(indent);
     } else {
       // Block comment
       state.write('/*');
@@ -269,7 +270,8 @@ function formatComments(state, comments) {
       if (
         !((value === '#__PURE__' || value === '@__PURE__') && i === length - 1)
       ) {
-        state.write(state.lineEnd + indent);
+        state.write(state.lineEnd);
+        state.write(indent);
       }
     }
   }


### PR DESCRIPTION
Fixes #5630. astring has an optimization that only checks for newlines at the end of the string of code being printed rather than in the middle. This broke our custom comment generator which added the next indent at the end of the string rather than being printed separately causing astring not to count lines properly. Added a test for this as well.