### PR TITLE
Bundle CSSNano optimizer (make Parcel 2-5 s faster)

### DIFF
--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -35,6 +35,7 @@
         "css-declaration-sorter": false,
         "browserslist": false,
         "util-deprecate": false,
+        "cosmiconfig": false,
         "@parcel/source-map": false,
         "@parcel/plugin": false
       },

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -24,5 +24,19 @@
     "@parcel/source-map": "2.0.0-alpha.4.19",
     "cssnano": "^4.1.10",
     "postcss": "^8.0.5"
+  },
+  "scripts": {
+    "build": "cross-env NODE_ENV=production parcel build --target main src/CSSNanoOptimizer.js"
+  },
+  "targets": {
+    "main": {
+      "context": "node",
+      "includeNodeModules": {
+        "css-declaration-sorter": false,
+        "browserslist": false,
+        "util-deprecate": false
+      },
+      "isLibrary": true
+    }
   }
 }

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -34,7 +34,9 @@
       "includeNodeModules": {
         "css-declaration-sorter": false,
         "browserslist": false,
-        "util-deprecate": false
+        "util-deprecate": false,
+        "@parcel/source-map": false,
+        "@parcel/plugin": false
       },
       "isLibrary": true
     }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -23,7 +23,7 @@ function shouldBuildNative() {
 
 function bundleBuild() {
   const packagesCustomBuild = ['packages/optimizers/cssnano'];
-  for (const path of packagesCustomBuild) {
-    execSync('yarn build', {cwd: path, stdio: 'inherit'});
+  for (const p of packagesCustomBuild) {
+    execSync('yarn build', {cwd: p, stdio: 'inherit'});
   }
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,11 @@
 /* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
+const {execSync} = require('child_process');
+
+if (process.env.PARCEL_BUILD_ENV == 'production') {
+  bundleBuild();
+}
 
 if (shouldBuildNative()) {
   require('./build-native');
@@ -14,4 +19,11 @@ function shouldBuildNative() {
     return false;
   }
   return true;
+}
+
+function bundleBuild() {
+  const packagesCustomBuild = ['packages/optimizers/cssnano'];
+  for (const path of packagesCustomBuild) {
+    execSync('yarn build', {cwd: path, stdio: 'inherit'});
+  }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR bundles CSSNano which results in a 2-5 seconds build time reduction in the projects that use CSS.

When CSSNano is used, 2-5 seconds is spent to load all the packages required for optimizing CSS. However, by bundling, this time which is spent for reading files from the disk is removed.

![image](https://user-images.githubusercontent.com/16418197/104778049-56c2d800-5742-11eb-8e01-069d07a3c4da.png)


Related to this issue: 
https://github.com/parcel-bundler/parcel/issues/5072#issuecomment-761254092

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

NOTE: 
The original PR is [this PR](https://github.com/cssnano/cssnano/pull/985) which uses ES modules for bundling. This PR works on the CJS outputs. Based on my tests, both work as expected without issues. However, the bundle resulting from the ESM code might result in better tree-shaking.

## 💻 Examples

For example, running this PR on [solid-simple-table](https://github.com/aminya/solid-simple-table) results in 5 seconds improvement on the build time.

After:
![image](https://user-images.githubusercontent.com/16418197/104793992-969db580-576a-11eb-871e-53ab17968647.png)
[profile-20210115-194214.zip](https://github.com/parcel-bundler/parcel/files/5823683/profile-20210115-194214.zip)

Before:
![image](https://user-images.githubusercontent.com/16418197/104793965-7837ba00-576a-11eb-9c7f-3a27fad6cf22.png)
[profile-20210115-142429.zip](https://github.com/parcel-bundler/parcel/files/5823685/profile-20210115-142429.zip)


## 🚨 Test instructions

Trigger the bundle build:
```
> $env:PARCEL_BUILD_ENV='production'
> yarn
```

Test wherever you want.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs


## Future Work
We can do the same thing for other optimizers and transformers. For example, @babel/preset-env also takes 1 second to load