### PR TITLE
Browser version of xxhash

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -20,7 +20,6 @@ import type {FileSystem, FileOptions} from '@parcel/fs';
 import invariant from 'assert';
 import {blobToStream, TapStream} from '@parcel/utils';
 import {PluginLogger} from '@parcel/logger';
-import {init as initSourcemaps} from '@parcel/source-map';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 import {Readable, Transform} from 'stream';
 import nullthrows from 'nullthrows';
@@ -268,8 +267,6 @@ export default class PackagerRunner {
     contents: Blob,
     map: ?string,
   |}> {
-    await initSourcemaps;
-
     let packaged = await this.package(bundle, bundleGraph, configs);
     let type = packaged.type ?? bundle.type;
     let res = await this.optimize(

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -37,6 +37,8 @@ import createAssetGraphRequest from './requests/AssetGraphRequest';
 import createValidationRequest from './requests/ValidationRequest';
 import createBundleGraphRequest from './requests/BundleGraphRequest';
 import {Disposable} from '@parcel/events';
+import {init as initSourcemaps} from '@parcel/source-map';
+import {init as initHash} from '@parcel/hash';
 
 registerCoreWithSerializer();
 
@@ -82,6 +84,9 @@ export default class Parcel {
     if (this.#initialized) {
       return;
     }
+
+    await initSourcemaps;
+    await initHash;
 
     let resolvedOptions: ParcelOptions = await resolveOptions(
       this.#initialOptions,

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -24,7 +24,6 @@ import path from 'path';
 import nullthrows from 'nullthrows';
 import {normalizeSeparators, objectSortedEntries} from '@parcel/utils';
 import logger, {PluginLogger} from '@parcel/logger';
-import {init as initSourcemaps} from '@parcel/source-map';
 import ThrowableDiagnostic, {
   errorToDiagnostic,
   escapeMarkdown,
@@ -113,8 +112,6 @@ export default class Transformation {
   }
 
   async run(): Promise<TransformationResult> {
-    await initSourcemaps;
-
     let asset = await this.loadAsset();
 
     if (!asset.mapBuffer && SOURCEMAP_EXTENSIONS.has(asset.value.type)) {

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -17,6 +17,8 @@ import Validation, {type ValidationOpts} from './Validation';
 import ParcelConfig from './ParcelConfig';
 import {registerCoreWithSerializer} from './utils';
 import {clearBuildCaches} from './buildCache';
+import {init as initSourcemaps} from '@parcel/source-map';
+import {init as initHash} from '@parcel/hash';
 
 import '@parcel/cache'; // register with serializer
 import '@parcel/package-manager';
@@ -50,6 +52,8 @@ function loadOptions(ref, workerApi) {
 }
 
 async function loadConfig(cachePath, options) {
+  await initSourcemaps;
+  await initHash;
   let config = parcelConfigCache.get(cachePath);
   if (config && config.options === options) {
     return config;
@@ -74,6 +78,8 @@ export async function runTransform(
   workerApi: WorkerApi,
   opts: WorkerTransformationOpts,
 ): Promise<TransformationResult> {
+  await initSourcemaps;
+  await initHash;
   let {optionsRef, configCachePath, ...rest} = opts;
   let options = loadOptions(optionsRef, workerApi);
   let config = await loadConfig(configCachePath, options);
@@ -90,6 +96,8 @@ export async function runValidate(
   workerApi: WorkerApi,
   opts: WorkerValidationOpts,
 ): Promise<void> {
+  await initSourcemaps;
+  await initHash;
   let {optionsRef, configCachePath, ...rest} = opts;
   let options = loadOptions(optionsRef, workerApi);
   let config = await loadConfig(configCachePath, options);
@@ -122,6 +130,8 @@ export async function runPackage(
     optionsRef: SharedReference,
   |},
 ): Promise<BundleInfo> {
+  await initSourcemaps;
+  await initHash;
   let bundleGraph = workerApi.getSharedReference(bundleGraphReference);
   invariant(bundleGraph instanceof BundleGraph);
   let options = loadOptions(optionsRef, workerApi);

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -52,8 +52,6 @@ function loadOptions(ref, workerApi) {
 }
 
 async function loadConfig(cachePath, options) {
-  await initSourcemaps;
-  await initHash;
   let config = parcelConfigCache.get(cachePath);
   if (config && config.options === options) {
     return config;
@@ -78,8 +76,6 @@ export async function runTransform(
   workerApi: WorkerApi,
   opts: WorkerTransformationOpts,
 ): Promise<TransformationResult> {
-  await initSourcemaps;
-  await initHash;
   let {optionsRef, configCachePath, ...rest} = opts;
   let options = loadOptions(optionsRef, workerApi);
   let config = await loadConfig(configCachePath, options);
@@ -96,8 +92,6 @@ export async function runValidate(
   workerApi: WorkerApi,
   opts: WorkerValidationOpts,
 ): Promise<void> {
-  await initSourcemaps;
-  await initHash;
   let {optionsRef, configCachePath, ...rest} = opts;
   let options = loadOptions(optionsRef, workerApi);
   let config = await loadConfig(configCachePath, options);
@@ -130,8 +124,6 @@ export async function runPackage(
     optionsRef: SharedReference,
   |},
 ): Promise<BundleInfo> {
-  await initSourcemaps;
-  await initHash;
   let bundleGraph = workerApi.getSharedReference(bundleGraphReference);
   invariant(bundleGraph instanceof BundleGraph);
   let options = loadOptions(optionsRef, workerApi);
@@ -161,6 +153,11 @@ export async function runPackage(
     (await runner.getBundleInfoFromCache(cacheKeys.info)) ??
     runner.getBundleInfo(bundle, bundleGraph, cacheKeys, configs)
   );
+}
+
+export async function childInit() {
+  await initSourcemaps;
+  await initHash;
 }
 
 const PKG_RE = /node_modules[/\\]((?:@[^/\\]+[/\\][^/\\]+)|[^/\\]+)(?!.*[/\\]node_modules[/\\])/;

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -68,6 +68,7 @@ export default class WorkerFarm extends EventEmitter {
   callQueue: Array<WorkerCall> = [];
   ending: boolean = false;
   localWorker: WorkerModule;
+  localWorkerInit: ?Promise<void>;
   options: FarmOptions;
   run: HandleFunction;
   warmWorkers: number = 0;
@@ -95,6 +96,8 @@ export default class WorkerFarm extends EventEmitter {
 
     // $FlowFixMe this must be dynamic
     this.localWorker = require(this.options.workerPath);
+    this.localWorkerInit =
+      this.localWorker.childInit != null ? this.localWorker.childInit() : null;
     this.run = this.createHandle('run');
 
     this.startMaxWorkers();
@@ -173,7 +176,7 @@ export default class WorkerFarm extends EventEmitter {
   }
 
   createHandle(method: string): HandleFunction {
-    return (...args) => {
+    return async (...args) => {
       // Child process workers are slow to start (~600ms).
       // While we're waiting, just run on the main thread.
       // This significantly speeds up startup time.
@@ -187,6 +190,11 @@ export default class WorkerFarm extends EventEmitter {
         let processedArgs = restoreDeserializedObject(
           prepareForSerialization([...args, false]),
         );
+
+        if (this.localWorkerInit != null) {
+          await this.localWorkerInit;
+          this.localWorkerInit = null;
+        }
         return this.localWorker[method](this.workerApi, ...processedArgs);
       }
     };

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -93,10 +93,14 @@ export class Child {
     this.child.send(data);
   }
 
-  childInit(module: string, childId: number): void {
+  async childInit(module: string, childId: number): Promise<void> {
     // $FlowFixMe this must be dynamic
     this.module = require(module);
     this.childId = childId;
+
+    if (this.module.childInit != null) {
+      await this.module.childInit();
+    }
   }
 
   async handleRequest(data: WorkerRequest): Promise<void> {
@@ -136,7 +140,7 @@ export class Child {
           unpatchConsole();
         }
 
-        result = responseFromContent(this.childInit(moduleName, child));
+        result = responseFromContent(await this.childInit(moduleName, child));
       } catch (e) {
         result = errorResponseFromError(e);
       }

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -44,8 +44,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "1.0.4",
-    "self-published": "npm:@parcel/transformer-js@2.0.0-beta.3.1",
-    "tiny-benchy": "^1.0.1"
+    "self-published": "npm:@parcel/transformer-js@2.0.0-beta.3.1"
   },
   "scripts": {
     "build": "napi build --platform --cargo-cwd napi",

--- a/packages/utils/hash/benchmark.js
+++ b/packages/utils/hash/benchmark.js
@@ -1,0 +1,85 @@
+const Benchmark = require('tiny-benchy');
+const crypto = require('crypto');
+const rust = require('./index.js');
+const wasm = require('./browser.js');
+
+const suite = new Benchmark(10000);
+
+suite.add('md5 crypto', () => {
+  crypto
+    .createHash('md5')
+    .update('hello world')
+    .digest('hex');
+});
+
+suite.add('hashString small rust', () => {
+  rust.hashString('hello world');
+});
+
+suite.add('hashString small wasm', () => {
+  wasm.hashString('hello world');
+});
+
+suite.add('hashString large rust', () => {
+  rust.hashString('hello world'.repeat(10000));
+});
+
+suite.add('hashString large wasm', () => {
+  wasm.hashString('hello world'.repeat(10000));
+});
+
+suite.add('hashBuffer small rust', () => {
+  rust.hashBuffer(Buffer.from('hello world'));
+});
+
+suite.add('hashBuffer small wasm', () => {
+  wasm.hashBuffer(Buffer.from('hello world'));
+});
+
+suite.add('hashBuffer large rust', () => {
+  rust.hashBuffer(Buffer.alloc(100000));
+});
+
+suite.add('hashBuffer large wasm', () => {
+  wasm.hashBuffer(Buffer.alloc(100000));
+});
+
+suite.add('object small rust', () => {
+  let h = new rust.Hash();
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeString('hello world');
+  h.finish();
+});
+
+suite.add('object small wasm', () => {
+  let h = new wasm.Hash();
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeBuffer(Buffer.from('hello'));
+  h.writeString('hello world');
+  h.finish();
+});
+
+suite.add('object big rust', () => {
+  let h = new rust.Hash();
+  h.writeBuffer(Buffer.alloc(100000));
+  h.writeString('hello world');
+  h.finish();
+});
+
+suite.add('object big wasm', () => {
+  let h = new wasm.Hash();
+  h.writeBuffer(Buffer.alloc(100000));
+  h.writeString('hello world');
+  h.finish();
+});
+
+wasm.init.then(() => {
+  suite.run();
+});

--- a/packages/utils/hash/browser.js
+++ b/packages/utils/hash/browser.js
@@ -1,0 +1,75 @@
+// @flow
+import xxhash from 'xxhash-wasm';
+
+let h64Raw;
+export const init: Promise<void> = xxhash().then(xxh => {
+  ({h64Raw} = xxh);
+});
+
+const encoder = new TextEncoder();
+export function hashString(s: string): string {
+  return toHex(h64Raw(encoder.encode(s)));
+}
+export function hashBuffer(b: Uint8Array): string {
+  return toHex(h64Raw(b));
+}
+export class Hash {
+  data: Array<Uint8Array>;
+  constructor() {
+    this.data = [];
+  }
+  writeString(s: string) {
+    this.data.push(encoder.encode(s));
+  }
+  writeBuffer(b: Uint8Array) {
+    this.data.push(b);
+  }
+  finish(): string {
+    return hashBuffer(concatUint8Arrays(this.data));
+  }
+}
+
+function concatUint8Arrays(arrays: Array<Uint8Array>): Uint8Array {
+  let totalLength = 0;
+  for (let a of arrays) {
+    totalLength += a.byteLength;
+  }
+  let result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (let a of arrays) {
+    result.set(a, offset);
+    offset += a.byteLength;
+  }
+  return result;
+}
+
+// https://blog.xaymar.com/2020/12/08/fastest-uint8array-to-hex-string-conversion-in-javascript/
+const LUT_HEX_4b = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  'a',
+  'b',
+  'c',
+  'd',
+  'e',
+  'f',
+];
+const LUT_HEX_8b = new Array(0x100);
+for (let n = 0; n < 0x100; n++) {
+  LUT_HEX_8b[n] = `${LUT_HEX_4b[(n >>> 4) & 0xf]}${LUT_HEX_4b[n & 0xf]}`;
+}
+function toHex(buffer) {
+  let out = '';
+  for (let idx = 0, edx = buffer.length; idx < edx; idx++) {
+    out += LUT_HEX_8b[buffer[idx]];
+  }
+  return out;
+}

--- a/packages/utils/hash/browser.js
+++ b/packages/utils/hash/browser.js
@@ -1,35 +1,38 @@
 // @flow
-import xxhash from 'xxhash-wasm';
+const xxhash = require('xxhash-wasm');
 
 let h64, h64Raw;
-export const init: Promise<void> = xxhash().then(xxh => {
+module.exports.init = (xxhash().then(xxh => {
   ({h64, h64Raw} = xxh);
-});
+}) /*: Promise<void> */);
 
 const encoder = new TextEncoder();
-export function hashString(s: string): string {
+function hashString(s /*: string */) /*: string */ {
   return h64(s);
 }
-export function hashBuffer(b: Uint8Array): string {
+module.exports.hashString = hashString;
+function hashBuffer(b /*: Uint8Array */) /*: string */ {
   return toHex(h64Raw(b));
 }
-export class Hash {
-  data: Array<Uint8Array>;
+module.exports.hashBuffer = hashBuffer;
+class Hash {
+  /*:: data: Array<Uint8Array>; */
   constructor() {
     this.data = [];
   }
-  writeString(s: string) {
+  writeString(s /*: string */) {
     this.data.push(encoder.encode(s));
   }
-  writeBuffer(b: Uint8Array) {
+  writeBuffer(b /*: Uint8Array */) {
     this.data.push(b);
   }
-  finish(): string {
+  finish() /*: string */ {
     return hashBuffer(concatUint8Arrays(this.data));
   }
 }
+module.exports.Hash = Hash;
 
-function concatUint8Arrays(arrays: Array<Uint8Array>): Uint8Array {
+function concatUint8Arrays(arrays) {
   let totalLength = 0;
   for (let a of arrays) {
     totalLength += a.byteLength;

--- a/packages/utils/hash/index.js
+++ b/packages/utils/hash/index.js
@@ -21,3 +21,5 @@ if (process.env.PARCEL_BUILD_ENV === 'production') {
   // This has to be published first...
   // module.exports = require('self-published');
 }
+
+module.exports.init = Promise.resolve();

--- a/packages/utils/hash/index.js.flow
+++ b/packages/utils/hash/index.js.flow
@@ -1,5 +1,6 @@
 // @flow
 
+declare export var init: Promise<void>;
 declare export function hashString(s: string): string;
 declare export function hashBuffer(b: Buffer): string;
 declare export class Hash {

--- a/packages/utils/hash/package.json
+++ b/packages/utils/hash/package.json
@@ -2,6 +2,8 @@
   "name": "@parcel/hash",
   "version": "2.0.0-beta.3.1",
   "license": "MIT",
+  "main": "index.js",
+  "browser": "browser.js",
   "publishConfig": {
     "access": "public"
   },
@@ -17,7 +19,9 @@
     "node": ">= 12.0.0"
   },
   "files": [
+    "browser.js",
     "index.js",
+    "index.js.flow",
     "*.node"
   ],
   "napi": {
@@ -28,7 +32,8 @@
     "build-release": "napi build --platform --release"
   },
   "dependencies": {
-    "detect-libc": "^1.0.3"
+    "detect-libc": "^1.0.3",
+    "xxhash-wasm": "^0.4.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "1.0.4"

--- a/packages/utils/hash/package.json
+++ b/packages/utils/hash/package.json
@@ -36,6 +36,7 @@
     "xxhash-wasm": "^0.4.1"
   },
   "devDependencies": {
-    "@napi-rs/cli": "1.0.4"
+    "@napi-rs/cli": "1.0.4",
+    "tiny-benchy": "^1.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8899,7 +8899,12 @@ mz@^2.5.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.12.1, nan@^2.14.2:
+nan@^2.12.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
+nan@^2.14.2:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
@@ -13971,6 +13976,11 @@ xtend@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.2.0.tgz#eef6b1f198c1c8deafad8b1765a04dad4a01c5a9"
   integrity sha1-7vax8ZjByN6vrYsXZaBNrUoBxak=
+
+xxhash-wasm@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/xxhash-wasm/-/xxhash-wasm-0.4.1.tgz#4795fdf243d01f03a17ac37d2ed92d001f3a1b5e"
+  integrity sha512-sAaACjH5Th5O2Y1Pl6Mm03bHdie8htTm7ZG146by2ITXuxD1Ksx46ZEOYaDhtlCY3fHrmDfdvzTOGzO1R00COA==
 
 y18n@^3.2.1:
   version "3.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12613,7 +12613,7 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-benchy@^1.0.1:
+tiny-benchy@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-benchy/-/tiny-benchy-1.0.2.tgz#ed13db50876b54ded3d4cdf7710a5c2856b234ae"
   integrity sha512-IpawVd9wuRyVXyajQ/La9ugQXKJohIEA6ufdPZsNuqOH7U4//xq4ivc7YdyCBshYccrUJovwYhMKWhxwdFgDsA==


### PR DESCRIPTION
This is much easier and smaller than a wasm version of the existing Rust code (because wasm can't leverage hashing a buffer without copying anyway)

Depends on https://github.com/parcel-bundler/parcel/pull/6373

- [x] call `await init()` at an appropriate place
- [x] benchmark (out of curiousity):
```
md5 crypto 301,998.58 opts/sec (mean: 0.003ms, stddev: 0.022ms, 10,000 samples)
hashString small rust 879,952.48 opts/sec (mean: 0.001ms, stddev: 0.013ms, 10,000 samples)
hashString small wasm 368,596.74 opts/sec (mean: 0.003ms, stddev: 0.012ms, 10,000 samples)
hashString large rust 7,885.93 opts/sec (mean: 0.127ms, stddev: 0.045ms, 10,000 samples)
hashString large wasm 7,265.14 opts/sec (mean: 0.138ms, stddev: 0.043ms, 10,000 samples)
hashBuffer small rust 729,925.99 opts/sec (mean: 0.001ms, stddev: 0.008ms, 10,000 samples)
hashBuffer small wasm 437,063.34 opts/sec (mean: 0.002ms, stddev: 0.012ms, 10,000 samples)
hashBuffer large rust 41,663.71 opts/sec (mean: 0.024ms, stddev: 0.121ms, 10,000 samples)
hashBuffer large wasm 42,099.39 opts/sec (mean: 0.024ms, stddev: 0.017ms, 10,000 samples)
object small rust 137,315.77 opts/sec (mean: 0.007ms, stddev: 0.024ms, 10,000 samples)
object small wasm 204,852.2 opts/sec (mean: 0.005ms, stddev: 0.025ms, 10,000 samples)
object big rust 44,933.61 opts/sec (mean: 0.022ms, stddev: 0.029ms, 10,000 samples)
object big wasm 28,529.95 opts/sec (mean: 0.035ms, stddev: 0.092ms, 10,000 samples)
```