### PR TITLE
Add bundle builds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -122,6 +122,9 @@ function renameStream(fn) {
 
 function bundleBuild(done) {
   if (process.env.PARCEL_BUILD_ENV == 'production') {
+    // link current parcel binary to node_modules
+    execSync('yarn link', {cwd: 'packages/core/parcel', stdio: 'inherit'});
+    // bundle packages
     const packagesCustomBuild = ['packages/core/parcel'];
     for (const pack of packagesCustomBuild) {
       execSync('yarn bundle', {cwd: pack, stdio: 'inherit'});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -125,7 +125,7 @@ function bundleBuild(done) {
     // link current parcel binary to node_modules
     execSync('yarn link', {cwd: 'packages/core/parcel', stdio: 'inherit'});
     // bundle packages
-    const packagesCustomBuild = ['packages/core/parcel'];
+    const packagesCustomBuild = ['packages/core/core', 'packages/core/parcel'];
     for (const pack of packagesCustomBuild) {
       execSync('yarn bundle', {cwd: pack, stdio: 'inherit'});
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ const gulp = require('gulp');
 const path = require('path');
 const rimraf = require('rimraf');
 const babelConfig = require('./babel.config.json');
+const {execSync} = require('child_process');
 
 const IGNORED_PACKAGES = [
   '!packages/examples/**',
@@ -73,6 +74,8 @@ exports.default = exports.build = gulp.series(
   ),
 );
 
+exports.bundle = gulp.series(bundleBuild);
+
 function buildBabel() {
   return gulp
     .src(paths.packageSrc)
@@ -115,4 +118,14 @@ function renameStream(fn) {
     let relative = path.relative(vinyl.base, vinyl.path);
     vinyl.path = path.join(vinyl.base, fn(relative));
   });
+}
+
+function bundleBuild(done) {
+  if (process.env.PARCEL_BUILD_ENV == 'production') {
+    const packagesCustomBuild = ['packages/core/parcel'];
+    for (const pack of packagesCustomBuild) {
+      execSync('yarn bundle', {cwd: pack, stdio: 'inherit'});
+    }
+  }
+  done();
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production gulp",
     "build-native": "node scripts/build-native.js",
     "build-native-release": "node scripts/build-native.js --release",
-    "build:bundle": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production PARCEL_BUNDLE_ENV=production gulp bundle",
+    "build:bundle": "yarn build && cross-env NODE_ENV=production PARCEL_BUILD_ENV=production PARCEL_BUNDLE_ENV=production gulp bundle",
     "clean-test": "rimraf packages/core/integration-tests/.parcel-cache && rimraf packages/core/integration-tests/dist",
     "clean": "yarn clean-test && lerna clean --yes && lerna exec -- rimraf ./lib && yarn",
     "format": "prettier --write \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\" && cargo fmt --all",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production gulp",
     "build-native": "node scripts/build-native.js",
     "build-native-release": "node scripts/build-native.js --release",
+    "build:bundle": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production gulp bundle",
     "clean-test": "rimraf packages/core/integration-tests/.parcel-cache && rimraf packages/core/integration-tests/dist",
     "clean": "yarn clean-test && lerna clean --yes && lerna exec -- rimraf ./lib && yarn",
     "format": "prettier --write \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\" && cargo fmt --all",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production gulp",
     "build-native": "node scripts/build-native.js",
     "build-native-release": "node scripts/build-native.js --release",
-    "build:bundle": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production gulp bundle",
+    "build:bundle": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=production PARCEL_BUNDLE_ENV=production gulp bundle",
     "clean-test": "rimraf packages/core/integration-tests/.parcel-cache && rimraf packages/core/integration-tests/dist",
     "clean": "yarn clean-test && lerna clean --yes && lerna exec -- rimraf ./lib && yarn",
     "format": "prettier --write \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\" && cargo fmt --all",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -15,12 +15,16 @@
   },
   "main": "lib/index.js",
   "source": "src/index.js",
+  "bundle": "lib/index.bundle.js",
+  "worker-bundle": "lib/worker.bundle.js",
   "engines": {
     "node": ">= 12.0.0"
   },
   "scripts": {
     "test": "mocha",
-    "test-ci": "mocha"
+    "test-ci": "mocha",
+    "worker-bundle": "cross-env NODE_ENV=production PARCEL_BUILD_ENV=worker parcel build --target worker-bundle src/worker.js --no-scope-hoist",
+    "bundle": "npm run worker-bundle && cross-env NODE_ENV=production PARCEL_BUILD_ENV=production parcel build --target bundle src/index.js --no-scope-hoist"
   },
   "dependencies": {
     "@parcel/cache": "2.0.0-beta.2",
@@ -50,5 +54,30 @@
   "devDependencies": {
     "graphviz": "^0.0.9",
     "tempy": "^0.2.1"
+  },
+  "targets": {
+    "bundle": {
+      "context": "node",
+      "includeNodeModules": {
+        "@parcel/workers": false,
+        "@parcel/fs": false,
+        "@parcel/package-manager": false,
+        "@parcel/fs-search": false,
+        "@parcel/source-map": false
+      },
+      "isLibrary": true,
+      "outputFormat": "commonjs"
+    },
+    "worker-bundle": {
+      "context": "node",
+      "includeNodeModules": {
+        "@parcel/fs": false,
+        "@parcel/package-manager": false,
+        "@parcel/fs-search": false,
+        "@parcel/source-map": false
+      },
+      "isLibrary": true,
+      "outputFormat": "commonjs"
+    }
   }
 }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -14,6 +14,7 @@ import type {Diagnostic} from '@parcel/diagnostic';
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 
 import invariant from 'assert';
+import path from 'path';
 import ThrowableDiagnostic, {anyToDiagnostic} from '@parcel/diagnostic';
 import {assetFromValue} from './public/Asset';
 import {PackagedBundle} from './public/Bundle';
@@ -455,6 +456,6 @@ export function createWorkerFarm(
 ): WorkerFarm {
   return new WorkerFarm({
     ...options,
-    workerPath: require.resolve('./worker'),
+    workerPath: path.join(__dirname, 'worker.js').replace(/\\/g, '/'),
   });
 }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -456,6 +456,13 @@ export function createWorkerFarm(
 ): WorkerFarm {
   return new WorkerFarm({
     ...options,
-    workerPath: path.join(__dirname, 'worker.js').replace(/\\/g, '/'),
+    workerPath: path
+      .join(
+        __dirname,
+        process.env.PARCEL_BUNDLE_ENV == 'worker'
+          ? 'worker.bundle.js'
+          : 'worker.js',
+      )
+      .replace(/\\/g, '/'),
   });
 }

--- a/packages/core/parcel/babel.config.json
+++ b/packages/core/parcel/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../babel.config.json"
+}

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -55,7 +55,8 @@
         "@parcel/package-manager": false,
         "@parcel/fs-search": false
       },
-      "isLibrary": true
+      "isLibrary": true,
+      "outputFormat": "commonjs"
     }
   }
 }

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -59,5 +59,8 @@
       "isLibrary": true,
       "outputFormat": "commonjs"
     }
