### PR TITLE
Fix dev server serving inline bundles

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -32,12 +32,11 @@ describe('html', function() {
 
     assertBundles(b, [
       {
-        name: 'index.html',
+        type: 'css',
         assets: ['index.html'],
       },
       {
-        name: 'index.HASH_REF_e5cf7117b2aa99548decd63ab74b27b6.css',
-        type: 'css',
+        name: 'index.html',
         assets: ['index.html'],
       },
       {

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -36,6 +36,11 @@ describe('html', function() {
         assets: ['index.html'],
       },
       {
+        name: 'index.HASH_REF_e5cf7117b2aa99548decd63ab74b27b6.css',
+        type: 'css',
+        assets: ['index.html'],
+      },
+      {
         type: 'png',
         assets: ['100x100.png'],
       },

--- a/packages/core/integration-tests/test/integration/html/index.html
+++ b/packages/core/integration-tests/test/integration/html/index.html
@@ -19,6 +19,11 @@
   <script src="https://unpkg.com/parcel-bundler"></script>
   <i>hello</i> <i>world</i>
   <svg><use href="icons.svg#icon-code"></use></svg>
+  <style>
+    body {
+      background: gray;
+    }
+  </style>
 </body>
 
 </html>

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -452,6 +452,11 @@ describe('server', function() {
         name: 'index.html',
         assets: ['index.html'],
       },
+      {
+        name: 'index.HASH_REF_2d285d6f29236f5b00e1db199488d505.css',
+        type: 'css',
+        assets: ['index.html'],
+      },
     ]);
 
     // Bundle should exist in the graph, but not written to disk as it is just a placeholder
@@ -470,6 +475,11 @@ describe('server', function() {
     assertBundles(build.bundleGraph, [
       {
         name: 'index.html',
+        assets: ['index.html'],
+      },
+      {
+        name: 'index.HASH_REF_2d285d6f29236f5b00e1db199488d505.css',
+        type: 'css',
         assets: ['index.html'],
       },
       {

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -449,12 +449,11 @@ describe('server', function() {
     invariant(build.type === 'buildSuccess');
     assertBundles(build.bundleGraph, [
       {
-        name: 'index.html',
+        type: 'css',
         assets: ['index.html'],
       },
       {
-        name: 'index.HASH_REF_2d285d6f29236f5b00e1db199488d505.css',
-        type: 'css',
+        name: 'index.html',
         assets: ['index.html'],
       },
     ]);
@@ -474,12 +473,11 @@ describe('server', function() {
     invariant(build?.type === 'buildSuccess');
     assertBundles(build.bundleGraph, [
       {
-        name: 'index.html',
+        type: 'css',
         assets: ['index.html'],
       },
       {
-        name: 'index.HASH_REF_2d285d6f29236f5b00e1db199488d505.css',
-        type: 'css',
+        name: 'index.html',
         assets: ['index.html'],
       },
       {

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -207,6 +207,7 @@ export default class Server {
       let requestedPath = path.normalize(pathname.slice(1));
       let bundle = bundleGraph
         .getBundles()
+        .filter(b => !b.isInline)
         .find(
           b =>
             path.relative(this.options.distDir, b.filePath) === requestedPath,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

Fixes #6043. Fix recommended by @mischnic 

Dev server fails when serving inline bundle processed by @parcel/transformer-raw

I would consider this as regression bug, because it worked with parcel@2.0.0-beta.2 and @parcel/transformer-raw@2.0.0-beta.2

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

package.json
```
{
    "name": "parcel-serve-fails-for-inlines",
    "scripts": {
        "serve": "parcel serve ./src/index.html"
    },
    "devDependencies": {
        "parcel": "2.0.0-nightly.632"
    }
}
```

.parcelrc
```
{
    "extends": "@parcel/config-default",
    "transformers": {
        "*.props": ["@parcel/transformer-raw"]
    },
}
```

index.html
```
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>Title</title>
</head>
<body>
    <h1>Test</h1>
    <div data-widget="TextFromImage">
        <script type="text/props">
            {
                "some": "value"
            }
        </script>
    </div>
</body>
</html>
```


## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

I was unable to create the correct unit test. Reproducing the issue:

- Repo https://github.com/martinsvoboda/parcel-serve-fails-for-inlines
- Run `parcel serve ./src/index.html` it is finished successfully
- Open localhost:1234 in browser, serve process fails with following exception

```
parcel serve ./src/index.html

ℹ️ Server running at http://localhost:1234
✨ Built in 230ms
Error: Got unexpected null
    at nullthrows (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/nullthrows/nullthrows.js:7:15)
    at PackagedBundle.get filePath [as filePath] (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/@parcel/core/lib/public/Bundle.js:367:38)
    at /Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/@parcel/reporter-dev-server/lib/Server.js:272:104
    at Array.find (<anonymous>)
    at Server.serveBundle (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/@parcel/reporter-dev-server/lib/Server.js:272:45)
    at Server.respond (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/@parcel/reporter-dev-server/lib/Server.js:219:19)
    at /Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/@parcel/reporter-dev-server/lib/Server.js:441:14
    at call (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/connect/index.js:239:7)
    at next (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/connect/index.js:183:5)
    at Function.handle (/Users/martin.svoboda/workspace/parcel-serve-fails-for-inlines/node_modules/connect/index.js:186:3) {
  framesToPop: 1
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! parcel-serve-fails-for-inlines@ serve: `parcel serve ./src/index.html`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the parcel-serve-fails-for-inlines@ serve script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
