### PR TITLE
Apply suggestions from rust-clippy

### DIFF
--- a/packages/transformers/js/core/src/decl_collector.rs
+++ b/packages/transformers/js/core/src/decl_collector.rs
@@ -14,7 +14,7 @@ pub fn collect_decls(module: &ast::Module) -> HashSet<(JsWord, SyntaxContext)> {
     in_var: false,
   };
   module.visit_with(&ast::Invalid { span: DUMMY_SP } as _, &mut c);
-  return c.decls;
+  c.decls
 }
 
 struct DeclCollector {

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -315,15 +315,8 @@ impl<'a> Fold for DependencyCollector<'a> {
     let block = node.block.fold_with(self);
     self.in_try = false;
 
-    let handler = match node.handler {
-      Some(handler) => Some(handler.fold_with(self)),
-      None => None,
-    };
-
-    let finalizer = match node.finalizer {
-      Some(finalizer) => Some(finalizer.fold_with(self)),
-      None => None,
-    };
+    let handler = node.handler.map(|handler| handler.fold_with(self));
+    let finalizer = node.finalizer.map(|finalizer| finalizer.fold_with(self));
 
     ast::TryStmt {
       span: node.span,
@@ -882,11 +875,7 @@ impl<'a> DependencyCollector<'a> {
       if let Some(arg) = args.get(0) {
         let (resolve, expr) = match &*arg.expr {
           Fn(f) => {
-            let param = if let Some(param) = f.function.params.get(0) {
-              Some(&param.pat)
-            } else {
-              None
-            };
+            let param = f.function.params.get(0).map(|param| &param.pat);
             let body = if let Some(body) = &f.function.body {
               self.match_block_stmt_expr(body)
             } else {
@@ -1429,10 +1418,5 @@ fn match_worker_type(expr: Option<&ast::ExprOrSpread>) -> (SourceType, Option<as
     }
   }
 
-  let expr = match expr {
-    None => None,
-    Some(e) => Some(e.clone()),
-  };
-
-  (SourceType::Script, expr)
+  (SourceType::Script, expr.cloned())
 }

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -274,7 +274,7 @@ impl<'a> Fold for DependencyCollector<'a> {
       self.config.source_type,
     );
 
-    return node;
+    node
   }
 
   fn fold_named_export(&mut self, node: ast::NamedExport) -> ast::NamedExport {
@@ -293,7 +293,7 @@ impl<'a> Fold for DependencyCollector<'a> {
       );
     }
 
-    return node;
+    node
   }
 
   fn fold_export_all(&mut self, node: ast::ExportAll) -> ast::ExportAll {
@@ -306,7 +306,7 @@ impl<'a> Fold for DependencyCollector<'a> {
       self.config.source_type,
     );
 
-    return node;
+    node
   }
 
   fn fold_try_stmt(&mut self, node: ast::TryStmt) -> ast::TryStmt {
@@ -797,7 +797,7 @@ impl<'a> Fold for DependencyCollector<'a> {
       }
     }
 
-    return node.fold_children_with(self);
+    node.fold_children_with(self)
   }
 
   fn fold_member_expr(&mut self, mut node: ast::MemberExpr) -> ast::MemberExpr {
@@ -1048,7 +1048,7 @@ fn build_promise_chain(node: ast::CallExpr, require_node: ast::CallExpr) -> ast:
     }
   }
 
-  return node;
+  node
 }
 
 fn create_url_constructor(url: ast::Expr, use_import_meta: bool) -> ast::Expr {
@@ -1113,7 +1113,7 @@ impl Fold for PromiseTransformer {
       }
     }
 
-    return swc_ecmascript::visit::fold_return_stmt(self, node);
+    swc_ecmascript::visit::fold_return_stmt(self, node)
   }
 
   fn fold_arrow_expr(&mut self, node: ast::ArrowExpr) -> ast::ArrowExpr {
@@ -1127,7 +1127,7 @@ impl Fold for PromiseTransformer {
       }
     }
 
