### PR TITLE
Fix spread in parcelrc with empty parent

### DIFF
--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -541,16 +541,16 @@ export function mergePipelines(
     return base ?? [];
   }
 
+  if (ext.filter(v => v === '...').length > 1) {
+    throw new Error(
+      'Only one spread element can be included in a config pipeline',
+    );
+  }
+
   if (base) {
     // Merge the base pipeline if a rest element is defined
     let spreadIndex = ext.indexOf('...');
     if (spreadIndex >= 0) {
-      if (ext.filter(v => v === '...').length > 1) {
-        throw new Error(
-          'Only one spread element can be included in a config pipeline',
-        );
-      }
-
       return [
         ...ext.slice(0, spreadIndex),
         ...(base || []),
@@ -559,7 +559,7 @@ export function mergePipelines(
     }
   }
 
-  return ext;
+  return ext?.filter(s => s !== '...');
 }
 
 export function mergeMaps<K: string, V>(

--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -426,6 +426,55 @@ describe('loadParcelConfig', () => {
         );
       }, /Only one spread element can be included in a config pipeline/);
     });
+
+    it('should remove spread element even without a base map', () => {
+      assert.deepEqual(
+        mergePipelines(null, [
+          {
+            packageName: 'parcel-transform-bar',
+            resolveFrom: '.parcelrc',
+            keyPath: '/transformers/*.js/0',
+          },
+          '...',
+          {
+            packageName: 'parcel-transform-baz',
+            resolveFrom: '.parcelrc',
+            keyPath: '/transformers/*.js/2',
+          },
+        ]),
+        [
+          {
+            packageName: 'parcel-transform-bar',
+            resolveFrom: '.parcelrc',
+            keyPath: '/transformers/*.js/0',
+          },
+          {
+            packageName: 'parcel-transform-baz',
+            resolveFrom: '.parcelrc',
+            keyPath: '/transformers/*.js/2',
+          },
+        ],
+      );
+    });
+
+    it('should throw if more than one spread element is in a pipeline even without a base map', () => {
+      assert.throws(() => {
+        mergePipelines(null, [
+          {
+            packageName: 'parcel-transform-bar',
+            resolveFrom: '.parcelrc',
+            keyPath: '/transformers/*.js/0',
+          },
+          '...',
+          {
+            packageName: 'parcel-transform-baz',
+            resolveFrom: '.parcelrc',
+            keyPath: '/transformers/*.js/2',
+          },
+          '...',
+        ]);
+      }, /Only one spread element can be included in a config pipeline/);
+    });
   });
 
   describe('mergeMaps', () => {


### PR DESCRIPTION
https://github.com/parcel-bundler/parcel/pull/5905 completely removed the `reporters` entry in the default config.

Adding a parcelrc with `{"extends": "@parcel/config-default", "reporters": ["...", "parcel-reporter-something"]}` then caused an exception because `...` wasn't being replaced if the `"reporters"` entry in the parent config was completely missing.

This was once again caused by `$FlowFixMe` and `any`....

Manifested in `Cannot read property 'includes' of undefined`