### PR TITLE
md: support undefined/null

### DIFF
--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -293,7 +293,7 @@ export function md(
     let param = params[i];
     result.push(
       strings[i],
-      param[mdVerbatim] ? param.value : escapeMarkdown(`${param}`),
+      param?.[mdVerbatim] ? param.value : escapeMarkdown(`${param}`),
     );
   }
   return result.join('') + strings[strings.length - 1];

--- a/packages/core/diagnostic/test/markdown.test.js
+++ b/packages/core/diagnostic/test/markdown.test.js
@@ -74,4 +74,8 @@ describe('md tagged template literal', () => {
     };
     assert.strictEqual('Test: b', md`Test: ${v}`);
   });
+
+  it('supports null and undefined', () => {
+    assert.strictEqual('Test: undefined null', md`Test: ${undefined} ${null}`);
+  });
 });


### PR DESCRIPTION
Prevent:
```
TypeError: Cannot read property 'Symbol()' of undefined
    at md (.../node_modules/@parcel/diagnostic/lib/diagnostic.js:234:34)
```
with 
```js
md`${undefined}`
```