-    return swc_ecmascript::visit::fold_arrow_expr(self, node);
+    swc_ecmascript::visit::fold_arrow_expr(self, node)
   }
 
   fn fold_expr(&mut self, node: ast::Expr) -> ast::Expr {
@@ -1143,7 +1143,7 @@ impl Fold for PromiseTransformer {
       }
     }
 
-    return node;
+    node
   }
 }
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -450,7 +450,7 @@ impl<'a> Fold for DependencyCollector<'a> {
           // Promise.resolve(require('foo'))
           if match_member_expr(member, vec!["Promise", "resolve"], self.decls) {
             if let Some(expr) = node.args.get(0) {
-              if let Some(_) = match_require(&*expr.expr, self.decls, Mark::fresh(Mark::root())) {
+              if match_require(&*expr.expr, self.decls, Mark::fresh(Mark::root())).is_some() {
                 self.in_promise = true;
                 let node = node.fold_children_with(self);
                 self.in_promise = was_in_promise;
@@ -905,9 +905,7 @@ impl<'a> DependencyCollector<'a> {
               if let ast::Expr::Ident(id) = &**callee {
                 if id.to_id() == resolve_id {
                   if let Some(arg) = call.args.get(0) {
-                    if let Some(_) =
-                      match_require(&*arg.expr, self.decls, Mark::fresh(Mark::root()))
-                    {
+                    if match_require(&*arg.expr, self.decls, Mark::fresh(Mark::root())).is_some() {
                       let was_in_promise = self.in_promise;
                       self.in_promise = true;
                       let node = node.fold_children_with(self);

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -242,11 +242,7 @@ impl<'a> EnvReplacer<'a> {
                 span: DUMMY_SP,
                 name: *kv.value.clone().fold_with(self),
                 init: if let Some(key) = key {
-                  if let Some(init) = self.replace(&key, false) {
-                    Some(Box::new(init))
-                  } else {
-                    None
-                  }
+                  self.replace(&key, false).map(Box::new)
                 } else {
                   None
                 },

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -100,7 +100,7 @@ impl<'a> InlineFS<'a> {
         match &member.obj {
           ExprOrSuper::Expr(expr) => {
             if let Some(source) = self.collect.match_require(expr) {
-              return Some((source.clone(), prop));
+              return Some((source, prop));
             }
 
             match &**expr {

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -123,7 +123,7 @@ impl<'a> InlineFS<'a> {
       _ => {}
     }
 
-    return None;
+    None
   }
 
   fn evaluate_fs_arg(
@@ -234,7 +234,7 @@ impl<'a> InlineFS<'a> {
           Some(contents)
         }
       }
-      _ => return None,
+      _ => None,
     }
   }
 }
@@ -332,7 +332,7 @@ impl<'a> Fold for Evaluator<'a> {
           }
         }
 
-        return node;
+        node
       }
       _ => node,
     }

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -193,7 +193,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
       _ => {}
     }
 
-    return node;
+    node
   }
 
   fn fold_module(&mut self, node: ast::Module) -> ast::Module {
@@ -206,7 +206,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
         .values()
         .map(|stmt| ast::ModuleItem::Stmt(stmt.clone())),
     );
-    return node;
+    node
   }
 }
 

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1022,7 +1022,7 @@ impl<'a> Hoist<'a> {
     self
       .imported_symbols
       .insert(new_name.clone(), (source.clone(), local.clone(), loc));
-    return Ident::new(new_name, span);
+    Ident::new(new_name, span)
   }
 
   fn get_require_ident(&self, local: &JsWord) -> Ident {
@@ -1046,7 +1046,7 @@ impl<'a> Hoist<'a> {
 
     let mut span = span;
     span.ctxt = SyntaxContext::empty();
-    return Ident::new(new_name, span);
+    Ident::new(new_name, span)
   }
 
   fn handle_non_const_require(&mut self, v: &VarDeclarator, source: &JsWord) {
@@ -1949,7 +1949,7 @@ mod tests {
       emitter.emit_module(&program).unwrap();
     }
 
-    return String::from_utf8(buf).unwrap();
+    String::from_utf8(buf).unwrap()
   }
 
   macro_rules! map(

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1647,10 +1647,7 @@ impl Visit for Collect {
                   match node.args.get(0) {
                     Some(ExprOrSpread { expr, .. }) => {
                       let param = match &**expr {
-                        Expr::Fn(func) => match func.function.params.get(0) {
-                          Some(param) => Some(&param.pat),
-                          None => None,
-                        },
+                        Expr::Fn(func) => func.function.params.get(0).map(|param| &param.pat),
                         Expr::Arrow(arrow) => arrow.params.get(0),
                         _ => None,
                       };

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -919,7 +919,7 @@ impl<'a> Fold for Hoist<'a> {
             } else {
               PatOrExpr::Pat(Box::new(Pat::Expr(Box::new(Expr::Member(MemberExpr {
                 span: member.span,
-                obj: ExprOrSuper::Expr(Box::new(Expr::Ident(ident.id.clone()))),
+                obj: ExprOrSuper::Expr(Box::new(Expr::Ident(ident.id))),
                 prop: member.prop.clone().fold_with(self),
                 computed: member.computed,
               })))))
@@ -1942,7 +1942,7 @@ mod tests {
       let mut emitter = swc_ecmascript::codegen::Emitter {
         cfg: config,
         comments: Some(&comments),
-        cm: source_map.clone(),
+        cm: source_map,
         wr: writer,
       };
 

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -744,7 +744,7 @@ impl<'a> Fold for Hoist<'a> {
       .enumerate()
       .map(|(i, expr)| {
         if i != len - 1 {
-          if let Some(_) = match_require(&*expr, &self.collect.decls, self.collect.ignore_mark) {
+          if match_require(&*expr, &self.collect.decls, self.collect.ignore_mark).is_some() {
             return Box::new(Expr::Unary(UnaryExpr {
               op: UnaryOp::Bang,
               arg: expr.fold_with(self),

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -409,9 +409,10 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
             let (buf, mut src_map_buf) =
               emit(source_map.clone(), comments, &program, config.source_maps)?;
             if config.source_maps {
-              if let Ok(_) = source_map
+              if source_map
                 .build_source_map(&mut src_map_buf)
                 .to_writer(&mut map_buf)
+                .is_ok()
               {
                 result.map = Some(String::from_utf8(map_buf).unwrap());
               }

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -503,5 +503,5 @@ fn emit(
     emitter.emit_module(&program)?;
   }
 
-  return Ok((buf, src_map_buf));
+  Ok((buf, src_map_buf))
 }

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -496,7 +496,7 @@ fn emit(
     let mut emitter = swc_ecmascript::codegen::Emitter {
       cfg: config,
       comments: Some(&comments),
-      cm: source_map.clone(),
+      cm: source_map,
       wr: writer,
     };
 

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -46,7 +46,7 @@ pub fn match_member_expr(
     }
   }
 
-  return false;
+  false
 }
 
 pub fn create_require(specifier: swc_atoms::JsWord) -> ast::CallExpr {

--- a/packages/utils/fs-search/src/lib.rs
+++ b/packages/utils/fs-search/src/lib.rs
@@ -43,7 +43,7 @@ fn find_ancestor_file(ctx: CallContext) -> Result<Either<JsNull, JsString>> {
     }
   }
 
-  return ctx.env.get_null().map(Either::A);
+  ctx.env.get_null().map(Either::A)
 }
 
 #[js_function(1)]
@@ -59,7 +59,7 @@ fn find_first_file(ctx: CallContext) -> Result<Either<JsNull, JsString>> {
     }
   }
 
-  return ctx.env.get_null().map(Either::A);
+  ctx.env.get_null().map(Either::A)
 }
 
 #[js_function(2)]
@@ -86,7 +86,7 @@ fn find_node_module(ctx: CallContext) -> Result<Either<JsNull, JsString>> {
     }
   }
 
-  return ctx.env.get_null().map(Either::A);
+  ctx.env.get_null().map(Either::A)
 }
 
 #[module_exports]

--- a/packages/utils/hash/src/lib.rs
+++ b/packages/utils/hash/src/lib.rs
@@ -13,7 +13,7 @@ fn hash_string(ctx: CallContext) -> Result<JsString> {
   let s = s.as_slice();
   let res = xxh3_64(s);
   let res_str = format!("{:016x}", res);
-  return ctx.env.create_string_from_std(res_str);
+  ctx.env.create_string_from_std(res_str)
 }
 
 #[js_function(1)]
@@ -22,7 +22,7 @@ fn hash_buffer(ctx: CallContext) -> Result<JsString> {
   let s = s.as_ref();
   let res = xxh3_64(s);
   let res_str = format!("{:016x}", res);
-  return ctx.env.create_string_from_std(res_str);
+  ctx.env.create_string_from_std(res_str)
 }
 
 #[js_function(1)]
@@ -30,7 +30,7 @@ fn constructor(ctx: CallContext) -> Result<JsUndefined> {
   let mut this: JsObject = ctx.this_unchecked();
   let h = Xxh3::new();
   ctx.env.wrap(&mut this, h)?;
-  return ctx.env.get_undefined();
+  ctx.env.get_undefined()
 }
 
 #[js_function(1)]
@@ -40,7 +40,7 @@ fn write_string(ctx: CallContext) -> Result<JsUndefined> {
   let s = ctx.get::<JsString>(0)?.into_utf8()?;
   let s = s.as_slice();
   h.write(s);
-  return ctx.env.get_undefined();
+  ctx.env.get_undefined()
 }
 
 #[js_function(1)]
@@ -50,7 +50,7 @@ fn write_buffer(ctx: CallContext) -> Result<JsUndefined> {
   let s = ctx.get::<JsBuffer>(0)?.into_value()?;
   let s = s.as_ref();
   h.write(s);
-  return ctx.env.get_undefined();
+  ctx.env.get_undefined()
 }
 
 #[js_function(1)]
@@ -59,7 +59,7 @@ fn finish(ctx: CallContext) -> Result<JsString> {
   let h: &mut Xxh3 = ctx.env.unwrap(&this)?;
   let res = h.finish();
   let res_str = format!("{:016x}", res);
-  return ctx.env.create_string_from_std(res_str);
+  ctx.env.create_string_from_std(res_str)
 }
 
 #[module_exports]


### PR DESCRIPTION
Fix some warnings produced by running https://github.com/rust-lang/rust-clippy

**Make Github hide whitespace changes when viewing the diff** 

- unnecessary `.clone()`s
- use `if let Foo(y) = x ...` instead of `match x { Foo(y) => ..., _ => {} }`
- merge nested if statements into a single one with the `conditionA && conditionB`
- remove unnecessary `return` keywords
- merge nested type checking if possible:
```rust
      if let Lit(lit) = &*arg.expr {
        if let ast::Lit::Str(str_) = lit {
```
can be
```rust
      if let Lit(ast::Lit::Str(str_)) = &*arg.expr {
```
(same for match)
- use `.map(|v| something(v))` instead of `if let Some(v) = ... { something(v)} else {None}`
- use `.is_empty()` when possible
- `.iter().flatten()` instead of `for n in list { if Some(n) = n { ...`
- "Object spreading":
```rust
    let mut esconfig = EsConfig::default();
    esconfig.jsx = config.is_jsx;
    esconfig.dynamic_import = true;
    esconfig.export_default_from = true;
    esconfig.export_namespace_from = true;
    esconfig.import_meta = true;
    Syntax::Es(esconfig)
```
becomes:
```rust
    Syntax::Es(EsConfig {
      jsx: config.is_jsx,
      dynamic_import: true,
      export_default_from: true,
      export_namespace_from: true,
      import_meta: true,
      ..Default::default()
    })
```
- `.or_insert(something())` should rather be `.or_insert_with(|| something())` so that the function is only called when needed