### PR TITLE
Allow specifying reporters on the CLI

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -65,9 +65,5 @@
     "*.{jsonld,webmanifest}": "@parcel/packager-raw-url",
     "*": "@parcel/packager-raw"
   },
-  "resolvers": ["@parcel/resolver-default"],
-  "reporters": [
-    "@parcel/reporter-cli",
-    "@parcel/reporter-dev-server"
-  ]
+  "resolvers": ["@parcel/resolver-default"]
 }

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -23,8 +23,6 @@
     "@parcel/optimizer-terser": "2.0.0-beta.1",
     "@parcel/packager-js": "2.0.0-beta.1",
     "@parcel/packager-raw": "2.0.0-beta.1",
-    "@parcel/reporter-cli": "2.0.0-beta.1",
-    "@parcel/reporter-dev-server": "2.0.0-beta.1",
     "@parcel/resolver-default": "2.0.0-beta.1",
     "@parcel/runtime-browser-hmr": "2.0.0-beta.1",
     "@parcel/runtime-js": "2.0.0-beta.1",

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -1,14 +1,9 @@
 // @flow strict-local
 
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
-import type {
-  Bundle as IBundle,
-  Namer,
-  FilePath,
-  ConfigOutput,
-} from '@parcel/types';
+import type {Bundle as IBundle, Namer, ConfigOutput} from '@parcel/types';
 import type WorkerFarm, {SharedReference} from '@parcel/workers';
-import type ParcelConfig from './ParcelConfig';
+import type ParcelConfig, {LoadedPlugin} from './ParcelConfig';
 import type RequestTracker from './RequestTracker';
 import type {Bundle as InternalBundle, ParcelOptions} from './types';
 
@@ -210,13 +205,7 @@ export default class BundlerRunner {
   }
 
   async nameBundle(
-    namers: Array<{|
-      name: string,
-      version: string,
-      plugin: Namer,
-      resolveFrom: FilePath,
-      keyPath: string,
-    |}>,
+    namers: Array<LoadedPlugin<Namer>>,
     internalBundle: InternalBundle,
     internalBundleGraph: InternalBundleGraph,
   ): Promise<void> {

--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -38,7 +38,7 @@ export type LoadedPlugin<T> = {|
   version: Semver,
   plugin: T,
   resolveFrom: FilePath,
-  keyPath: string,
+  keyPath?: string,
 |};
 
 export default class ParcelConfig {

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -859,7 +859,7 @@ type TransformerWithNameAndConfig = {|
   name: PackageName,
   plugin: Transformer,
   config: ?Config,
-  configKeyPath: string,
+  configKeyPath?: string,
   resolveFrom: FilePath,
 |};
 

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -351,7 +351,7 @@ export default class UncommittedAsset {
     result: TransformerResult,
     plugin: PackageName,
     configPath: FilePath,
-    configKeyPath: string,
+    configKeyPath?: string,
   ): UncommittedAsset {
     let content = result.content ?? null;
 

--- a/packages/core/core/src/loadParcelPlugin.js
+++ b/packages/core/core/src/loadParcelPlugin.js
@@ -23,7 +23,7 @@ const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 export default async function loadPlugin<T>(
   pluginName: PackageName,
   configPath: FilePath,
-  keyPath: string,
+  keyPath?: string,
   options: ParcelOptions,
 ): Promise<{|plugin: T, version: Semver, resolveFrom: FilePath|}> {
   let resolveFrom = configPath;
@@ -105,18 +105,22 @@ export default async function loadPlugin<T>(
         origin: '@parcel/core',
         filePath: configPath,
         language: 'json5',
-        codeFrame: {
-          code: configContents,
-          codeHighlights: generateJSONCodeHighlights(configContents, [
-            {
-              key: keyPath,
-              type: 'value',
-              message: md`Cannot find module "${pluginName}"${
-                alternatives[0] ? `, did you mean "${alternatives[0]}"?` : ''
-              }`,
-            },
-          ]),
-        },
+        codeFrame: keyPath
+          ? {
+              code: configContents,
+              codeHighlights: generateJSONCodeHighlights(configContents, [
+                {
+                  key: keyPath,
+                  type: 'value',
+                  message: md`Cannot find module "${pluginName}"${
+                    alternatives[0]
+                      ? `, did you mean "${alternatives[0]}"?`
+                      : ''
+                  }`,
+                },
+              ]),
+            }
+          : undefined,
       },
     });
   }

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -167,11 +167,22 @@ export async function resolveParcelConfig(
     });
   }
 
