### PR TITLE
Fix throw statement with leading comment on argument

### DIFF
--- a/packages/shared/babel-ast-utils/src/generator.js
+++ b/packages/shared/babel-ast-utils/src/generator.js
@@ -249,6 +249,21 @@ export const generator = {
       GENERATOR.ReturnStatement.call(this, node, state);
     }
   },
+  ThrowStatement(node, state) {
+    // Add parentheses if there are leading comments
+    if (node.argument?.leadingComments?.length > 0) {
+      let indent = state.indent.repeat(state.indentLevel);
+      state.write('throw (' + state.lineEnd);
+      state.write(indent + state.indent);
+      state.indentLevel++;
+      this[node.argument.type](node.argument, state);
+      state.indentLevel--;
+      state.write(state.lineEnd);
+      state.write(indent + ');');
+    } else {
+      GENERATOR.ThrowStatement.call(this, node, state);
+    }
+  },
 };
 
 // Make every node support comments. Important for preserving /*@__PURE__*/ comments for terser.

--- a/packages/shared/babel-ast-utils/test/fixtures/control.js
+++ b/packages/shared/babel-ast-utils/test/fixtures/control.js
@@ -1,3 +1,7 @@
+throw (
+  /*comment*/
+  new Error("abc")
+);
 if (a > b) {} else {}
 if (c != d) {}
 var a = b > c ? d : e;


### PR DESCRIPTION
Closes #5931

```js
throw (
  /*comment*/
  new Error("abc")
);
```

became

```js
throw /*comment*/
new Error("abc");
```