### PR TITLE
Update babel-types to make toIdentifier work with non-ASCII chars

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/non-ascii-identifiers/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/non-ascii-identifiers/a.js
@@ -1,0 +1,6 @@
+const ɵ2 = 1;
+const ɵ3 = 2;
+const ꝍ2 = 3
+const ꝍ3 = 4
+
+output = [ɵ2, ɵ3, ꝍ2, ꝍ3];

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -122,6 +122,18 @@ describe('scope hoisting', function() {
       assert.equal(output, 2);
     });
 
+    it('supports renaming non-ASCII identifiers', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/non-ascii-identifiers/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, [1, 2, 3, 4]);
+    });
+
     it('supports renaming superclass identifiers', async function() {
       let b = await bundle(
         path.join(

--- a/packages/shared/scope-hoisting/package.json
+++ b/packages/shared/scope-hoisting/package.json
@@ -23,7 +23,7 @@
     "@babel/parser": "^7.0.0",
     "@babel/template": "^7.4.0",
     "@babel/traverse": "^7.2.3",
-    "@babel/types": "^7.12.11",
+    "@babel/types": "^7.12.13",
     "@parcel/babel-ast-utils": "2.0.0-beta.1",
     "@parcel/babylon-walk": "2.0.0-beta.1",
     "@parcel/diagnostic": "2.0.0-beta.1",

--- a/packages/shared/scope-hoisting/src/utils.js
+++ b/packages/shared/scope-hoisting/src/utils.js
@@ -40,16 +40,7 @@ export function getName(
   ...rest: Array<string>
 ): string {
   return t.toIdentifier(
-    '$' +
-      asset.id +
-      '$' +
-      type +
-      (rest.length
-        ? '$' +
-          rest
-            .map(name => (name === 'default' ? name : t.toIdentifier(name)))
-            .join('$')
-        : ''),
+    '$' + asset.id + '$' + type + (rest.length ? '$' + rest.join('$') : ''),
   );
 }
 

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -24,7 +24,7 @@
     "@babel/parser": "^7.0.0",
     "@babel/template": "^7.4.0",
     "@babel/traverse": "^7.0.0",
-    "@babel/types": "^7.12.11",
+    "@babel/types": "^7.12.13",
     "@parcel/babel-ast-utils": "2.0.0-beta.1",
     "@parcel/babylon-walk": "2.0.0-beta.1",
     "@parcel/diagnostic": "2.0.0-beta.1",

--- a/packages/transformers/react-refresh-wrap/package.json
+++ b/packages/transformers/react-refresh-wrap/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/parser": "^7.0.0",
     "@babel/template": "^7.4.0",
-    "@babel/types": "^7.12.11",
+    "@babel/types": "^7.12.13",
     "@parcel/babel-ast-utils": "2.0.0-beta.1",
     "@parcel/plugin": "2.0.0-beta.1",
     "@parcel/utils": "2.0.0-beta.1",

--- a/packages/utils/babylon-walk/package.json
+++ b/packages/utils/babylon-walk/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Timothy Gu <timothygu99@gmail.com>",
   "dependencies": {
-    "@babel/types": "^7.12.11",
+    "@babel/types": "^7.12.13",
     "lodash.clone": "^4.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,19 +1243,10 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.11", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.4.4", "@babel/types@^7.8.0", "@babel/types@^7.8.3", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
-  version "7.12.11"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.11.tgz#a86e4d71e30a9b6ee102590446c98662589283ce"
-  integrity sha512-ukA9SQtKThINm++CX1CwmliMrE54J6nIYB5XTwL5f/CLFW9owfls+YSU8tVW15RQ2w+a3fSbPjC6HdQNtWZkiA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.12.11"
-    lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.10.5", "@babel/types@^7.12.10", "@babel/types@^7.12.12":
-  version "7.12.12"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
-  integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
+"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.12.0", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.12", "@babel/types@^7.12.13", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.4.4", "@babel/types@^7.8.0", "@babel/types@^7.8.3", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.13.tgz#8be1aa8f2c876da11a9cf650c0ecf656913ad611"
+  integrity sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==
   dependencies:
     "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
@@ -6778,11 +6769,23 @@ has-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
   integrity sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
 
 has-values@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
   integrity sha1-bWHeldkd/Km5oCCJrThL/49it3E=
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  integrity sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 has@^1.0.0, has@^1.0.3:
   version "1.0.3"
@@ -8001,6 +8004,13 @@ kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
   dependencies:
     is-buffer "^1.1.5"
 


### PR DESCRIPTION
Version bump for https://github.com/babel/babel/pull/12575

Closes https://github.com/parcel-bundler/parcel/issues/5547