### PR TITLE
Add missing mode: production to test fixture

### DIFF
--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -551,6 +551,7 @@ describe('scope hoisting', function() {
             f,
           ),
         ),
+        {mode: 'production'},
       );
 
       let output = await runBundle(


### PR DESCRIPTION
It's called `supports live bindings across bundles` after all, but there wasn't a shared bundle without this change