### PR TITLE
Fix browserslist env config in package.json and use options.mode for env selection

### DIFF
--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -286,10 +286,21 @@ export class TargetResolver {
         'Invalid engines in package.json',
       ) || {};
     if (pkgEngines.browsers == null) {
+      let env =
+        this.options.env.BROWSERSLIST_ENV ??
+        this.options.env.NODE_ENV ??
+        this.options.mode;
+
       if (pkg.browserslist != null) {
+        let pkgBrowserslist = pkg.browserslist;
+        let browserslist =
+          typeof pkgBrowserslist === 'object' && !Array.isArray(pkgBrowserslist)
+            ? pkgBrowserslist[env]
+            : pkgBrowserslist;
+
         pkgEngines = {
           ...pkgEngines,
-          browsers: pkg.browserslist,
+          browsers: browserslist,
         };
       } else {
         let browserslistConfig = await resolveConfig(
@@ -303,10 +314,6 @@ export class TargetResolver {
         if (browserslistConfig != null) {
           let contents = await this.fs.readFile(browserslistConfig, 'utf8');
           let config = browserslist.parseConfig(contents);
-          let env =
-            this.options.env.BROWSERSLIST_ENV ??
-            this.options.env.NODE_ENV ??
-            'production';
           let browserslistBrowsers = config[env] || config.defaults;
 
           if (browserslistBrowsers) {

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -2546,6 +2546,53 @@ describe('cache', function() {
       );
       assert(contents.includes('TRANSFORMED CODE'));
     });
+
+    it('should update env browserslist in package.json when mode changes', async function() {
+      let env = process.env.NODE_ENV;
+      delete process.env.NODE_ENV;
+      try {
+        let b = await testCache({
+          scopeHoist: false,
+          minify: false,
+          mode: 'development',
+          async setup() {
+            let pkg = JSON.parse(
+              await overlayFS.readFile(
+                path.join(inputDir, 'package.json'),
+                'utf8',
+              ),
+            );
+            pkg.browserslist = {
+              production: ['ie 11'],
+              development: ['Chrome 80'],
+            };
+            await overlayFS.writeFile(
+              path.join(inputDir, 'package.json'),
+              JSON.stringify(pkg, null, 2),
+            );
+          },
+          async update(b) {
+            let contents = await overlayFS.readFile(
+              b.bundleGraph.getBundles()[0].filePath,
+              'utf8',
+            );
+            assert(/class Test/.test(contents), 'should include class');
+
+            return {
+              mode: 'production',
+            };
+          },
+        });
+
+        let contents = await overlayFS.readFile(
+          b.bundleGraph.getBundles()[0].filePath,
+          'utf8',
+        );
+        assert(!/class Test/.test(contents), 'does not include class');
+      } finally {
+        process.env.NODE_ENV = env;
+      }
+    });
   });
 
   describe('resolver', function() {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -235,7 +235,7 @@ export type PackageJSON = {
   browser?: FilePath | {[FilePath]: FilePath | boolean, ...},
   source?: FilePath | {[FilePath]: FilePath, ...},
   alias?: {[PackageName | FilePath | Glob]: PackageName | FilePath, ...},
-  browserslist?: Array<string>,
+  browserslist?: Array<string> | {[string]: Array<string>},
   engines?: Engines,
   targets?: {[string]: PackageTargetDescriptor, ...},
   dependencies?: PackageDependencies,


### PR DESCRIPTION
Closes #5724

1. `package.json#browserslist` can be an object with a per-environment config

```
// package.json
...
  "browserslist": {
    "production": [
      "last 1 chrome version",x
      "last 1 firefox version",
      "last 1 safari version"
    ],
    "development": [
      "last 1 chrome version",
      "last 1 firefox version",
      "last 1 safari version"
    ]
  },
...
```

This was never normalized.

2. The used browserslist environment was previously `env.BROWSERSLIST_ENV ?? env.NODE_ENV ?? 'production'`

It makes more sense to fall back to `options.mode`, to enable to pattern from above and enable setting a custom dev & production env without having to introduce two different targets.