### PR TITLE
Escape object keys in schema errors

### DIFF
--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -98,7 +98,7 @@ describe('loadParcelConfig', () => {
     it('should require pipeline to be an array', () => {
       assert.throws(() => {
         validateConfigFile(
-          // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
+          // $FlowExpectedError[incompatible-call]
           {
             filePath: '.parcelrc',
             resolvers: '123',
@@ -113,7 +113,7 @@ describe('loadParcelConfig', () => {
         validateConfigFile(
           {
             filePath: '.parcelrc',
-            // $FlowFixMe
+            // $FlowExpectedError[incompatible-call]
             resolvers: [1, '123', 5],
           },
           '.parcelrc',
@@ -158,7 +158,7 @@ describe('loadParcelConfig', () => {
         validateConfigFile(
           {
             filePath: '.parcelrc',
-            // $FlowFixMe
+            // $FlowExpectedError[incompatible-call]
             transformers: ['parcel-transformer-test', '...'],
           },
           '.parcelrc',
@@ -184,7 +184,7 @@ describe('loadParcelConfig', () => {
     it('should require extends to be a string or array of strings', () => {
       assert.throws(() => {
         validateConfigFile(
-          // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
+          // $FlowExpectedError[incompatible-call]
           {
             filePath: '.parcelrc',
             extends: 2,
@@ -197,7 +197,7 @@ describe('loadParcelConfig', () => {
         validateConfigFile(
           {
             filePath: '.parcelrc',
-            // $FlowFixMe
+            // $FlowExpectedError[incompatible-call]
             extends: [2, 7],
           },
           '.parcelrc',
@@ -265,7 +265,7 @@ describe('loadParcelConfig', () => {
       assert.throws(
         () => {
           validateConfigFile(
-            // $FlowFixMe this is of course invalid
+            // $FlowExpectedError
             {
               extends: '@parcel/config-default',
               '@parcel/transformer-js': {
@@ -740,7 +740,7 @@ describe('loadParcelConfig', () => {
         column: 14,
       };
 
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       await assert.rejects(
         () => parseAndProcessConfig(configFilePath, code, DEFAULT_OPTIONS),
         {
@@ -776,7 +776,7 @@ describe('loadParcelConfig', () => {
       );
       let code = await DEFAULT_OPTIONS.inputFS.readFile(configFilePath, 'utf8');
 
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       await assert.rejects(
         () => parseAndProcessConfig(configFilePath, code, DEFAULT_OPTIONS),
         {
@@ -813,7 +813,7 @@ describe('loadParcelConfig', () => {
       );
       let code = await DEFAULT_OPTIONS.inputFS.readFile(configFilePath, 'utf8');
 
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       await assert.rejects(
         () => parseAndProcessConfig(configFilePath, code, DEFAULT_OPTIONS),
         {
@@ -850,7 +850,7 @@ describe('loadParcelConfig', () => {
       );
       let code = await DEFAULT_OPTIONS.inputFS.readFile(configFilePath, 'utf8');
 
-      // $FlowFixMe
+      // $FlowFixMe[prop-missing]
       await assert.rejects(
         () => parseAndProcessConfig(configFilePath, code, DEFAULT_OPTIONS),
         {

--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -261,6 +261,30 @@ describe('loadParcelConfig', () => {
       );
     });
 
+    it('should throw for invalid top level keys', () => {
+      assert.throws(
+        () => {
+          validateConfigFile(
+            // $FlowFixMe this is of course invalid
+            {
+              extends: '@parcel/config-default',
+              '@parcel/transformer-js': {
+                inlineEnvironment: false,
+              },
+            },
+            '.parcelrc',
+          );
+        },
+        e => {
+          assert.strictEqual(
+            e.diagnostics[0].codeFrame.codeHighlights[0].message,
+            `Did you mean "transformers"?`,
+          );
+          return true;
+        },
+      );
+    });
+
     it('should succeed on valid config', () => {
       validateConfigFile(
         {
@@ -702,7 +726,7 @@ describe('loadParcelConfig', () => {
       assert.deepEqual(config.reporters, defaultConfig.reporters || []);
     });
 
-    it('should emit a codeframe when a malformed .parcelrc was found', async () => {
+    it('should emit a codeframe.codeHighlights when a malformed .parcelrc was found', async () => {
       let configFilePath = path.join(
         __dirname,
         'fixtures',

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -212,7 +212,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   k =>
                     ({
                       type: 'forbidden-prop',
-                      dataPath: dataPath + '/' + encodeJSONKeyComponent(k), // todo
+                      dataPath: dataPath + '/' + encodeJSONKeyComponent(k),
                       dataType: 'key',
                       prop: k,
                       expectedProps: Object.keys(schemaNode.properties),

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -2,6 +2,7 @@
 import ThrowableDiagnostic, {
   generateJSONCodeHighlights,
   escapeMarkdown,
+  encodeJSONKeyComponent,
 } from '@parcel/diagnostic';
 import type {Mapping} from 'json-source-map';
 import nullthrows from 'nullthrows';
@@ -211,7 +212,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   k =>
                     ({
                       type: 'forbidden-prop',
-                      dataPath: dataPath + '/' + k,
+                      dataPath: dataPath + '/' + encodeJSONKeyComponent(k), // todo
                       dataType: 'key',
                       prop: k,
                       expectedProps: Object.keys(schemaNode.properties),
@@ -254,7 +255,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                     [schemaNode.properties[k]].concat(schemaAncestors),
                     // $FlowFixMe type was already checked
                     dataNode[k],
-                    dataPath + '/' + k,
+                    dataPath + '/' + encodeJSONKeyComponent(k),
                   );
                   if (result) results.push(result);
                 } else {
@@ -263,7 +264,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                       results.push({
                         type: 'enum',
                         dataType: 'key',
-                        dataPath: dataPath + '/' + k,
+                        dataPath: dataPath + '/' + encodeJSONKeyComponent(k),
                         expectedValues: Object.keys(
                           schemaNode.properties,
                         ).filter(
@@ -280,7 +281,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                       [additionalProperties].concat(schemaAncestors),
                       // $FlowFixMe type was already checked
                       dataNode[k],
-                      dataPath + '/' + k,
+                      dataPath + '/' + encodeJSONKeyComponent(k),
                     );
                     if (result) results.push(result);
                   }


### PR DESCRIPTION
# ↪️ Pull Request

See https://github.com/parcel-bundler/parcel/issues/6093#issuecomment-817267633

There was an `Got unexpected undefined` error instead of a diagnostic because the object key with a slash wasn't escaped.