### PR TITLE
esm2cjs: var declarations can shadow outside the block

### DIFF
--- a/packages/core/integration-tests/test/integration/js-import-shadow-for-var/index.js
+++ b/packages/core/integration-tests/test/integration/js-import-shadow-for-var/index.js
@@ -1,0 +1,14 @@
+import { f, g, h } from "./other.js";
+
+export function baz() {
+  {
+    class g {}
+    var h = {};
+  }
+
+	for (var f = [], i = 0; i < 4; i++) {
+		f[i] = i;
+	}
+
+	return typeof g === 'number' && typeof h === 'object' && f;
+}

--- a/packages/core/integration-tests/test/integration/js-import-shadow-for-var/other.js
+++ b/packages/core/integration-tests/test/integration/js-import-shadow-for-var/other.js
@@ -1,0 +1,3 @@
+export const f = 10;
+export const g = 20;
+export const h = 30;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3300,6 +3300,14 @@ describe('javascript', function() {
     assert.strictEqual(res.baz(), 'foo');
   });
 
+  it('should not replace identifier with a var declaration inside a for loop', async function() {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-import-shadow-for-var/index.js'),
+    );
+    let res = await run(b);
+    assert.deepEqual(res.baz(), [0, 1, 2, 3]);
+  });
+
   it('should not freeze live default imports', async function() {
     let b = await bundle(
       path.join(__dirname, 'integration/js-import-default-live/index.js'),

--- a/packages/transformers/js/src/visitors/modules.js
+++ b/packages/transformers/js/src/visitors/modules.js
@@ -370,7 +370,7 @@ export function esm2cjs(ast: BabelNodeFile, asset?: MutableAsset) {
       ]);
 
       prepend.push(decl);
-      scope.addBinding(names.name, decl);
+      scope.addBinding(names.name, decl, 'var');
     }
 
     if (isExportAllDeclaration(imp)) {


### PR DESCRIPTION
Closes #5718

Example:
```js
import { f } from "./b.js";
(function () {
	for (var f = [], i = 0; i < 10; i++) { // f is imported and also locally declared inside the loop head
		f[i] = i;
	}

	console.log(f);
})();
```

previously became: 

```js
var _bJs = require("./b.js");
(function () {
  for (var f = [], i = 0; i < 10; i++) {
    f[i] = i;
  }
  console.log(_bJs.f); // !!!
})();
```