### PR TITLE
Correctly forward preload script with spaces

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -4,6 +4,7 @@ import type {FilePath} from '@parcel/types';
 import type {BackendType, WorkerImpl, WorkerMessage} from './types';
 import type {SharedReference} from './WorkerFarm';
 
+import nullthrows from 'nullthrows';
 import EventEmitter from 'events';
 import ThrowableDiagnostic from '@parcel/diagnostic';
 import {getWorkerBackend} from './backend';
@@ -63,7 +64,19 @@ export default class Worker extends EventEmitter {
 
     // Workaround for https://github.com/nodejs/node/issues/29117
     if (process.env.NODE_OPTIONS) {
-      let opts = process.env.NODE_OPTIONS.split(' ');
+      // arg parsing logic adapted from https://stackoverflow.com/a/46946420/2352201
+      let opts = [''];
+      let quote = false;
+      for (let c of nullthrows(process.env.NODE_OPTIONS.match(/\\?.|^$/g))) {
+        if (c === '"') {
+          quote = !quote;
+        } else if (!quote && c === ' ') {
+          opts.push('');
+        } else {
+          opts[opts.length - 1] += c.replace(/\\(.)/, '$1');
+        }
+      }
+
       for (let i = 0; i < opts.length; i++) {
         let opt = opts[i];
         if (opt === '-r' || opt === '--require') {


### PR DESCRIPTION
Previously, a NODE_OPTIONS value of `--require "/Users/foo/bar/space test/preload.js"` was parsed into:
 `['--require', '"/Users/foo/bar/space']`, now it's:
`['--require', '/Users/foo/bar/space test/preload.js' ]`

(This workaround is needed until Node v12.16.2, released 2020-04-08.)

Closes https://github.com/parcel-bundler/parcel/issues/6123