### PR TITLE
Scope hoisting: only execute bundle wrappers once

### DIFF
--- a/packages/shared/scope-hoisting/src/generate.js
+++ b/packages/shared/scope-hoisting/src/generate.js
@@ -31,8 +31,8 @@ const REGISTER_TEMPLATE = template.statement<
 >(`(function() {
   function $parcel$bundleWrapper() {
     if ($parcel$bundleWrapper._executed) return;
-    STATEMENTS;
     $parcel$bundleWrapper._executed = true;
+    STATEMENTS;
   }
   var $parcel$referencedAssets = REFERENCED_IDS;
   for (var $parcel$i = 0; $parcel$i < $parcel$referencedAssets.length; $parcel$i++) {

--- a/packages/shared/scope-hoisting/src/prelude.js
+++ b/packages/shared/scope-hoisting/src/prelude.js
@@ -5,8 +5,9 @@ if (parcelRequire == null) {
   parcelRequire = function(name) {
     // Execute the bundle wrapper function if there is one registered.
     if (name in $parcel$bundles) {
-      $parcel$bundles[name]();
+      let wrapper = $parcel$bundles[name];
       delete $parcel$bundles[name];
+      wrapper();
     }
 
     if (name in $parcel$modules) {


### PR DESCRIPTION
This prevents the scope hoisting bundle wrapper from being executed more than once. Previously, it was possible to re-enter the bundle wrapper in the case two bundles depended on assets registered by one another.