### PR TITLE
Prevents function from being called twice

### DIFF
--- a/packages/transformers/postcss/src/loadConfig.js
+++ b/packages/transformers/postcss/src/loadConfig.js
@@ -80,6 +80,8 @@ async function configHydrator(
   });
 }
 
+let count = 0;
+
 export async function load({
   config,
   options,
@@ -89,6 +91,7 @@ export async function load({
   options: PluginOptions,
   logger: PluginLogger,
 |}): Promise<void> {
+  if (count > 0) return;
   let configFile: any = await config.getConfig(
     ['.postcssrc', '.postcssrc.json', '.postcssrc.js', 'postcss.config.js'],
     {packageKey: 'postcss'},


### PR DESCRIPTION
The PostCSS transformer is calling this function twice and that is causing build and serve to fail intermittently (Once a successful pass is cached it always work for the same command). I know this is not the right solution but it might give y'all a hint on what is going on. 

During build or serve this function ends up being called twice and at the second pass the config object shows up modified, missing the original plugins property value.

I tried to mess up with this a little bit but didn't insisted too much as I don't have my local environment configured with the proper tooling to debug child processes.

I noticed that commenting out https://github.com/parcel-bundler/parcel/blob/a3aa86815e098c90fda72a08d29646ff059ab74d/packages/transformers/postcss/src/loadConfig.js#L42 doesn't fix the issue but breaks the code path somewhere else.

Sorry for the messy bug report. Let me know if I can help in any way.


<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs


