### PR TITLE
Don't override HMR port in default case

### DIFF
--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -21,7 +21,14 @@ export default (new Runtime({
       filePath: __filename,
       code:
         `var HMR_HOST = ${JSON.stringify(host != null ? host : null)};` +
-        `var HMR_PORT = ${JSON.stringify(port != null ? port : null)};` +
+        `var HMR_PORT = ${JSON.stringify(
+          port != null &&
+            // Default to the HTTP port in the browser, only override
+            // in watch mode or if hmr port != serve port
+            (!options.serveOptions || options.serveOptions.port !== port)
+            ? port
+            : null,
+        )};` +
         `var HMR_SECURE = ${JSON.stringify(
           !!(options.serveOptions && options.serveOptions.https),
         )};` +


### PR DESCRIPTION
Previously, if you started Parcel in serve mode, started `ngrok http 1234` and opened the ngrok url, it would still try to connect to the WebSocket server on `:1234` (although the page was now served at `abc123fee.ngrok.io`). 

Instead only override the used HMR port in watch mode or if the hmr and server port differ (in the runtime).

This way, both `localhost:1234` and `abc123fee.ngrok.io` work correctly (without having to override the hmr port)