### PR TITLE
Make remove external dependancy safe if edge isnt present

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -477,8 +477,8 @@ export default class BundleGraph {
     for (let bundleGroupNode of this._graph
       .getNodesConnectedFrom(nullthrows(this._graph.getNode(dependency.id)))
       .filter(node => node.type === 'bundle_group')) {
-      if (this._graph.hasEdge(bundle.id, bundleGroupNode.id, 'bundle')) {
-        return;
+      if (!this._graph.hasEdge(bundle.id, bundleGroupNode.id, 'bundle')) {
+        continue;
       }
 
       let inboundDependencies = this._graph

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -477,6 +477,10 @@ export default class BundleGraph {
     for (let bundleGroupNode of this._graph
       .getNodesConnectedFrom(nullthrows(this._graph.getNode(dependency.id)))
       .filter(node => node.type === 'bundle_group')) {
+      if (this._graph.hasEdge(bundle.id, bundleGroupNode.id, 'bundle')) {
+        return;
+      }
+
       let inboundDependencies = this._graph
         .getNodesConnectedTo(bundleGroupNode)
         .filter(node => node.type === 'dependency')


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR is for altering `removeExternalDependency` method, which may be called multiple times on the same bundle. Method should safely return if called multiple times. 

## 🚨 Test instructions

Tested on external app

## ✔️ PR Todo

- [ ] Add test displaying that `removeExternalDependency` is safe to call twice. (upcoming PR)

