### PR TITLE
Use IE 11 compatible syntax for runtime JS/CSS browser loaders

### DIFF
--- a/packages/runtimes/js/src/loaders/browser/css-loader.js
+++ b/packages/runtimes/js/src/loaders/browser/css-loader.js
@@ -4,11 +4,11 @@ module.exports = cacheLoader(function loadCSSBundle(bundle) {
   return new Promise(function(resolve, reject) {
     // Don't insert the same link element twice (e.g. if it was already in the HTML)
     let existingLinks = document.getElementsByTagName('link');
-    if (
-      [...existingLinks].some(
-        link => link.href === bundle && link.rel.indexOf('stylesheet') > -1,
-      )
-    ) {
+    let isCurrentBundle = function(link) {
+      return link.href === bundle && link.rel.indexOf('stylesheet') > -1;
+    }
+
+    if ([].concat(existingLinks).some(isCurrentBundle)) {
       resolve();
       return;
     }

--- a/packages/runtimes/js/src/loaders/browser/css-loader.js
+++ b/packages/runtimes/js/src/loaders/browser/css-loader.js
@@ -6,7 +6,7 @@ module.exports = cacheLoader(function loadCSSBundle(bundle) {
     let existingLinks = document.getElementsByTagName('link');
     let isCurrentBundle = function(link) {
       return link.href === bundle && link.rel.indexOf('stylesheet') > -1;
-    }
+    };
 
     if ([].concat(existingLinks).some(isCurrentBundle)) {
       resolve();

--- a/packages/runtimes/js/src/loaders/browser/js-loader.js
+++ b/packages/runtimes/js/src/loaders/browser/js-loader.js
@@ -4,7 +4,11 @@ module.exports = cacheLoader(function loadJSBundle(bundle) {
   return new Promise(function(resolve, reject) {
     // Don't insert the same script twice (e.g. if it was already in the HTML)
     let existingScripts = document.getElementsByTagName('script');
-    if ([...existingScripts].some(script => script.src === bundle)) {
+    let isCurrentBundle = function(script) {
+      return script.src === bundle;
+    }
+
+    if ([].concat(existingScripts).some(isCurrentBundle)) {
       resolve();
       return;
     }

--- a/packages/runtimes/js/src/loaders/browser/js-loader.js
+++ b/packages/runtimes/js/src/loaders/browser/js-loader.js
@@ -6,7 +6,7 @@ module.exports = cacheLoader(function loadJSBundle(bundle) {
     let existingScripts = document.getElementsByTagName('script');
     let isCurrentBundle = function(script) {
       return script.src === bundle;
-    }
+    };
 
     if ([].concat(existingScripts).some(isCurrentBundle)) {
       resolve();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

Solves issue #6059. Code splitting generates a bundle containing unsupported syntax (spread operator, Promise) even browserslist contains IE 11. This cause syntax error when running the bundle on IE 11.

This pull request replace array spread and array function syntax. 

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
