### PR TITLE
Remove invalid unused CJS exports statements

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-unused/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-unused/a.js
@@ -1,0 +1,3 @@
+if (Date.now() > 0) {
+	output = require("./b").foo();
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-unused/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-unused/b.js
@@ -1,0 +1,10 @@
+function foo() {
+  return 1;
+}
+
+function bar() {
+  return 2;
+}
+
+exports.foo = foo;
+exports.bar = bar;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3643,6 +3643,20 @@ describe('scope hoisting', function() {
       assert.equal(output, 2);
     });
 
+    it('should remove unused exports assignments for wrapped modules', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/wrap-unused/a.js',
+        ),
+      );
+
+      // console.log(await outputFS.readFile(b.getBundles()[0].filePath, 'utf8'));
+
+      let output = await run(b);
+      assert.equal(output, 1);
+    });
+
     it('should hoist all vars in the scope', async function() {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/5816

~Apparently enabling strict mode for all tests has revealed some more errors and so CI is failing...~ Deferred that change for now

Previously, this could be produced: there's a stray assignment doing `$id$export$foo = $id$var$foo;`. The `$id$exports.foo = ` statement was correctly removed, but this wasn't.
```js
(function () {
  // ASSET: bundle-url.js
  var $a$exports, $a$export$getBundleURL, $a$executed = false;
  function $a$var$getBundleURL() {
    return "bundle";
  }
  function $a$var$getBaseURL(url) {
    return "base";
  }
  function $a$exec() {
    $a$exports = {};
    $a$export$getBundleURL = $a$var$getBundleURL;
    $a$exports.getBundleURL = $a$export$getBundleURL;
    $a$export$getBaseURL = $a$var$getBaseURL; // <---------
  }
  function $a$init() {
    if (!$a$executed) {
      $a$executed = true;
      $a$exec();
    }
    return $a$exports;
  }
  if (Date.now() > 0) {
    console.log($a$init().getBundleURL());
  }
})();


```