### PR TITLE
swc wasm: convert HashMap to objects directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ version = "0.1.0"
 dependencies = [
  "js-sys",
  "parcel-js-swc-core",
+ "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
 ]
@@ -827,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515286919c7a28f96c362f42cd42aec7ef6d417334118be69d1ad96160aa5f5"
+checksum = "1102fa7714968fcf70fd8efa29fb3b189e20ef0e7701fbab9634384dda034bf3"
 dependencies = [
  "fnv",
  "js-sys",

--- a/packages/transformers/js/native-browser.js
+++ b/packages/transformers/js/native-browser.js
@@ -8,29 +8,6 @@ function transformWrapper(config) {
     ...result,
     // Hydrate Uint8Array into Buffer
     code: Buffer.from(result.code.buffer),
-    // https://github.com/cloudflare/serde-wasm-bindgen/issues/10
-    dependencies: result.dependencies?.map(d => ({
-      ...d,
-      attributes:
-        d.attributes != null
-          ? Object.fromEntries([...d.attributes])
-          : undefined,
-    })),
-    hoist_result:
-      result.hoist_result != null
-        ? {
-            ...result.hoist_result,
-            imported_symbols: Object.fromEntries([
-              ...result.hoist_result.imported_symbols,
-            ]),
-            exported_symbols: Object.fromEntries([
-              ...result.hoist_result.exported_symbols,
-            ]),
-            dynamic_imports: Object.fromEntries([
-              ...result.hoist_result.dynamic_imports,
-            ]),
-          }
-        : undefined,
   };
 }
 

--- a/packages/transformers/js/native.js
+++ b/packages/transformers/js/native.js
@@ -24,29 +24,6 @@ if (process.env.PARCEL_BUILD_ENV === 'production') {
       ...result,
       // Hydrate Uint8Array into Buffer
       code: Buffer.from(result.code.buffer),
-      // https://github.com/cloudflare/serde-wasm-bindgen/issues/10
-      dependencies: result.dependencies?.map(d => ({
-        ...d,
-        attributes:
-          d.attributes != null
-            ? Object.fromEntries([...d.attributes])
-            : undefined,
-      })),
-      hoist_result:
-        result.hoist_result != null
-          ? {
-              ...result.hoist_result,
-              imported_symbols: Object.fromEntries([
-                ...result.hoist_result.imported_symbols,
-              ]),
-              exported_symbols: Object.fromEntries([
-                ...result.hoist_result.exported_symbols,
-              ]),
-              dynamic_imports: Object.fromEntries([
-                ...result.hoist_result.dynamic_imports,
-              ]),
-            }
-          : undefined,
     };
   };
 } else if (require('fs').existsSync(require('path').join(__dirname, name))) {

--- a/packages/transformers/js/wasm/Cargo.toml
+++ b/packages/transformers/js/wasm/Cargo.toml
@@ -10,5 +10,6 @@ crate-type = ["cdylib"]
 [dependencies]
 js-sys = "0.3"
 parcel-js-swc-core = { path = "../core" }
-serde-wasm-bindgen = "0.2.0"
+serde = "1"
+serde-wasm-bindgen = "0.3.0"
 wasm-bindgen = "0.2"

--- a/packages/transformers/js/wasm/src/lib.rs
+++ b/packages/transformers/js/wasm/src/lib.rs
@@ -1,14 +1,17 @@
 extern crate parcel_js_swc_core;
 
 use js_sys::Error;
-use serde_wasm_bindgen;
+use serde::ser::Serialize;
+use serde_wasm_bindgen::{from_value, Serializer};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn transform(config_val: JsValue) -> Result<JsValue, JsValue> {
-  let config: parcel_js_swc_core::Config =
-    serde_wasm_bindgen::from_value(config_val).map_err(|err| JsValue::from(err))?;
+  let config: parcel_js_swc_core::Config = from_value(config_val).map_err(JsValue::from)?;
+
   let result = parcel_js_swc_core::transform(config)
     .map_err(|e| Error::from(JsValue::from_str(&e.to_string())))?;
-  Ok(serde_wasm_bindgen::to_value(&result).map_err(|err| JsValue::from(err))?)
+
+  let serializer = Serializer::new().serialize_maps_as_objects(true);
+  Ok(result.serialize(&serializer).map_err(JsValue::from)?)
 }


### PR DESCRIPTION
Leverage https://github.com/cloudflare/serde-wasm-bindgen/pull/12 to avoid additional wrapper code