### PR TITLE
Fixups for browsers

### DIFF
--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -9,11 +9,11 @@ import type {
 } from '@parcel/types';
 import type {Asset, Dependency, ParcelOptions} from './types';
 
-import v8 from 'v8';
 import {Readable} from 'stream';
 import SourceMap from '@parcel/source-map';
 import {bufferStream, blobToStream, streamFromPromise} from '@parcel/utils';
 import {getConfig, generateFromAST} from './assetUtils';
+import {deserializeRaw} from './serializer';
 
 export default class CommittedAsset {
   value: Asset;
@@ -131,10 +131,7 @@ export default class CommittedAsset {
     if (this.ast == null) {
       this.ast = this.options.cache
         .getBlob(this.value.astKey)
-        .then(serializedAst =>
-          // $FlowFixMe
-          v8.deserialize(serializedAst),
-        );
+        .then(serializedAst => deserializeRaw(serializedAst));
     }
 
     return this.ast;

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -19,7 +19,6 @@ import type {
   ParcelOptions,
 } from './types';
 
-import v8 from 'v8';
 import invariant from 'assert';
 import {Readable} from 'stream';
 import SourceMap from '@parcel/source-map';
@@ -32,6 +31,7 @@ import {
   SOURCEMAP_RE,
 } from '@parcel/utils';
 import {hashString} from '@parcel/hash';
+import {serializeRaw} from './serializer';
 import {createDependency, mergeDependencies} from './Dependency';
 import {mergeEnvironments} from './Environment';
 import {PARCEL_VERSION} from './constants';
@@ -120,11 +120,7 @@ export default class UncommittedAsset {
         mapKey != null &&
         this.options.cache.setBlob(mapKey, this.mapBuffer),
       astKey != null &&
-        this.options.cache.setBlob(
-          astKey,
-          // $FlowFixMe
-          v8.serialize(this.ast),
-        ),
+        this.options.cache.setBlob(astKey, serializeRaw(this.ast)),
     ]);
     this.value.contentKey = contentKey;
     this.value.mapKey = mapKey;

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -10,7 +10,7 @@ import type {Config, ParcelOptions} from '../types';
 import type {LoadedPlugin} from '../ParcelConfig';
 import type {RunAPI} from '../RequestTracker';
 
-import v8 from 'v8';
+import {serializeRaw} from '../serializer.js';
 import {PluginLogger} from '@parcel/logger';
 import PluginOptions from '../public/PluginOptions';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
@@ -139,8 +139,7 @@ export async function getConfigHash(
       );
     } else if (config.result != null) {
       try {
-        // $FlowFixMe
-        hash.writeBuffer(v8.serialize(config.result));
+        hash.writeBuffer(serializeRaw(config.result));
       } catch (err) {
         throw new ThrowableDiagnostic({
           diagnostic: {

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -3,14 +3,13 @@
 import type {FilePath, InitialParcelOptions} from '@parcel/types';
 import type {ParcelOptions} from './types';
 
-import {getRootDir} from '@parcel/utils';
-import loadDotEnv from './loadDotEnv';
 import path from 'path';
-import {resolveConfig} from '@parcel/utils';
 import {hashString} from '@parcel/hash';
 import {NodeFS} from '@parcel/fs';
 import {LMDBCache, FSCache} from '@parcel/cache';
 import {NodePackageManager} from '@parcel/package-manager';
+import {getRootDir, resolveConfig} from '@parcel/utils';
+import loadDotEnv from './loadDotEnv';
 
 // Default cache directory name
 const DEFAULT_CACHE_DIRNAME = '.parcel-cache';
@@ -26,21 +25,26 @@ function generateInstanceId(entries: Array<FilePath>): string {
 export default async function resolveOptions(
   initialOptions: InitialParcelOptions,
 ): Promise<ParcelOptions> {
+  let inputFS = initialOptions.inputFS || new NodeFS();
+  let outputFS = initialOptions.outputFS || new NodeFS();
+
+  let inputCwd = inputFS.cwd();
+  let outputCwd = outputFS.cwd();
+
   let entries: Array<FilePath>;
   if (initialOptions.entries == null || initialOptions.entries === '') {
     entries = [];
   } else if (Array.isArray(initialOptions.entries)) {
-    entries = initialOptions.entries.map(entry => path.resolve(entry));
+    entries = initialOptions.entries.map(entry =>
+      path.resolve(inputCwd, entry),
+    );
   } else {
-    entries = [path.resolve(initialOptions.entries)];
+    entries = [path.resolve(inputCwd, initialOptions.entries)];
   }
-
-  let inputFS = initialOptions.inputFS || new NodeFS();
-  let outputFS = initialOptions.outputFS || new NodeFS();
 
   let entryRoot =
     initialOptions.entryRoot != null
-      ? path.resolve(initialOptions.entryRoot)
+      ? path.resolve(inputCwd, initialOptions.entryRoot)
       : getRootDir(entries);
 
   let projectRootFile =
@@ -49,7 +53,7 @@ export default async function resolveOptions(
       path.join(entryRoot, 'index'),
       [...LOCK_FILE_NAMES, '.git', '.hg'],
       path.parse(entryRoot).root,
-    )) || path.join(inputFS.cwd(), 'index'); // ? Should this just be rootDir
+    )) || path.join(inputCwd, 'index'); // ? Should this just be rootDir
 
   let lockFile = null;
   let rootFileName = path.basename(projectRootFile);
@@ -62,9 +66,6 @@ export default async function resolveOptions(
     initialOptions.packageManager ||
     new NodePackageManager(inputFS, projectRoot);
 
-  let inputCwd = inputFS.cwd();
-  let outputCwd = outputFS.cwd();
-
   let cacheDir =
     // If a cacheDir is provided, resolve it relative to cwd. Otherwise,
     // use a default directory resolved relative to the project root.
@@ -73,9 +74,10 @@ export default async function resolveOptions(
       : path.resolve(projectRoot, DEFAULT_CACHE_DIRNAME);
 
   let cache =
-    initialOptions.cache ?? outputFS instanceof NodeFS
+    initialOptions.cache ??
+    (outputFS instanceof NodeFS
       ? new LMDBCache(cacheDir)
-      : new FSCache(outputFS, cacheDir);
+      : new FSCache(outputFS, cacheDir));
 
   let mode = initialOptions.mode ?? 'development';
   let shouldOptimize =

--- a/packages/core/core/src/serializer.js
+++ b/packages/core/core/src/serializer.js
@@ -2,6 +2,11 @@
 import v8 from 'v8';
 import {createBuildCache} from './buildCache';
 
+// $FlowFixMe - Flow doesn't know about this method yet
+export let serializeRaw = v8.serialize;
+// $FlowFixMe - Flow doesn't know about this method yet
+export let deserializeRaw = v8.deserialize;
+
 const nameToCtor: Map<string, Class<*>> = new Map();
 const ctorToName: Map<Class<*>, string> = new Map();
 
@@ -233,13 +238,11 @@ export function serialize(object: any): Buffer {
   }
 
   let mapped = prepareForSerialization(object);
-  // $FlowFixMe - flow doesn't know about this method yet
-  return v8.serialize(mapped);
+  return serializeRaw(mapped);
 }
 
 export function deserialize(buffer: Buffer): any {
-  // $FlowFixMe - flow doesn't know about this method yet
-  let obj = v8.deserialize(buffer);
+  let obj = deserializeRaw(buffer);
   return restoreDeserializedObject(obj);
 }
 

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -669,7 +669,7 @@ class FSError extends Error {
     this.name = 'FSError';
     this.code = code;
     this.path = path;
-    Error.captureStackTrace(this, this.constructor);
+    Error.captureStackTrace?.(this, this.constructor);
   }
 }
 
@@ -920,7 +920,7 @@ function makeShared(contents: Buffer | string): Buffer {
   if (typeof contents === 'string') {
     buffer.write(contents);
   } else {
-    contents.copy(buffer);
+    buffer.set(contents);
   }
 
   return buffer;


### PR DESCRIPTION
1. `SharedArrayBuffer.prototype.copy` doesn't exist in browsers. `set` does the same
2. `Error.captureStackTrace` exists only in chrome
3. Abstract all uses of `v8` into `serialize.js`
4. Resolve entries relative to `inputFS.cwd()`, not `process.cwd()`