### PR TITLE
Native packages: compile with CentOS 7 to target glibc 2.17

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -23,9 +23,6 @@ jobs:
         run: node scripts/link-native.js
       - uses: bahmutov/npm-install@v1.1.0
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: strip native-packages/*/*.node
-      - name: Strip debug symbols
         if: ${{ matrix.os == 'macos-latest' }}
         run: strip -x native-packages/*/*.node # Must use -x on macOS. This produces larger results on linux.
       - name: Upload artifacts
@@ -35,6 +32,36 @@ jobs:
           path: native-packages/*/*.node
       - name: Smoke test
         run: node -e "require('@parcel/fs-search')"
+
+  build-linux-gnu-x64:
+    name: linux-gnu-x64
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/centos/nodejs-12-centos7
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install yarn
+        run: npm install --global yarn@1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Link native packages
+        run: node scripts/link-native.js
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip native-packages/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-linux-gnu-x64
+          path: native-packages/*/*.node
+      - name: debug
+        run: ls -l native-packages/*/*.node
+      - name: Smoke test
+        run: node -e 'require("@parcel/fs-search")'
 
   build-linux-gnu-arm:
     strategy:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [macos-latest, windows-latest]
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -22,9 +22,6 @@ jobs:
         run: node scripts/link-native.js
       - uses: bahmutov/npm-install@v1.1.0
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: strip native-packages/*/*.node
-      - name: Strip debug symbols
         if: ${{ matrix.os == 'macos-latest' }}
         run: strip -x native-packages/*/*.node # Must use -x on macOS. This produces larger results on linux.
       - name: Upload artifacts
@@ -34,6 +31,36 @@ jobs:
           path: native-packages/*/*.node
       - name: Smoke test
         run: node -e "require('@parcel/fs-search')"
+
+  build-linux-gnu-x64:
+    name: linux-gnu-x64
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/centos/nodejs-12-centos7
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install yarn
+        run: npm install --global yarn@1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Link native packages
+        run: node scripts/link-native.js
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip native-packages/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-linux-gnu-x64
+          path: native-packages/*/*.node
+      - name: debug
+        run: ls -l native-packages/*/*.node
+      - name: Smoke test
+        run: node -e 'require("@parcel/fs-search")'
 
   build-linux-gnu-arm:
     strategy:

--- a/native-packages/fs-search/index.js
+++ b/native-packages/fs-search/index.js
@@ -1,8 +1,7 @@
-const fs = require('fs');
-
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  if (fs.existsSync('/etc/alpine-release')) {
+  const {MUSL, family} = require('detect-libc');
+  if (family === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {
     parts.push('gnueabihf');

--- a/native-packages/fs-search/package.json
+++ b/native-packages/fs-search/package.json
@@ -16,7 +16,10 @@
   "engines": {
     "node": ">= 12.0.0"
   },
-  "files": ["index.js", "*.node"],
+  "files": [
+    "index.js",
+    "*.node"
+  ],
   "napi": {
     "name": "fs-search"
   },
@@ -26,5 +29,8 @@
   "scripts": {
     "build": "napi build --platform",
     "build-release": "napi build --platform --release"
+  },
+  "dependencies": {
+    "detect-libc": "^1.0.3"
   }
 }


### PR DESCRIPTION
This makes native packages build on CentOS 7, which includes glibc 2.17,  rather than the latest Ubuntu. Glibc is backward compatible, but not forward compatible, so building against an older glibc is safe to run on systems with later glibc, but not the other way around [0].

Closes https://github.com/parcel-bundler/parcel/issues/5599

Test Plan: 
* [x] Github actions
* [x] Run binary on a system with a newer glibc 
* [x] Run binary on CentOS 7

[0] https://stackoverflow.com/a/11108336