### PR TITLE
Moving the request graph from visualization

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -303,6 +303,9 @@ export default class Parcel {
       );
       assertSignalNotAborted(signal);
 
+      // $FlowFixMe
+      dumpGraphToGraphViz(this.#requestTracker.graph, 'RequestGraph');
+
       let event = {
         type: 'buildSuccess',
         changedAssets: new Map(

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -196,9 +196,6 @@ export class AssetGraphBuilder {
       this.propagateSymbols();
     }
     dumpToGraphViz(this.assetGraph, this.name);
-    // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
-    dumpToGraphViz(this.requestGraph, 'RequestGraph');
-
     dumpToGraphViz(this.assetGraph, 'AssetGraph');
 
     return {


### PR DESCRIPTION
# ↪️ Pull Request

The request graph was removed previously; the flow ignore hides that the object doesn't exist when sent to graphviz. 

Without the change, the graph visualization functionality errors out (undefined graph).

## 🚨 Test instructions

- [x] Run `PARCEL_DUMP_GRAPHVIZ=1 parcel build src/index.js` in simple to see the different graph visualizations

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
