### PR TITLE
Pass version to presetEnv

### DIFF
--- a/packages/transformers/babel/src/env.js
+++ b/packages/transformers/babel/src/env.js
@@ -47,9 +47,8 @@ export default async function getEnvOptions(
 }
 
 function getNeededPlugins(targets: BabelTargets): Array<PresetEnvPlugin> {
-  const { version } = require("@babel/core")
   return presetEnv(
-    {version: version , assertVersion: () => true},
+    {version: require('@babel/core').version, assertVersion: () => true},
     {targets: targets},
   ).plugins.filter(p => p[0]);
 }

--- a/packages/transformers/babel/src/env.js
+++ b/packages/transformers/babel/src/env.js
@@ -47,8 +47,9 @@ export default async function getEnvOptions(
 }
 
 function getNeededPlugins(targets: BabelTargets): Array<PresetEnvPlugin> {
+  const { version } = require("@babel/core")
   return presetEnv(
-    {version: '7.13.0', assertVersion: () => true}, // version is required since https://github.com/babel/babel/pull/12934/
+    {version: version , assertVersion: () => true},
     {targets: targets},
   ).plugins.filter(p => p[0]);
 }

--- a/packages/transformers/babel/src/env.js
+++ b/packages/transformers/babel/src/env.js
@@ -48,7 +48,7 @@ export default async function getEnvOptions(
 
 function getNeededPlugins(targets: BabelTargets): Array<PresetEnvPlugin> {
   return presetEnv(
-    {assertVersion: () => true},
+    {version: '7.13.0', assertVersion: () => true}, // version is required since https://github.com/babel/babel/pull/12934/
     {targets: targets},
   ).plugins.filter(p => p[0]);
 }


### PR DESCRIPTION
# ↪️ Pull Request

Fixing #5943

[This change](https://github.com/babel/babel/pull/12934/files#diff-cddb13dc00454073d19373b40529b8047e25b9141ab627eb8be482601f16eabeR301) in babel breaks Parcel if version doesn't pass into `presetEnv()`. By setting version as 7.13.0 `presetEnv()` will continue other checking, just like the logic before.