### PR TITLE
Remap diagnostics and other source locations using input source map

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,7 @@
 <PROJECT_ROOT>/packages/core/integration-tests/dist/**
 <PROJECT_ROOT>/packages/core/integration-tests/test/input/**
 <PROJECT_ROOT>/packages/core/integration-tests/test/integration/babel-strip-flow-types/**
+<PROJECT_ROOT>/packages/core/integration-tests/test/integration/diagnostic-sourcemap/**
 
 [untyped]
 .*/node_modules/graphql/error/GraphQLError.js.flow

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -25,7 +25,6 @@ import {NamedBundle} from './public/Bundle';
 import {PluginLogger} from '@parcel/logger';
 import {md5FromString} from '@parcel/utils';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
-import SourceMap from '@parcel/source-map';
 import {dependencyToInternalDependency} from './public/Dependency';
 import createAssetGraphRequest from './requests/AssetGraphRequest';
 import {createDevDependency, runDevDepRequest} from './requests/DevDepRequest';

--- a/packages/core/integration-tests/test/integration/diagnostic-sourcemap/index.js
+++ b/packages/core/integration-tests/test/integration/diagnostic-sourcemap/index.js
@@ -1,0 +1,13 @@
+// @flow
+
+type Test = {|
+  foo: string
+|};
+
+let test: Test = {
+	foo: 'hi'
+};
+
+import foo from 'foo';
+
+console.log(test);

--- a/packages/core/integration-tests/test/integration/diagnostic-sourcemap/index.scss
+++ b/packages/core/integration-tests/test/integration/diagnostic-sourcemap/index.scss
@@ -1,0 +1,6 @@
+$foo: red;
+
+.foo {
+  color: $foo;
+  background: url(x.png);
+}

--- a/packages/core/integration-tests/test/integration/diagnostic-sourcemap/package.json
+++ b/packages/core/integration-tests/test/integration/diagnostic-sourcemap/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "flow-bin": "*"
+  }
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3538,4 +3538,45 @@ describe('javascript', function() {
     let res = await run(b);
     assert.equal(await res, true);
   });
+
+  it('should remap locations in diagnostics using the input source map', async () => {
+    let fixture = path.join(
+      __dirname,
+      'integration/diagnostic-sourcemap/index.js',
+    );
+    let code = await inputFS.readFileSync(fixture, 'utf8');
+    await assert.rejects(
+      () =>
+        bundle(fixture, {
+          defaultTargetOptions: {
+            shouldOptimize: true,
+          },
+        }),
+      {
+        name: 'BuildError',
+        diagnostics: [
+          {
+            message: "Failed to resolve 'foo' from './index.js'",
+            origin: '@parcel/core',
+            filePath: fixture,
+            codeFrame: {
+              code,
+              codeHighlights: [
+                {
+                  start: {
+                    line: 11,
+                    column: 17,
+                  },
+                  end: {
+                    line: 11,
+                    column: 21,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    );
+  });
 });

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -69,4 +69,5 @@ export {
   matchSourceMappingURL,
   loadSourceMapUrl,
   loadSourceMap,
+  remapSourceLocation,
 } from './sourcemap';

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -5,7 +5,11 @@ import type {FilePath} from '@parcel/types';
 
 import SourceMap from '@parcel/source-map';
 import {Transformer} from '@parcel/plugin';
-import {createDependencyLocation, isURL} from '@parcel/utils';
+import {
+  createDependencyLocation,
+  isURL,
+  remapSourceLocation,
+} from '@parcel/utils';
 import postcss from 'postcss';
 import nullthrows from 'nullthrows';
 import valueParser from 'postcss-value-parser';
@@ -77,6 +81,19 @@ export default (new Transformer({
     }
 
     let program: Root = postcss.fromJSON(ast.program);
+    let originalSourceMap = await asset.getMap();
+    let createLoc = (start, specifier, lineOffset, colOffset) => {
+      let loc = createDependencyLocation(
+        start,
+        specifier,
+        lineOffset,
+        colOffset,
+      );
+      if (originalSourceMap) {
+        loc = remapSourceLocation(loc, originalSourceMap);
+      }
+      return loc;
+    };
 
     let isDirty = false;
     program.walkAtRules('import', rule => {
@@ -99,12 +116,7 @@ export default (new Transformer({
 
       if (isURL(moduleSpecifier)) {
         name.value = asset.addURLDependency(moduleSpecifier, {
-          loc: createDependencyLocation(
-            nullthrows(rule.source.start),
-            asset.filePath,
-            0,
-            8,
-          ),
+          loc: createLoc(nullthrows(rule.source.start), asset.filePath, 0, 8),
         });
       } else {
         // If this came from an inline <style> tag, don't inline the imported file. Replace with the correct URL instead.
@@ -119,12 +131,7 @@ export default (new Transformer({
         let dep = {
           moduleSpecifier,
           // Offset by 8 as it does not include `@import `
-          loc: createDependencyLocation(
-            nullthrows(rule.source.start),
-            moduleSpecifier,
-            0,
-            8,
-          ),
+          loc: createLoc(nullthrows(rule.source.start), moduleSpecifier, 0, 8),
           meta: {
             media,
           },
@@ -149,9 +156,11 @@ export default (new Transformer({
             !node.nodes[0].value.startsWith('#') // IE's `behavior: url(#default#VML)`
           ) {
             let url = asset.addURLDependency(node.nodes[0].value, {
-              loc: createDependencyLocation(
+              loc: createLoc(
                 nullthrows(decl.source.start),
                 node.nodes[0].value,
+                0,
+                node.nodes[0].sourceIndex,
               ),
             });
             isDeclDirty = node.nodes[0].value !== url;

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -263,7 +263,7 @@ export default (new Transformer({
         let start = originalMap.findClosestMapping(start_line, start_col);
         let end = originalMap.findClosestMapping(end_line, end_col);
 
-        if (start) {
+        if (start?.original) {
           if (start.source) {
             filePath = start.source;
           }
@@ -272,7 +272,7 @@ export default (new Transformer({
           start_col++; // source map columns are 0-based
         }
 
-        if (end) {
+        if (end?.original) {
           ({line: end_line, column: end_col} = end.original);
           end_col++;
 


### PR DESCRIPTION
Based on #6286 and #6238.

Fixes T-1063

This attempts to remap source locations used in diagnostics, dependencies, and symbols using the input source map. This could come from Babel or another transformer that runs before SWC, or an original source map e.g. a library with a source map. This second one is a bit questionable potentially?

Question: should this be done in core so it applies to all transformers?