### PR TITLE
Dev server: enqueue request and response tuples rather than event handlers

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -54,8 +54,9 @@ const TEMPLATE_500 = fs.readFileSync(
 );
 type NextFunction = (req: Request, res: Response, next?: (any) => any) => any;
 
-export default class Server extends EventEmitter {
+export default class Server {
   pending: boolean;
+  pendingRequests: Array<[Request, Response]>;
   options: DevServerOptions;
   rootPath: string;
   bundleGraph: BundleGraph<NamedBundle> | null;
@@ -67,8 +68,6 @@ export default class Server extends EventEmitter {
   stopServer: ?() => Promise<void>;
 
   constructor(options: DevServerOptions) {
-    super();
-
     this.options = options;
     try {
       this.rootPath = new URL(options.publicUrl).pathname;
@@ -76,6 +75,7 @@ export default class Server extends EventEmitter {
       this.rootPath = options.publicUrl;
     }
     this.pending = true;
+    this.pendingRequests = [];
     this.bundleGraph = null;
     this.errors = null;
   }
@@ -89,7 +89,13 @@ export default class Server extends EventEmitter {
     this.errors = null;
     this.pending = false;
 
-    this.emit('bundled');
+    if (this.pendingRequests.length > 0) {
+      let pendingRequests = this.pendingRequests;
+      this.pendingRequests = [];
+      for (let [req, res] of pendingRequests) {
+        this.respond(req, res);
+      }
+    }
   }
 
   async buildError(options: PluginOptions, diagnostics: Array<Diagnostic>) {
@@ -348,13 +354,11 @@ export default class Server extends EventEmitter {
     const finalHandler = (req: Request, res: Response) => {
       this.logAccessIfVerbose(req);
 
-      const response = () => this.respond(req, res);
-
       // Wait for the parcelInstance to finish bundling if needed
       if (this.pending) {
-        this.once('bundled', response);
+        this.pendingRequests.push([req, res]);
       } else {
-        response();
+        this.respond(req, res);
       }
     };
 

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -12,7 +12,6 @@ import type {FileSystem} from '@parcel/fs';
 import type {HTTPServer} from '@parcel/utils';
 
 import invariant from 'assert';
-import EventEmitter from 'events';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import url from 'url';


### PR DESCRIPTION
When Parcel is pending, we hold open requests and respond to them when the builds completes. This enqueues request/response object pairs in an array rather than registering new event handlers for each request. We only register one event handler to flush all of these pending requests.

Previously, we would reach EventEmitter's threshold for warning about a maximum number of handlers on the `bundle` event. While the same could be achieved by simply increasing the threshold for this particular emitter, it feels cleaner to not register handlers for every request.

Test Plan:

Run Parcel with `parcel serve` on a large project to keep it busy on a cold build. Use curl to open 11+ requests and verify there is no message printed to stdio about the number of handlers. Verify requests continue to be held pending and responded to when the build completes.