-  let {config, extendedFiles} = await parseAndProcessConfig(
+  let {config, extendedFiles}: ParcelConfigChain = await parseAndProcessConfig(
     configPath,
     contents,
     options,
   );
+  if (options.reporters.length > 0) {
+    config.reporters = [
+      ...options.reporters.map(name => {
+        return {
+          packageName: name,
+          resolveFrom: options.inputFS.cwd(),
+        };
+      }),
+      ...(config.reporters ?? []),
+    ];
+  }
   return {config, extendedFiles, usedDefault};
 }
 

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -175,12 +175,10 @@ export async function resolveParcelConfig(
 
   if (options.additionalReporters.length > 0) {
     config.reporters = [
-      ...options.additionalReporters.map(name => {
-        return {
-          packageName: name,
-          resolveFrom: options.inputFS.cwd(),
-        };
-      }),
+      ...options.additionalReporters.map(({packageName, resolveFrom}) => ({
+        packageName,
+        resolveFrom,
+      })),
       ...(config.reporters ?? []),
     ];
   }

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -172,9 +172,10 @@ export async function resolveParcelConfig(
     contents,
     options,
   );
-  if (options.reporters.length > 0) {
+
+  if (options.additionalReporters.length > 0) {
     config.reporters = [
-      ...options.reporters.map(name => {
+      ...options.additionalReporters.map(name => {
         return {
           packageName: name,
           resolveFrom: options.inputFS.cwd(),
@@ -183,6 +184,7 @@ export async function resolveParcelConfig(
       ...(config.reporters ?? []),
     ];
   }
+
   return {config, extendedFiles, usedDefault};
 }
 

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -167,7 +167,7 @@ export async function resolveParcelConfig(
     });
   }
 
-  let {config, extendedFiles}: ParcelConfigChain = await parseAndProcessConfig(
+  let {config, extendedFiles} = await parseAndProcessConfig(
     configPath,
     contents,
     options,

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -127,7 +127,7 @@ export default async function resolveOptions(
     outputFS,
     cache,
     packageManager,
-    reporters: initialOptions.reporters ?? [],
+    additionalReporters: initialOptions.additionalReporters ?? [],
     instanceId: generateInstanceId(entries),
     detailedReport: initialOptions.detailedReport,
     defaultTargetOptions: {

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -127,6 +127,7 @@ export default async function resolveOptions(
     outputFS,
     cache,
     packageManager,
+    reporters: initialOptions.reporters ?? [],
     instanceId: generateInstanceId(entries),
     detailedReport: initialOptions.detailedReport,
     defaultTargetOptions: {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -196,7 +196,10 @@ export type ParcelOptions = {|
   outputFS: FileSystem,
   cache: Cache,
   packageManager: PackageManager,
-  additionalReporters: Array<PackageName>,
+  additionalReporters: Array<{|
+    packageName: ModuleSpecifier,
+    resolveFrom: FilePath,
+  |}>,
 
   instanceId: string,
 

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -196,7 +196,7 @@ export type ParcelOptions = {|
   outputFS: FileSystem,
   cache: Cache,
   packageManager: PackageManager,
-  reporters: Array<PackageName>,
+  additionalReporters: Array<PackageName>,
 
   instanceId: string,
 

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -37,7 +37,7 @@ import type {PackageManager} from '@parcel/package-manager';
 export type ParcelPluginNode = {|
   packageName: PackageName,
   resolveFrom: FilePath,
-  keyPath: string,
+  keyPath?: string,
 |};
 
 export type PureParcelConfigPipeline = $ReadOnlyArray<ParcelPluginNode>;
@@ -196,6 +196,7 @@ export type ParcelOptions = {|
   outputFS: FileSystem,
   cache: Cache,
   packageManager: PackageManager,
+  reporters: Array<PackageName>,
 
   instanceId: string,
 

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -96,6 +96,7 @@ const ignoreOptions = new Set([
   'shouldProfile',
   'shouldPatchConsole',
   'projectRoot',
+  'additionalReporters',
 ]);
 
 export function optionsProxy(

--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -34,6 +34,7 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
   cache,
   shouldPatchConsole: false,
   packageManager: new NodePackageManager(inputFS),
+  reporters: [],
   instanceId: 'test',
   defaultTargetOptions: {
     shouldScopeHoist: false,

--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -34,7 +34,7 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
   cache,
   shouldPatchConsole: false,
   packageManager: new NodePackageManager(inputFS),
-  reporters: [],
+  additionalReporters: [],
   instanceId: 'test',
   defaultTargetOptions: {
     shouldScopeHoist: false,

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -31,7 +31,12 @@ describe('JS API', function() {
     let b = await bundle(
       path.join(__dirname, '/integration/js-comment/index.js'),
       {
-        additionalReporters: ['@parcel/reporter-bundle-buddy'],
+        additionalReporters: [
+          {
+            packageName: '@parcel/reporter-bundle-buddy',
+            resolveFrom: __dirname,
+          },
+        ],
       },
     );
 

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -26,4 +26,22 @@ describe('JS API', function() {
 
     assert(await outputFS.exists(path.join(distDir, NAME)));
   });
+
+  it('should run additional reports from the options', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/js-comment/index.js'),
+      {
+        reporters: ['@parcel/reporter-bundle-buddy'],
+      },
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.js'],
+      },
+    ]);
+
+    assert(await outputFS.exists(path.join(distDir, 'bundle-buddy.json')));
+  });
 });

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -31,7 +31,7 @@ describe('JS API', function() {
     let b = await bundle(
       path.join(__dirname, '/integration/js-comment/index.js'),
       {
-        reporters: ['@parcel/reporter-bundle-buddy'],
+        additionalReporters: ['@parcel/reporter-bundle-buddy'],
       },
     );
 

--- a/packages/core/package-manager/src/Yarn.js
+++ b/packages/core/package-manager/src/Yarn.js
@@ -135,7 +135,7 @@ export class Yarn implements PackageInstaller {
     try {
       return await promiseFromProcess(installProcess);
     } catch (e) {
-      throw new Error('Yarn failed to install modules');
+      throw new Error('Yarn failed to install modules:' + e.message);
     }
   }
 }

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -28,6 +28,8 @@
     "@parcel/fs": "2.0.0-beta.1",
     "@parcel/logger": "2.0.0-beta.1",
     "@parcel/package-manager": "2.0.0-beta.1",
+    "@parcel/reporter-cli": "2.0.0-beta.1",
+    "@parcel/reporter-dev-server": "2.0.0-beta.1",
     "@parcel/utils": "2.0.0-beta.1",
     "chalk": "^4.1.0",
     "commander": "^7.0.0",

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -81,12 +81,12 @@ const commonOptions = {
   '--profile': 'enable build profiling',
   '-V, --version': 'output the version number',
   '--detailed-report [count]': [
-    'Print the asset timings and sizes in the build report',
+    'print the asset timings and sizes in the build report',
     parseOptionInt,
     '10',
   ],
   '--reporter <name>': [
-    'reporters',
+    'additional reporters to run',
     (val, acc) => {
       acc.push(val);
       return acc;
@@ -215,8 +215,8 @@ async function run(
   }
   let Parcel = require('@parcel/core').default;
   let fs = new NodeFS();
+  let options = await normalizeOptions(command, fs);
   let packageManager = new NodePackageManager(fs);
-  let options = await normalizeOptions(command, packageManager);
   let parcel = new Parcel({
     entries,
     packageManager,
@@ -369,7 +369,7 @@ function parseOptionInt(value) {
 
 async function normalizeOptions(
   command,
-  packageManager,
+  inputFS,
 ): Promise<InitialParcelOptions> {
   let nodeEnv;
   if (command.name() === 'build') {
@@ -440,7 +440,7 @@ async function normalizeOptions(
     {packageName: '@parcel/reporter-dev-server', resolveFrom: __filename},
     ...(command.reporter: Array<string>).map(packageName => ({
       packageName,
-      resolveFrom: path.join(packageManager.fs.cwd(), 'index'),
+      resolveFrom: path.join(inputFS.cwd(), 'index'),
     })),
   ];
 

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -435,9 +435,8 @@ async function normalizeOptions(
     command.detailedReport = '10';
   }
 
-  let reporters = [];
-
-  repoterOuter: for (let name of (command.reporter: Array<string>)) {
+  let additionalReporters = [];
+  reporterOuter: for (let name of (command.reporter: Array<string>)) {
     let potentialNames = [
       name,
       `@parcel/reporter-${name}`,
@@ -446,8 +445,8 @@ async function normalizeOptions(
     for (let packageName of potentialNames) {
       try {
         await packageManager.resolveSync(packageName, packageManager.fs.cwd());
-        reporters.push(packageName);
-        continue repoterOuter;
+        additionalReporters.push(packageName);
+        continue reporterOuter;
       } catch (e) {
         // noop
       }
@@ -457,7 +456,6 @@ async function normalizeOptions(
         potentialNames.join(', '),
     );
   }
-  console.log(reporters);
 
   let mode = command.name() === 'build' ? 'production' : 'development';
   return {
@@ -481,7 +479,7 @@ async function normalizeOptions(
     env: {
       NODE_ENV: nodeEnv,
     },
-    reporters: reporters,
+    additionalReporters,
     defaultTargetOptions: {
       shouldOptimize:
         command.optimize != null ? command.optimize : mode === 'production',

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -85,6 +85,14 @@ const commonOptions = {
     parseOptionInt,
     '10',
   ],
+  '--reporter <name>': [
+    'reporters',
+    (val, acc) => {
+      acc.push(val);
+      return acc;
+    },
+    [],
+  ],
 };
 
 var hmrOptions = {
@@ -201,17 +209,18 @@ async function run(
   entries = entries.map(entry => path.resolve(entry));
 
   if (entries.length === 0) {
+    // TODO move this into core, a glob could still lead to no entries
     INTERNAL_ORIGINAL_CONSOLE.log('No entries found');
     return;
   }
   let Parcel = require('@parcel/core').default;
-  let options = await normalizeOptions(command);
   let fs = new NodeFS();
   let packageManager = new NodePackageManager(fs);
+  let options = await normalizeOptions(command, packageManager);
   let parcel = new Parcel({
     entries,
     packageManager,
-    // $FlowFixMe - flow doesn't know about the `paths` option (added in Node v8.9.0)
+    // $FlowFixMe[extra-arg] - flow doesn't know about the `paths` option (added in Node v8.9.0)
     defaultConfig: require.resolve('@parcel/config-default', {
       paths: [fs.cwd(), __dirname],
     }),
@@ -358,7 +367,10 @@ function parseOptionInt(value) {
   return parsedValue;
 }
 
-async function normalizeOptions(command): Promise<InitialParcelOptions> {
+async function normalizeOptions(
+  command,
+  packageManager,
+): Promise<InitialParcelOptions> {
   let nodeEnv;
   if (command.name() === 'build') {
     nodeEnv = process.env.NODE_ENV || 'production';
@@ -423,6 +435,30 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     command.detailedReport = '10';
   }
 
+  let reporters = [];
+
+  repoterOuter: for (let name of (command.reporter: Array<string>)) {
+    let potentialNames = [
+      name,
+      `@parcel/reporter-${name}`,
+      `parcel-reporter-${name}`,
+    ];
+    for (let packageName of potentialNames) {
+      try {
+        await packageManager.resolveSync(packageName, packageManager.fs.cwd());
+        reporters.push(packageName);
+        continue repoterOuter;
+      } catch (e) {
+        // noop
+      }
+    }
+    throw new Error(
+      `Could not find reporter for ${name}, tried: ` +
+        potentialNames.join(', '),
+    );
+  }
+  console.log(reporters);
+
   let mode = command.name() === 'build' ? 'production' : 'development';
   return {
     shouldDisableCache: command.cache === false,
@@ -445,6 +481,7 @@ async function normalizeOptions(command): Promise<InitialParcelOptions> {
     env: {
       NODE_ENV: nodeEnv,
     },
+    reporters: reporters,
     defaultTargetOptions: {
       shouldOptimize:
         command.optimize != null ? command.optimize : mode === 'production',

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -436,33 +436,13 @@ async function normalizeOptions(
   }
 
   let additionalReporters = [
-    '@parcel/reporter-cli',
-    '@parcel/reporter-dev-server',
-  ].map(packageName => ({packageName, resolveFrom: __dirname}));
-
-  reporterOuter: for (let name of (command.reporter: Array<string>)) {
-    let potentialNames = [
-      name,
-      `@parcel/reporter-${name}`,
-      `parcel-reporter-${name}`,
-    ];
-    for (let packageName of potentialNames) {
-      try {
-        await packageManager.resolveSync(packageName, packageManager.fs.cwd());
-        additionalReporters.push({
-          packageName,
-          resolveFrom: packageManager.fs.cwd(),
-        });
-        continue reporterOuter;
-      } catch (e) {
-        // noop, try next name
-      }
-    }
-    throw new Error(
-      `Could not find reporter for ${name}, tried: ` +
-        potentialNames.join(', '),
-    );
-  }
+    {packageName: '@parcel/reporter-cli', resolveFrom: __filename},
+    {packageName: '@parcel/reporter-dev-server', resolveFrom: __filename},
+    ...(command.reporter: Array<string>).map(packageName => ({
+      packageName,
+      resolveFrom: path.join(packageManager.fs.cwd(), 'index'),
+    })),
+  ];
 
   let mode = command.name() === 'build' ? 'production' : 'development';
   return {

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -435,7 +435,11 @@ async function normalizeOptions(
     command.detailedReport = '10';
   }
 
-  let additionalReporters = [];
+  let additionalReporters = [
+    '@parcel/reporter-cli',
+    '@parcel/reporter-dev-server',
+  ].map(packageName => ({packageName, resolveFrom: __dirname}));
+
   reporterOuter: for (let name of (command.reporter: Array<string>)) {
     let potentialNames = [
       name,
@@ -445,10 +449,13 @@ async function normalizeOptions(
     for (let packageName of potentialNames) {
       try {
         await packageManager.resolveSync(packageName, packageManager.fs.cwd());
-        additionalReporters.push(packageName);
+        additionalReporters.push({
+          packageName,
+          resolveFrom: packageManager.fs.cwd(),
+        });
         continue reporterOuter;
       } catch (e) {
-        // noop
+        // noop, try next name
       }
     }
     throw new Error(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -288,6 +288,8 @@ export type InitialParcelOptions = {|
     +engines?: Engines,
   |},
 
+  +reporters?: Array<PackageName>,
+
   // throwErrors
   // global?
 |};

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -288,7 +288,10 @@ export type InitialParcelOptions = {|
     +engines?: Engines,
   |},
 
-  +additionalReporters?: Array<PackageName>,
+  +additionalReporters?: Array<{|
+    packageName: ModuleSpecifier,
+    resolveFrom: FilePath,
+  |}>,
 
   // throwErrors
   // global?

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -288,7 +288,7 @@ export type InitialParcelOptions = {|
     +engines?: Engines,
   |},
 
-  +reporters?: Array<PackageName>,
+  +additionalReporters?: Array<PackageName>,
 
   // throwErrors
   // global?

--- a/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
+++ b/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
@@ -10,12 +10,7 @@ import nullthrows from 'nullthrows';
 
 export default (new Reporter({
   async report({event, options}) {
-    if (
-      event.type !== 'buildSuccess' ||
-      process.env.PARCEL_BUNDLE_ANALYZER == null ||
-      // $FlowFixMe
-      process.env.PARCEL_BUNDLE_ANALYZER == false
-    ) {
+    if (event.type !== 'buildSuccess') {
       return;
     }
 

--- a/packages/reporters/bundle-buddy/src/BundleBuddyReporter.js
+++ b/packages/reporters/bundle-buddy/src/BundleBuddyReporter.js
@@ -4,13 +4,8 @@ import {Reporter} from '@parcel/plugin';
 import path from 'path';
 
 export default (new Reporter({
-  async report({event, options}) {
-    if (
-      event.type !== 'buildSuccess' ||
-      process.env.BUNDLE_BUDDY == null ||
-      // $FlowFixMe
-      process.env.BUNDLE_BUDDY == false
-    ) {
+  async report({event, options, logger}) {
+    if (event.type !== 'buildSuccess') {
       return;
     }
 
@@ -48,9 +43,15 @@ export default (new Reporter({
       }
 
       await options.outputFS.writeFile(
-        `${targetDir}/bundle-buddy.json`,
+        path.join(targetDir, 'bundle-buddy.json'),
         JSON.stringify(out),
       );
+      logger.info({
+        message: `Wrote report to ${path.relative(
+          options.outputFS.cwd(),
+          path.join(targetDir, 'bundle-buddy.json'),
+        )}`,
+      });
     }
   },
 }): Reporter);


### PR DESCRIPTION
```sh
yarn parcel build src/index.js --reporter @parcel/reporter-bundle-buddy
```

- [x] Is `options.reporters` is misleading? Maybe `additionalReporters` is better?

Closes T-786