### PR TITLE
Serve non index.html files if it's the only html entrypoint

### DIFF
--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -112,7 +112,42 @@ describe('server', function() {
 
   it('should serve a default page if the main bundle is an HTML asset', async function() {
     let port = await getPort();
-    let inputPath = path.join(__dirname, '/integration/html/index.html');
+    let b = bundler(
+      [
+        path.join(__dirname, '/integration/html/other.html'),
+        path.join(__dirname, '/integration/html/index.html'),
+      ],
+      {
+        defaultTargetOptions: {
+          distDir,
+        },
+        config,
+        serveOptions: {
+          https: false,
+          port: port,
+          host: 'localhost',
+        },
+      },
+    );
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let outputFile = await outputFS.readFile(
+      path.join(distDir, 'index.html'),
+      'utf8',
+    );
+
+    let data = await get('/', port);
+    assert.equal(data, outputFile);
+
+    data = await get('/foo/bar', port);
+    assert.equal(data, outputFile);
+  });
+
+  it('should serve a default page if the main bundle is an HTML asset even if it is not called index', async function() {
+    let port = await getPort();
+    let inputPath = path.join(__dirname, '/integration/html/other.html');
     let b = bundler(inputPath, {
       defaultTargetOptions: {
         distDir,
@@ -129,7 +164,7 @@ describe('server', function() {
     await getNextBuild(b);
 
     let outputFile = await outputFS.readFile(
-      path.join(distDir, 'index.html'),
+      path.join(distDir, 'other.html'),
       'utf8',
     );
 

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -151,11 +151,9 @@ export default class Server {
       // If the main asset is an HTML file, serve it
       let htmlBundleFilePaths = [];
       this.bundleGraph.traverseBundles(bundle => {
-        if (bundle.type !== 'html' || !bundle.isEntry) {
-          return;
+        if (bundle.type === 'html' && bundle.isEntry) {
+          htmlBundleFilePaths.push(bundle.filePath);
         }
-
-        htmlBundleFilePaths.push(bundle.filePath);
       });
 
       let indexFilePath =

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -165,7 +165,7 @@ export default class Server {
                 return a.length - b.length;
               })
               .find(f => {
-                return f.endsWith('index.html');
+                return path.basename(f).startsWith('index');
               })
           : htmlBundleFilePaths[0];
       if (indexFilePath) {

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -159,17 +159,19 @@ export default class Server {
         htmlBundleFilePaths.length > 1
           ? htmlBundleFilePaths
               .sort((a, b) => {
-                return a.length - b.length;
+                let lengthDiff = a.length - b.length;
+                if (lengthDiff === 0) {
+                  return a.localeCompare(b);
+                } else {
+                  return lengthDiff;
+                }
               })
               .find(f => {
                 return path.basename(f).startsWith('index');
               })
           : htmlBundleFilePaths[0];
       if (indexFilePath) {
-        req.url = `/${path.relative(
-          this.options.distDir,
-          indexFilePath,
-        )}`;
+        req.url = `/${path.relative(this.options.distDir, indexFilePath)}`;
 
         this.serveDist(req, res, () => this.send404(req, res));
       } else {

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -12,7 +12,6 @@ import type {FileSystem} from '@parcel/fs';
 import type {HTTPServer} from '@parcel/utils';
 
 import invariant from 'assert';
-import nullthrows from 'nullthrows';
 import path from 'path';
 import url from 'url';
 import {
@@ -169,7 +168,7 @@ export default class Server {
       if (indexFilePath) {
         req.url = `/${path.relative(
           this.options.distDir,
-          nullthrows(indexFilePath),
+          indexFilePath,
         )}`;
 
         this.serveDist(req, res, () => this.send404(req, res));


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR changes the serving logic to serve the index file if there's multiple html entrypoints and serve the html entrypoint if there's only one.

Closes #5752

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
