### PR TITLE
Include namespace object when importing a missing symbol from a CJS asset

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-missing/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-missing/a.js
@@ -1,3 +1,3 @@
-import { x } from "./empty.js";
+import { x } from "./b.js";
 
 output = x;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-missing/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-missing/a.js
@@ -1,0 +1,3 @@
+import { x } from "./empty.js";
+
+output = x;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-missing/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-commonjs-missing/b.js
@@ -1,0 +1,1 @@
+module.exports.y = 2;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -784,6 +784,18 @@ describe('scope hoisting', function() {
       });
     });
 
+    it('supports importing from an empty asset', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-commonjs-missing/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, undefined);
+    });
+
     it('does not export reassigned CommonJS exports references', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -784,7 +784,7 @@ describe('scope hoisting', function() {
       });
     });
 
-    it('supports importing from an empty asset', async function() {
+    it('falls back when importing missing symbols from CJS', async function() {
       let b = await bundle(
         path.join(
           __dirname,


### PR DESCRIPTION
Closes #6304

A situation where the used symbols of a CJS object contains are `"x"`  while the symbols are `"*", "y"`. In this case, we insert `$id$exports$.x` at runtime, so the namespace object needs to be included.