### PR TITLE
Function parameters shouldn't shadow imports

### DIFF
--- a/packages/core/integration-tests/test/integration/js-import-shadow-param/index.js
+++ b/packages/core/integration-tests/test/integration/js-import-shadow-param/index.js
@@ -1,0 +1,5 @@
+import { foo } from "./other.js";
+
+function func(foo) {}
+
+export default foo;

--- a/packages/core/integration-tests/test/integration/js-import-shadow-param/other.js
+++ b/packages/core/integration-tests/test/integration/js-import-shadow-param/other.js
@@ -1,0 +1,1 @@
+export const foo = 123;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3308,6 +3308,14 @@ describe('javascript', function() {
     assert.deepEqual(res.baz(), [0, 1, 2, 3]);
   });
 
+  it('should replace an imported identifier with function param of the same name', async function() {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-import-shadow-param/index.js'),
+    );
+    let res = await run(b);
+    assert.deepEqual(res.default, 123);
+  });
+
   it('should not freeze live default imports', async function() {
     let b = await bundle(
       path.join(__dirname, 'integration/js-import-default-live/index.js'),

--- a/packages/utils/babylon-walk/src/scope.js
+++ b/packages/utils/babylon-walk/src/scope.js
@@ -63,14 +63,15 @@ export class Scope {
     return uid;
   }
 
-  addBinding(name: string, decl: Node, type: BindingType) {
-    if (type === 'var' && type != 'block' && this.parent) {
+  addBinding(name: string, decl: Node, type: BindingType | 'param') {
+    if (type === 'var' && this.parent) {
       this.parent.addBinding(name, decl, type);
     } else {
+      if (type === 'param') type = 'var';
       this.names.add(name);
       this.bindings.set(name, decl);
+      this.program.names.add(name);
     }
-    this.program.names.add(name);
   }
 
   getBinding(name: string): ?Node {
@@ -210,7 +211,7 @@ export let scopeVisitor: Visitors<ScopeState> = {
     let inner = t.getBindingIdentifiers(node);
     for (let id in inner) {
       if (id !== name) {
-        state.scope.addBinding(id, inner[id], 'var');
+        state.scope.addBinding(id, inner[id], 'param');
       }
     }
   },


### PR DESCRIPTION
The function parameter bindings were added to the parent scope

@wbinnssmith 