### PR TITLE
Replace imports for assets importing themselves

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-self/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-self/a.js
@@ -1,0 +1,3 @@
+const { b } = require("./b.js");
+
+output = b;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-self/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/require-self/b.js
@@ -1,0 +1,4 @@
+const other = require("./b.js");
+module.exports.a = 3;
+module.exports.b = other.a + 1;
+

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-self/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-self/a.js
@@ -1,0 +1,3 @@
+import { b } from "./b.js";
+
+output = b;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-self/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-self/b.js
@@ -1,0 +1,3 @@
+import * as other from "./b.js";
+export const a = 3;
+export const b = other.a + 1;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1779,6 +1779,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'foo');
     });
 
+    it('should support assets importing themselves', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-self/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, 4);
+    });
+
     it('should support named imports on wrapped modules', async function() {
       let b = await bundle(
         path.join(
@@ -4400,6 +4412,18 @@ describe('scope hoisting', function() {
         },
       });
       assert.deepEqual(output, 'my-resolved-fs');
+    });
+
+    it('should support assets requiring themselves', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/require-self/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, 4);
     });
 
     it('supports requiring a re-exported ES6 import', async function() {

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -544,7 +544,7 @@ ${code}
         }
       }
 
-      if (!resolved || resolved === asset) {
+      if (!resolved) {
         continue;
       }
 


### PR DESCRIPTION
Closes T-1024

Allows cases like

```js
// other.js:
import * as other from "./other.js";
export const a = 1;
export const b = other.a + 1;
```

Previously, `$id$import$other` was never replaced