### PR TITLE
Lazy load node-forge only if needed (Make Parcel ~300KB smaller)

### DIFF
--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -1,6 +1,7 @@
 // @flow
 import type {FileSystem} from '@parcel/fs';
-import forge from 'node-forge';
+import {default as forgePki} from 'node-forge/lib/pki';
+import {default as forgeMd} from 'node-forge/lib/md';
 import path from 'path';
 import logger from '@parcel/logger';
 
@@ -27,7 +28,7 @@ export default async function generateCertificate(
 
   logger.progress('Generating SSL Certificate...');
 
-  const pki = forge.pki;
+  const pki = forgePki;
   const keys = pki.rsa.generateKeyPair(2048);
   const cert = pki.createCertificate();
 
@@ -124,7 +125,7 @@ export default async function generateCertificate(
     },
   ]);
 
-  cert.sign(keys.privateKey, forge.md.sha256.create());
+  cert.sign(keys.privateKey, forgeMd.sha256.create());
 
   const privPem = pki.privateKeyToPem(keys.privateKey);
   const certPem = pki.certificateToPem(cert);

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -34,7 +34,8 @@ export async function createHTTPServer(
   if (!options.https) {
     server = http.createServer(options.listener);
   } else if (options.https === true) {
-    const generateCertificate = (await import('./generateCertificate')).default;
+    const generateCertificate = (await import('./generateCertificate.js'))
+      .default.default;
     let {cert, key} = await generateCertificate(
       options.outputFS,
       options.cacheDir,

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -9,7 +9,7 @@ import type {FileSystem} from '@parcel/fs';
 import http from 'http';
 import https from 'https';
 import nullthrows from 'nullthrows';
-import {getCertificate} from './';
+import getCertificate from './getCertificate';
 
 type CreateHTTPServerOpts = {|
   https: ?(HTTPSOptions | boolean),

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -34,8 +34,11 @@ export async function createHTTPServer(
   if (!options.https) {
     server = http.createServer(options.listener);
   } else if (options.https === true) {
-    const generateCertificate = /* $FlowIgnore[prop-missing] the exports of the dynamic import are wrapped in an excess object */
-    (await import('./generateCertificate.js')).default.default;
+    const generateCertificateModule = (await import('./generateCertificate.js'))
+      .default;
+    const generateCertificate =
+      /* $FlowIgnore[prop-missing] the exports of the dynamic import are wrapped in an excess object */
+      generateCertificateModule.default ?? generateCertificateModule;
     let {cert, key} = await generateCertificate(
       options.outputFS,
       options.cacheDir,

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -34,8 +34,8 @@ export async function createHTTPServer(
   if (!options.https) {
     server = http.createServer(options.listener);
   } else if (options.https === true) {
-    const generateCertificate = (await import('./generateCertificate.js'))
-      .default.default;
+    const generateCertificate = /* $FlowIgnore[prop-missing] the exports of the dynamic import are wrapped in an excess object */
+    (await import('./generateCertificate.js')).default.default;
     let {cert, key} = await generateCertificate(
       options.outputFS,
       options.cacheDir,

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -9,7 +9,7 @@ import type {FileSystem} from '@parcel/fs';
 import http from 'http';
 import https from 'https';
 import nullthrows from 'nullthrows';
-import {getCertificate, generateCertificate} from './';
+import {getCertificate} from './';
 
 type CreateHTTPServerOpts = {|
   https: ?(HTTPSOptions | boolean),
@@ -34,6 +34,7 @@ export async function createHTTPServer(
   if (!options.https) {
     server = http.createServer(options.listener);
   } else if (options.https === true) {
+    const generateCertificate = (await import('./generateCertificate')).default;
     let {cert, key} = await generateCertificate(
       options.outputFS,
       options.cacheDir,

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -7,7 +7,6 @@ export type * from './http-server';
 
 export {default as countLines} from './countLines';
 export {default as generateBuildMetrics} from './generateBuildMetrics';
-export {default as generateCertificate} from './generateCertificate';
 export {default as getCertificate} from './getCertificate';
 export {default as getRootDir} from './getRootDir';
 export {default as isDirectoryInside} from './isDirectoryInside';

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -7,7 +7,6 @@ export type * from './http-server';
 
 export {default as countLines} from './countLines';
 export {default as generateBuildMetrics} from './generateBuildMetrics';
-export {default as getCertificate} from './getCertificate';
 export {default as getRootDir} from './getRootDir';
 export {default as isDirectoryInside} from './isDirectoryInside';
 export {default as isURL} from './is-url';


### PR DESCRIPTION
# ↪️ Pull Request

This changes the usage of `generateCertificate` so it is only loaded when a HTTPS server is going to be created. Node-forge which is used by `generateCertificate` is ~300KB or more which is now lazy loaded.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 🚨 Test instructions

The current server/hmr integration tests cover this.
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
