### PR TITLE
Fix astring generation of nested comment

### DIFF
--- a/packages/shared/babel-ast-utils/src/generator.js
+++ b/packages/shared/babel-ast-utils/src/generator.js
@@ -256,6 +256,16 @@ export const generator = {
 for (let key in generator) {
   let orig = generator[key];
   generator[key] = function(node, state, skipComments) {
+    // These are printed by astring itself
+    if (node.trailingComments) {
+      for (let c of node.trailingComments) {
+        if (c.type === 'CommentLine') {
+          c.type = 'LineComment';
+        } else {
+          c.type = 'BlockComment';
+        }
+      }
+    }
     if (
       !skipComments &&
       node.leadingComments &&
@@ -288,7 +298,7 @@ function formatComments(state, comments) {
   const {length} = comments;
   for (let i = 0; i < length; i++) {
     const comment = comments[i];
-    if (comment.type === 'CommentLine') {
+    if (comment.type === 'CommentLine' || comment.type === 'LineComment') {
       // Line comment
       state.write('// ' + comment.value.trim() + state.lineEnd, {
         ...comment,

--- a/packages/shared/babel-ast-utils/test/fixtures/valid-only.js
+++ b/packages/shared/babel-ast-utils/test/fixtures/valid-only.js
@@ -1,0 +1,10 @@
+// These are currently not correctly reproduced, but should still
+// remain syntactically valid.
+
+if (1) {
+	a();
+}
+// /* */
+else {
+	b();
+}

--- a/packages/shared/babel-ast-utils/test/index.js
+++ b/packages/shared/babel-ast-utils/test/index.js
@@ -27,12 +27,16 @@ describe('astring babel generator', () => {
         originalSourceMap: null,
         options: {projectRoot: '/foo'},
       });
-      assert.equal(
-        content,
-        code,
-        filename.substring(0, filename.length - 3),
-        'Generates code with the expected format',
-      );
+      if (filename === 'valid-only.js') {
+        babelParse(content), options;
+      } else {
+        assert.equal(
+          content,
+          code,
+          filename.substring(0, filename.length - 3),
+          'Generates code with the expected format',
+        );
+      }
     });
   });
 });


### PR DESCRIPTION
This fixes a case where
`// /* */`

became

`/* /* */ */`

But the comment in the test is still duplicated because of Babel's AST format (https://github.com/babel/babel/issues/12769).

Fixes part of #5787 (so at least the produced code is syntactically valid now).