### PR TITLE
Add origin to diagnostic in loadConfig

### DIFF
--- a/packages/core/core/src/ConfigLoader.js
+++ b/packages/core/core/src/ConfigLoader.js
@@ -8,6 +8,7 @@ import nullthrows from 'nullthrows';
 import {md5FromString, PromiseQueue} from '@parcel/utils';
 import {PluginLogger} from '@parcel/logger';
 import path from 'path';
+import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 
 import {createConfig} from './InternalConfig';
 import PublicConfig from './public/Config';
@@ -100,18 +101,25 @@ export default class ConfigLoader {
 
     invariant(typeof parcelConfigPath === 'string');
     invariant(typeof parcelConfigKeyPath === 'string');
+    let packageName = nullthrows(plugin);
     let {plugin: pluginInstance} = await this.parcelConfig.loadPlugin({
-      packageName: nullthrows(plugin),
+      packageName,
       resolveFrom: parcelConfigPath,
       keyPath: parcelConfigKeyPath,
     });
 
     if (pluginInstance.loadConfig != null) {
-      await pluginInstance.loadConfig({
-        config: new PublicConfig(config, this.options),
-        options: this.options,
-        logger: new PluginLogger({origin: nullthrows(plugin)}),
-      });
+      try {
+        await pluginInstance.loadConfig({
+          config: new PublicConfig(config, this.options),
+          options: this.options,
+          logger: new PluginLogger({origin: nullthrows(plugin)}),
+        });
+      } catch (e) {
+        throw new ThrowableDiagnostic({
+          diagnostic: errorToDiagnostic(e, packageName),
+        });
+      }
     }
 
     return config;

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -139,7 +139,21 @@ export class NodePackageManager implements PackageManager {
           e.code !== 'MODULE_NOT_FOUND' ||
           options?.shouldAutoInstall !== true
         ) {
-          throw e;
+          if (
+            e.code === 'MODULE_NOT_FOUND' &&
+            options?.shouldAutoInstall !== true
+          ) {
+            throw new ThrowableDiagnostic({
+              diagnostic: {
+                message: e.message,
+                hints: [
+                  'Autoinstall is disabled, please install this package manually and restart Parcel.',
+                ],
+              },
+            });
+          } else {
+            throw e;
+          }
         }
 
         let conflicts = await getConflictingLocalDependencies(

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -240,7 +240,9 @@ export class NodePackageManager implements PackageManager {
           throw new ThrowableDiagnostic({
             diagnostic: {
               message,
-              origin: '@parcel/package-manager',
+              hints: [
+                'Looks like the incompatible version was installed transitively. Add this package as a direct dependency with a compatible version range.',
+              ],
             },
           });
         }


### PR DESCRIPTION
Came up in #5532, @aminya

1. Added a hint to the diagnostic when autoinstall is disabled
2. Added `errorToDiagnostic` around loadConfig so that the plugin name is attached as a origin.


New behaviour:

<img width="1098" alt="Bildschirmfoto 2021-01-28 um 12 27 58" src="https://user-images.githubusercontent.com/4586894/106132459-42300800-6164-11eb-8df2-17cea0939a33.png">

Also for incompatible versions where it couldn't be found in package.json (and was installed transivitely)

<img width="1174" alt="Bildschirmfoto 2021-01-28 um 13 28 01" src="https://user-images.githubusercontent.com/4586894/106138615-a5be3380-616c-11eb-95cf-bc0d7964bf68.png">

