### PR TITLE
Fix graph dumping

### DIFF
--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -46,9 +46,8 @@ export default async function dumpGraphToGraphViz(
   const graphviz = require('graphviz');
   const tempy = require('tempy');
   let g = graphviz.digraph('G');
-  let nodes = Array.from(graph.nodes.values());
-  for (let node of nodes) {
-    let n = g.addNode(node.id);
+  for (let [id, node] of graph.nodes) {
+    let n = g.addNode(nodeId(id));
     // $FlowFixMe default is fine. Not every type needs to be in the map.
     n.set('color', COLORS[node.type || 'default']);
     n.set('shape', 'box');
@@ -129,7 +128,7 @@ export default async function dumpGraphToGraphViz(
     n.set('label', label);
   }
   for (let edge of graph.getAllEdges()) {
-    let gEdge = g.addEdge(edge.from, edge.to);
+    let gEdge = g.addEdge(nodeId(edge.from), nodeId(edge.to));
     let color = edge.type != null ? TYPE_COLORS[edge.type] : null;
     if (color != null) {
       gEdge.set('color', color);
@@ -139,6 +138,11 @@ export default async function dumpGraphToGraphViz(
   await g.output('png', tmp);
   // eslint-disable-next-line no-console
   console.log('Dumped', tmp);
+}
+
+function nodeId(id) {
+  // $FlowFixMe
+  return `node${id}`;
 }
 
 function getEnvDescription(env: Environment) {


### PR DESCRIPTION
Probably happened when the numeric ids were introduced

(numbers themselves don't seem to be valid graphviz ids, so I prepended some text to the actual graph numbers)