### PR TITLE
Fix Apple Silicon builds in CI

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,165 +1,165 @@
 name: release-nightly
-on: push
-#   schedule:
-#     - cron: '0 0 * * *'
-#   workflow_dispatch:
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 jobs:
-  # build:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-latest, windows-latest]
-  #   name: ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       if: ${{ matrix.os == 'macos-latest' }}
-  #       run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-${{ matrix.os }}
-  #         path: packages/*/*/*.node
-  #     - name: Smoke test
-  #       run: node -e "require('@parcel/fs-search')"
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-${{ matrix.os }}
+          path: packages/*/*/*.node
+      - name: Smoke test
+        run: node -e "require('@parcel/fs-search')"
 
-  # build-linux-gnu-x64:
-  #   name: linux-gnu-x64
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: docker.io/centos/nodejs-12-centos7
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install yarn
-  #       run: npm install --global yarn@1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       run: strip packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-linux-gnu-x64
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
-  #     - name: Smoke test
-  #       run: node -e 'require("@parcel/fs-search")'
+  build-linux-gnu-x64:
+    name: linux-gnu-x64
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/centos/nodejs-12-centos7
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install yarn
+        run: npm install --global yarn@1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-linux-gnu-x64
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        run: node -e 'require("@parcel/fs-search")'
 
-  # build-linux-gnu-arm:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - target: arm-unknown-linux-gnueabihf
-  #           arch: armhf
-  #           strip: arm-linux-gnueabihf-strip
-  #         - target: aarch64-unknown-linux-gnu
-  #           arch: arm64
-  #           strip: aarch64-linux-gnu-strip
-  #   name: ${{ matrix.target }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #         target: ${{ matrix.target }}
-  #     - name: Install cross compile toolchains
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #       env:
-  #         RUST_TARGET: ${{ matrix.target }}
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       run: ${{ matrix.strip }} packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-${{ matrix.target }}
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
-  #     - name: Configure binfmt-support
-  #       run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-  #     - name: Smoke test
-  #       uses: addnab/docker-run-action@v1
-  #       with:
-  #         image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
-  #         options: -v ${{github.workspace}}:/work
-  #         run: cd /work && node -e "require('@parcel/fs-search')"
+  build-linux-gnu-arm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: arm-unknown-linux-gnueabihf
+            arch: armhf
+            strip: arm-linux-gnueabihf-strip
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+            strip: aarch64-linux-gnu-strip
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+      - name: Install cross compile toolchains
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: ${{ matrix.strip }} packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-${{ matrix.target }}
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Configure binfmt-support
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: Smoke test
+        uses: addnab/docker-run-action@v1
+        with:
+          image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
+          options: -v ${{github.workspace}}:/work
+          run: cd /work && node -e "require('@parcel/fs-search')"
 
