### PR TITLE
Astring generator: Handle OptionalCallExpression

### DIFF
--- a/packages/shared/babel-ast-utils/src/generator.js
+++ b/packages/shared/babel-ast-utils/src/generator.js
@@ -76,11 +76,15 @@ export const generator = {
     this.Literal(node, state);
   },
   ArrowFunctionExpression(node, state) {
+    // the ArrowFunctionExpression visitor in astring checks the type of the body
     if (node.body.type === 'OptionalMemberExpression') {
-      // the ArrowFunctionExpression visitor in astring checks the type of the body
       node.body.optional = true;
       node.body.type = 'MemberExpression';
+    } else if (node.body.type === 'OptionalCallExpression') {
+      node.body.optional = true;
+      node.body.type = 'CallExpression';
     }
+
     baseGenerator.ArrowFunctionExpression.call(this, node, state);
   },
   ObjectProperty(node, state) {

--- a/packages/shared/babel-ast-utils/test/fixtures/function.js
+++ b/packages/shared/babel-ast-utils/test/fixtures/function.js
@@ -38,4 +38,5 @@ let y = () => ({
   b: 2
 });
 let z = a => a?.b;
+let z1 = a => a?.();
 let f1 = a => 1;


### PR DESCRIPTION
Like #5640, but for `OptionalCallExpression`: handle expressions like `a?.()` as bodies for arrow function expressions.

Test Plan: added a generator fixture