### PR TITLE
Pure comment for $parcel$interopDefault

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-pure/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/interop-pure/a.js
@@ -1,4 +1,6 @@
 import x from "./b.js";
+
+let value = x;
 if (false) {
-	console.log(x);
+	console.log(value);
 }

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -707,7 +707,7 @@ ${code}
         this.needsDefaultInterop(resolvedAsset)
       ) {
         this.usedHelpers.add('$parcel$interopDefault');
-        return `($parcel$interopDefault(${obj}))`;
+        return `(/*@__PURE__*/$parcel$interopDefault(${obj}))`;
       } else {
         if (IDENTIFIER_RE.test(exportSymbol)) {
           return `${obj}.${exportSymbol}`;


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/6270

Wasn't caught be the existing test because the `$parcel$interopDefault` was excluded entirely after `if(false){...}` was removed by swc before collecting the dependencies.