-  # build-linux-musl:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - target: x86_64-unknown-linux-musl
-  #           strip: strip
-  #         - target: aarch64-unknown-linux-musl
-  #           strip: aarch64-linux-musl-strip
-  #   name: ${{ matrix.target }}
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: docker.pkg.github.com/napi-rs/napi-rs/rust-nodejs-alpine:lts
-  #     credentials:
-  #       username: ${{ github.actor }}
-  #       password: ${{ secrets.GHCR_TOKEN }}
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #         target: ${{ matrix.target }}
-  #     - name: Install cross compile toolchains
-  #       if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
-  #       run: |
-  #         curl -O https://musl.cc/aarch64-linux-musl-cross.tgz
-  #         tar xzf aarch64-linux-musl-cross.tgz
-  #         cp -R aarch64-linux-musl-cross/* /usr
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #       env:
-  #         RUST_TARGET: ${{ matrix.target }}
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       run: ${{ matrix.strip }} packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-linux-musl
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
-  #     - name: Smoke test
-  #       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
-  #       run: node -e 'require("@parcel/fs-search")'
+  build-linux-musl:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            strip: strip
+          - target: aarch64-unknown-linux-musl
+            strip: aarch64-linux-musl-strip
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.pkg.github.com/napi-rs/napi-rs/rust-nodejs-alpine:lts
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+      - name: Install cross compile toolchains
+        if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
+        run: |
+          curl -O https://musl.cc/aarch64-linux-musl-cross.tgz
+          tar xzf aarch64-linux-musl-cross.tgz
+          cp -R aarch64-linux-musl-cross/* /usr
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: ${{ matrix.strip }} packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-linux-musl
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        run: node -e 'require("@parcel/fs-search")'
 
   build-apple-silicon:
     name: aarch64-apple-darwin
@@ -175,7 +175,7 @@ jobs:
           target: aarch64-apple-darwin
       - uses: bahmutov/npm-install@v1.1.0
       - name: Build native packages
-        run: yarn build-native
+        run: yarn build-native-release
         env:
           RUST_TARGET: aarch64-apple-darwin
       - name: Strip debug symbols
@@ -188,28 +188,28 @@ jobs:
       - name: debug
         run: ls -l packages/*/*/*.node
 
-  # build-and-release:
-  #   runs-on: ubuntu-latest
-  #   name: Build and release nightly
-  #   needs:
-  #     - build
-  #     - build-linux-musl
-  #     - build-linux-gnu-arm
-  #     - build-apple-silicon
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: artifacts
-  #     - name: Move artifacts
-  #       run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
-  #     - name: Debug
-  #       run: ls -l packages/*/*/*.node
-  #     - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-  #       env:
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  #     - run: yarn nightly:release
+  build-and-release:
+    runs-on: ubuntu-latest
+    name: Build and release nightly
+    needs:
+      - build
+      - build-linux-musl
+      - build-linux-gnu-arm
+      - build-apple-silicon
+    steps:
+      - uses: actions/checkout@v1
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Move artifacts
+        run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+      - name: Debug
+        run: ls -l packages/*/*/*.node
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: yarn nightly:release

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,5 +1,5 @@
 name: release-nightly
-# on:
+on: push
 #   schedule:
 #     - cron: '0 0 * * *'
 #   workflow_dispatch:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,165 +1,165 @@
 name: release-nightly
-on:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
+# on:
+#   schedule:
+#     - cron: '0 0 * * *'
+#   workflow_dispatch:
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-${{ matrix.os }}
-          path: packages/*/*/*.node
-      - name: Smoke test
-        run: node -e "require('@parcel/fs-search')"
+  # build:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-latest, windows-latest]
+  #   name: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       if: ${{ matrix.os == 'macos-latest' }}
+  #       run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-${{ matrix.os }}
+  #         path: packages/*/*/*.node
+  #     - name: Smoke test
+  #       run: node -e "require('@parcel/fs-search')"
 
-  build-linux-gnu-x64:
-    name: linux-gnu-x64
-    runs-on: ubuntu-latest
-    container:
-      image: docker.io/centos/nodejs-12-centos7
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install yarn
-        run: npm install --global yarn@1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: strip packages/*/*/*.node
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-linux-gnu-x64
-          path: packages/*/*/*.node
-      - name: debug
-        run: ls -l packages/*/*/*.node
-      - name: Smoke test
-        run: node -e 'require("@parcel/fs-search")'
+  # build-linux-gnu-x64:
+  #   name: linux-gnu-x64
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: docker.io/centos/nodejs-12-centos7
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install yarn
+  #       run: npm install --global yarn@1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       run: strip packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-linux-gnu-x64
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
+  #     - name: Smoke test
+  #       run: node -e 'require("@parcel/fs-search")'
 
-  build-linux-gnu-arm:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: arm-unknown-linux-gnueabihf
-            arch: armhf
-            strip: arm-linux-gnueabihf-strip
-          - target: aarch64-unknown-linux-gnu
-            arch: arm64
-            strip: aarch64-linux-gnu-strip
-    name: ${{ matrix.target }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
-      - name: Install cross compile toolchains
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-        env:
-          RUST_TARGET: ${{ matrix.target }}
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: ${{ matrix.strip }} packages/*/*/*.node
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-${{ matrix.target }}
-          path: packages/*/*/*.node
-      - name: debug
-        run: ls -l packages/*/*/*.node
-      - name: Configure binfmt-support
-        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - name: Smoke test
-        uses: addnab/docker-run-action@v1
-        with:
-          image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
-          options: -v ${{github.workspace}}:/work
-          run: cd /work && node -e "require('@parcel/fs-search')"
+  # build-linux-gnu-arm:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - target: arm-unknown-linux-gnueabihf
+  #           arch: armhf
+  #           strip: arm-linux-gnueabihf-strip
+  #         - target: aarch64-unknown-linux-gnu
+  #           arch: arm64
+  #           strip: aarch64-linux-gnu-strip
+  #   name: ${{ matrix.target }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #         target: ${{ matrix.target }}
+  #     - name: Install cross compile toolchains
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #       env:
+  #         RUST_TARGET: ${{ matrix.target }}
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       run: ${{ matrix.strip }} packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-${{ matrix.target }}
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
+  #     - name: Configure binfmt-support
+  #       run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  #     - name: Smoke test
+  #       uses: addnab/docker-run-action@v1
+  #       with:
+  #         image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
+  #         options: -v ${{github.workspace}}:/work
+  #         run: cd /work && node -e "require('@parcel/fs-search')"
 
-  build-linux-musl:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-musl
-            strip: strip
-          - target: aarch64-unknown-linux-musl
-            strip: aarch64-linux-musl-strip
-    name: ${{ matrix.target }}
-    runs-on: ubuntu-latest
-    container:
-      image: docker.pkg.github.com/napi-rs/napi-rs/rust-nodejs-alpine:lts
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_TOKEN }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
-      - name: Install cross compile toolchains
-        if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
-        run: |
-          curl -O https://musl.cc/aarch64-linux-musl-cross.tgz
-          tar xzf aarch64-linux-musl-cross.tgz
-          cp -R aarch64-linux-musl-cross/* /usr
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-        env:
-          RUST_TARGET: ${{ matrix.target }}
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: ${{ matrix.strip }} packages/*/*/*.node
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-linux-musl
-          path: packages/*/*/*.node
-      - name: debug
-        run: ls -l packages/*/*/*.node
-      - name: Smoke test
-        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
-        run: node -e 'require("@parcel/fs-search")'
+  # build-linux-musl:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - target: x86_64-unknown-linux-musl
+  #           strip: strip
+  #         - target: aarch64-unknown-linux-musl
+  #           strip: aarch64-linux-musl-strip
+  #   name: ${{ matrix.target }}
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: docker.pkg.github.com/napi-rs/napi-rs/rust-nodejs-alpine:lts
+  #     credentials:
+  #       username: ${{ github.actor }}
+  #       password: ${{ secrets.GHCR_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #         target: ${{ matrix.target }}
+  #     - name: Install cross compile toolchains
+  #       if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
+  #       run: |
+  #         curl -O https://musl.cc/aarch64-linux-musl-cross.tgz
+  #         tar xzf aarch64-linux-musl-cross.tgz
+  #         cp -R aarch64-linux-musl-cross/* /usr
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #       env:
+  #         RUST_TARGET: ${{ matrix.target }}
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       run: ${{ matrix.strip }} packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-linux-musl
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
+  #     - name: Smoke test
+  #       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+  #       run: node -e 'require("@parcel/fs-search")'
 
   build-apple-silicon:
     name: aarch64-apple-darwin
@@ -175,7 +175,7 @@ jobs:
           target: aarch64-apple-darwin
       - uses: bahmutov/npm-install@v1.1.0
       - name: Build native packages
-        run: yarn build-native-release
+        run: yarn build-native
         env:
           RUST_TARGET: aarch64-apple-darwin
       - name: Strip debug symbols
@@ -188,28 +188,28 @@ jobs:
       - name: debug
         run: ls -l packages/*/*/*.node
 
-  build-and-release:
-    runs-on: ubuntu-latest
-    name: Build and release nightly
-    needs:
-      - build
-      - build-linux-musl
-      - build-linux-gnu-arm
-      - build-apple-silicon
-    steps:
-      - uses: actions/checkout@v1
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-      - name: Move artifacts
-        run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
-      - name: Debug
-        run: ls -l packages/*/*/*.node
-      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: yarn nightly:release
+  # build-and-release:
+  #   runs-on: ubuntu-latest
+  #   name: Build and release nightly
+  #   needs:
+  #     - build
+  #     - build-linux-musl
+  #     - build-linux-gnu-arm
+  #     - build-apple-silicon
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: artifacts
+  #     - name: Move artifacts
+  #       run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+  #     - name: Debug
+  #       run: ls -l packages/*/*/*.node
+  #     - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+  #       env:
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  #     - run: yarn nightly:release

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -11,7 +11,6 @@ async function build() {
   if (process.platform === 'darwin') {
     await setupMacBuild();
   }
-  return;
 
   let packages = glob.sync('packages/*/*')
   for (let pkg of packages) {

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -40,10 +40,11 @@ async function build() {
   }
 }
 
