### PR TITLE
Fix Worker regex to support Windows paths

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -67,7 +67,7 @@ export default class Worker extends EventEmitter {
       // arg parsing logic adapted from https://stackoverflow.com/a/46946420/2352201
       let opts = [''];
       let quote = false;
-      for (let c of nullthrows(process.env.NODE_OPTIONS.match(/\\?.|^$/g))) {
+      for (let c of nullthrows(process.env.NODE_OPTIONS.match(/.|^$/g))) {
         if (c === '"') {
           quote = !quote;
         } else if (!quote && c === ' ') {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Resolves #6340 by removing the part of the regex that matches the Windows path separator.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

Sending `--require \Users\jaggern\this\is\a\Windows\Path "'and\' stand"` to a Worker should now result in `[
  '--require',
  '\\Users\\jaggern\\this\\is\\a\\Windows\\Path',
  "'and\\' stand"
]` internally rather than `[ '--require', 'UsersjaggernthisisaWindowsPath', "'and' stand" ]`.

Basically, it should no longer delete `\` characters from strings.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Check if you can do anything with Parcel on Windows using Windows-style paths. This was a problem that I encountered in #6340 where parcel could not build nor serve files because it was destroying the path to the .pnp.js file (as I am using Yarn 2).

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