+  },
+  "alias": {
+    "@parcel/core": "@parcel/core/lib/index.bundle.js"
   }
 }

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -53,8 +53,7 @@
         "@parcel/core": false,
         "@parcel/fs": false,
         "@parcel/package-manager": false,
-        "@parcel/fs-search": false,
-        "highlight.js": false
+        "@parcel/fs-search": false
       },
       "isLibrary": true
     }

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -14,8 +14,12 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "src/bin.js",
+  "bin": {
+    "parcel": "lib/bin.js",
+    "parcel-bundle": "lib/bin.bundle.js"
+  },
   "main": "lib/bin.js",
+  "bundle": "lib/bin.bundle.js",
   "source": "src/bin.js",
   "engines": {
     "node": ">= 12.0.0"
@@ -38,5 +42,22 @@
   },
   "devDependencies": {
     "@parcel/babel-register": "2.0.0-beta.2"
+  },
+  "scripts": {
+    "bundle": "cross-env NODE_ENV=production parcel build --target bundle lib/bin.js --no-scope-hoist"
+  },
+  "targets": {
+    "bundle": {
+      "context": "node",
+      "includeNodeModules": {
+        "@parcel/core": false,
+        "@parcel/fs": false,
+        "@parcel/package-manager": false,
+        "@parcel/fs-search": false,
+        "highlight.js": false,
+        "node-forge": false
+      },
+      "isLibrary": true
+    }
   }
 }

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -44,7 +44,7 @@
     "@parcel/babel-register": "2.0.0-beta.2"
   },
   "scripts": {
-    "bundle": "cross-env NODE_ENV=production parcel build --target bundle lib/bin.js --no-scope-hoist"
+    "bundle": "cross-env NODE_ENV=production parcel build --target bundle src/bin.js --no-scope-hoist"
   },
   "targets": {
     "bundle": {

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -53,7 +53,8 @@
         "@parcel/core": false,
         "@parcel/fs": false,
         "@parcel/package-manager": false,
-        "@parcel/fs-search": false
+        "@parcel/fs-search": false,
+        "@parcel/source-map": false
       },
       "isLibrary": true,
       "outputFormat": "commonjs"

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -54,8 +54,7 @@
         "@parcel/fs": false,
         "@parcel/package-manager": false,
         "@parcel/fs-search": false,
-        "highlight.js": false,
-        "node-forge": false
+        "highlight.js": false
       },
       "isLibrary": true
     }

