### PR TITLE
pnpm autoinstall support 

### DIFF
--- a/packages/core/core/test/Parcel.test.js
+++ b/packages/core/core/test/Parcel.test.js
@@ -9,7 +9,7 @@ import path from 'path';
 import Parcel, {createWorkerFarm} from '../src/Parcel';
 
 describe('Parcel', function() {
-  this.timeout(40000);
+  this.timeout(60000);
 
   let workerFarm;
   before(() => {

--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -25,7 +25,6 @@ export class Pnpm implements PackageInstaller {
       modules.map(npmSpecifierFromModuleRequest),
     );
 
-    console.log({cwd, args});
     let addedCount = 0;
     let removedCount = 0;
     let installProcess = spawn(PNPM_CMD, args, {
@@ -37,7 +36,6 @@ export class Pnpm implements PackageInstaller {
       .pipe(split())
       .pipe(new JSONParseStream())
       .on('error', e => {
-        console.log('[ERROR]', e);
         logger.warn({
           origin: '@parcel/package-manager',
           message: e.chunk,
@@ -45,7 +43,6 @@ export class Pnpm implements PackageInstaller {
         });
       })
       .on('data', (json: PNPMResults) => {
-        console.log('[stdout]', json);
         if (json.level === 'error') {
           logger.error({
             origin: '@parcel/package-manager',
@@ -109,11 +106,9 @@ export class Pnpm implements PackageInstaller {
     let stderr = [];
     installProcess.stderr
       .on('data', str => {
-        console.log('[sdterr]', str.toString());
         stderr.push(str.toString());
       })
       .on('error', e => {
-        console.log('[ERROR] install', e);
         logger.warn({
           origin: '@parcel/package-manager',
           message: e.message,

--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -1,0 +1,161 @@
+// @flow strict-local
+
+import type {PackageInstaller, InstallerOptions} from './types';
+
+import spawn from 'cross-spawn';
+import logger from '@parcel/logger';
+import promiseFromProcess from './promiseFromProcess';
+import {registerSerializableClass} from '@parcel/core';
+import {npmSpecifierFromModuleRequest} from './utils';
+import split from 'split2';
+import JSONParseStream from './JSONParseStream';
+
+// $FlowFixMe
+import pkg from '../package.json';
+
+const PNPM_CMD = 'pnpm';
+
+export class Pnpm implements PackageInstaller {
+  async install({
+    modules,
+    cwd,
+    packagePath,
+    saveDev = true,
+  }: InstallerOptions): Promise<void> {
+    let args = ['install', '--reporter ndjson', saveDev ? '--dev' : ''].concat(
+      modules.map(npmSpecifierFromModuleRequest),
+    );
+
+    let addedCount = 0;
+    let removedCount = 0;
+    let installProcess = spawn(PNPM_CMD, args, {cwd});
+
+    installProcess.stdout
+      .pipe(split())
+      .pipe(new JSONParseStream())
+      .on('error', e => {
+        logger.warn(e.chunk, '@parcel/package-manager');
+        logger.warn(e, '@parcel/package-manager');
+      })
+      .on('data', (json: PNPMResults) => {
+        if (json.level === 'info') {
+          logger.info({
+            origin: '@parcel/package-manager',
+            message: prefix(json.message),
+          });
+          return;
+        }
+
+        switch (json.name) {
+          case 'pnpm:importing':
+            logger.progress(prefix(`[importing] ${json.to}`));
+            return;
+          case 'pnpm:link':
+            logger.progress(prefix(`[link] ${json.link}`));
+            return;
+          case 'pnpm:progress':
+            logger.info(prefix(`[${json.status}] ${json.packageId}`));
+            return;
+          case 'pnpm:root':
+            if (json.added) {
+              logger.info({
+                origin: '@parcel/package-manager',
+                message: prefix(
+                  `[added] ${json.added.name} (${json.added.version})`,
+                ),
+              });
+            }
+            return;
+          case 'pnpm:stats':
+            addedCount += json.added || 0;
+            removedCount += json.removed || 0;
+
+            const data = JSON.stringify(json);
+
+            logger.info({
+              origin: '@parcel/package-manager',
+              message: prefix(data),
+            });
+            return;
+        }
+      });
+
+    let stderr = [];
+    installProcess.stderr
+      .on('data', str => {
+        stderr.push(str.toString());
+      })
+      .on('error', e => {
+        logger.warn({
+          origin: '@parcel/package-manager',
+          message: e.message,
+        });
+      });
+
+    try {
+      await promiseFromProcess(installProcess);
+
+      if (addedCount > 0) {
+        logger.log({
+          origin: '@parcel/package-manager',
+          message: `Added ${addedCount} packages via pnpm`,
+        });
+      }
+      if (removedCount > 0) {
+        logger.log({
+          origin: '@parcel/package-manager',
+          message: `Removed ${removedCount} packages via pnpm`,
+        });
+      }
+
+      // Since we succeeded, stderr might have useful information not included
+      // in the json written to stdout. It's also not necessary to log these as
+      // errors as they often aren't.
+      for (let message of stderr) {
+        logger.log({
+          origin: '@parcel/package-manager',
+          message,
+        });
+      }
+    } catch (e) {
+      throw new Error('pnpm failed to install modules');
+    }
+  }
+}
+
+type PNPMResults =
+  | {|
+      +level: 'info',
+      message: string,
+    |}
+  | {|
+      +name: 'pnpm:progress',
+      packageId: string,
+      status: 'fetched' | 'found_in_store' | 'resolved',
+    |}
+  | {|
+      +name: 'pnpm:root',
+      added?: {|
+        id?: string,
+        name: string,
+        realName: string,
+        version?: string,
+        dependencyType?: 'prod' | 'dev' | 'optional',
+        latest?: string,
+        linkedFrom?: string,
+      |},
+      removed?: {|
+        name: string,
+        version?: string,
+        dependencyType?: 'prod' | 'dev' | 'optional',
+      |},
+    |}
+  | {|+name: 'pnpm:importing', from: string, method: string, to: string|}
+  | {|+name: 'pnpm:link', target: string, link: string|}
+  | {|+name: 'pnpm:stats', prefix: string, removed?: number, added?: number|};
+
+function prefix(message: string): string {
+  return 'pnpm: ' + message;
+}
+
+registerSerializableClass(`${pkg.version}:Pnpm`, Pnpm);

--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -2,6 +2,7 @@
 
 import type {PackageInstaller, InstallerOptions} from './types';
 
+import commandExists from 'command-exists';
 import spawn from 'cross-spawn';
 import logger from '@parcel/logger';
 import promiseFromProcess from './promiseFromProcess';
@@ -15,7 +16,22 @@ import pkg from '../package.json';
 
 const PNPM_CMD = 'pnpm';
 
+let hasPnpm: ?boolean;
 export class Pnpm implements PackageInstaller {
+  static async exists(): Promise<boolean> {
+    if (hasPnpm != null) {
+      return hasPnpm;
+    }
+
+    try {
+      hasPnpm = Boolean(await commandExists('pnpm'));
+    } catch (err) {
+      hasPnpm = false;
+    }
+
+    return hasPnpm;
+  }
+
   async install({
     modules,
     cwd,

--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -5,162 +5,16 @@ import type {PackageInstaller, InstallerOptions} from './types';
 import commandExists from 'command-exists';
 import spawn from 'cross-spawn';
 import logger from '@parcel/logger';
+import split from 'split2';
+import JSONParseStream from './JSONParseStream';
 import promiseFromProcess from './promiseFromProcess';
 import {registerSerializableClass} from '@parcel/core';
 import {npmSpecifierFromModuleRequest} from './utils';
-import split from 'split2';
-import JSONParseStream from './JSONParseStream';
 
 // $FlowFixMe
 import pkg from '../package.json';
 
 const PNPM_CMD = 'pnpm';
-
-let hasPnpm: ?boolean;
-export class Pnpm implements PackageInstaller {
-  static async exists(): Promise<boolean> {
-    if (hasPnpm != null) {
-      return hasPnpm;
-    }
-
-    try {
-      hasPnpm = Boolean(await commandExists('pnpm'));
-    } catch (err) {
-      hasPnpm = false;
-    }
-
-    return hasPnpm;
-  }
-
-  async install({
-    modules,
-    cwd,
-    saveDev = true,
-  }: InstallerOptions): Promise<void> {
-    let args = ['add', '--reporter', 'ndjson', saveDev ? '-D' : ''].concat(
-      modules.map(npmSpecifierFromModuleRequest),
-    );
-
-    let addedCount = 0;
-    let removedCount = 0;
-    let installProcess = spawn(PNPM_CMD, args, {
-      cwd,
-      env: {...process.env, NODE_ENV: 'development'},
-    });
-
-    installProcess.stdout
-      .pipe(split())
-      .pipe(new JSONParseStream())
-      .on('error', e => {
-        logger.warn({
-          origin: '@parcel/package-manager',
-          message: e.chunk,
-          stack: e.stack,
-        });
-      })
-      .on('data', (json: PNPMResults) => {
-        if (json.level === 'error') {
-          logger.error({
-            origin: '@parcel/package-manager',
-            message: json.err.message,
-            stack: json.err.stack,
-          });
-          return;
-        }
-        if (json.level === 'info' && typeof json.message === 'string') {
-          logger.info({
-            origin: '@parcel/package-manager',
-            message: prefix(json.message),
-          });
-          return;
-        }
-
-        switch (json.name) {
-          case 'pnpm:importing':
-            logger.progress(prefix(`[importing] ${json.to}`));
-            return;
-          case 'pnpm:link':
-            logger.progress(prefix(`[link] ${json.link}`));
-            return;
-          case 'pnpm:progress':
-            logger.info({
-              origin: '@parcel/package-manager',
-              message: prefix(`[${json.status}] ${json.packageId}`),
-            });
-            return;
-          case 'pnpm:root':
-            if (json.added) {
-              logger.info({
-                origin: '@parcel/package-manager',
-                message: prefix(
-                  `[added] ${json.added.name} (${json.added.version || ''})`,
-                ),
-              });
-            }
-            if (json.removed) {
-              logger.info({
-                origin: '@parcel/package-manager',
-                message: prefix(
-                  `[added] ${json.removed.name} (${json.removed.version ||
-                    ''})`,
-                ),
-              });
-            }
-            return;
-          case 'pnpm:stats':
-            addedCount += json.added || 0;
-            removedCount += json.removed || 0;
-
-            logger.info({
-              origin: '@parcel/package-manager',
-              message: prefix(JSON.stringify(json)),
-            });
-            return;
-        }
-      });
-
-    let stderr = [];
-    installProcess.stderr
-      .on('data', str => {
-        stderr.push(str.toString());
-      })
-      .on('error', e => {
-        logger.warn({
-          origin: '@parcel/package-manager',
-          message: e.message,
-        });
-      });
-
-    try {
-      await promiseFromProcess(installProcess);
-
-      if (addedCount > 0) {
-        logger.log({
-          origin: '@parcel/package-manager',
-          message: `Added ${addedCount} packages via pnpm`,
-        });
-      }
-      if (removedCount > 0) {
-        logger.log({
-          origin: '@parcel/package-manager',
-          message: `Removed ${removedCount} packages via pnpm`,
-        });
-      }
-
-      // Since we succeeded, stderr might have useful information not included
-      // in the json written to stdout. It's also not necessary to log these as
-      // errors as they often aren't.
-      for (let message of stderr) {
-        logger.log({
-          origin: '@parcel/package-manager',
-          message,
-        });
-      }
-    } catch (e) {
-      throw new Error('pnpm failed to install modules');
-    }
-  }
-}
 
 type LogLevel = 'error' | 'warn' | 'info' | 'debug';
 
@@ -206,6 +60,150 @@ type PNPMResults = {|
   ...ErrorLog,
   ...PNPMLog,
 |};
+
+let hasPnpm: ?boolean;
+export class Pnpm implements PackageInstaller {
+  static async exists(): Promise<boolean> {
+    if (hasPnpm != null) {
+      return hasPnpm;
+    }
+
+    try {
+      hasPnpm = Boolean(await commandExists('pnpm'));
+    } catch (err) {
+      hasPnpm = false;
+    }
+
+    return hasPnpm;
+  }
+
+  async install({
+    modules,
+    cwd,
+    saveDev = true,
+  }: InstallerOptions): Promise<void> {
+    let args = ['add', '--reporter', 'ndjson'];
+    if (saveDev) {
+      args.push('-D');
+    }
+    args = args.concat(modules.map(npmSpecifierFromModuleRequest));
+
+    let addedCount = 0;
+    let removedCount = 0;
+    let installProcess = spawn(PNPM_CMD, args, {
+      cwd,
+    });
+
+    installProcess.stdout
+      .pipe(split())
+      .pipe(new JSONParseStream())
+      .on('error', e => {
+        logger.warn({
+          origin: '@parcel/package-manager',
+          message: e.chunk,
+          stack: e.stack,
+        });
+      })
+      .on('data', (json: PNPMResults) => {
+        if (json.level === 'error') {
+          logger.error({
+            origin: '@parcel/package-manager',
+            message: json.err.message,
+            stack: json.err.stack,
+          });
+        } else if (json.level === 'info' && typeof json.message === 'string') {
+          logger.info({
+            origin: '@parcel/package-manager',
+            message: prefix(json.message),
+          });
+        } else {
+          switch (json.name) {
+            case 'pnpm:importing':
+              logger.progress(prefix(`[importing] ${json.to}`));
+              return;
+            case 'pnpm:link':
+              logger.progress(prefix(`[link] ${json.link}`));
+              return;
+            case 'pnpm:progress':
+              logger.info({
+                origin: '@parcel/package-manager',
+                message: prefix(`[${json.status}] ${json.packageId}`),
+              });
+              return;
+            case 'pnpm:root':
+              if (json.added) {
+                logger.info({
+                  origin: '@parcel/package-manager',
+                  message: prefix(
+                    `[added] ${json.added.name} (${json.added.version || ''})`,
+                  ),
+                });
+              }
+              if (json.removed) {
+                logger.info({
+                  origin: '@parcel/package-manager',
+                  message: prefix(
+                    `[added] ${json.removed.name} (${json.removed.version ||
+                      ''})`,
+                  ),
+                });
+              }
+              return;
+            case 'pnpm:stats':
+              addedCount += json.added || 0;
+              removedCount += json.removed || 0;
+
+              logger.info({
+                origin: '@parcel/package-manager',
+                message: prefix(JSON.stringify(json)),
+              });
+              return;
+          }
+        }
+      });
+
+    let stderr = [];
+    installProcess.stderr
+      .on('data', str => {
+        stderr.push(str.toString());
+      })
+      .on('error', e => {
+        logger.warn({
+          origin: '@parcel/package-manager',
+          message: e.message,
+        });
+      });
+
+    try {
+      await promiseFromProcess(installProcess);
+
+      if (addedCount > 0) {
+        logger.log({
+          origin: '@parcel/package-manager',
+          message: `Added ${addedCount} packages via pnpm`,
+        });
+      }
+      if (removedCount > 0) {
+        logger.log({
+          origin: '@parcel/package-manager',
+          message: `Removed ${removedCount} packages via pnpm`,
+        });
+      }
+
+      // Since we succeeded, stderr might have useful information not included
+      // in the json written to stdout. It's also not necessary to log these as
+      // errors as they often aren't.
+      for (let message of stderr) {
+        logger.log({
+          origin: '@parcel/package-manager',
+          message,
+        });
+      }
+    } catch (e) {
+      throw new Error('pnpm failed to install modules');
+    }
+  }
+}
 
 function prefix(message: string): string {
   return 'pnpm: ' + message;

--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -19,7 +19,6 @@ export class Pnpm implements PackageInstaller {
   async install({
     modules,
     cwd,
-    packagePath,
     saveDev = true,
   }: InstallerOptions): Promise<void> {
     let args = ['install', '--reporter ndjson', saveDev ? '--dev' : ''].concat(
@@ -85,11 +84,9 @@ export class Pnpm implements PackageInstaller {
             addedCount += json.added || 0;
             removedCount += json.removed || 0;
 
-            const data = JSON.stringify(json);
-
             logger.info({
               origin: '@parcel/package-manager',
-              message: prefix(data),
+              message: prefix(JSON.stringify(json)),
             });
             return;
         }

--- a/packages/core/package-manager/src/index.js
+++ b/packages/core/package-manager/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 export type * from './types';
 export * from './Npm';
+export * from './Pnpm';
 export * from './Yarn';
 export * from './MockPackageInstaller';
 export * from './NodePackageManager';

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -132,24 +132,35 @@ async function determinePackageInstaller(
   filepath: FilePath,
 ): Promise<PackageInstaller> {
   let configFile = await resolveConfig(fs, filepath, [
+    'pnpm-lock.yaml',
     'yarn.lock',
     'package-lock.json',
-    'pnpm-lock.yaml',
   ]);
-  let hasYarn = await Yarn.exists();
 
-  // If Yarn isn't available, or there is a package-lock.json file, use npm.
   let configName = configFile && path.basename(configFile);
-  if (!hasYarn || configName) {
-    if (configName === 'package-lock.json') {
+
+  switch (configName) {
+    case 'pnpm-lock.yaml':
+      if (await Pnpm.exists()) {
+        return new Pnpm();
+      }
+      break;
+    case 'yarn.lock':
+      if (await Yarn.exists()) {
+        return new Yarn();
+      }
+      break;
+    case 'package-lock.json':
       return new Npm();
-    }
-    if (configName === 'pnpm-lock.yaml') {
-      return new Pnpm();
-    }
   }
 
-  return new Yarn();
+  if (await Pnpm.exists()) {
+    return new Pnpm();
+  }
+  if (await Yarn.exists()) {
+    return new Yarn();
+  }
+  return new Npm();
 }
 
 let queue = new PromiseQueue({maxConcurrent: 1});

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -151,6 +151,8 @@ async function determinePackageInstaller(
 
   if (await Yarn.exists()) {
     return new Yarn();
+  } else if (await Pnpm.exists()) {
+    return new Pnpm();
   } else {
     return new Npm();
   }

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -24,6 +24,7 @@ import WorkerFarm from '@parcel/workers';
 
 import {Npm} from './Npm';
 import {Yarn} from './Yarn';
+import {Pnpm} from './Pnpm.js';
 import {getConflictingLocalDependencies} from './utils';
 import validateModuleSpecifier from './validateModuleSpecifier';
 
@@ -133,13 +134,19 @@ async function determinePackageInstaller(
   let configFile = await resolveConfig(fs, filepath, [
     'yarn.lock',
     'package-lock.json',
+    'pnpm-lock.yaml',
   ]);
   let hasYarn = await Yarn.exists();
 
   // If Yarn isn't available, or there is a package-lock.json file, use npm.
   let configName = configFile && path.basename(configFile);
-  if (!hasYarn || configName === 'package-lock.json') {
-    return new Npm();
+  if (!hasYarn || configName) {
+    if (configName === 'package-lock.json') {
+      return new Npm();
+    }
+    if (configName === 'pnpm-lock.yaml') {
+      return new Pnpm();
+    }
   }
 
   return new Yarn();

--- a/packages/core/utils/src/alternatives.js
+++ b/packages/core/utils/src/alternatives.js
@@ -24,7 +24,7 @@ export async function findAlternativeNodeModules(
       let modulesDir = path.join(dir, 'node_modules');
       let stats = await fs.stat(modulesDir);
       if (stats.isDirectory()) {
-        let dirContent = await fs.readdir(modulesDir);
+        let dirContent = (await fs.readdir(modulesDir)).sort();
 
         // Filter out the modules that interest us
         let modules = dirContent.filter(i =>
@@ -36,7 +36,7 @@ export async function findAlternativeNodeModules(
           await Promise.all(
             modules.map(async item => {
               let orgDirPath = path.join(modulesDir, item);
-              let orgDirContent = await fs.readdir(orgDirPath);
+              let orgDirContent = (await fs.readdir(orgDirPath)).sort();
 
               // Add all org packages
               potentialModules.push(...orgDirContent.map(i => `${item}/${i}`));
@@ -70,7 +70,7 @@ async function findAllFilesUp({
   maxlength: number,
   collected: Array<string>,
 |}): Promise<mixed> {
-  let dirContent = await fs.readdir(dir);
+  let dirContent = (await fs.readdir(dir)).sort();
   return Promise.all(
     dirContent.map(async item => {
       let fullPath = path.join(dir, item);


### PR DESCRIPTION
Based on https://github.com/parcel-bundler/parcel/pull/4920 (cc @aminya @dishuostec)

Closes https://github.com/parcel-bundler/parcel/issues/3408

```sh
$ pnpx parcel build index.html
Installing @parcel/transformer-posthtml...
@parcel/package-manager: Added 11 packages via pnpm
Installing @parcel/transformer-html...
@parcel/package-manager: Added 1 packages via pnpm
Installing @parcel/packager-html...
@parcel/package-manager: Added 1 packages via pnpm
Installing @parcel/optimizer-htmlnano...
@parcel/package-manager: Added 212 packages via pnpm
✨ Built in 10.52s

dist/index.bba55d6c.js               62 B     32ms
├── Code from unknown sourcefiles    43 B      0ms
└── index.js                         19 B    522ms

dist/index.html                      42 B    5.30s
└── index.html                       57 B    3.67s
````

<br>

The big question: how should the package manager be selected? I've made it so that
- if a lockfile was found, always try to use that package manager (because not running the one used by the project sounds like a bad idea)
- if no lockfile was found, Yarn if installed or npm. Not sure if we should prefer pnpm here (before npm) if installed. This is really more of a personal preference
