### PR TITLE
Include src in the published js transformer

### DIFF
--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -23,8 +23,9 @@
     "node": ">= 12.0.0"
   },
   "files": [
-    "lib/*.js",
-    "*.node"
+    "lib",
+    "*.node",
+    "src"
   ],
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-beta.2",


### PR DESCRIPTION
Closes #6254

This is needed because we do add a dependency to `@parcel/transformer-js/src/esmodule-helpers.js`