### PR TITLE
Update Flow to v0.146.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -38,4 +38,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.145.0
+0.146.0

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cross-env": "^7.0.0",
     "doctoc": "^1.4.0",
     "eslint": "^7.20.0",
-    "flow-bin": "0.145.0",
+    "flow-bin": "0.146.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "husky": "^4.2.5",

--- a/packages/core/cache/src/Cache.js
+++ b/packages/core/cache/src/Cache.js
@@ -44,9 +44,8 @@ export default class Cache {
     return this.fs.exists(this._getCachePath(key, '.blob'));
   }
 
-  getBlob<T>(key: string, encoding?: buffer$Encoding): Promise<?T> {
-    // $FlowFixMe
-    return this.fs.readFile(this._getCachePath(key, '.blob'), encoding);
+  getBlob(key: string): Promise<Buffer> {
+    return this.fs.readFile(this._getCachePath(key, '.blob'));
   }
 
   async setBlob(key: string, contents: Buffer | string): Promise<string> {

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -89,14 +89,20 @@ export default class BundlerRunner {
       cacheKey = await this.getCacheKey(graph, configResult);
       let cachedBundleGraphBuffer;
       try {
-        cachedBundleGraphBuffer = await this.options.cache.getBlob(cacheKey);
+        cachedBundleGraphBuffer = await this.options.cache.getBlob<Buffer>(
+          cacheKey,
+        );
       } catch {
         // Cache miss
       }
       assertSignalNotAborted(signal);
 
-      if (cachedBundleGraphBuffer) {
-        return [deserialize(cachedBundleGraphBuffer), cachedBundleGraphBuffer];
+      let _cachedBundleGraphBuffer = cachedBundleGraphBuffer; // For Flow
+      if (_cachedBundleGraphBuffer) {
+        return [
+          deserialize(_cachedBundleGraphBuffer),
+          _cachedBundleGraphBuffer,
+        ];
       }
     }
 

--- a/packages/core/core/src/BundlerRunner.js
+++ b/packages/core/core/src/BundlerRunner.js
@@ -89,9 +89,7 @@ export default class BundlerRunner {
       cacheKey = await this.getCacheKey(graph, configResult);
       let cachedBundleGraphBuffer;
       try {
-        cachedBundleGraphBuffer = await this.options.cache.getBlob<Buffer>(
-          cacheKey,
-        );
+        cachedBundleGraphBuffer = await this.options.cache.getBlob(cacheKey);
       } catch {
         // Cache miss
       }

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -27,9 +27,10 @@ export default class Graph<TNode: Node, TEdgeType: string | null = null> {
     this.nodes = opts.nodes || new Map();
     this.rootNodeId = opts.rootNodeId;
 
-    if (opts.edges) {
-      this.inboundEdges = new AdjacencyList(opts.edges.inboundEdges);
-      this.outboundEdges = new AdjacencyList(opts.edges.outboundEdges);
+    let edges = opts.edges;
+    if (edges != null) {
+      this.inboundEdges = new AdjacencyList(edges.inboundEdges);
+      this.outboundEdges = new AdjacencyList(edges.outboundEdges);
     } else {
       this.inboundEdges = new AdjacencyList();
       this.outboundEdges = new AdjacencyList();
@@ -141,7 +142,7 @@ export default class Graph<TNode: Node, TEdgeType: string | null = null> {
         }
       }
     } else {
-      nodes = inboundByType.get(type)?.values() ?? [];
+      nodes = new Set(inboundByType.get(type)?.values() ?? []);
     }
 
     return [...nodes].map(to => nullthrows(this.nodes.get(to)));
@@ -174,7 +175,7 @@ export default class Graph<TNode: Node, TEdgeType: string | null = null> {
         }
       }
     } else {
-      nodes = outboundByType.get(type)?.values() ?? [];
+      nodes = new Set(outboundByType.get(type)?.values() ?? []);
     }
 
     return [...nodes].map(to => nullthrows(this.nodes.get(to)));

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -1,7 +1,6 @@
 // @flow strict-local
 
 import type {
-  AST,
   FilePath,
   FileCreateInvalidation,
   GenerateOutput,
@@ -576,12 +575,15 @@ export default class Transformation {
             : null;
         let mapBuffer =
           value.astKey != null
-            ? await this.options.cache.getBlob<Buffer>(value.astKey)
+            ? await this.options.cache.getBlob(value.astKey)
             : null;
         let ast =
           value.astKey != null
-            ? await this.options.cache.getBlob<AST>(value.astKey)
+            ? // TODO: Capture with a test and likely use cache.get() as this returns a buffer.
+              // $FlowFixMe[incompatible-call]
+              await this.options.cache.getBlob(value.astKey)
             : null;
+
         return new UncommittedAsset({
           value,
           options: this.options,

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -796,8 +796,9 @@ export default class Transformation {
     let config = preloadedConfig;
 
     // Parse if there is no AST available from a previous transform.
-    if (!asset.ast && transformer.parse) {
-      let ast = await transformer.parse({
+    let parse = transformer.parse?.bind(transformer);
+    if (!asset.ast && parse) {
+      let ast = await parse({
         asset: new MutableAsset(asset),
         config,
         options: pipeline.pluginOptions,
@@ -825,10 +826,12 @@ export default class Transformation {
 
     // Create generate function that can be called later
     pipeline.generate = (input: UncommittedAsset): Promise<GenerateOutput> => {
-      if (transformer.generate && input.ast) {
-        let generated = transformer.generate({
+      let generate = transformer.generate?.bind(transformer);
+      let ast = input.ast;
+      if (generate && ast) {
+        let generated = generate({
           asset: new Asset(input),
-          ast: input.ast,
+          ast,
           options: pipeline.pluginOptions,
           logger,
         });

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -828,11 +828,11 @@ export default class Transformation {
 
     // Create generate function that can be called later
     pipeline.generate = (input: UncommittedAsset): Promise<GenerateOutput> => {
-      let generate = transformer.generate?.bind(transformer);
       let ast = input.ast;
-      if (generate && ast) {
-        let generated = generate({
-          asset: new Asset(input),
+      let asset = new Asset(input);
+      if (transformer.generate && ast) {
+        let generated = transformer.generate({
+          asset,
           ast,
           options: pipeline.pluginOptions,
           logger,

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -88,25 +88,25 @@ export default class Validation {
             // Otherwise, pass the assets one-at-a-time
             else if (plugin.validate && !this.dedicatedThread) {
               await Promise.all(
-                assets.map(async asset => {
+                assets.map(async input => {
                   let config = null;
-                  let getConfig = plugin.getConfig?.bind(plugin);
-                  if (getConfig) {
-                    config = await getConfig({
-                      asset: new Asset(asset),
+                  let asset = new Asset(input);
+                  if (plugin.getConfig) {
+                    config = await plugin.getConfig({
+                      asset,
                       options: pluginOptions,
                       logger: validatorLogger,
                       resolveConfig: (configNames: Array<string>) =>
                         resolveConfig(
                           this.options.inputFS,
-                          asset.value.filePath,
+                          input.value.filePath,
                           configNames,
                         ),
                     });
                   }
 
                   let validatorResult = await plugin.validate({
-                    asset: new Asset(asset),
+                    asset,
                     options: pluginOptions,
                     config,
                     logger: validatorLogger,

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -90,8 +90,9 @@ export default class Validation {
               await Promise.all(
                 assets.map(async asset => {
                   let config = null;
-                  if (plugin.getConfig) {
-                    config = await plugin.getConfig({
+                  let getConfig = plugin.getConfig?.bind(plugin);
+                  if (getConfig) {
+                    config = await getConfig({
                       asset: new Asset(asset),
                       options: pluginOptions,
                       logger: validatorLogger,

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -142,11 +142,12 @@ async function _generateFromAST(asset: CommittedAsset | UncommittedAsset) {
     nullthrows(asset.value.configKeyPath),
     asset.options,
   );
-  if (!plugin.generate) {
+  let generate = plugin.generate?.bind(plugin);
+  if (!generate) {
     throw new Error(`${pluginName} does not have a generate method`);
   }
 
-  let {content, map} = await plugin.generate({
+  let {content, map} = await generate({
     asset: new PublicAsset(asset),
     ast,
     options: new PluginOptions(asset.options),

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -321,13 +321,13 @@ export class TargetResolver {
           },
         });
       }
-      pkgFilePath = pkgFile.filePath;
-      pkgDir = path.dirname(pkgFilePath);
-      pkgContents = await this.fs.readFile(pkgFilePath, 'utf8');
+      let _pkgFilePath = (pkgFilePath = pkgFile.filePath); // For Flow
+      pkgDir = path.dirname(_pkgFilePath);
+      pkgContents = await this.fs.readFile(_pkgFilePath, 'utf8');
       pkgMap = jsonMap.parse(pkgContents.replace(/\t/g, ' '));
 
-      this.api.invalidateOnFileUpdate(pkgFilePath);
-      this.api.invalidateOnFileDelete(pkgFilePath);
+      this.api.invalidateOnFileUpdate(_pkgFilePath);
+      this.api.invalidateOnFileDelete(_pkgFilePath);
     } else {
       pkg = {};
       pkgDir = this.fs.cwd();
@@ -433,7 +433,7 @@ export class TargetResolver {
     }
 
     for (let targetName of COMMON_TARGETS) {
-      let targetDist;
+      let _targetDist;
       let pointer;
       if (
         targetName === 'browser' &&
@@ -441,19 +441,20 @@ export class TargetResolver {
         typeof pkg[targetName] === 'object'
       ) {
         // The `browser` field can be a file path or an alias map.
-        targetDist = pkg[targetName][pkg.name];
+        _targetDist = pkg[targetName][pkg.name];
         pointer = `/${targetName}/${pkg.name}`;
       } else {
-        targetDist = pkg[targetName];
+        _targetDist = pkg[targetName];
         pointer = `/${targetName}`;
       }
 
+      // For Flow
+      let targetDist = _targetDist;
       if (typeof targetDist === 'string' || pkgTargets[targetName]) {
         let distDir;
         let distEntry;
         let loc;
 
-        invariant(typeof pkgFilePath === 'string');
         invariant(pkgMap != null);
 
         let _descriptor: mixed = pkgTargets[targetName] ?? {};
@@ -461,7 +462,7 @@ export class TargetResolver {
           distDir = path.resolve(pkgDir, path.dirname(targetDist));
           distEntry = path.basename(targetDist);
           loc = {
-            filePath: pkgFilePath,
+            filePath: nullthrows(pkgFilePath),
             ...getJSONSourceLocation(pkgMap.pointers[pointer], 'value'),
           };
         } else {

--- a/packages/core/core/src/serializer.js
+++ b/packages/core/core/src/serializer.js
@@ -119,9 +119,10 @@ function mapObject(object: any, fn: (val: any) => any, preOrder = false): any {
         if (result instanceof Map) {
           result.set(key, newValue);
         } else if (result instanceof Set) {
+          let _result = result; // For Flow
           // TODO: do we care about iteration order??
-          result.delete(value);
-          result.add(newValue);
+          _result.delete(value);
+          _result.add(newValue);
         } else {
           result[key] = newValue;
         }

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -16,6 +16,7 @@ import json5 from 'json5';
 import getPort from 'get-port';
 // flowlint-next-line untyped-import:off
 import JSDOM from 'jsdom';
+import nullthrows from 'nullthrows';
 
 const config = path.join(
   __dirname,
@@ -95,7 +96,7 @@ describe('hmr', function() {
       }
     }
 
-    await nextWSMessage(ws);
+    await nextWSMessage(nullthrows(ws));
     await sleep(100);
 
     // Fixup the prototypes so that strict assertions work
@@ -141,7 +142,7 @@ describe('hmr', function() {
         'exports.a = 5;\nexports.b = 5;',
       );
 
-      let message = await nextWSMessage(ws);
+      let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'update');
 
@@ -170,7 +171,7 @@ describe('hmr', function() {
         'require("fs"); exports.a = 5; exports.b = 5;',
       );
 
-      let message = await nextWSMessage(ws);
+      let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'update');
 
@@ -195,7 +196,7 @@ describe('hmr', function() {
         'require("fs"; exports.a = 5; exports.b = 5;',
       );
 
-      let message = await nextWSMessage(ws);
+      let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'error');
 
@@ -244,7 +245,7 @@ describe('hmr', function() {
         'require("fs"; exports.a = 5; exports.b = 5;',
       );
 
-      let message = await nextWSMessage(ws);
+      let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'error');
 
@@ -253,7 +254,7 @@ describe('hmr', function() {
         'require("fs"); exports.a = 5; exports.b = 5;',
       );
 
-      message = await nextWSMessage(ws);
+      message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'update');
     });
@@ -283,7 +284,7 @@ describe('hmr', function() {
         'exports.a = 5;\nexports.b = 5;',
       );
 
-      let message = await nextWSMessage(ws);
+      let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'update');
     });
@@ -316,7 +317,7 @@ describe('hmr', function() {
         'exports.a = 5;\nexports.b = 5;',
       );
 
-      let message = await nextWSMessage(ws);
+      let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'update');
     });
@@ -801,17 +802,17 @@ module.hot.dispose((data) => {
             pretendToBeVisual: true,
           },
         );
-        window = dom.window;
+        let _window = (window = dom.window); // For Flow
         window.WebSocket = WebSocket;
         await new Promise(res =>
           dom.window.document.addEventListener('load', () => {
             res();
           }),
         );
-        window.console.clear = () => {};
-        window.console.warn = () => {};
+        _window.console.clear = () => {};
+        _window.console.warn = () => {};
 
-        let initialHref = window.document.querySelector('link').href;
+        let initialHref = _window.document.querySelector('link').href;
 
         await overlayFS.copyFile(
           path.join(testDir, 'index.2.css'),
@@ -820,7 +821,7 @@ module.hot.dispose((data) => {
         assert.equal((await getNextBuild(b)).type, 'buildSuccess');
         await sleep(200);
 
-        let newHref = window.document.querySelector('link').href;
+        let newHref = _window.document.querySelector('link').href;
 
         assert.notStrictEqual(initialHref, newHref);
       } finally {

--- a/packages/core/package-manager/src/NodeResolver.js
+++ b/packages/core/package-manager/src/NodeResolver.js
@@ -16,16 +16,13 @@ export class NodeResolver extends NodeResolverBase<Promise<ResolveResult>> {
       id = path.resolve(path.dirname(from), id);
     }
 
-    let res;
-    if (path.isAbsolute(id)) {
-      res = await this.loadRelative(id, ctx);
-    } else {
-      res = await this.loadNodeModules(id, from, ctx);
-    }
+    let res = path.isAbsolute(id)
+      ? await this.loadRelative(id, ctx)
+      : await this.loadNodeModules(id, from, ctx);
 
     if (!res) {
       let e = new Error(`Could not resolve module "${id}" from "${from}"`);
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       e.code = 'MODULE_NOT_FOUND';
       throw e;
     }

--- a/packages/core/package-manager/src/NodeResolverSync.js
+++ b/packages/core/package-manager/src/NodeResolverSync.js
@@ -16,12 +16,9 @@ export class NodeResolverSync extends NodeResolverBase<ResolveResult> {
       id = path.resolve(path.dirname(from), id);
     }
 
-    let res;
-    if (path.isAbsolute(id)) {
-      res = this.loadRelative(id, ctx);
-    } else {
-      res = this.loadNodeModules(id, from, ctx);
-    }
+    let res = path.isAbsolute(id)
+      ? this.loadRelative(id, ctx)
+      : this.loadNodeModules(id, from, ctx);
 
     if (!res) {
       let e = new Error(`Could not resolve module "${id}" from "${from}"`);

--- a/packages/optimizers/terser/src/TerserOptimizer.js
+++ b/packages/optimizers/terser/src/TerserOptimizer.js
@@ -90,9 +90,10 @@ export default (new Optimizer({
 
     let sourceMap = null;
     let minifiedContents: string = nullthrows(result.code);
-    if (result.map && typeof result.map !== 'string') {
+    let resultMap = result.map;
+    if (resultMap && typeof resultMap !== 'string') {
       sourceMap = new SourceMap(options.projectRoot);
-      sourceMap.addRawMappings(result.map);
+      sourceMap.addRawMappings(resultMap);
       let sourcemapReference = await getSourceMapReference(sourceMap);
       if (sourcemapReference) {
         minifiedContents += `\n//# sourceMappingURL=${sourcemapReference}\n`;

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -137,7 +137,7 @@ async function replaceInlineAssetContent(
         : contents
       ).toString();
 
-      if (bundle.env.outputFormat === 'esmodule') {
+      if (nullthrows(bundle).env.outputFormat === 'esmodule') {
         node.attrs.type = 'module';
       }
 

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -53,13 +53,11 @@ export default (new Reporter({
           }
         }
 
-        if (hmrOptions && typeof hmrOptions.port === 'number') {
-          let hmrServerOptions = {
-            port: hmrOptions.port,
-            logger,
-          };
+        let port = hmrOptions?.port;
+        if (typeof port === 'number') {
+          let hmrServerOptions = {port, logger};
           hmrServer = new HMRServer(hmrServerOptions);
-          hmrServers.set(hmrOptions.port, hmrServer);
+          hmrServers.set(port, hmrServer);
           hmrServer.start();
         }
         break;

--- a/packages/shared/scope-hoisting/src/hoist.js
+++ b/packages/shared/scope-hoisting/src/hoist.js
@@ -750,7 +750,7 @@ const VISITOR: Visitor<MutableAsset> = {
       dep.symbols.ensure();
       if (memberAccesses != null) {
         // The import() return value was statically analyzable
-        for (let {name, loc} of memberAccesses) {
+        for (let {name, loc} of nullthrows(memberAccesses)) {
           dep.symbols.set(
             name,
             getName(asset, 'importAsync', dep.id, name),

--- a/packages/shared/scope-hoisting/src/link.js
+++ b/packages/shared/scope-hoisting/src/link.js
@@ -717,12 +717,13 @@ export function link({
               asyncResolution?.type === 'asset' &&
               !isExpressionStatement(newNode)
             ) {
+              let _newNode = newNode; // For Flow
               newNode = t.callExpression(
                 t.memberExpression(
                   t.identifier('Promise'),
                   t.identifier('resolve'),
                 ),
-                [newNode],
+                [_newNode],
               );
             }
           }

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -178,13 +178,14 @@ async function buildDefaultBabelConfig(options: PluginOptions, config: Config) {
   babelOptions = mergeOptions(babelOptions, jsxOptions?.config);
 
   if (babelOptions != null) {
-    babelOptions.presets = (babelOptions.presets || []).map(preset =>
+    let _babelOptions = babelOptions; // For Flow
+    _babelOptions.presets = (_babelOptions.presets || []).map(preset =>
       babelCore.createConfigItem(preset, {
         type: 'preset',
         dirname: BABEL_TRANSFORMER_DIR,
       }),
     );
-    babelOptions.plugins = (babelOptions.plugins || []).map(plugin =>
+    _babelOptions.plugins = (_babelOptions.plugins || []).map(plugin =>
       babelCore.createConfigItem(plugin, {
         type: 'plugin',
         dirname: BABEL_TRANSFORMER_DIR,

--- a/packages/transformers/js/src/visitors/fs.js
+++ b/packages/transformers/js/src/visitors/fs.js
@@ -19,6 +19,7 @@ import {
 } from '@babel/types';
 import invariant from 'assert';
 import Path from 'path';
+import nullthrows from 'nullthrows';
 import template from '@babel/template';
 import {errorToDiagnostic} from '@parcel/diagnostic';
 import {convertBabelLoc} from '@parcel/babel-ast-utils';
@@ -67,7 +68,7 @@ export default ({
 
           filename = Path.resolve(filename);
           if (!Path.relative(options.projectRoot, filename).startsWith('..')) {
-            res = options.inputFS.readFileSync(filename, ...args);
+            res = options.inputFS.readFileSync(nullthrows(filename), ...args);
           }
         } catch (_err) {
           let err: Error = _err;
@@ -209,12 +210,14 @@ function referencesImport(path: NodePath<CallExpression>, name, method) {
     return;
   }
 
-  let bindingNode: Node = bindingPath.getData('__require') || bindingPath.node;
-  let parent: Node = bindingPath.parent;
+  let _bindingPath = bindingPath; // For Flow
+  let bindingNode: Node =
+    _bindingPath.getData('__require') || _bindingPath.node;
+  let parent: Node = _bindingPath.parent;
 
   if (isImportDeclaration(parent)) {
     // e.g. import fs from 'fs';
-    let {node: bindingPathNode} = bindingPath;
+    let {node: bindingPathNode} = _bindingPath;
     if (
       isImportSpecifier(bindingPathNode) &&
       bindingPathNode.imported.name !== method

--- a/packages/transformers/typescript-types/src/collect.js
+++ b/packages/transformers/typescript-types/src/collect.js
@@ -1,4 +1,5 @@
 // @flow
+import nullthrows from 'nullthrows';
 import {TSModule} from './TSModule';
 import type {TSModuleGraph} from './TSModuleGraph';
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
@@ -10,21 +11,22 @@ export function collect(
   context: any,
   sourceFile: any,
 ): any {
-  let currentModule: ?TSModule;
+  let _currentModule: ?TSModule;
   let visit = (node: any): any => {
     if (ts.isBundle(node)) {
       return ts.updateBundle(node, ts.visitNodes(node.sourceFiles, visit));
     }
 
     if (ts.isModuleDeclaration(node)) {
-      currentModule = new TSModule();
-      moduleGraph.addModule(node.name.text, currentModule);
+      _currentModule = new TSModule();
+      moduleGraph.addModule(node.name.text, _currentModule);
     }
 
-    if (!currentModule) {
+    if (!_currentModule) {
       return ts.visitEachChild(node, visit, context);
     }
 
+    let currentModule = nullthrows(_currentModule);
     if (ts.isImportDeclaration(node) && node.importClause) {
       if (node.importClause.namedBindings) {
         if (node.importClause.namedBindings.elements) {

--- a/packages/transformers/typescript-types/src/shake.js
+++ b/packages/transformers/typescript-types/src/shake.js
@@ -19,7 +19,7 @@ export function shake(
   // Propagate exports from the main module to determine what types should be included
   let exportedNames = moduleGraph.propagate(context);
 
-  let currentModule: ?TSModule;
+  let _currentModule: ?TSModule;
   let visit = (node: any): any => {
     if (ts.isBundle(node)) {
       return ts.updateBundle(node, ts.visitNodes(node.sourceFiles, visit));
@@ -27,8 +27,8 @@ export function shake(
 
     // Flatten all module declarations into the top-level scope
     if (ts.isModuleDeclaration(node)) {
-      let isFirstModule = !currentModule;
-      currentModule = moduleGraph.getModule(node.name.text);
+      let isFirstModule = !_currentModule;
+      _currentModule = moduleGraph.getModule(node.name.text);
       let statements = ts.visitEachChild(node, visit, context).body.statements;
 
       if (isFirstModule) {
@@ -38,7 +38,7 @@ export function shake(
       return statements;
     }
 
-    if (!currentModule) {
+    if (!_currentModule) {
       return ts.visitEachChild(node, visit, context);
     }
 
@@ -47,6 +47,7 @@ export function shake(
       return null;
     }
 
+    let currentModule = nullthrows(_currentModule);
     // Remove exports from flattened modules
     if (ts.isExportDeclaration(node)) {
       if (

--- a/packages/utils/events/src/ValueEmitter.js
+++ b/packages/utils/events/src/ValueEmitter.js
@@ -41,9 +41,10 @@ export default class ValueEmitter<TValue> implements IDisposable {
           return;
         }
 
-        let listenerIndex = emitter._listeners.indexOf(listener);
+        let listeners = emitter._listeners;
+        let listenerIndex = listeners.indexOf(listener);
         if (listenerIndex > -1) {
-          emitter._listeners.splice(listenerIndex, 1);
+          listeners.splice(listenerIndex, 1);
         }
 
         emitter = null;

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -171,10 +171,11 @@ export default class NodeResolver {
       }
 
       if (resolved) {
+        let _resolved = resolved; // For Flow
         return {
-          filePath: await this.fs.realpath(resolved.path),
+          filePath: await this.fs.realpath(_resolved.path),
           sideEffects:
-            resolved.pkg && !this.hasSideEffects(resolved.path, resolved.pkg)
+            _resolved.pkg && !this.hasSideEffects(_resolved.path, _resolved.pkg)
               ? false
               : undefined,
           invalidateOnFileCreate: ctx.invalidateOnFileCreate,
@@ -301,7 +302,7 @@ export default class NodeResolver {
       if (alternativeModules.length) {
         throw new ThrowableDiagnostic({
           diagnostic: {
-            message: md`Cannot find module ${resolved.moduleName}`,
+            message: md`Cannot find module ${nullthrows(resolved).moduleName}`,
             hints: alternativeModules.map(r => {
               return `Did you mean __${r}__?`;
             }),

--- a/packages/validators/eslint/src/EslintValidator.js
+++ b/packages/validators/eslint/src/EslintValidator.js
@@ -2,6 +2,7 @@
 import {Validator} from '@parcel/plugin';
 import {type DiagnosticCodeFrame, escapeMarkdown} from '@parcel/diagnostic';
 import eslint from 'eslint';
+import invariant from 'assert';
 
 let cliEngine = null;
 
@@ -11,6 +12,8 @@ export default (new Validator({
       cliEngine = new eslint.CLIEngine({});
     }
     let code = await asset.getCode();
+
+    invariant(cliEngine != null);
     let report = cliEngine.executeOnText(code, asset.filePath);
 
     let validatorResult = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6296,10 +6296,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@0.145.0:
-  version "0.145.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.145.0.tgz#922f7c3568caaa5eb64621ec536deb56b24d1795"
-  integrity sha512-+9fi9BMxRBtSWC1x0hWggWTb8Vih+AC7wyvLAX5wR1m6u2lF2HLtixXqy2GX8bWgaynSEJR5lmPxYYC4wMI8cA==
+flow-bin@0.146.0:
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.146.0.tgz#fafa002663a0e13bf3c08c3972dd93d68289ccc6"
+  integrity sha512-TP8eCwltqc7fo6ad5klgsrZ2veZIK2qM1vHf1A/cnXTStPh8hLAz1cOXmlQIFZR/7fjSMI39TS3CgF6M/HUhAw==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This updates Flow to v0.146.0 [0] , which invalidates refinements (particularly object properties and variables declared with `let` passed to functions) much more frequently. This required introducing additional invariants, `nullthrows`, or temporary locals, depending on the number of violations in a given scope.

This is probably a good motivation to use `const` to retain refinements of locals when Flow thinks they could be modified through function calls.

[0] https://github.com/facebook/flow/releases/tag/v0.146.0