### PR TITLE
Fix concat order with wrapped assets

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-concat-order/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-concat-order/a.js
@@ -1,0 +1,9 @@
+sideEffect(1);
+require("./b.js");
+sideEffect(3);
+if (Date.now() > 0) {
+	sideEffect(4);
+	require("./c.js");
+	sideEffect(6);
+}
+sideEffect(7);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-concat-order/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-concat-order/b.js
@@ -1,0 +1,1 @@
+sideEffect(2);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-concat-order/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-concat-order/c.js
@@ -1,0 +1,1 @@
+sideEffect(5);

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4125,6 +4125,23 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 42);
     });
 
+    it('should retain the correct concat order with wrapped assets', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/wrap-concat-order/a.js',
+        ),
+      );
+
+      let calls = [];
+      await run(b, {
+        sideEffect(v) {
+          calls.push(v);
+        },
+      });
+      assert.deepStrictEqual(calls, [1, 2, 3, 4, 5, 6, 7]);
+    });
+
     it('should support optional requires', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -172,9 +172,19 @@ export async function concat({
           .map(([, ast]) => ast)
           .flat();
       } else {
+        // splice assets with missing statementIndices last (= put wrapped asset at the top)
+        let wrapped = [];
         for (let [assetId, ast] of [...context.children].reverse()) {
-          let index = statementIndices.get(assetId) ?? 0;
-          statements.splice(index, 0, ...ast);
+          let index = statementIndices.get(assetId);
+          if (index) {
+            statements.splice(index, 0, ...ast);
+          } else {
+            wrapped.push(ast);
+          }
+        }
+
+        for (let ast of wrapped) {
+          statements.unshift(...ast);
         }
       }
 


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/5668

Wrapped assets aren't visited when traversing the statements here: https://github.com/parcel-bundler/parcel/blob/49ac217507d5914a2e38ca402593d26527cdb673/packages/shared/scope-hoisting/src/concat.js#L145-L146
instead, they are inserted before the asset.

The problem was that when splicing 
- a wrapped child asset into index 0 and then
- a non-wrapped child asset  into the calculated index 2,
the index `2` is wrong because some other asset was already spliced before that.

Now, wrapped assets are unshifted once all assets with a known index were already spliced. This way, the indices are always correct.