+// This forces Clang/LLVM to be used as a C compiler instead of GCC.
+// This is necessary for cross-compilation for Apple Silicon in GitHub Actions.
 function setupMacBuild() {
   let xcodeDir = execSync('xcode-select -p | head -1', {encoding: 'utf8'}).trim();
   let sysRoot = execSync('xcrun --sdk macosx --show-sdk-path', {encoding: 'utf8'}).trim();
-  console.log(xcodeDir, sysRoot);
   process.env.CC = `${xcodeDir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang`;
   process.env.CXX = `${xcodeDir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++`;
   process.env.CFLAGS = `-isysroot ${sysRoot} -isystem ${sysRoot}`;

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -42,7 +42,9 @@ async function build() {
 
 function setupMacBuild() {
   let xcodeDir = execSync('xcode-select -p | head -1', {encoding: 'utf8'}).trim();
-  console.log(xcodeDir);
+  let sysRoot = execSync('xcrun --sdk macosx --show-sdk-path', {encoding: 'utf8'}).trim();
+  console.log(xcodeDir, sysRoot);
   process.env.CC = `${xcodeDir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang`;
   process.env.CXX = `${xcodeDir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++`;
+  process.env.CFLAGS = `-isysroot ${sysRoot} -isystem ${sysRoot}`;
 }

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -9,7 +9,7 @@ build();
 
 async function build() {
   if (process.platform === 'darwin') {
-    await setupMacBuild();
+    setupMacBuild();
   }
 
   let packages = glob.sync('packages/*/*')

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -2,11 +2,17 @@
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
-const {spawn} = require('child_process');
+const {spawn, execSync} = require('child_process');
 
 let release = process.argv.includes('--release');
+build();
 
 async function build() {
+  if (process.platform === 'darwin') {
+    await setupMacBuild();
+  }
+  return;
+
   let packages = glob.sync('packages/*/*')
   for (let pkg of packages) {
     try {
@@ -35,4 +41,9 @@ async function build() {
   }
 }
 
-build();
+function setupMacBuild() {
+  let xcodeDir = execSync('xcode-select -p | head -1', {encoding: 'utf8'}).trim();
+  console.log(xcodeDir);
+  process.env.CC = `${xcodeDir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang`;
+  process.env.CXX = `${xcodeDir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++`;
+}


### PR DESCRIPTION
This fixes Apple Silicon builds in CI, which were failing because jemalloc relies on a C compiler to build and gcc is installed in Github Actions. The fix is to ensure we use Clang/LLVM as our C compiler, which supports compiling for Apple Silicon targets.