### PR TITLE
Don't rerun request if another instance is still running (and not finished)

### DIFF
--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -6,6 +6,7 @@ import RequestTracker from '../src/RequestTracker';
 import WorkerFarm from '@parcel/workers';
 import {DEFAULT_OPTIONS} from './test-utils';
 import {INITIAL_BUILD} from '../src/constants';
+import {makeDeferredWithPromise} from '@parcel/utils';
 
 const options = DEFAULT_OPTIONS;
 const farm = new WorkerFarm({workerPath: require.resolve('../src/worker.js')});
@@ -149,7 +150,7 @@ describe('RequestTracker', () => {
       },
       input: null,
     });
-    let result = await await tracker.runRequest({
+    let result = await tracker.runRequest({
       id: 'abc',
       type: 'mock_request',
       run: async () => {},
@@ -181,5 +182,52 @@ describe('RequestTracker', () => {
         .map(req => req.id)
         .includes('abc'),
     );
+  });
+
+  it('should not requeue requests if the previous request is still running', async () => {
+    let tracker = new RequestTracker({farm, options});
+
+    let lockA = makeDeferredWithPromise();
+    let lockB = makeDeferredWithPromise();
+
+    let requestA = tracker.runRequest({
+      id: 'abc',
+      type: 'mock_request',
+      run: async ({api}) => {
+        await lockA.promise;
+        api.storeResult('a');
+        return 'a';
+      },
+      input: null,
+    });
+
+    let calledB = false;
+    let requestB = tracker.runRequest({
+      id: 'abc',
+      type: 'mock_request',
+      run: async ({api}) => {
+        calledB = true;
+        await lockB.promise;
+        api.storeResult('b');
+        return 'b';
+      },
+      input: null,
+    });
+
+    lockA.deferred.resolve();
+    lockB.deferred.resolve();
+    let resultA = await requestA;
+    let resultB = await requestB;
+    assert.strictEqual(resultA, 'a');
+    assert.strictEqual(resultB, 'a');
+    assert.strictEqual(calledB, false);
+
+    let cachedResult = await tracker.runRequest({
+      id: 'abc',
+      type: 'mock_request',
+      run: () => {},
+      input: null,
+    });
+    assert.strictEqual(cachedResult, 'a');
   });
 });

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -1,5 +1,6 @@
 // @flow strict-local
 export type * from './config';
+export type * from './Deferred';
 export type * from './generateBuildMetrics';
 export type * from './prettyDiagnostic';
 export type * from './schema';


### PR DESCRIPTION
Fixes a race condition (which only really seems to happen with `PARCEL_WORKERS=0`) that caused this error:
```
Error: Got unexpected undefined
    at nullthrows (.../node_modules/nullthrows/nullthrows.js:7:15)
    at Object.run (.../packages/core/core/src/requests/DevDepRequest.js:152:28)
    at RequestTracker.runRequest (.../packages/core/core/src/RequestTracker.js:770:34)
    at Object.runRequest (.../packages/core/core/src/RequestTracker.js:837:21)
    at runDevDepRequest (.../packages/core/core/src/requests/DevDepRequest.js:144:13)
    at Object.run (.../packages/core/core/src/requests/AssetRequest.js:161:11)
    at RequestTracker.runRequest (.../packages/core/core/src/RequestTracker.js:770:20)
    at AssetGraphBuilder.runAssetRequest (.../packages/core/core/src/requests/AssetGraphRequest.js:810:18)
    at PromiseQueue._runFn (.../packages/core/utils/src/PromiseQueue.js:85:7)
    at PromiseQueue._next (.../packages/core/utils/src/PromiseQueue.js:74:5)
```

This happened because a situation like
```js
await Promise.all([
	tracker.runRequest({id: "x", run: ...}),
	tracker.runRequest({id: "x", run: ...})
]
```
would actually invoke both `run` callbacks ("concurrently"). Instead, the second `runRequest` now waits for the result of the first `runRequest` and returns that without rerunning the request. So in that regard, it is equivalent to

```js
await tracker.runRequest({id: "x", run: ...});
await tracker.runRequest({id: "x", run: ...});
```
