### PR TITLE
Fix: Parcel removes sourcemaps data if ast is nullish

### DIFF
--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -96,7 +96,6 @@ export default class UncommittedAsset {
     // must be regenerated later and shouldn't be committed.
     if (this.ast != null && this.isASTDirty) {
       this.content = null;
-      this.mapBuffer = null;
     }
 
     let size = 0;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Parcel used to remove mapBuffer in case there is not AST, but the original sourcemap is also removed in this case, which makes this behaviour incorrect.

Closes #5620 
