### PR TITLE
Add dev server back to the default config

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -58,5 +58,6 @@
     "*.{jsonld,webmanifest}": "@parcel/packager-raw-url",
     "*": "@parcel/packager-raw"
   },
-  "resolvers": ["@parcel/resolver-default"]
+  "resolvers": ["@parcel/resolver-default"],
+  "reporters": ["@parcel/reporter-dev-server"]
 }

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -27,6 +27,7 @@
     "@parcel/packager-html": "2.0.0-beta.2",
     "@parcel/packager-js": "2.0.0-beta.2",
     "@parcel/packager-raw": "2.0.0-beta.2",
+    "@parcel/reporter-dev-server": "2.0.0-beta.2",
     "@parcel/resolver-default": "2.0.0-beta.2",
     "@parcel/runtime-browser-hmr": "2.0.0-beta.2",
     "@parcel/runtime-js": "2.0.0-beta.2",

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -449,7 +449,6 @@ async function normalizeOptions(
 
   let additionalReporters = [
     {packageName: '@parcel/reporter-cli', resolveFrom: __filename},
-    {packageName: '@parcel/reporter-dev-server', resolveFrom: __filename},
     ...(command.reporter: Array<string>).map(packageName => ({
       packageName,
       resolveFrom: path.join(inputFS.cwd(), 'index'),


### PR DESCRIPTION
Was changed by #5905

This was confusing when using the JS API because:
- `options.serveOptions` and `options.hmrOptions` are ignored unless you add the server reporter via `additionalReporters`
- the hmr runtime is always added, but the server isn't?

Related: https://github.com/parcel-bundler/parcel/discussions/6088, https://github.com/parcel-bundler/website/issues/849#issuecomment-827210515