--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -1,6 +1,7 @@
 // @flow
 import type {FileSystem} from '@parcel/fs';
-import forge from 'node-forge';
+import {default as forgePki} from 'node-forge/lib/pki';
+import {default as forgeMd} from 'node-forge/lib/md';
 import path from 'path';
 import logger from '@parcel/logger';
 
@@ -27,7 +28,7 @@ export default async function generateCertificate(
 
   logger.progress('Generating SSL Certificate...');
 
-  const pki = forge.pki;
+  const pki = forgePki;
   const keys = pki.rsa.generateKeyPair(2048);
   const cert = pki.createCertificate();
 
@@ -124,7 +125,7 @@ export default async function generateCertificate(
     },
   ]);
 
-  cert.sign(keys.privateKey, forge.md.sha256.create());
+  cert.sign(keys.privateKey, forgeMd.sha256.create());
 
   const privPem = pki.privateKeyToPem(keys.privateKey);
   const certPem = pki.certificateToPem(cert);

--- a/packages/dev/babel-preset/index.js
+++ b/packages/dev/babel-preset/index.js
@@ -16,12 +16,14 @@ module.exports = () => ({
     require('@babel/plugin-proposal-class-properties'),
     require('@babel/plugin-proposal-nullish-coalescing-operator'),
     require('@babel/plugin-proposal-optional-chaining'),
-    process.env.PARCEL_BUNDLE_ENV !== 'production' ? [
-      require('@babel/plugin-transform-modules-commonjs'),
-      {
-        lazy: () => process.env.NODE_ENV !== 'test',
-      },
-    ] : {},
+    !process.env.PARCEL_BUNDLE_ENV
+      ? [
+          require('@babel/plugin-transform-modules-commonjs'),
+          {
+            lazy: () => process.env.NODE_ENV !== 'test',
+          },
+        ]
+      : {},
   ],
   env: {
     production: {

--- a/packages/dev/babel-preset/index.js
+++ b/packages/dev/babel-preset/index.js
@@ -16,12 +16,12 @@ module.exports = () => ({
     require('@babel/plugin-proposal-class-properties'),
     require('@babel/plugin-proposal-nullish-coalescing-operator'),
     require('@babel/plugin-proposal-optional-chaining'),
-    [
+    process.env.PARCEL_BUNDLE_ENV !== 'production' ? [
       require('@babel/plugin-transform-modules-commonjs'),
       {
         lazy: () => process.env.NODE_ENV !== 'test',
       },
-    ],
+    ] : {},
   ],
   env: {
     production: {

--- a/packages/packagers/js/src/dev-prelude.js
+++ b/packages/packagers/js/src/dev-prelude.js
@@ -27,10 +27,15 @@
 
   var cache = previousRequire.cache || {};
   // Do not use `require` to prevent Webpack from trying to bundle this call
-  var nodeRequire =
-    typeof module !== 'undefined' &&
-    typeof module.require === 'function' &&
-    module.require.bind(module);
+  let nodeRequire;
+  if (typeof module !== 'undefined' && typeof module.require === 'function') {
+    nodeRequire = module.require.bind(module);
+  } else {
+    const req = eval('require');
+    if (typeof req === 'function') {
+      nodeRequire = req;
+    }
+  }
 
   function newRequire(name, jumped) {
     if (!cache[name]) {


### PR DESCRIPTION
# ↪️ Pull Request

- This PR tries to add bundle builds for Parcel to speed up loading time. The plan is to provide a `parcel-bundle` binary that uses the bundled builds instead of the source files. This is the second take on #5671, but without modifying the default behavior of the packages (with `parcel` binary).

- It's always a very good test to use a tool on itself. Bundling Parcel using Parcel can reveal many bugs, and also result in improving the Parcel code itself.

## 💻 Examples


## 🚨 Test instructions


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
