### PR TITLE
detect when multiple bundles have conflicting output filenames

### DIFF
--- a/packages/core/parcel-bundler/src/Bundle.js
+++ b/packages/core/parcel-bundler/src/Bundle.js
@@ -183,6 +183,9 @@ class Bundle {
     let mappings = [];
 
     if (!this.isEmpty) {
+      if (newHashes.has(this.name)) {
+        throw new Error(`Multiple bundles conflict creating "${this.name}"`);
+      }
       let hash = this.getHash();
       newHashes.set(this.name, hash);
 


### PR DESCRIPTION
# ↪️ Pull Request

This pull request detects and reports the problem reported in #5890: when multiple entry points are provided by the user, in some situations multiple bundles create the same output filenames.

Closes #5890

## 💻 Examples


The user runs `parcel watch index.ts index.scss`.
* index.ts is packaged into index.js
* index.scss is packaged into index.scss and _also_ index.js, where the HMR code goes into

These two builders race for writing into the same file, resulting in an invalid JS file.

## 🚨 Test instructions

* run `parcel build index.ts index.scss`, see that everything runs fine
* run `parcel watch foo.ts bar.scss`, see that everything runs fine
* run `parcel watch foo.ts foo.scss`, see the error reporting the naming collision
