### PR TITLE
Fix regular expression for file:/// URLs

### DIFF
--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -38,6 +38,7 @@ function getBaseURL(url) {
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
   let matches = ('' + url).match(/(https?|file|ftp):\/\/[^/]+/);
+  let matches = ('' + url).match(/(https?|file|ftp):\/\/(\/)?[^/]+/);
   if (!matches) {
     throw new Error('Origin not found');
   }

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -37,7 +37,10 @@ function getBaseURL(url) {
 
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
-  let matches = ('' + url).match(/(https?|file|ftp):\/\/(\/)?[^/]+/);
+  if (url.slice(0, 7) === 'file://') {
+    return 'file://';    
+  }
+  let matches = ('' + url).match(/(https?|file|ftp):\/\/[^/]+/);
   if (!matches) {
     throw new Error('Origin not found');
   }

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -31,14 +31,13 @@ function getBundleURL() {
 
 function getBaseURL(url) {
   return (
-    ('' + url).replace(/^((?:https?|file|ftp):\/\/.+)\/[^/]+$/, '$1') + '/'
+    ('' + url).replace(/^((?:https?|file|ftp):\/\/.+)\/+$/, '$1') + '/'
   );
 }
 
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
-  let matches = ('' + url).match(/(https?|file|ftp):\/\/[^/]+/);
-  let matches = ('' + url).match(/(https?|file|ftp):\/\/(\/)?[^/]+/);
+  let matches = ('' + url).match(/(https?|file|ftp):\/\/+/);
   if (!matches) {
     throw new Error('Origin not found');
   }

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -37,7 +37,7 @@ function getBaseURL(url) {
 
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
-  let matches = ('' + url).match((https?|file|ftp):\/\/(\/)?[^/]+);
+  let matches = ('' + url).match(/(https?|file|ftp):\/\/(\/)?[^/]+/);
   if (!matches) {
     throw new Error('Origin not found');
   }

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -31,13 +31,13 @@ function getBundleURL() {
 
 function getBaseURL(url) {
   return (
-    ('' + url).replace(/^((?:https?|file|ftp):\/\/.+)\/+$/, '$1') + '/'
+    ('' + url).replace(/^((?:https?|file|ftp):\/\/.+)\/[^/]+$/, '$1') + '/'
   );
 }
 
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
-  let matches = ('' + url).match(/(https?|file|ftp):\/\/+/);
+  let matches = ('' + url).match((https?|file|ftp):\/\/(\/)?[^/]+);
   if (!matches) {
     throw new Error('Origin not found');
   }

--- a/packages/runtimes/js/src/bundle-url.js
+++ b/packages/runtimes/js/src/bundle-url.js
@@ -38,7 +38,7 @@ function getBaseURL(url) {
 // TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
   if (url.slice(0, 7) === 'file://') {
-    return 'file://';    
+    return 'file://';
   }
   let matches = ('' + url).match(/(https?|file|ftp):\/\/[^/]+/);
   if (!matches) {


### PR DESCRIPTION
It seems as though file:/// URLs aren't currently matched correctly on their origins.

The `file:///` URL has an extra slash when finding a local file, which isn't accounted for in this regular expression. This PR adds an extra optional `/` to the end of the regular expression's matcher for origin.

Closes https://github.com/parcel-bundler/parcel/issues/6141

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
