### PR TITLE
Don't transpile spread in JSX with modern targets

### DIFF
--- a/packages/core/integration-tests/test/integration/jsx-spread/index.jsx
+++ b/packages/core/integration-tests/test/integration/jsx-spread/index.jsx
@@ -1,0 +1,3 @@
+const a = { a: 2 };
+
+module.exports = <div v="1" {...a}></div>;

--- a/packages/core/integration-tests/test/integration/jsx-spread/package.json
+++ b/packages/core/integration-tests/test/integration/jsx-spread/package.json
@@ -1,0 +1,3 @@
+{
+  "browserslist": "Chrome 70"
+}

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -142,6 +142,18 @@ describe('transpilation', function() {
     assert(file.includes('h("div"'));
   });
 
+  it('should not transpile spread in JSX with modern targets', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/jsx-spread/index.jsx'),
+    );
+
+    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    console.log(file);
+    assert(file.includes('React.createElement("div"'));
+    assert(file.includes('...a'));
+    assert(!file.includes('@swc/helpers'));
+  });
+
   it('should support transpiling optional chaining', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/babel-optional-chaining/index.js'),

--- a/packages/transformers/js/src/lib.rs
+++ b/packages/transformers/js/src/lib.rs
@@ -216,6 +216,7 @@ fn transform(ctx: CallContext) -> Result<JsUnknown> {
           || {
             let mut react_options = react::Options::default();
             if config.is_jsx {
+              react_options.use_spread = true;
               if let Some(jsx_pragma) = config.jsx_pragma {
                 react_options.pragma = jsx_pragma;
               }


### PR DESCRIPTION
Previously, the swc react transformer unconditionally transpiled spread in JSX (see below) away and called out to `@swc/helpers`.

Now, the react transformer leaves the object spread as it is and leaves the downleveling to preset-env which runs afterwards (and also respects the browserslist config).

## 💻 Examples

```jsx
const a = { a: 2 };

console.log(<h1 x="1" {...a}></h1>);
```
