### PR TITLE
Disable jemalloc on M1 for now

### DIFF
--- a/packages/transformers/js/Cargo.toml
+++ b/packages/transformers/js/Cargo.toml
@@ -20,7 +20,7 @@ data-encoding = "2.3.2"
 sha-1 = "0.9.4"
 dunce = "1.0.1"
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(all(target_os = "macos", not(target_arch = "aarch64")))'.dependencies]
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/packages/transformers/js/src/lib.rs
+++ b/packages/transformers/js/src/lib.rs
@@ -12,7 +12,7 @@ extern crate inflector;
 extern crate serde;
 extern crate sha1;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(target_arch = "aarch64")))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
Because we cross compile rather than building on actual M1 hardware, we don't have the right page sizes. This results in errors like:

```
bash-3.2$ yarn parcel build index.html | cat
yarn run v1.22.10
warning package.json: No license field                                                                       
$ /Users/devongovett/Downloads/test6/node_modules/.bin/parcel build index.html
Building...
<jemalloc>: Unsupported system page size
<jemalloc>: Unsupported system page size
memory allocation of 10 bytes failed
error Command failed with signal "SIGABRT".                                                                  
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

We can either disable it for now, or hard code the page sizes via environment variables: https://github.com/gnzlbg/jemallocator/blob/master/jemalloc-sys/README.md#environment-variables