### PR TITLE
WebExtensionTransformer: Beautify manifest.json

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -275,7 +275,7 @@ export default (new Transformer({
       data.content_security_policy = cspPatchHMR(data.content_security_policy);
     }
     asset.meta.handled = true;
-    asset.setCode(JSON.stringify(data));
+    asset.setCode(JSON.stringify(data, null, 2));
     return [asset];
   },
 }): Transformer);


### PR DESCRIPTION
# ↪️ Pull Request

`manifest.json` entry files are being "minified" by default, regardless of the `--no-minify` option. Given that these are small configuration files I think they could avoid being minified by default for the sake of readability. Also because they're downloaded only when the extension is updated.

## 💻 Examples

Before this PR:

```json5
// manifest.json
{"name":"Awesome Extension","version":"0.0.0","description":"An awesome new browser extension","homepage_url":"https://github.com/awesome-templates/browser-extension-template","manifest_version":2,"minimum_chrome_version":"74","applications":{"gecko":{"id":"awesome-extension@notlmn.github.io","strict_min_version":"67.0"}},"icons":{"128":"/icon.png"},"permissions":["storage"],"options_ui":{"chrome_style":true,"page":"/options.html"},"background":{"persistent":false,"scripts":["/__/node_modules/webextension-polyfill/dist/browser-polyfill.js","/background.js"]}}
```

After this PR:

```json5
// manifest.json
{
  "name": "Awesome Extension",
  "version": "0.0.0",
  "description": "An awesome new browser extension",
  "homepage_url": "https://github.com/awesome-templates/browser-extension-template",
  "manifest_version": 2,
  "minimum_chrome_version": "74",
// etc
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs

This is a minimal change/proposal, I'm not sure I'd be able to add unit tests for this change, should they be required.