### PR TITLE
Declare babylon-traverse as a dependency of babel-ast-utils

### DIFF
--- a/packages/shared/babel-ast-utils/package.json
+++ b/packages/shared/babel-ast-utils/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.0.0",
+    "@parcel/babylon-walk": "2.0.0-beta.3.1",
     "@parcel/source-map": "2.0.0-rc.4",
     "@parcel/utils": "2.0.0-beta.3.1",
     "astring": "^1.6.2"


### PR DESCRIPTION
Used here:

https://github.com/parcel-bundler/parcel/blob/b636a99a7b66ad03b4c0dfbb9d9a02d61059ca87/packages/shared/babel-ast-utils/src/index.js#L19