### PR TITLE
fix github action benchmark rustup not found

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,11 @@ jobs:
   prBenchmarks:
     name: PR Benchmarks
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -leo pipefail {0}
     steps:
       - name: PR Benchmarks
         uses: parcel-bundler/parcel-benchmark-action@master
-        shell: bash -leo pipefail {0}
         env:
           PARCEL_BENCHMARK_APIKEY: ${{ secrets.PARCEL_BENCHMARK_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
         shell: bash -leo pipefail {0}
     steps:
       - name: PR Benchmarks
-        uses: parcel-bundler/parcel-benchmark-action@master
+        uses: Magi-KS/parcel-benchmark-action@fix-github-action-benchmark
         env:
           PARCEL_BENCHMARK_APIKEY: ${{ secrets.PARCEL_BENCHMARK_APIKEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,5 +9,6 @@ jobs:
     steps:
       - name: PR Benchmarks
         uses: parcel-bundler/parcel-benchmark-action@master
+        shell: bash -leo pipefail {0}
         env:
           PARCEL_BENCHMARK_APIKEY: ${{ secrets.PARCEL_BENCHMARK_APIKEY }}


### PR DESCRIPTION
GitHub Action benchmark is failing, this PR is attempt at fixing it.

turns out GitHub Action executes shell script in non-interactive mode, so .bashrc is not loaded by default.
https://github.community/t/self-hosted-not-using-bashrc/18358