### PR TITLE
Mark $parcel$interopDefault calls as pure

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-pure/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-pure/a.js
@@ -1,0 +1,4 @@
+import x from "./b.js";
+if (false) {
+	console.log(x);
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-pure/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-pure/b.js
@@ -1,0 +1,1 @@
+module.exports = "some unused data"

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1784,6 +1784,28 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, ['client', 'client', 'viewer']);
     });
 
+    it('should enable minifier to remove unused modules despite of interopDefault', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/interop-pure/a.js',
+        ),
+        {
+          mode: 'production',
+          defaultTargetOptions: {
+            shouldOptimize: true,
+            sourceMaps: false,
+          },
+        },
+      );
+
+      let contents = await outputFS.readFileSync(
+        b.getBundles()[0].filePath,
+        'utf8',
+      );
+      assert.strictEqual(contents.trim().length, 0);
+    });
+
     it('should support the jsx pragma', async function() {
       let b = await bundle(
         path.join(__dirname, '/integration/scope-hoisting/es6/jsx-pragma/a.js'),

--- a/packages/shared/scope-hoisting/src/concat.js
+++ b/packages/shared/scope-hoisting/src/concat.js
@@ -62,7 +62,9 @@ const DEFAULT_INTEROP_TEMPLATE = template.statement<
     MODULE: Expression,
   |},
   VariableDeclaration,
->('var NAME = $parcel$interopDefault(MODULE);');
+>('var NAME = /*@__PURE__*/$parcel$interopDefault(MODULE);', {
+  preserveComments: true,
+});
 
 const ESMODULE_TEMPLATE = template.statement<
   {|EXPORTS: Expression|},


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/5765

Otherwise, Terser cannot completely remove a module if it's unused:
```js
!function(){var e;(e="some unused data")&&e.__esModule&&e.default}();
```
e.g. with 
```js
import x from "./other.js";
if (false) {
	console.log(x);
}
```

