### PR TITLE
Allow bundling browserify bundles by replacing free requires with undefined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,18 +839,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.125"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038c0425a6f47d7f30dd8949d96c5eecb34fde1487188c5ba6ab931a888e5137"
+checksum = "b5caaad25f28ac82e0e569af764ae456e1d6fe5d92a65d961269d1596ff64efb"
 dependencies = [
  "arrayvec",
  "fxhash",
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ece73c3e0ca0f985c9c481061dffe7a87668ef11ffa4622b921d06b56a1cc4"
+checksum = "fcf5cd928380e2565d1f3dc6ad3529a0fbdb098a70b5d8bb5f6c3712e2ef2445"
 dependencies = [
  "dashmap",
  "fxhash",
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc406e5278f55f7b6417403cc87ba6d9353280ef3aaf1669b276013402faef8"
+checksum = "cf1d8c6d21471c019bfeca82979c717819b52b1a7a20de9c7cb0f29add09ad7c"
 dependencies = [
  "base64 0.13.0",
  "dashmap",
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e5b2325c529541722ea3c6ea6aad4227b03ead45a2a3ff289178a29b60e608"
+checksum = "0fcfebf35e1fc00fd104961e53278ca35514f290afdc2c0747b9df38d5e09719"
 dependencies = [
  "fxhash",
  "serde",

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/browserify-bundle.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/browserify-bundle.js
@@ -1,0 +1,105 @@
+/*
+ * The following is a browserify-produced umd bundle created with:
+ * `echo "module.exports = 'foo';" | browserify - -s foo | prettier --parser babel`
+ * using browserify@16.5.0
+ *
+ * Includes the prelude and umd wrapper from browserify. Browserify's MIT
+ * license is reproduced below.
+ * https://github.com/browserify/browserify/blob/b8ddf68ac3ebc80ee3b9b1cb67e013256503efe9/LICENSE
+ * https://github.com/browserify/browser-pack/blob/cd0bd31f8c110e19a80429019b64e887b1a82b2b/LICENSE
+ */
+
+/**
+ * MIT License
+ *
+ * Copyright (c) 2010 James Halliday
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+(function(f) {
+  if (typeof exports === "object" && typeof module !== "undefined") {
+    module.exports = f();
+  } else if (typeof define === "function" && define.amd) {
+    define([], f);
+  } else {
+    var g;
+    if (typeof window !== "undefined") {
+      g = window;
+    } else if (typeof global !== "undefined") {
+      g = global;
+    } else if (typeof self !== "undefined") {
+      g = self;
+    } else {
+      g = this;
+    }
+    g.foo = f();
+  }
+})(function() {
+  var define, module, exports;
+  return (function() {
+    function r(e, n, t) {
+      function o(i, f) {
+        if (!n[i]) {
+          if (!e[i]) {
+            var c = "function" == typeof require && require;
+            if (!f && c) return c(i, !0);
+            if (u) return u(i, !0);
+            var a = new Error("Cannot find module '" + i + "'");
+            throw ((a.code = "MODULE_NOT_FOUND"), a);
+          }
+          var p = (n[i] = { exports: {} });
+          e[i][0].call(
+            p.exports,
+            function(r) {
+              var n = e[i][1][r];
+              return o(n || r);
+            },
+            p,
+            p.exports,
+            r,
+            e,
+            n,
+            t
+          );
+        }
+        return n[i].exports;
+      }
+      for (
+        var u = "function" == typeof require && require, i = 0;
+        i < t.length;
+        i++
+      )
+        o(t[i]);
+      return o;
+    }
+    return r;
+  })()(
+    {
+      1: [
+        function(require, module, exports) {
+          module.exports = "foo";
+        },
+        {}
+      ]
+    },
+    {},
+    [1]
+  )(1);
+});

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/browserify-compat/index.js
@@ -1,0 +1,1 @@
+output = require('./browserify-bundle');

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4643,6 +4643,17 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 9);
     });
 
+    it('can bundle browserify-produced umd bundles', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/browserify-compat/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), 'foo');
+    });
+
     it('should support two aliases to the same module', async function() {
       let b = await bundle(
         path.join(

--- a/packages/transformers/js/src/hoist.rs
+++ b/packages/transformers/js/src/hoist.rs
@@ -703,6 +703,55 @@ impl<'a> Fold for Hoist<'a> {
           }
         }
       }
+      Expr::Bin(ref binary) => {
+        let is_typeof_require = |expr: &Expr| -> bool {
+          if let Expr::Unary(UnaryExpr {
+            op: UnaryOp::TypeOf,
+            ref arg,
+            ..
+          }) = expr
+          {
+            if let Expr::Ident(ref ident) = &**arg {
+              if ident.sym == js_word!("require") && !self.collect.decls.contains(&id!(ident)) {
+                return true;
+              }
+            }
+          }
+          false
+        };
+        let is_function_str = |expr: &Expr| -> bool {
+          if let Expr::Lit(Lit::Str(ref str)) = expr {
+            if str.value == js_word!("function") {
+              return true;
+            }
+          }
+          false
+        };
+
+        let is_typeof_require_function = if let Expr::Bin(BinExpr {
+          op,
+          ref left,
+          ref right,
+          ..
+        }) = &*binary.left
+        {
+          (op == &BinaryOp::EqEq || op == &BinaryOp::EqEqEq)
+            && ((is_function_str(&**left) && is_typeof_require(&**right))
+              || (is_function_str(&**right) && is_typeof_require(&**left)))
+        } else {
+          false
+        };
+
+        let is_require_ident = if let Expr::Ident(ref ident) = &*binary.right {
+          ident.sym == js_word!("require") && !self.collect.decls.contains(&id!(ident))
+        } else {
+          false
+        };
+
+        if is_typeof_require_function && is_require_ident {
+          return Expr::Ident(Ident::new("undefined".into(), DUMMY_SP));
+        }
+      }
       _ => {}
     }
 
@@ -3756,6 +3805,12 @@ mod tests {
     console.log(typeof module);
     console.log(typeof require);
     console.log(module.hot);
+    console.log("function" == typeof require && require);
+    console.log("function" === typeof require && require);
+    console.log(typeof require == "function" && require);
+    console.log(typeof require === "function" && require);
+    console.log(require && "function" == typeof require);
+    console.log(require && typeof require == "function");
     "#,
     );
     assert_eq!(
@@ -3764,6 +3819,12 @@ mod tests {
     console.log("object");
     console.log("function");
     console.log(null);
+    console.log(undefined);
+    console.log(undefined);
+    console.log(undefined);
+    console.log(undefined);
+    console.log(require && "function" == "function");
+    console.log(require && "function" == "function");
     "#}
     );
   }


### PR DESCRIPTION
Closes #3933, Closes #4634, Closes T-1002

~This replaces `typeof require == "function" && require` (and commutative equivalents, or with `===`) with `undefined`, so that browserify bundles don't throw. `require` is never actually called, but still assigned to a local variable.~

~Previously, it was replaced with `"function" == "function" && require`.~

This replaces free `require`s (so everything except `typeof require` and `require("some...string")` with `undefined`.