### PR TITLE
Updating compileTemplate to use `id` instead of `compilerOptions.scopeId`

### DIFF
--- a/packages/core/integration-tests/test/vue.js
+++ b/packages/core/integration-tests/test/vue.js
@@ -55,7 +55,7 @@ describe('vue', function() {
     );
     let output = (await run(b)).default;
     assert.equal(typeof output.render, 'function');
-    assert(/^data-v-[0-9a-h]{6}$/.test(output.__scopeId));
+    assert(/^[0-9a-h]{6}$/.test(output.__scopeId));
     assert.deepEqual(output.data(), {ok: true});
     let contents = await outputFS.readFile(
       path.join(distDir, 'App.css'),

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -70,7 +70,7 @@ export default (new Transformer({
     let baseId = md5FromObject({
       filePath: asset.filePath,
     }).slice(-6);
-    let scopeId = 'data-v-' + baseId;
+    let scopeId = baseId;
     let hmrId = baseId + '-hmr';
     let basePath = basename(asset.filePath);
     let {template, script, styles, customBlocks} = nullthrows(
@@ -249,9 +249,7 @@ async function processPipeline({
         source: content,
         inMap: template.src ? undefined : template.map,
         isFunctional,
-        compilerOptions: {
-          scopeId,
-        },
+        id: scopeId,
       });
       if (templateComp.errors.length) {
         throw new ThrowableDiagnostic({


### PR DESCRIPTION
Closes #5629 

Vue have changed their API to require the `id` field instead of `compilerOptions.scopeId`. They also remove the `data-v-` prefix.
