### PR TITLE
eval require if it is not a property of module

### DIFF
--- a/packages/packagers/js/src/prelude.js
+++ b/packages/packagers/js/src/prelude.js
@@ -27,10 +27,15 @@
 
   var cache = previousRequire.cache || {};
   // Do not use `require` to prevent Webpack from trying to bundle this call
-  var nodeRequire =
-    typeof module !== 'undefined' &&
-    typeof module.require === 'function' &&
-    module.require.bind(module);
+  let nodeRequire;
+  if (typeof module !== 'undefined' && typeof module.require === 'function') {
+    nodeRequire = module.require.bind(module);
+  } else {
+    const req = eval('require');
+    if (typeof req === 'function') {
+      nodeRequire = req;
+    }
+  }
 
   function newRequire(name, jumped) {
     if (!cache[name]) {

--- a/packages/shared/scope-hoisting/src/prelude.js
+++ b/packages/shared/scope-hoisting/src/prelude.js
@@ -16,8 +16,17 @@ if (parcelRequire == null) {
 
     // Try the node require function if it exists.
     // Do not use `require` to prevent Webpack from trying to bundle this call
+    let nodeRequire;
     if (typeof module !== 'undefined' && typeof module.require === 'function') {
-      return module.require(name);
+      nodeRequire = module.require.bind(module);
+    } else {
+      const req = eval('require');
+      if (typeof req === 'function') {
+        nodeRequire = req;
+      }
+    }
+    if (nodeRequire) {
+      return nodeRequire(name);
     }
 
     var err = new Error("Cannot find module '" + name + "'");


### PR DESCRIPTION
# ↪️ Pull Request

In #6194 I faced a situation where `v8` module couldn't be found (it is used in @parcel/core). I found out that `module.require` is not defined, but `eval("require")` is defined.

## 💻 Examples

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
