### PR TITLE
Resolver: correctly determine sideEffects for subdir imports `pkg/subdir/`

### DIFF
--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -609,7 +609,7 @@ export default class NodeResolver {
       file: path.join(dir, 'index'),
       extensions,
       env,
-      pkg: pkg || null,
+      pkg: pkg ?? (await this.findPackage(path.join(dir, 'index'), ctx)),
       ctx,
     });
   }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-false/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-false/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "side-effects-false",
+  "main": "src/index.js",
+  "sideEffects": false
+}

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -621,6 +621,164 @@ describe('resolver', function() {
         ],
       });
     });
+
+    describe('sideEffects: false', function() {
+      it('should determine sideEffects correctly (file)', async function() {
+        let resolved = await resolver.resolve({
+          env: BROWSER_ENV,
+          filename: 'side-effects-false/src/index.js',
+          isURL: false,
+          parent: path.join(rootDir, 'foo.js'),
+        });
+        assert.deepEqual(resolved, {
+          filePath: path.resolve(
+            rootDir,
+            'node_modules/side-effects-false/src/index.js',
+          ),
+          sideEffects: false,
+          invalidateOnFileCreate: [
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'index'),
+            },
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+            {
+              fileName: 'node_modules/side-effects-false',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+          ],
+          invalidateOnFileChange: [
+            path.join(rootDir, 'package.json'),
+            path.join(
+              rootDir,
+              'node_modules',
+              'side-effects-false',
+              'package.json',
+            ),
+          ],
+        });
+      });
+
+      it('should determine sideEffects correctly (extensionless file)', async function() {
+        let resolved = await resolver.resolve({
+          env: BROWSER_ENV,
+          filename: 'side-effects-false/src/index',
+          isURL: false,
+          parent: path.join(rootDir, 'foo.js'),
+        });
+        assert.deepEqual(resolved, {
+          filePath: path.resolve(
+            rootDir,
+            'node_modules/side-effects-false/src/index.js',
+          ),
+          sideEffects: false,
+          invalidateOnFileCreate: [
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'index'),
+            },
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+            {
+              fileName: 'node_modules/side-effects-false',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+          ],
+          invalidateOnFileChange: [
+            path.join(rootDir, 'package.json'),
+            path.join(
+              rootDir,
+              'node_modules',
+              'side-effects-false',
+              'package.json',
+            ),
+          ],
+        });
+      });
+
+      it('should determine sideEffects correctly (sub folder)', async function() {
+        let resolved = await resolver.resolve({
+          env: BROWSER_ENV,
+          filename: 'side-effects-false/src/',
+          isURL: false,
+          parent: path.join(rootDir, 'foo.js'),
+        });
+        assert.deepEqual(resolved, {
+          filePath: path.resolve(
+            rootDir,
+            'node_modules/side-effects-false/src/index.js',
+          ),
+          sideEffects: false,
+          invalidateOnFileCreate: [
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'index'),
+            },
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+            {
+              fileName: 'node_modules/side-effects-false',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+          ],
+          invalidateOnFileChange: [
+            path.join(rootDir, 'package.json'),
+            path.join(
+              rootDir,
+              'node_modules',
+              'side-effects-false',
+              'package.json',
+            ),
+          ],
+        });
+      });
+
+      it('should determine sideEffects correctly (main field)', async function() {
+        let resolved = await resolver.resolve({
+          env: BROWSER_ENV,
+          filename: 'side-effects-false/src/',
+          isURL: false,
+          parent: path.join(rootDir, 'foo.js'),
+        });
+        assert.deepEqual(resolved, {
+          filePath: path.resolve(
+            rootDir,
+            'node_modules/side-effects-false/src/index.js',
+          ),
+          sideEffects: false,
+          invalidateOnFileCreate: [
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'index'),
+            },
+            {
+              fileName: 'package.json',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+            {
+              fileName: 'node_modules/side-effects-false',
+              aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+          ],
+          invalidateOnFileChange: [
+            path.join(rootDir, 'package.json'),
+            path.join(
+              rootDir,
+              'node_modules',
+              'side-effects-false',
+              'package.json',
+            ),
+          ],
+        });
+      });
+    });
   });
 
   describe('aliases', function() {

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -727,6 +727,25 @@ describe('resolver', function() {
               fileName: 'node_modules/side-effects-false',
               aboveFilePath: path.join(rootDir, 'foo.js'),
             },
+            {
+              filePath: path.join(
+                rootDir,
+                'node_modules',
+                'side-effects-false',
+                'src',
+                'package.json',
+              ),
+            },
+            {
+              aboveFilePath: path.join(
+                rootDir,
+                'node_modules',
+                'side-effects-false',
+                'src',
+                'index',
+              ),
+              fileName: 'package.json',
+            },
           ],
           invalidateOnFileChange: [
             path.join(rootDir, 'package.json'),
@@ -765,6 +784,25 @@ describe('resolver', function() {
             {
               fileName: 'node_modules/side-effects-false',
               aboveFilePath: path.join(rootDir, 'foo.js'),
+            },
+            {
+              filePath: path.join(
+                rootDir,
+                'node_modules',
+                'side-effects-false',
+                'src',
+                'package.json',
+              ),
+            },
+            {
+              aboveFilePath: path.join(
+                rootDir,
+                'node_modules',
+                'side-effects-false',
+                'src',
+                'index',
+              ),
+              fileName: 'package.json',
             },
           ],
           invalidateOnFileChange: [


### PR DESCRIPTION
For imports of subdirectories like `pkg/subdir`, `sideEffects` wasn't read in from `pkg/package.json`.

Prevents situations like

![Main](https://user-images.githubusercontent.com/4586894/110376334-5a445280-8053-11eb-9175-40b1392e6015.png)

(It's unclear whether this situation has caused actual bugs)

(And this also makes clear why resolvers should behave somewhat deterministically 😄 )