### PR TITLE
Add getMainBundle BundleGraph method

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -2103,4 +2103,12 @@ export default class BundleGraph {
     this._targetEntryRoots.set(target.distDir, root);
     return root;
   }
+
+  getMainBundle(bundleGroup: BundleGroup): Bundle {
+    return nullthrows(
+      this.getBundlesInBundleGroup(bundleGroup).find(
+        b => b.mainEntryId === bundleGroup.entryAssetId,
+      ),
+    );
+  }
 }

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -314,4 +314,13 @@ export default class BundleGraph<TBundle: IBundle>
       targetToInternalTarget(target),
     );
   }
+
+  getMainBundle(bundleGroup: BundleGroup): TBundle {
+    return this.#createBundle.call(
+      null,
+      this.#graph.getMainBundle(bundleGroup),
+      this.#graph,
+      this.#options,
+    );
+  }
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1520,6 +1520,7 @@ export interface BundleGraph<TBundle: Bundle> {
   getUsedSymbols(Asset | Dependency): ?$ReadOnlySet<Symbol>;
   /** Returns the common root directory for the entry assets of a target. */
   getEntryRoot(target: Target): FilePath;
+  getMainBundle(bundleGroup: BundleGroup): TBundle;
 }
 
 /**

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -35,11 +35,7 @@ export default (new Namer({
       );
     }
 
-    let mainBundle = nullthrows(
-      bundleGroupBundles.find(b =>
-        b.getEntryAssets().some(a => a.id === bundleGroup.entryAssetId),
-      ),
-    );
+    let mainBundle = bundleGraph.getMainBundle(bundleGroup);
 
     if (
       bundle.id === mainBundle.id &&

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -347,11 +347,7 @@ function getLoaderRuntime({
   }
 
   let externalBundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
-  let mainBundle = nullthrows(
-    externalBundles.find(
-      bundle => bundle.getMainEntry()?.id === bundleGroup.entryAssetId,
-    ),
-  );
+  let mainBundle = bundleGraph.getMainBundle(bundleGroup);
 
   // CommonJS is a synchronous module system, so there is no need to load bundles in parallel.
   // Importing of the other bundles will be handled by the bundle group entry.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR adds a method to `BundleGraph` that accepts a `BundleGroup` parameter and returns the `Bundle` in the group whose `mainEntryId` matches the group's `entryAssetId`.

## Rationale
Since there may be multiple bundles found within a bundle group, it is not always straightforward to know which bundle might contain the entry asset for the group:

![mainBundle](https://user-images.githubusercontent.com/210630/113631135-fb183480-9636-11eb-85f5-7a236659f754.png)

This method conveniently finds the bundle that contains the entry asset for the given bundle group.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

- In the [`DefaultNamer`](https://github.com/parcel-bundler/parcel/compare/lettertwo/get-main-bundle?expand=1#diff-6b9143d466d76f97dde27b2a6fd3d4274157cd71ae3984b3ab8a22b95cd395f7), bundle names are based on the first bundle in their group.
- When constructing the [`JSRuntime`](https://github.com/parcel-bundler/parcel/compare/lettertwo/get-main-bundle?expand=1#diff-18ebcd5dae5cac429df63367d5be15952210f6f33b2a4acd18adb8ae91871d32), the main bundle is identified to make sure the proper load order occurs.


## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

No new tests were added; this intended to be a 'drop-in' replacement for existing behavior.

