### PR TITLE
Update flow to v0.150.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -22,9 +22,6 @@ implicit-inexact-object=error
 untyped-type-import=error
 
 [options]
-esproposal.export_star_as=enable
-esproposal.nullish_coalescing=enable
-esproposal.optional_chaining=enable
 module.system.node.main_field=source
 module.system.node.main_field=main
 
@@ -38,4 +35,4 @@ untyped-import
 untyped-type-import
 
 [version]
-0.148.0
+0.150.0

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cross-env": "^7.0.0",
     "doctoc": "^1.4.0",
     "eslint": "^7.20.0",
-    "flow-bin": "0.148.0",
+    "flow-bin": "0.150.0",
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "husky": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6086,10 +6086,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-bin@0.148.0:
-  version "0.148.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.148.0.tgz#1d264606dbb4d6e6070cc98a775e21dcd64e6890"
-  integrity sha512-7Cx6BUm8UAlbqtYJNYXdMrh900MQhNV+SjtBxZuWN7UmlVG4tIRNzNLEOjNnj2DN2vcL1wfI5IlSUXnws/QCEw==
+flow-bin@0.150.0:
+  version "0.150.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.150.0.tgz#213277bbaaf271ddc7c7b8fd2d994cd84901689e"
+  integrity sha512-s+0dcKJnZZO6mkS92YtJzBZ6vq7i1o77+NggEiiefPpCVsehwPlyRLmEnb6XN9OI5OfXp+kFnZt4q8a3zLNuUg==
 
 flush-write-stream@^1.0.0, flush-write-stream@^1.0.2:
   version "1.1.1"


### PR DESCRIPTION
This release removed some `esproposal` options that are now always enabled. Required no other code changes.

Test Plan: `yarn flow check`