### PR TITLE
Correctly print leading block comments for class methods

### DIFF
--- a/packages/shared/babel-ast-utils/src/generator.js
+++ b/packages/shared/babel-ast-utils/src/generator.js
@@ -274,7 +274,7 @@ for (let key in generator) {
     // These are printed by astring itself
     if (node.trailingComments) {
       for (let c of node.trailingComments) {
-        if (c.type === 'CommentLine') {
+        if (c.type === 'CommentLine' || c.type === 'LineComment') {
           c.type = 'LineComment';
         } else {
           c.type = 'BlockComment';

--- a/packages/shared/babel-ast-utils/test/fixtures/class.js
+++ b/packages/shared/babel-ast-utils/test/fixtures/class.js
@@ -7,6 +7,7 @@ class C extends A {
   get property() {
     return this._property;
   }
+  // /* foo */
   set property(value) {
     this._property = value;
   }


### PR DESCRIPTION
Closes #6164

Looks like recursive calling to other nodes types when printing class methods turned a line comment into a block comment (and that if statement was called multiple times on a comment, causing `CommentLine` -> `LineComment` -> `BlockComment`)