### PR TITLE
Update flow to 0.145.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -38,4 +38,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.143.0
+0.145.0

--- a/flow-typed/npm/mocha_v8.x.x.js
+++ b/flow-typed/npm/mocha_v8.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 03fc62001bb373473e2e4208d31a9f73
-// flow-typed version: c6154227d1/mocha_v6.x.x/flow_>=v0.104.x
+// flow-typed signature: 195cec6dc98ab7533f0eb927ee493f99
+// flow-typed version: 1a6d5d1968/mocha_v8.x.x/flow_>=v0.104.x
 
 declare interface $npm$mocha$SetupOptions {
   slow?: number;
@@ -34,20 +34,20 @@ declare interface $npm$mocha$Suite {
   fullTitle(): string;
 }
 
-declare interface $npm$mocha$ContextDefinition {
+declare type $npm$mocha$ContextDefinition = {|
   (description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
   only(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
   skip(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): void;
   timeout(ms: number): void;
-}
+|}
 
-declare interface $npm$mocha$TestDefinition {
+declare type $npm$mocha$TestDefinition = {|
   (expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
   only(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
   skip(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): void;
   timeout(ms: number): void;
   state: 'failed' | 'passed';
-}
+|}
 
 declare interface $npm$mocha$Runner {}
 
@@ -181,46 +181,58 @@ declare var xit: $npm$mocha$TestDefinition;
 declare var test: $npm$mocha$TestDefinition;
 declare var specify: $npm$mocha$TestDefinition;
 
-declare function run(): void;
+type Run = () => void;
 
-declare function setup(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
-declare function teardown(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
-declare function suiteSetup(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
-declare function suiteTeardown(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
-declare function before(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
-declare function before(description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
-declare function after(callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
-declare function after(description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed): void;
-declare function beforeEach(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
-declare function beforeEach(description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
-declare function afterEach(callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
-declare function afterEach(description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed): void;
+declare var run: Run;
+
+type Setup = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type Teardown = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type SuiteSetup = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type SuiteTeardown = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type Before =
+  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type After =
+  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type BeforeEach =
+  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+type AfterEach =
+  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+
+
+declare var setup: Setup;
+declare var teardown: Teardown;
+declare var suiteSetup: SuiteSetup;
+declare var suiteTeardown;
+declare var before: Before
+declare var after: After;
+declare var beforeEach: BeforeEach;
+declare var afterEach: AfterEach;
 
 declare module "mocha" {
-  declare export var mocha: typeof mocha;
-  declare export var describe: typeof describe;
-  declare export var xdescribe: typeof xdescribe;
-  declare export var context: typeof context;
-  declare export var suite: typeof suite;
-  declare export var it: typeof it;
-  declare export var xit: typeof xit;
-  declare export var test: typeof test;
-  declare export var specify: typeof specify;
+  declare export var mocha: $npm$mocha$TestDefinition;
+  declare export var describe: $npm$mocha$ContextDefinition;
+  declare export var xdescribe: $npm$mocha$ContextDefinition;
+  declare export var context: $npm$mocha$ContextDefinition;
+  declare export var suite: $npm$mocha$ContextDefinition;
+  declare export var it: $npm$mocha$TestDefinition;
+  declare export var xit: $npm$mocha$TestDefinition;
+  declare export var test: $npm$mocha$TestDefinition;
+  declare export var specify: $npm$mocha$TestDefinition;
 
-  declare export var run: typeof run;
+  declare export var run: Run;
 
-  declare export var setup: typeof setup;
-  declare export var teardown: typeof teardown;
-  declare export var suiteSetup: typeof suiteSetup;
-  declare export var suiteTeardown: typeof suiteTeardown;
-  declare export var before: typeof before;
-  declare export var before: typeof before;
-  declare export var after: typeof after;
-  declare export var after: typeof after;
-  declare export var beforeEach: typeof beforeEach;
-  declare export var beforeEach: typeof beforeEach;
-  declare export var afterEach: typeof afterEach;
-  declare export var afterEach: typeof afterEach;
+  declare export var setup: Setup;
+  declare export var teardown: Teardown;
+  declare export var suiteSetup: SuiteSetup;
+  declare export var suiteTeardown: SuiteTeardown;
+  declare export var before: Before;
+  declare export var after: After;
+  declare export var beforeEach: BeforeEach;
+  declare export var afterEach: AfterEach;
 
   declare export default $npm$mocha$Mocha;
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cross-env": "^7.0.0",
     "doctoc": "^1.4.0",
     "eslint": "^7.20.0",
-    "flow-bin": "0.143.0",
+    "flow-bin": "0.145.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "husky": "^4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6120,10 +6120,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@0.143.0:
-  version "0.143.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.143.0.tgz#f802a18ae86ba87e11dbbbba5922039b551e3f1c"
-  integrity sha512-wduASzl276BkxWBQ83wFMf43ZRNSCQdb4de7JA6GAGsJ7pAbETc1tGWRP/lnk9wnjxmH/tPeqIyLoRK1gvHkiA==
+flow-bin@0.145.0:
+  version "0.145.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.145.0.tgz#922f7c3568caaa5eb64621ec536deb56b24d1795"
+  integrity sha512-+9fi9BMxRBtSWC1x0hWggWTb8Vih+AC7wyvLAX5wR1m6u2lF2HLtixXqy2GX8bWgaynSEJR5lmPxYYC4wMI8cA==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
Latest news regarding autoimports: they work somewhat correctly now for importing npm packages, but when importing from a different monorepo package, a relative path is added instead of the package name