### PR TITLE
Resolve helpers relative to JS transformer

### DIFF
--- a/packages/core/integration-tests/test/integration/swc-helpers/index.js
+++ b/packages/core/integration-tests/test/integration/swc-helpers/index.js
@@ -1,0 +1,3 @@
+(async () => {
+	console.log(await Promise.resolve(1));
+})();

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -6,7 +6,9 @@ import {
   distDir,
   inputFS as fs,
   outputFS,
+  overlayFS,
   run,
+  ncp,
 } from '@parcel/test-utils';
 import {symlinkSync} from 'fs';
 
@@ -148,7 +150,6 @@ describe('transpilation', function() {
     );
 
     let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    console.log(file);
     assert(file.includes('React.createElement("div"'));
     assert(file.includes('...a'));
     assert(!file.includes('@swc/helpers'));
@@ -177,6 +178,26 @@ describe('transpilation', function() {
     // NOTE: This may change if core-js internals change.
     assert(file.includes('esnext.global-this'));
     assert(!file.includes('es.array.concat'));
+  });
+
+  it('should resolve @swc/helpers and regenerator-runtime relative to parcel', async function() {
+    let dir = path.join(
+      '/tmp/' +
+        Math.random()
+          .toString(36)
+          .slice(2),
+    );
+    await outputFS.mkdirp(dir);
+    ncp(path.join(__dirname, '/integration/swc-helpers'), dir);
+    await bundle(path.join(dir, 'index.js'), {
+      mode: 'production',
+      inputFS: overlayFS,
+      defaultTargetOptions: {
+        engines: {
+          browsers: '>= 0.25%',
+        },
+      },
+    });
   });
 
   describe('tests needing the real filesystem', () => {

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -339,6 +339,7 @@ export default (new Transformer({
           isAsync: dep.kind === 'DynamicImport',
           isOptional: dep.is_optional,
           meta,
+          resolveFrom: dep.is_helper ? __filename : undefined,
         });
       }
     }

--- a/packages/transformers/js/src/dependency_collector.rs
+++ b/packages/transformers/js/src/dependency_collector.rs
@@ -36,6 +36,7 @@ pub struct DependencyDescriptor {
   pub specifier: swc_atoms::JsWord,
   pub attributes: Option<HashMap<swc_atoms::JsWord, bool>>,
   pub is_optional: bool,
+  pub is_helper: bool,
 }
 
 /// This pass collects dependencies in a module and compiles references as needed to work with Parcel's JSRuntime.
@@ -84,6 +85,7 @@ impl<'a> DependencyCollector<'a> {
       specifier,
       attributes,
       is_optional,
+      is_helper: span.is_dummy(),
     });
   }
 }

--- a/packages/transformers/js/src/fs.rs
+++ b/packages/transformers/js/src/fs.rs
@@ -195,6 +195,7 @@ impl<'a> InlineFS<'a> {
           specifier: path.to_str().unwrap().into(),
           attributes: None,
           is_optional: false,
+          is_helper: false,
         });
 
         // If buffer, wrap in Buffer.from(base64String, 'base64')

--- a/packages/transformers/js/src/global_replacer.rs
+++ b/packages/transformers/js/src/global_replacer.rs
@@ -69,6 +69,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
               specifier,
               attributes: None,
               is_optional: false,
+              is_helper: false,
             });
           }
           "Buffer" => {
@@ -93,6 +94,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
               specifier,
               attributes: None,
               is_optional: false,
+              is_helper: false,
             });
           }
           "__filename" => {


### PR DESCRIPTION
Fixes T-1031

Detects if the require/import is synthetic. If so, resolves relative to the js transformer. This should fix errors like `Failed to resolve '@swc/helpers'` and `regenerator-runtime`.