### PR TITLE
Fix TS types transformer when external import names conflict with local names

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/import-export-collision/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/import-export-collision/expected.d.ts
@@ -1,0 +1,5 @@
+import { Test as _Test1 } from "external";
+export class Test implements _Test1 {
+}
+
+//# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/import-export-collision/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/import-export-collision/index.ts
@@ -1,0 +1,2 @@
+import {Test as ITest} from 'external';
+export class Test implements ITest {}

--- a/packages/core/integration-tests/test/integration/ts-types/import-export-collision/package.json
+++ b/packages/core/integration-tests/test/integration/ts-types/import-export-collision/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ts-types-externals",
+  "private": true,
+  "main": "dist/main.js",
+  "types": "dist/types.d.ts"
+}

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -170,6 +170,44 @@ describe('typescript types', function() {
     assert.equal(dist, expected);
   });
 
+  it('should generate ts declarations with externals that conflict with exported names', async function() {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/ts-types/import-export-collision/index.ts',
+      ),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.ts', 'esmodule-helpers.js'],
+      },
+      {
+        type: 'ts',
+        assets: ['index.ts'],
+      },
+    ]);
+
+    let dist = (
+      await outputFS.readFile(
+        path.join(
+          __dirname,
+          '/integration/ts-types/import-export-collision/dist/types.d.ts',
+        ),
+        'utf8',
+      )
+    ).replace(/\r\n/g, '\n');
+    let expected = await inputFS.readFile(
+      path.join(
+        __dirname,
+        '/integration/ts-types/import-export-collision/expected.d.ts',
+      ),
+      'utf8',
+    );
+    assert.equal(dist, expected);
+  });
+
   it('should remove private properties', async function() {
     await bundle(
       path.join(__dirname, '/integration/ts-types/private/index.ts'),

--- a/packages/transformers/typescript-types/src/TSModuleGraph.js
+++ b/packages/transformers/typescript-types/src/TSModuleGraph.js
@@ -244,10 +244,10 @@ export class TSModuleGraph {
 
       // If it's external, then we need to dedup duplicate imported names, and ensure
       // that they do not conflict with any exported or local names.
-      let importedNames = imports.get(imported.specifier);
+      let importedNames = imports.get(imp.specifier);
       if (!importedNames) {
         importedNames = new Map();
-        imports.set(imported.specifier, importedNames);
+        imports.set(imp.specifier, importedNames);
       }
 
       let name = importedNames.get(imported.imported);

--- a/packages/transformers/typescript-types/src/TSModuleGraph.js
+++ b/packages/transformers/typescript-types/src/TSModuleGraph.js
@@ -229,9 +229,40 @@ export class TSModuleGraph {
       }
     }
 
+    // Map of imported specifiers -> map of imported names to local names
+    let imports = new Map();
+
     for (let [m, orig] of importedSymbolsToUpdate) {
+      let imp = nullthrows(m.imports.get(orig));
       let imported = nullthrows(this.resolveImport(m, orig));
-      m.names.set(orig, imported.imported);
+
+      // If the module is bundled, map the local name to the original exported name.
+      if (this.modules.has(imp.specifier)) {
+        m.names.set(orig, imported.imported);
+        continue;
+      }
+
+      // If it's external, then we need to dedup duplicate imported names, and ensure
+      // that they do not conflict with any exported or local names.
+      let importedNames = imports.get(imported.specifier);
+      if (!importedNames) {
+        importedNames = new Map();
+        imports.set(imported.specifier, importedNames);
+      }
+
+      let name = importedNames.get(imported.imported);
+      if (!name) {
+        if (names[imported.imported]) {
+          name = `_${imported.imported}${names[imported.imported]++}`;
+        } else {
+          name = imported.imported;
+          names[imported.imported] = 1;
+        }
+
+        importedNames.set(imported.imported, name);
+      }
+
+      m.names.set(orig, name);
     }
 
     return exportedNames;

--- a/packages/transformers/typescript-types/src/shake.js
+++ b/packages/transformers/typescript-types/src/shake.js
@@ -223,8 +223,8 @@ function generateImports(moduleGraph: TSModuleGraph) {
       } else {
         namedSpecifiers.push(
           ts.createImportSpecifier(
-            name === imported ? undefined : ts.createIdentifier(name),
-            ts.createIdentifier(imported),
+            name === imported ? undefined : ts.createIdentifier(imported),
+            ts.createIdentifier(name),
           ),
         );
       }


### PR DESCRIPTION
This fixes an issue where imported symbols from external modules would conflict with exported or local names declared in the bundle. This makes sure we both deduplicate the same symbol from being imported multiple times as well as deconflict the names with local names.