### PR TITLE
empty string for --open cli param is treated as undefined

### DIFF
--- a/packages/core/utils/src/openInBrowser.js
+++ b/packages/core/utils/src/openInBrowser.js
@@ -49,7 +49,7 @@ function getAppName(appName: string): string {
 export default async function openInBrowser(url: string, browser: string) {
   try {
     const options =
-      typeof browser === 'string' ? {app: [getAppName(browser)]} : undefined;
+      typeof browser === 'string' && browser.length > 0 ? {app: [getAppName(browser)]} : undefined;
 
     await open(url, options);
   } catch (err) {

--- a/packages/core/utils/src/openInBrowser.js
+++ b/packages/core/utils/src/openInBrowser.js
@@ -49,7 +49,9 @@ function getAppName(appName: string): string {
 export default async function openInBrowser(url: string, browser: string) {
   try {
     const options =
-      typeof browser === 'string' && browser.length > 0 ? {app: [getAppName(browser)]} : undefined;
+      typeof browser === 'string' && browser.length > 0
+        ? {app: [getAppName(browser)]}
+        : undefined;
 
     await open(url, options);
   } catch (err) {


### PR DESCRIPTION
# ↪️ Pull Request

Makes it so the `--open` option treats an empty string in the same way as `undefined` (i.e. will open the default browser)

So,  `--open $BROWSER` will behave in the same way as this `--open "$BROWSER"`

For this issue: https://github.com/parcel-bundler/parcel/issues/5775

## 💻 Examples

In package.json you should be able to do this:
```
  "scripts": {
    "dev": "parcel serve src/index.html --open \"$BROWSER\""
  },
```
and if `$BROWSER` is unset, it will open the default browser.

## 🚨 Test instructions

Confirm that this:
```
  "scripts": {
    "dev": "parcel serve src/index.html --open \"$BROWSER\""
  },
```

behaves the same way as this:
```
  "scripts": {
    "dev": "parcel serve src/index.html --open $BROWSER"
  },
```

when `$BROWSER` is an actual string and when it is empty.