### PR TITLE
API audit: Refactor dependency options

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -216,11 +216,13 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     let depNodes = targets.map(target => {
       let node = nodeFromDep(
         createDependency({
-          moduleSpecifier: entry.filePath,
+          specifier: entry.filePath,
+          specifierType: 'esm', // ???
           pipeline: target.pipeline,
           target: target,
           env: target.env,
           isEntry: true,
+          needsStableName: true,
           symbols: target.env.isLibrary
             ? new Map([['*', {local: '*', isWeak: true, loc: null}]])
             : undefined,
@@ -423,9 +425,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
 
       let dependentAssets = [];
       for (let dep of asset.dependencies.values()) {
-        let dependentAsset = assets.find(
-          a => a.uniqueKey === dep.moduleSpecifier,
-        );
+        let dependentAsset = assets.find(a => a.uniqueKey === dep.specifier);
         if (dependentAsset) {
           dependentAssetKeys.push(dependentAsset.uniqueKey);
           dependentAssets.push(dependentAsset);
@@ -470,7 +470,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
         depNode.value.meta = existing.value.meta;
       }
       let dependentAsset = dependentAssets.find(
-        a => a.uniqueKey === dep.moduleSpecifier,
+        a => a.uniqueKey === dep.specifier,
       );
       if (dependentAsset) {
         depNode.complete = true;

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -25,6 +25,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import {objectSortedEntriesDeep} from '@parcel/utils';
 import {Hash, hashString} from '@parcel/hash';
+import {Priority} from './types';
 
 import {getBundleGroupId, getPublicId} from './utils';
 import {ALL_EDGE_TYPES, mapVisitor} from './Graph';
@@ -274,7 +275,7 @@ export default class BundleGraph {
   }
 
   internalizeAsyncDependency(bundle: Bundle, dependency: Dependency) {
-    if (!dependency.isAsync) {
+    if (dependency.priority === Priority.sync) {
       throw new Error('Expected an async dependency');
     }
 
@@ -688,8 +689,11 @@ export default class BundleGraph {
       this._graph
         .getNodeIdsConnectedTo(assetNodeId, 'references')
         .map(id => this._graph.getNode(id))
-        .filter(node => node?.type === 'dependency' && node.value.isAsync)
-        .length > 0
+        .filter(
+          node =>
+            node?.type === 'dependency' &&
+            node.value.priority === Priority.lazy,
+        ).length > 0
     ) {
       // If this asset is referenced by any async dependency, it's referenced.
       return true;

--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -140,18 +140,4 @@ export default class CommittedAsset {
   getDependencies(): Array<Dependency> {
     return Array.from(this.value.dependencies.values());
   }
-
-  async getConfig(
-    filePaths: Array<FilePath>,
-    options: ?{|
-      packageKey?: string,
-      parse?: boolean,
-    |},
-  ): Promise<ConfigResult | null> {
-    return (await getConfig(this, filePaths, options))?.config;
-  }
-
-  getPackage(): Promise<PackageJSON | null> {
-    return this.getConfig(['package.json']);
-  }
 }

--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -1,18 +1,12 @@
 // @flow strict-local
 
-import type {
-  AST,
-  Blob,
-  ConfigResult,
-  FilePath,
-  PackageJSON,
-} from '@parcel/types';
+import type {AST, Blob} from '@parcel/types';
 import type {Asset, Dependency, ParcelOptions} from './types';
 
 import {Readable} from 'stream';
 import SourceMap from '@parcel/source-map';
 import {bufferStream, blobToStream, streamFromPromise} from '@parcel/utils';
-import {getConfig, generateFromAST} from './assetUtils';
+import {generateFromAST} from './assetUtils';
 import {deserializeRaw} from './serializer';
 
 export default class CommittedAsset {

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -2,22 +2,23 @@
 import type {
   SourceLocation,
   Meta,
-  ModuleSpecifier,
+  DependencySpecifier,
   Symbol,
 } from '@parcel/types';
 import type {Dependency, Environment, Target} from './types';
 import {hashString} from '@parcel/hash';
+import {SpecifierType, Priority} from './types';
 
 type DependencyOpts = {|
   id?: string,
   sourcePath?: string,
   sourceAssetId?: string,
-  moduleSpecifier: ModuleSpecifier,
-  isAsync?: boolean,
+  specifier: DependencySpecifier,
+  specifierType: $Keys<typeof SpecifierType>,
+  priority?: $Keys<typeof Priority>,
+  needsStableName?: boolean,
   isEntry?: boolean,
   isOptional?: boolean,
-  isURL?: boolean,
-  isIsolated?: boolean,
   loc?: SourceLocation,
   env: Environment,
   meta?: Meta,
@@ -35,7 +36,7 @@ export function createDependency(opts: DependencyOpts): Dependency {
     opts.id ||
     hashString(
       (opts.sourceAssetId ?? '') +
-        opts.moduleSpecifier +
+        opts.specifier +
         opts.env.id +
         (opts.target ? JSON.stringify(opts.target) : '') +
         (opts.pipeline ?? ''),
@@ -44,11 +45,11 @@ export function createDependency(opts: DependencyOpts): Dependency {
   return {
     ...opts,
     id,
-    isAsync: opts.isAsync ?? false,
-    isEntry: opts.isEntry,
+    specifierType: SpecifierType[opts.specifierType],
+    priority: Priority[opts.priority ?? 'sync'],
+    needsStableName: opts.needsStableName ?? false,
+    isEntry: opts.isEntry ?? false,
     isOptional: opts.isOptional ?? false,
-    isURL: opts.isURL ?? false,
-    isIsolated: opts.isIsolated ?? false,
     meta: opts.meta || {},
     symbols: opts.symbols,
   };

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -213,7 +213,7 @@ export default class PackagerRunner {
           this.previousDevDeps,
           this.options,
         );
-        let key = `${devDep.moduleSpecifier}:${devDep.resolveFrom}`;
+        let key = `${devDep.specifier}:${devDep.resolveFrom}`;
         this.devDepRequests.set(key, devDepRequest);
       }
 
@@ -366,7 +366,7 @@ export default class PackagerRunner {
       // the potential for lazy require() that aren't executed until the request runs.
       let devDepRequest = await createDevDependency(
         {
-          moduleSpecifier: name,
+          specifier: name,
           resolveFrom,
         },
         packager,
@@ -445,7 +445,7 @@ export default class PackagerRunner {
         // the potential for lazy require() that aren't executed until the request runs.
         let devDepRequest = await createDevDependency(
           {
-            moduleSpecifier: optimizer.name,
+            specifier: optimizer.name,
             resolveFrom: optimizer.resolveFrom,
           },
           optimizer,

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -251,7 +251,7 @@ export default class Transformation {
     for (let transformer of pipeline.transformers) {
       await this.addDevDependency(
         {
-          moduleSpecifier: transformer.name,
+          specifier: transformer.name,
           resolveFrom: transformer.resolveFrom,
           range: transformer.range,
         },
@@ -315,7 +315,7 @@ export default class Transformation {
         hashes += await getConfigHash(config, transformer.name, this.options);
 
         for (let devDep of config.devDeps) {
-          let key = `${devDep.moduleSpecifier}:${devDep.resolveFrom}`;
+          let key = `${devDep.specifier}:${devDep.resolveFrom}`;
           hashes += nullthrows(this.devDepRequests.get(key)).hash;
         }
       }
@@ -328,14 +328,14 @@ export default class Transformation {
     opts: DevDepOptions,
     transformer: LoadedPlugin<Transformer> | TransformerWithNameAndConfig,
   ): Promise<void> {
-    let {moduleSpecifier, resolveFrom, range} = opts;
-    let key = `${moduleSpecifier}:${resolveFrom}`;
+    let {specifier, resolveFrom, range} = opts;
+    let key = `${specifier}:${resolveFrom}`;
     if (this.devDepRequests.has(key)) {
       return;
     }
 
     // Ensure that the package manager has an entry for this resolution.
-    await this.options.packageManager.resolve(moduleSpecifier, resolveFrom, {
+    await this.options.packageManager.resolve(specifier, resolveFrom, {
       range,
     });
 
@@ -633,7 +633,8 @@ export default class Transformation {
         await pipeline.resolverRunner.resolve(
           createDependency({
             env: asset.value.env,
-            moduleSpecifier: to,
+            specifier: to,
+            specifierType: 'esm', // ???
             sourcePath: from,
           }),
         ),

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -419,29 +419,6 @@ export default class UncommittedAsset {
     return asset;
   }
 
-  async getConfig(
-    filePaths: Array<FilePath>,
-    options: ?{|
-      packageKey?: string,
-      parse?: boolean,
-    |},
-  ): Promise<ConfigResult | null> {
-    let conf = await getConfig(this, filePaths, options);
-    if (conf == null) {
-      return null;
-    }
-
-    for (let file of conf.files) {
-      this.addIncludedFile(file.filePath);
-    }
-
-    return conf.config;
-  }
-
-  getPackage(): Promise<PackageJSON | null> {
-    return this.getConfig(['package.json']);
-  }
-
   updateId() {
     // $FlowFixMe - this is fine
     this.value.id = createAssetIdFromOptions(this.value);

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -302,7 +302,7 @@ export default class UncommittedAsset {
 
   addDependency(opts: DependencyOptions): string {
     // eslint-disable-next-line no-unused-vars
-    let {env, target, symbols, ...rest} = opts;
+    let {env, symbols, ...rest} = opts;
     let dep = createDependency({
       ...rest,
       // $FlowFixMe "convert" the $ReadOnlyMaps to the interal mutable one

--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -3,12 +3,10 @@
 import type {
   AST,
   Blob,
-  ConfigResult,
   DependencyOptions,
   FilePath,
   FileCreateInvalidation,
   GenerateOutput,
-  PackageJSON,
   PackageName,
   TransformerResult,
 } from '@parcel/types';
@@ -38,7 +36,6 @@ import {PARCEL_VERSION} from './constants';
 import {
   createAsset,
   createAssetIdFromOptions,
-  getConfig,
   getInvalidationId,
   getInvalidationHash,
 } from './assetUtils';

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -114,7 +114,7 @@ export default async function applyRuntimes({
   for (let runtime of runtimes) {
     let devDepRequest = await createDevDependency(
       {
-        moduleSpecifier: runtime.name,
+        specifier: runtime.name,
         resolveFrom: runtime.resolveFrom,
       },
       runtime,
@@ -122,7 +122,7 @@ export default async function applyRuntimes({
       options,
     );
     devDepRequests.set(
-      `${devDepRequest.moduleSpecifier}:${devDepRequest.resolveFrom}`,
+      `${devDepRequest.specifier}:${devDepRequest.resolveFrom}`,
       devDepRequest,
     );
     await runDevDepRequest(api, devDepRequest);

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -173,42 +173,6 @@ async function _generateFromAST(asset: CommittedAsset | UncommittedAsset) {
   };
 }
 
-export async function getConfig(
-  asset: CommittedAsset | UncommittedAsset,
-  filePaths: Array<FilePath>,
-  options: ?{|
-    packageKey?: string,
-    parse?: boolean,
-  |},
-): Promise<ConfigOutput | null> {
-  let packageKey = options?.packageKey;
-  let parse = options && options.parse;
-
-  if (packageKey != null) {
-    let pkg = await asset.getPackage();
-    if (pkg && pkg[packageKey]) {
-      return {
-        config: pkg[packageKey],
-        // The package.json file was already registered by asset.getPackage() -> asset.getConfig()
-        files: [],
-      };
-    }
-  }
-
-  let conf = await loadConfig(
-    asset.options.inputFS,
-    asset.value.filePath,
-    filePaths,
-    asset.options.projectRoot,
-    parse == null ? null : {parse},
-  );
-  if (!conf) {
-    return null;
-  }
-
-  return conf;
-}
-
 export function getInvalidationId(invalidation: RequestInvalidation): string {
   switch (invalidation.type) {
     case 'file':

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -20,7 +20,6 @@ import type {
   ParcelOptions,
 } from './types';
 import {objectSortedEntries} from '@parcel/utils';
-import type {ConfigOutput} from '@parcel/utils';
 
 import {Readable} from 'stream';
 import {PluginLogger} from '@parcel/logger';
@@ -30,7 +29,7 @@ import UncommittedAsset from './UncommittedAsset';
 import loadPlugin from './loadParcelPlugin';
 import {Asset as PublicAsset} from './public/Asset';
 import PluginOptions from './public/PluginOptions';
-import {blobToStream, loadConfig, hashFile} from '@parcel/utils';
+import {blobToStream, hashFile} from '@parcel/utils';
 import {hashFromOption} from './utils';
 import {createBuildCache} from './buildCache';
 import {hashString} from '@parcel/hash';

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -4,6 +4,7 @@ import type {Environment} from './types';
 
 import type Graph from './Graph';
 import type {AssetGraphNode, BundleGraphNode} from './types';
+import {SpecifierType, Priority} from './types';
 
 import path from 'path';
 
@@ -54,13 +55,12 @@ export default async function dumpGraphToGraphViz(
     n.set('style', 'filled');
     let label = `${node.type || 'No Type'}: [${node.id}]: `;
     if (node.type === 'dependency') {
-      label += node.value.moduleSpecifier;
+      label += node.value.specifier;
       let parts = [];
-      if (node.value.isEntry) parts.push('entry');
-      if (node.value.isAsync) parts.push('async');
+      if (node.value.priority !== Priority.sync)
+        parts.push(node.value.priority);
       if (node.value.isOptional) parts.push('optional');
-      if (node.value.isIsolated) parts.push('isolated');
-      if (node.value.isURL) parts.push('url');
+      if (node.value.specifierType === SpecifierType.url) parts.push('url');
       if (node.hasDeferred) parts.push('deferred');
       if (node.excluded) parts.push('excluded');
       if (parts.length) label += ' (' + parts.join(', ') + ')';

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -153,22 +153,8 @@ class BaseAsset {
     return this.#asset.value.pipeline;
   }
 
-  getConfig(
-    filePaths: Array<FilePath>,
-    options: ?{|
-      packageKey?: string,
-      parse?: boolean,
-    |},
-  ): Promise<ConfigResult | null> {
-    return this.#asset.getConfig(filePaths, options);
-  }
-
   getDependencies(): $ReadOnlyArray<IDependency> {
     return this.#asset.getDependencies().map(dep => new Dependency(dep));
-  }
-
-  getPackage(): Promise<PackageJSON | null> {
-    return this.#asset.getPackage();
   }
 
   getCode(): Promise<string> {

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -8,7 +8,6 @@ import type {
   Asset as IAsset,
   AST,
   ASTGenerator,
-  ConfigResult,
   Dependency as IDependency,
   DependencyOptions,
   Environment as IEnvironment,
@@ -17,7 +16,6 @@ import type {
   FilePath,
   Meta,
   MutableAsset as IMutableAsset,
-  PackageJSON,
   Stats,
   MutableAssetSymbols as IMutableAssetSymbols,
   AssetSymbols as IAssetSymbols,
@@ -302,9 +300,9 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
 
   addURLDependency(url: string, opts: $Shape<DependencyOptions>): string {
     return this.addDependency({
-      moduleSpecifier: url,
-      isURL: true,
-      isAsync: true, // The browser has native loaders for url dependencies
+      specifier: url,
+      specifierType: 'url',
+      priority: 'lazy',
       ...opts,
     });
   }

--- a/packages/core/core/src/public/Dependency.js
+++ b/packages/core/core/src/public/Dependency.js
@@ -5,6 +5,8 @@ import type {
   SourceLocation,
   Meta,
   MutableDependencySymbols as IMutableDependencySymbols,
+  SpecifierType,
+  DependencyPriority,
 } from '@parcel/types';
 import type {Dependency as InternalDependency} from '../types';
 
@@ -12,6 +14,10 @@ import Environment from './Environment';
 import Target from './Target';
 import {MutableDependencySymbols} from './Symbols';
 import nullthrows from 'nullthrows';
+import {SpecifierType as SpecifierTypeMap, Priority} from '../types';
+
+const SpecifierTypeNames = Object.keys(SpecifierTypeMap);
+const PriorityNames = Object.keys(Priority);
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
@@ -46,35 +52,35 @@ export default class Dependency implements IDependency {
 
   // $FlowFixMe
   [inspect](): string {
-    return `Dependency(${String(this.sourcePath)} -> ${this.moduleSpecifier})`;
+    return `Dependency(${String(this.sourcePath)} -> ${this.specifier})`;
   }
 
   get id(): string {
     return this.#dep.id;
   }
 
-  get moduleSpecifier(): string {
-    return this.#dep.moduleSpecifier;
+  get specifier(): string {
+    return this.#dep.specifier;
   }
 
-  get isAsync(): boolean {
-    return !!this.#dep.isAsync;
+  get specifierType(): SpecifierType {
+    return SpecifierTypeNames[this.#dep.specifierType];
   }
 
-  get isEntry(): ?boolean {
+  get priority(): DependencyPriority {
+    return PriorityNames[this.#dep.priority];
+  }
+
+  get needsStableName(): boolean {
+    return this.#dep.needsStableName;
+  }
+
+  get isEntry(): boolean {
     return this.#dep.isEntry;
   }
 
   get isOptional(): boolean {
-    return !!this.#dep.isOptional;
-  }
-
-  get isURL(): boolean {
-    return !!this.#dep.isURL;
-  }
-
-  get isIsolated(): boolean {
-    return !!this.#dep.isIsolated;
+    return this.#dep.isOptional;
   }
 
   get loc(): ?SourceLocation {

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -107,7 +107,7 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
     this.#graph._graph.addEdge(dependencyNodeId, resolvedNodeId, 'references');
     this.#graph._graph.removeEdge(dependencyNodeId, resolvedNodeId);
 
-    if (dependency.isEntry) {
+    if (dependency.isEntry || resolved.isIsolated) {
       this.#graph._graph.addEdge(
         nullthrows(this.#graph._graph.rootNodeId),
         bundleGroupNodeId,

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -3,7 +3,7 @@
 import type {
   Async,
   FilePath,
-  ModuleSpecifier,
+  DependencySpecifier,
   Symbol,
   SourceLocation,
   Meta,
@@ -25,12 +25,14 @@ import type {
 import type {StaticRunOpts, RunAPI} from '../RequestTracker';
 import type {EntryResult} from './EntryRequest';
 import type {PathRequestInput} from './PathRequest';
+
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import {PromiseQueue} from '@parcel/utils';
 import {hashString} from '@parcel/hash';
 import ThrowableDiagnostic, {md} from '@parcel/diagnostic';
+import {Priority} from '../types';
 import AssetGraph from '../AssetGraph';
 import {PARCEL_VERSION} from '../constants';
 import createEntryRequest from './EntryRequest';
@@ -230,7 +232,7 @@ export class AssetGraphBuilder {
         } else if (!node.requested) {
           let isAsyncChild = this.assetGraph
             .getIncomingDependencies(node.value)
-            .every(dep => dep.isEntry || dep.isAsync);
+            .every(dep => dep.isEntry || dep.priority !== Priority.sync);
           if (isAsyncChild) {
             node.requested = false;
           } else {
@@ -775,7 +777,7 @@ export class AssetGraphBuilder {
     );
   }
 
-  async runEntryRequest(input: ModuleSpecifier) {
+  async runEntryRequest(input: DependencySpecifier) {
     let request = createEntryRequest(input);
     let result = await this.api.runRequest<FilePath, EntryResult>(request, {
       force: true,

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -102,10 +102,7 @@ async function run({input, api, farm, invalidateReason}: RunInput) {
     devDeps: new Map(
       [...previousDevDepRequests.entries()]
         .filter(([id]) => api.canSkipSubrequest(id))
-        .map(([, req]) => [
-          `${req.moduleSpecifier}:${req.resolveFrom}`,
-          req.hash,
-        ]),
+        .map(([, req]) => [`${req.specifier}:${req.resolveFrom}`, req.hash]),
     ),
     invalidDevDeps: await Promise.all(
       [...previousDevDepRequests.entries()]
@@ -113,7 +110,7 @@ async function run({input, api, farm, invalidateReason}: RunInput) {
         .flatMap(([, req]) => {
           return [
             {
-              moduleSpecifier: req.moduleSpecifier,
+              specifier: req.specifier,
               resolveFrom: req.resolveFrom,
             },
             ...(req.additionalInvalidations ?? []),

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -155,8 +155,8 @@ class BundlerRunner {
   }
 
   async runDevDepRequest(devDepRequest: DevDepRequest) {
-    let {moduleSpecifier, resolveFrom} = devDepRequest;
-    let key = `${moduleSpecifier}:${resolveFrom}`;
+    let {specifier, resolveFrom} = devDepRequest;
+    let key = `${specifier}:${resolveFrom}`;
     this.devDepRequests.set(key, devDepRequest);
     await runDevDepRequest(this.api, devDepRequest);
   }
@@ -248,7 +248,7 @@ class BundlerRunner {
     // the potential for lazy require() that aren't executed until the request runs.
     let devDepRequest = await createDevDependency(
       {
-        moduleSpecifier: name,
+        specifier: name,
         resolveFrom,
       },
       plugin,
@@ -320,7 +320,7 @@ class BundlerRunner {
     for (let namer of namers) {
       let devDepRequest = await createDevDependency(
         {
-          moduleSpecifier: namer.name,
+          specifier: namer.name,
           resolveFrom: namer.resolveFrom,
         },
         namer,

--- a/packages/core/core/src/requests/DevDepRequest.js
+++ b/packages/core/core/src/requests/DevDepRequest.js
@@ -1,5 +1,5 @@
 // @flow
-import type {DevDepOptions, ModuleSpecifier, FilePath} from '@parcel/types';
+import type {DevDepOptions, DependencySpecifier, FilePath} from '@parcel/types';
 import type ParcelConfig from '../ParcelConfig';
 import type {DevDepRequest, ParcelOptions} from '../types';
 import type {RunAPI} from '../RequestTracker';
@@ -10,12 +10,12 @@ import {createBuildCache} from '../buildCache';
 
 export async function createDevDependency(
   opts: DevDepOptions,
-  plugin: {name: ModuleSpecifier, resolveFrom: FilePath, ...},
+  plugin: {name: DependencySpecifier, resolveFrom: FilePath, ...},
   requestDevDeps: Map<string, string>,
   options: ParcelOptions,
 ): Promise<DevDepRequest> {
-  let {moduleSpecifier, resolveFrom, invalidateParcelPlugin} = opts;
-  let key = `${moduleSpecifier}:${resolveFrom}`;
+  let {specifier, resolveFrom, invalidateParcelPlugin} = opts;
+  let key = `${specifier}:${resolveFrom}`;
 
   // If the request sent us a hash, we know the dev dep and all of its dependencies didn't change.
   // Reuse the same hash in the response. No need to send back invalidations as the request won't
@@ -23,16 +23,16 @@ export async function createDevDependency(
   let hash = requestDevDeps.get(key);
   if (hash != null) {
     return {
-      moduleSpecifier,
+      specifier,
       resolveFrom,
       hash,
     };
   }
 
   // Ensure that the package manager has an entry for this resolution.
-  await options.packageManager.resolve(moduleSpecifier, resolveFrom);
+  await options.packageManager.resolve(specifier, resolveFrom);
   let invalidations = options.packageManager.getInvalidations(
-    moduleSpecifier,
+    specifier,
     resolveFrom,
   );
 
@@ -49,7 +49,7 @@ export async function createDevDependency(
   );
 
   let devDepRequest: DevDepRequest = {
-    moduleSpecifier,
+    specifier,
     resolveFrom,
     hash,
     invalidateOnFileCreate: invalidations.invalidateOnFileCreate,
@@ -61,7 +61,7 @@ export async function createDevDependency(
   if (invalidateParcelPlugin) {
     devDepRequest.additionalInvalidations = [
       {
-        moduleSpecifier: plugin.name,
+        specifier: plugin.name,
         resolveFrom: plugin.resolveFrom,
       },
     ];
@@ -71,7 +71,7 @@ export async function createDevDependency(
 }
 
 export type DevDepSpecifier = {|
-  moduleSpecifier: ModuleSpecifier,
+  specifier: DependencySpecifier,
   resolveFrom: FilePath,
 |};
 
@@ -97,10 +97,7 @@ export async function getDevDepRequests(api: RunAPI): Promise<DevDepRequests> {
     devDeps: new Map(
       [...previousDevDepRequests.entries()]
         .filter(([id]) => api.canSkipSubrequest(id))
-        .map(([, req]) => [
-          `${req.moduleSpecifier}:${req.resolveFrom}`,
-          req.hash,
-        ]),
+        .map(([, req]) => [`${req.specifier}:${req.resolveFrom}`, req.hash]),
     ),
     invalidDevDeps: await Promise.all(
       [...previousDevDepRequests.entries()]
@@ -108,7 +105,7 @@ export async function getDevDepRequests(api: RunAPI): Promise<DevDepRequests> {
         .flatMap(([, req]) => {
           return [
             {
-              moduleSpecifier: req.moduleSpecifier,
+              specifier: req.specifier,
               resolveFrom: req.resolveFrom,
             },
             ...(req.additionalInvalidations ?? []),
@@ -127,11 +124,11 @@ export function invalidateDevDeps(
   options: ParcelOptions,
   config: ParcelConfig,
 ) {
-  for (let {moduleSpecifier, resolveFrom} of invalidDevDeps) {
-    let key = `${moduleSpecifier}:${resolveFrom}`;
+  for (let {specifier, resolveFrom} of invalidDevDeps) {
+    let key = `${specifier}:${resolveFrom}`;
     if (!invalidatedDevDeps.has(key)) {
-      config.invalidatePlugin(moduleSpecifier);
-      options.packageManager.invalidate(moduleSpecifier, resolveFrom);
+      config.invalidatePlugin(specifier);
+      options.packageManager.invalidate(specifier, resolveFrom);
       invalidatedDevDeps.set(key, true);
     }
   }
@@ -142,11 +139,7 @@ export async function runDevDepRequest(
   devDepRequest: DevDepRequest,
 ) {
   await api.runRequest<null, void>({
-    id:
-      'dev_dep_request:' +
-      devDepRequest.moduleSpecifier +
-      ':' +
-      devDepRequest.hash,
+    id: 'dev_dep_request:' + devDepRequest.specifier + ':' + devDepRequest.hash,
     type: 'dev_dep_request',
     run: ({api}) => {
       for (let filePath of nullthrows(devDepRequest.invalidateOnFileChange)) {
@@ -161,7 +154,7 @@ export async function runDevDepRequest(
       }
 
       api.storeResult({
-        moduleSpecifier: devDepRequest.moduleSpecifier,
+        specifier: devDepRequest.specifier,
         resolveFrom: devDepRequest.resolveFrom,
         hash: devDepRequest.hash,
         additionalInvalidations: devDepRequest.additionalInvalidations,

--- a/packages/core/core/src/requests/DevDepRequest.js
+++ b/packages/core/core/src/requests/DevDepRequest.js
@@ -174,11 +174,11 @@ export function getWorkerDevDepRequests(
   return devDepRequests.map(devDepRequest => {
     // If we've already sent a matching transformer + hash to the main thread during this build,
     // there's no need to repeat ourselves.
-    let {moduleSpecifier, resolveFrom, hash} = devDepRequest;
-    if (hash === pluginCache.get(moduleSpecifier)) {
-      return {moduleSpecifier, resolveFrom, hash};
+    let {specifier, resolveFrom, hash} = devDepRequest;
+    if (hash === pluginCache.get(specifier)) {
+      return {specifier, resolveFrom, hash};
     } else {
-      pluginCache.set(moduleSpecifier, hash);
+      pluginCache.set(specifier, hash);
       return devDepRequest;
     }
   });

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -150,12 +150,12 @@ export class ResolverRunner {
     if (
       // Don't consider absolute paths. Absolute paths are only supported for entries,
       // and include e.g. `C:\` on Windows, conflicting with pipelines.
-      !path.isAbsolute(dependency.moduleSpecifier) &&
-      dependency.moduleSpecifier.includes(':')
+      !path.isAbsolute(dependency.specifier) &&
+      dependency.specifier.includes(':')
     ) {
-      [pipeline, filePath] = dependency.moduleSpecifier.split(':');
+      [pipeline, filePath] = dependency.specifier.split(':');
       if (!validPipelines.has(pipeline)) {
-        if (dep.isURL) {
+        if (dep.specifierType === 'url') {
           // This may be a url protocol or scheme rather than a pipeline, such as
           // `url('http://example.com/foo.png')`
           return null;
@@ -167,15 +167,18 @@ export class ResolverRunner {
         }
       }
     } else {
-      if (dependency.isURL && dependency.moduleSpecifier.startsWith('//')) {
+      if (
+        dep.specifierType === 'url' &&
+        dependency.specifier.startsWith('//')
+      ) {
         // A protocol-relative URL, e.g `url('//example.com/foo.png')`
         return null;
       }
-      filePath = dependency.moduleSpecifier;
+      filePath = dependency.specifier;
     }
 
     let queryPart = null;
-    if (dependency.isURL) {
+    if (dep.specifierType === 'url') {
       let parsed = URL.parse(filePath);
       if (typeof parsed.pathname !== 'string') {
         throw await this.getThrowableDiagnostic(
@@ -238,7 +241,7 @@ export class ResolverRunner {
                   result.pipeline === undefined
                     ? pipeline ?? dependency.pipeline
                     : result.pipeline,
-                isURL: dependency.isURL,
+                isURL: dep.specifierType === 'url',
               },
               invalidateOnFileCreate: result.invalidateOnFileCreate,
               invalidateOnFileChange: result.invalidateOnFileChange,
@@ -285,7 +288,7 @@ export class ResolverRunner {
     // $FlowFixMe because of the err.code assignment
     let err = await this.getThrowableDiagnostic(
       dependency,
-      md`Failed to resolve '${dependency.moduleSpecifier}' ${
+      md`Failed to resolve '${dependency.specifier}' ${
         dir ? `from '${dir}'` : ''
       }`,
     );

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -24,6 +24,7 @@ import ParcelConfig from '../ParcelConfig';
 import createParcelConfigRequest, {
   getCachedParcelConfig,
 } from './ParcelConfigRequest';
+import {Priority} from '../types';
 
 export type PathRequest = {|
   id: string,
@@ -220,8 +221,8 @@ export class ResolverRunner {
             };
           }
 
-          if (result.isAsync != null) {
-            dependency.isAsync = result.isAsync;
+          if (result.priority != null) {
+            dependency.priority = Priority[result.priority];
           }
 
           if (result.isExcluded) {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -12,10 +12,9 @@ import type {
   Glob,
   LogLevel,
   Meta,
-  ModuleSpecifier,
+  DependencySpecifier,
   PackageName,
   ReporterEvent,
-  Semver,
   ServerOptions,
   SourceLocation,
   Stats,
@@ -86,14 +85,27 @@ export type Target = {|
   source?: FilePath | Array<FilePath>,
 |};
 
+export const SpecifierType = {
+  esm: 0,
+  commonjs: 1,
+  url: 2,
+  custom: 3,
+};
+
+export const Priority = {
+  sync: 0,
+  parallel: 1,
+  lazy: 2,
+};
+
 export type Dependency = {|
   id: string,
-  moduleSpecifier: ModuleSpecifier,
-  isAsync: boolean,
-  isEntry: ?boolean,
+  specifier: DependencySpecifier,
+  specifierType: $Values<typeof SpecifierType>,
+  priority: $Values<typeof Priority>,
+  needsStableName: boolean,
+  isEntry: boolean,
   isOptional: boolean,
-  isURL: boolean,
-  isIsolated: boolean,
   loc: ?SourceLocation,
   env: Environment,
   meta: Meta,
@@ -159,13 +171,13 @@ export type RequestInvalidation =
   | OptionInvalidation;
 
 export type DevDepRequest = {|
-  moduleSpecifier: ModuleSpecifier,
+  specifier: DependencySpecifier,
   resolveFrom: FilePath,
   hash: string,
   invalidateOnFileCreate?: Array<FileCreateInvalidation>,
   invalidateOnFileChange?: Set<FilePath>,
   additionalInvalidations?: Array<{|
-    moduleSpecifier: ModuleSpecifier,
+    specifier: DependencySpecifier,
     resolveFrom: FilePath,
   |}>,
 |};
@@ -173,8 +185,8 @@ export type DevDepRequest = {|
 export type ParcelOptions = {|
   entries: Array<FilePath>,
   entryRoot: FilePath,
-  config?: ModuleSpecifier,
-  defaultConfig?: ModuleSpecifier,
+  config?: DependencySpecifier,
+  defaultConfig?: DependencySpecifier,
   env: EnvMap,
   targets: ?(Array<string> | {+[string]: TargetDescriptor, ...}),
 
@@ -198,7 +210,7 @@ export type ParcelOptions = {|
   cache: Cache,
   packageManager: PackageManager,
   additionalReporters: Array<{|
-    packageName: ModuleSpecifier,
+    packageName: DependencySpecifier,
     resolveFrom: FilePath,
   |}>,
 
@@ -308,7 +320,7 @@ export type TransformationRequest = {|
   invalidateReason: number,
   devDeps: Map<PackageName, string>,
   invalidDevDeps: Array<{|
-    moduleSpecifier: ModuleSpecifier,
+    specifier: DependencySpecifier,
     resolveFrom: FilePath,
   |}>,
 |};
@@ -328,7 +340,7 @@ export type AssetRequestNode = {|
 export type EntrySpecifierNode = {|
   id: ContentKey,
   +type: 'entry_specifier',
-  value: ModuleSpecifier,
+  value: DependencySpecifier,
   correspondingRequest?: string,
 |};
 
@@ -376,20 +388,8 @@ export type Config = {|
   shouldInvalidateOnStartup: boolean,
 |};
 
-export type DepVersionRequestNode = {|
-  id: ContentKey,
-  +type: 'dep_version_request',
-  value: DepVersionRequestDesc,
-|};
-
-export type DepVersionRequestDesc = {|
-  moduleSpecifier: PackageName,
-  resolveFrom: FilePath,
-  result?: Semver,
-|};
-
 export type EntryRequest = {|
-  specifier: ModuleSpecifier,
+  specifier: DependencySpecifier,
   result?: FilePath,
 |};
 

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -105,7 +105,8 @@ describe('AssetGraph', () => {
     assert(
       graph.hasContentKey(
         createDependency({
-          moduleSpecifier: '/path/to/index1/src/main.js',
+          specifier: '/path/to/index1/src/main.js',
+          specifierType: 'esm',
           target: DEFAULT_TARGETS[0],
           env: DEFAULT_ENV,
         }).id,
@@ -114,7 +115,8 @@ describe('AssetGraph', () => {
     assert(
       graph.hasContentKey(
         createDependency({
-          moduleSpecifier: '/path/to/index2/src/main.js',
+          specifier: '/path/to/index2/src/main.js',
+          specifierType: 'esm',
           target: DEFAULT_TARGETS[0],
           env: DEFAULT_ENV,
         }).id,
@@ -160,7 +162,8 @@ describe('AssetGraph', () => {
         ),
         to: graph.getNodeIdByContentKey(
           createDependency({
-            moduleSpecifier: '/path/to/index1/src/main.js',
+            specifier: '/path/to/index1/src/main.js',
+            specifierType: 'esm',
             target: DEFAULT_TARGETS[0],
             env: DEFAULT_ENV,
           }).id,
@@ -176,7 +179,8 @@ describe('AssetGraph', () => {
         ),
         to: graph.getNodeIdByContentKey(
           createDependency({
-            moduleSpecifier: '/path/to/index2/src/main.js',
+            specifier: '/path/to/index2/src/main.js',
+            specifierType: 'esm',
             target: DEFAULT_TARGETS[0],
             env: DEFAULT_ENV,
           }).id,
@@ -205,7 +209,8 @@ describe('AssetGraph', () => {
     );
 
     let dep = createDependency({
-      moduleSpecifier: '/path/to/index/src/main.js',
+      specifier: '/path/to/index/src/main.js',
+      specifierType: 'esm',
       target: DEFAULT_TARGETS[0],
       env: DEFAULT_ENV,
     });
@@ -254,7 +259,8 @@ describe('AssetGraph', () => {
     );
 
     let dep = createDependency({
-      moduleSpecifier: '/path/to/index/src/main.js',
+      specifier: '/path/to/index/src/main.js',
+      specifierType: 'esm',
       target: DEFAULT_TARGETS[0],
       env: DEFAULT_ENV,
       sourcePath: '',
@@ -275,7 +281,8 @@ describe('AssetGraph', () => {
           [
             'utils',
             createDependency({
-              moduleSpecifier: './utils',
+              specifier: './utils',
+              specifierType: 'esm',
               env: DEFAULT_ENV,
               sourcePath,
             }),
@@ -294,7 +301,8 @@ describe('AssetGraph', () => {
           [
             'styles',
             createDependency({
-              moduleSpecifier: './styles',
+              specifier: './styles',
+              specifierType: 'esm',
               env: DEFAULT_ENV,
               sourcePath,
             }),
@@ -354,7 +362,8 @@ describe('AssetGraph', () => {
           [
             'utils',
             createDependency({
-              moduleSpecifier: './utils',
+              specifier: './utils',
+              specifierType: 'esm',
               env: DEFAULT_ENV,
               sourcePath,
             }),
@@ -407,7 +416,8 @@ describe('AssetGraph', () => {
     );
 
     let dep = createDependency({
-      moduleSpecifier: '/path/to/index/src/main.js',
+      specifier: '/path/to/index/src/main.js',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       target: DEFAULT_TARGETS[0],
     });
@@ -416,12 +426,14 @@ describe('AssetGraph', () => {
     graph.resolveDependency(dep, req, '123');
     let sourcePath = filePath;
     let dep1 = createDependency({
-      moduleSpecifier: 'dependent-asset-1',
+      specifier: 'dependent-asset-1',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       sourcePath,
     });
     let dep2 = createDependency({
-      moduleSpecifier: 'dependent-asset-2',
+      specifier: 'dependent-asset-2',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       sourcePath,
     });
@@ -491,12 +503,14 @@ describe('AssetGraph', () => {
     let indexAssetGroup = {filePath: '/index.js', env: DEFAULT_ENV, query: {}};
     graph.setRootConnections({assetGroups: [indexAssetGroup]});
     let indexFooDep = createDependency({
-      moduleSpecifier: './foo',
+      specifier: './foo',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       sourcePath: '/index.js',
     });
     let indexBarDep = createDependency({
-      moduleSpecifier: './bar',
+      specifier: './bar',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       sourcePath: '/index.js',
     });
@@ -520,7 +534,8 @@ describe('AssetGraph', () => {
     graph.resolveDependency(indexFooDep, fooAssetGroup, '0');
     let fooAssetGroupNode = nodeFromAssetGroup(fooAssetGroup);
     let fooUtilsDep = createDependency({
-      moduleSpecifier: './utils',
+      specifier: './utils',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       sourcePath: '/foo.js',
     });
@@ -557,7 +572,8 @@ describe('AssetGraph', () => {
     graph.resolveDependency(indexBarDep, barAssetGroup, '0');
     let barAssetGroupNode = nodeFromAssetGroup(barAssetGroup);
     let barUtilsDep = createDependency({
-      moduleSpecifier: './utils',
+      specifier: './utils',
+      specifierType: 'esm',
       env: DEFAULT_ENV,
       sourcePath: '/bar.js',
     });

--- a/packages/core/core/test/BundleGraph.test.js
+++ b/packages/core/core/test/BundleGraph.test.js
@@ -59,7 +59,8 @@ function createMockAssetGraph(ids: [string, string]) {
   );
 
   let dep = createDependency({
-    moduleSpecifier: '/path/to/index/src/main.js',
+    specifier: '/path/to/index/src/main.js',
+    specifierType: 'esm',
     env: DEFAULT_ENV,
     target: DEFAULT_TARGETS[0],
   });
@@ -68,7 +69,8 @@ function createMockAssetGraph(ids: [string, string]) {
   graph.resolveDependency(dep, nodeFromAssetGroup(req).value, '3');
 
   let dep1 = createDependency({
-    moduleSpecifier: 'dependent-asset-1',
+    specifier: 'dependent-asset-1',
+    specifierType: 'esm',
     env: DEFAULT_ENV,
     sourcePath: filePath,
   });

--- a/packages/core/core/test/InternalAsset.test.js
+++ b/packages/core/core/test/InternalAsset.test.js
@@ -42,11 +42,11 @@ describe('InternalAsset', () => {
       options: DEFAULT_OPTIONS,
     });
 
-    asset.addDependency({moduleSpecifier: './foo'});
-    asset.addDependency({moduleSpecifier: './foo'});
+    asset.addDependency({specifier: './foo', specifierType: 'esm'});
+    asset.addDependency({specifier: './foo', specifierType: 'esm'});
     let dependencies = asset.getDependencies();
     assert(dependencies.length === 1);
-    assert(dependencies[0].moduleSpecifier === './foo');
+    assert(dependencies[0].specifier === './foo');
   });
 
   it('includes different dependencies if their id differs', () => {
@@ -61,9 +61,10 @@ describe('InternalAsset', () => {
       options: DEFAULT_OPTIONS,
     });
 
-    asset.addDependency({moduleSpecifier: './foo'});
+    asset.addDependency({specifier: './foo', specifierType: 'esm'});
     asset.addDependency({
-      moduleSpecifier: './foo',
+      specifier: './foo',
+      specifierType: 'esm',
       env: {context: 'web-worker', engines: {}},
     });
     let dependencies = asset.getDependencies();

--- a/packages/core/core/test/PublicDependency.test.js
+++ b/packages/core/core/test/PublicDependency.test.js
@@ -8,7 +8,8 @@ import Dependency from '../src/public/Dependency';
 describe('Public Dependency', () => {
   it('returns the same public Dependency given an internal dependency', () => {
     let internalDependency = createDependency({
-      moduleSpecifier: 'foo',
+      specifier: 'foo',
+      specifierType: 'esm',
       env: createEnvironment({}),
     });
 

--- a/packages/core/core/test/PublicMutableBundleGraph.test.js
+++ b/packages/core/core/test/PublicMutableBundleGraph.test.js
@@ -113,14 +113,16 @@ function createMockAssetGraph() {
   );
 
   let dep1 = createDependency({
-    moduleSpecifier: '/path/to/index/src/main.js',
-    isEntry: true,
+    specifier: '/path/to/index/src/main.js',
+    specifierType: 'esm',
+    needsStableName: true,
     env: DEFAULT_ENV,
     target: DEFAULT_TARGETS[0],
   });
   let dep2 = createDependency({
-    moduleSpecifier: '/path/to/index/src/main2.js',
-    isEntry: true,
+    specifier: '/path/to/index/src/main2.js',
+    specifierType: 'esm',
+    needsStableName: true,
     env: DEFAULT_ENV,
     target: DEFAULT_TARGETS[0],
   });

--- a/packages/core/integration-tests/test/integration/cache/node_modules/parcel-transformer-mock/index.js
+++ b/packages/core/integration-tests/test/integration/cache/node_modules/parcel-transformer-mock/index.js
@@ -4,7 +4,7 @@ module.exports = new Transformer({
   transform({asset}) {
     if (asset.isSource) {
       asset.addDependency({
-        moduleSpecifier: 'foo'
+        specifier: 'foo'
       });
       return [asset];
     }

--- a/packages/core/integration-tests/test/integration/resolver-canDefer/node_modules/parcel-resolver-no-defer/index.js
+++ b/packages/core/integration-tests/test/integration/resolver-canDefer/node_modules/parcel-resolver-no-defer/index.js
@@ -16,7 +16,7 @@ module.exports = new Resolver({
     });
     let result = await resolver.resolve({
       filename: filePath,
-      isURL: dependency.isURL,
+      isURL: dependency.specifierType === 'url',
       parent: dependency.sourcePath,
       env: dependency.env,
     });

--- a/packages/core/integration-tests/test/integration/resolver-dependency-meta/node_modules/parcel-resolver-meta/index.js
+++ b/packages/core/integration-tests/test/integration/resolver-dependency-meta/node_modules/parcel-resolver-meta/index.js
@@ -2,7 +2,7 @@ const {Resolver} = require('@parcel/plugin');
 
 module.exports = new Resolver({
   resolve({dependency, options, filePath}) {
-    if(dependency.moduleSpecifier === "foo"){
+    if(dependency.specifier === "foo"){
       return {isExcluded: true, meta: {customValue: 1234}};
     }
   }

--- a/packages/core/integration-tests/test/integration/resolver-dependency-meta/node_modules/parcel-runtime-meta/index.js
+++ b/packages/core/integration-tests/test/integration/resolver-dependency-meta/node_modules/parcel-runtime-meta/index.js
@@ -4,7 +4,7 @@ module.exports = new Runtime({
   apply({bundle}) {
     let dep;
     bundle.traverse((node, _, actions) => {
-      if (node.type === "dependency" && node.value.moduleSpecifier === "foo") {
+      if (node.type === "dependency" && node.value.specifier === "foo") {
         dep = node.value;
         actions.stop();
       }

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -1,5 +1,5 @@
 // @flow
-import type {FilePath, ModuleSpecifier, SemverRange} from '@parcel/types';
+import type {FilePath, DependencySpecifier, SemverRange} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import type {
   ModuleRequest,
@@ -31,8 +31,8 @@ import {NodeResolverSync} from './NodeResolverSync';
 
 // There can be more than one instance of NodePackageManager, but node has only a single module cache.
 // Therefore, the resolution cache and the map of parent to child modules should also be global.
-const cache = new Map<ModuleSpecifier, ResolveResult>();
-const children = new Map<FilePath, Set<ModuleSpecifier>>();
+const cache = new Map<DependencySpecifier, ResolveResult>();
+const children = new Map<FilePath, Set<DependencySpecifier>>();
 
 // This implements a package manager for Node by monkey patching the Node require
 // algorithm so that it uses the specified FileSystem instead of the native one.
@@ -77,7 +77,7 @@ export class NodePackageManager implements PackageManager {
   }
 
   async require(
-    name: ModuleSpecifier,
+    name: DependencySpecifier,
     from: FilePath,
     opts: ?{|
       range?: ?SemverRange,
@@ -89,7 +89,7 @@ export class NodePackageManager implements PackageManager {
     return this.load(resolved, from);
   }
 
-  requireSync(name: ModuleSpecifier, from: FilePath): any {
+  requireSync(name: DependencySpecifier, from: FilePath): any {
     let {resolved} = this.resolveSync(name, from);
     return this.load(resolved, from);
   }
@@ -134,7 +134,7 @@ export class NodePackageManager implements PackageManager {
   }
 
   async resolve(
-    name: ModuleSpecifier,
+    name: DependencySpecifier,
     from: FilePath,
     options?: ?{|
       range?: ?SemverRange,
@@ -286,7 +286,7 @@ export class NodePackageManager implements PackageManager {
     return resolved;
   }
 
-  resolveSync(name: ModuleSpecifier, from: FilePath): ResolveResult {
+  resolveSync(name: DependencySpecifier, from: FilePath): ResolveResult {
     let basedir = path.dirname(from);
     let key = basedir + ':' + name;
     let resolved = cache.get(key);
@@ -319,7 +319,7 @@ export class NodePackageManager implements PackageManager {
     });
   }
 
-  getInvalidations(name: ModuleSpecifier, from: FilePath): Invalidations {
+  getInvalidations(name: DependencySpecifier, from: FilePath): Invalidations {
     let res = {
       invalidateOnFileCreate: [],
       invalidateOnFileChange: new Set(),
@@ -358,7 +358,7 @@ export class NodePackageManager implements PackageManager {
     return res;
   }
 
-  invalidate(name: ModuleSpecifier, from: FilePath) {
+  invalidate(name: DependencySpecifier, from: FilePath) {
     let seen = new Set();
 
     let invalidate = (name, from) => {

--- a/packages/core/package-manager/src/NodeResolver.js
+++ b/packages/core/package-manager/src/NodeResolver.js
@@ -1,12 +1,15 @@
 // @flow
 
-import type {FilePath, ModuleSpecifier, PackageJSON} from '@parcel/types';
+import type {FilePath, DependencySpecifier, PackageJSON} from '@parcel/types';
 import type {ResolveResult, ResolverContext} from './NodeResolverBase';
 import path from 'path';
 import {NodeResolverBase} from './NodeResolverBase';
 
 export class NodeResolver extends NodeResolverBase<Promise<ResolveResult>> {
-  async resolve(id: ModuleSpecifier, from: FilePath): Promise<ResolveResult> {
+  async resolve(
+    id: DependencySpecifier,
+    from: FilePath,
+  ): Promise<ResolveResult> {
     let ctx = {
       invalidateOnFileCreate: [],
       invalidateOnFileChange: new Set(),
@@ -166,7 +169,7 @@ export class NodeResolver extends NodeResolverBase<Promise<ResolveResult>> {
   }
 
   async loadNodeModules(
-    id: ModuleSpecifier,
+    id: DependencySpecifier,
     from: FilePath,
     ctx: ResolverContext,
   ): Promise<?ResolveResult> {

--- a/packages/core/package-manager/src/NodeResolverBase.js
+++ b/packages/core/package-manager/src/NodeResolverBase.js
@@ -4,7 +4,7 @@ import type {
   PackageJSON,
   FileCreateInvalidation,
   FilePath,
-  ModuleSpecifier,
+  DependencySpecifier,
 } from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 // $FlowFixMe
@@ -19,7 +19,7 @@ for (let builtin of Module.builtinModules) {
 }
 
 export type ResolveResult = {|
-  resolved: FilePath | ModuleSpecifier,
+  resolved: FilePath | DependencySpecifier,
   pkg?: ?PackageJSON,
   invalidateOnFileCreate: Array<FileCreateInvalidation>,
   invalidateOnFileChange: Set<FilePath>,
@@ -57,7 +57,7 @@ export class NodeResolverBase<T> {
     this.packageCache = new Map();
   }
 
-  resolve(id: ModuleSpecifier, from: FilePath): T {
+  resolve(id: DependencySpecifier, from: FilePath): T {
     throw new Error(`Could not resolve "${id}" from "${from}"`);
   }
 
@@ -118,12 +118,12 @@ export class NodeResolverBase<T> {
     }
   }
 
-  isBuiltin(name: ModuleSpecifier): boolean {
+  isBuiltin(name: DependencySpecifier): boolean {
     return !!builtins[name];
   }
 
   findNodeModulePath(
-    id: ModuleSpecifier,
+    id: DependencySpecifier,
     sourceFile: FilePath,
     ctx: ResolverContext,
   ): ?ResolveResult | ?ModuleInfo {

--- a/packages/core/package-manager/src/NodeResolverSync.js
+++ b/packages/core/package-manager/src/NodeResolverSync.js
@@ -1,12 +1,12 @@
 // @flow
 
-import type {FilePath, ModuleSpecifier, PackageJSON} from '@parcel/types';
+import type {FilePath, DependencySpecifier, PackageJSON} from '@parcel/types';
 import type {ResolveResult, ResolverContext} from './NodeResolverBase';
 import path from 'path';
 import {NodeResolverBase} from './NodeResolverBase';
 
 export class NodeResolverSync extends NodeResolverBase<ResolveResult> {
-  resolve(id: ModuleSpecifier, from: FilePath): ResolveResult {
+  resolve(id: DependencySpecifier, from: FilePath): ResolveResult {
     let ctx = {
       invalidateOnFileCreate: [],
       invalidateOnFileChange: new Set(),
@@ -148,7 +148,7 @@ export class NodeResolverSync extends NodeResolverBase<ResolveResult> {
   }
 
   loadNodeModules(
-    id: ModuleSpecifier,
+    id: DependencySpecifier,
     from: FilePath,
     ctx: ResolverContext,
   ): ?ResolveResult {

--- a/packages/core/package-manager/src/types.js
+++ b/packages/core/package-manager/src/types.js
@@ -4,7 +4,7 @@ import type {
   FilePath,
   FileCreateInvalidation,
   SemverRange,
-  ModuleSpecifier,
+  DependencySpecifier,
 } from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import type {ResolveResult} from './NodeResolverBase';
@@ -35,17 +35,17 @@ export type Invalidations = {|
 
 export interface PackageManager {
   require(
-    id: ModuleSpecifier,
+    id: DependencySpecifier,
     from: FilePath,
     ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
   ): Promise<any>;
   resolve(
-    id: ModuleSpecifier,
+    id: DependencySpecifier,
     from: FilePath,
     ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
   ): Promise<ResolveResult>;
-  getInvalidations(id: ModuleSpecifier, from: FilePath): Invalidations;
-  invalidate(id: ModuleSpecifier, from: FilePath): void;
+  getInvalidations(id: DependencySpecifier, from: FilePath): Invalidations;
+  invalidate(id: DependencySpecifier, from: FilePath): void;
 }
 
 export type ModuleRequest = {|

--- a/packages/core/register/src/register.js
+++ b/packages/core/register/src/register.js
@@ -93,7 +93,7 @@ function register(inputOpts?: InitialParcelOptions): IDisposable {
       let resolved = syncPromise(
         // $FlowFixMe
         parcel[INTERNAL_RESOLVE]({
-          moduleSpecifier: targetFile,
+          specifier: targetFile,
           sourcePath: currFile,
           env,
         }),

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -149,7 +149,7 @@ export function findAsset(
 export function findDependency(
   bundleGraph: BundleGraph<PackagedBundle>,
   assetFileName: string,
-  moduleSpecifier: string,
+  specifier: string,
 ): Dependency {
   let asset = nullthrows(
     findAsset(bundleGraph, assetFileName),
@@ -158,10 +158,10 @@ export function findDependency(
 
   let dependency = bundleGraph
     .getDependencies(asset)
-    .find(d => d.moduleSpecifier === moduleSpecifier);
+    .find(d => d.specifier === specifier);
   invariant(
     dependency != null,
-    `Couldn't find dependency ${assetFileName} -> ${moduleSpecifier}`,
+    `Couldn't find dependency ${assetFileName} -> ${specifier}`,
   );
   return dependency;
 }
@@ -189,9 +189,9 @@ export function mergeParcelOptions(
 export function assertDependencyWasDeferred(
   bundleGraph: BundleGraph<PackagedBundle>,
   assetFileName: string,
-  moduleSpecifier: string,
+  specifier: string,
 ): void {
-  let dep = findDependency(bundleGraph, assetFileName, moduleSpecifier);
+  let dep = findDependency(bundleGraph, assetFileName, specifier);
   invariant(
     bundleGraph.isDependencySkipped(dep),
     util.inspect(dep) + " wasn't deferred",

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -554,18 +554,6 @@ export interface BaseAsset {
   /** A buffer representation of the sourcemap (if existent). */
   getMapBuffer(): Promise<?Buffer>;
   getDependencies(): $ReadOnlyArray<Dependency>;
-  /** Used to load config files, (looks in every parent folder until a module root) \
-   * for the specified filenames. <code>packageKey</code> can be used to also check <code>pkg#[packageKey]</code>.
-   */
-  getConfig(
-    filePaths: Array<FilePath>,
-    options: ?{|
-      packageKey?: string,
-      parse?: boolean,
-    |},
-  ): Promise<ConfigResult | null>;
-  /** Returns the package.json this file belongs to. */
-  getPackage(): Promise<PackageJSON | null>;
 }
 
 /**

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -384,6 +384,7 @@ export interface AssetSymbols // eslint-disable-next-line no-undef
   hasLocalSymbol(local: Symbol): boolean;
   exportSymbols(): Iterable<Symbol>;
 }
+
 export interface MutableAssetSymbols extends AssetSymbols {
   /**
    * Initilizes the map, sets isCleared to false.
@@ -397,6 +398,7 @@ export interface MutableAssetSymbols extends AssetSymbols {
   ): void;
   delete(exportSymbol: Symbol): void;
 }
+
 /**
  * isWeak means: the symbol is not used by the parent asset itself and is merely reexported
  */
@@ -482,7 +484,6 @@ export type DependencyOptions = {|
    * By default, this is the path of the source file where the dependency was specified.
    */
   +resolveFrom?: FilePath,
-  +target?: Target,
   /** The symbols within the resolved module that the source file depends on. */
   +symbols?: $ReadOnlyMap<
     Symbol,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1166,7 +1166,7 @@ export type ResolveResult = {|
   +filePath?: FilePath,
   +pipeline?: ?string,
   +isExcluded?: boolean,
-  +isAsync?: boolean,
+  +priority?: DependencyPriority,
   /** Corresponds to BaseAsset's <code>sideEffects</code>. */
   +sideEffects?: boolean,
   /** A resolver might want to resolve to a dummy, in this case <code>filePath</code> is rather "resolve from". */

--- a/packages/core/utils/src/dependency-location.js
+++ b/packages/core/utils/src/dependency-location.js
@@ -5,7 +5,7 @@ export default function createDependencyLocation(
     column: number,
     ...
   },
-  moduleSpecifier: string,
+  specifier: string,
   lineOffset: number = 0,
   columnOffset: number = 0,
   // Imports are usually wrapped in quotes
@@ -16,7 +16,7 @@ export default function createDependencyLocation(
   start: {|column: number, line: number|},
 |} {
   return {
-    filePath: moduleSpecifier,
+    filePath: specifier,
     start: {
       line: start.line + lineOffset,
       column: start.column + columnOffset,
@@ -25,7 +25,7 @@ export default function createDependencyLocation(
       line: start.line + lineOffset,
       column:
         start.column +
-        moduleSpecifier.length -
+        specifier.length -
         1 +
         importWrapperLength +
         columnOffset,

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -22,7 +22,7 @@ type ReplacementMap = Map<
 
 /*
  * Replaces references to dependency ids for URL dependencies with:
- *   - in the case of an unresolvable url dependency, the original moduleSpecifier.
+ *   - in the case of an unresolvable url dependency, the original specifier.
  *     These are external requests that Parcel did not bundle.
  *   - in the case of a reference to another bundle, the relative url to that
  *     bundle from the current bundle.
@@ -43,13 +43,13 @@ export function replaceURLReferences({
   let replacements = new Map();
   let urlDependencies = [];
   bundle.traverse(node => {
-    if (node.type === 'dependency' && node.value.isURL) {
+    if (node.type === 'dependency' && node.value.specifierType === 'url') {
       urlDependencies.push(node.value);
     }
   });
 
   for (let dependency of urlDependencies) {
-    if (!dependency.isURL) {
+    if (dependency.specifierType !== 'url') {
       continue;
     }
 
@@ -57,7 +57,7 @@ export function replaceURLReferences({
     if (resolved == null) {
       replacements.set(dependency.id, {
         from: dependency.id,
-        to: dependency.moduleSpecifier,
+        to: dependency.specifier,
       });
       continue;
     }

--- a/packages/core/utils/test/replaceBundleReferences.test.js
+++ b/packages/core/utils/test/replaceBundleReferences.test.js
@@ -33,7 +33,8 @@ describe('replace bundle references', () => {
     // $FlowFixMe
     let dependency: Dependency = {
       id: '074b36596e3147e900a8ad17ceb5c90b',
-      moduleSpecifier: 'url:./image.jpg?as=webp',
+      specifier: 'url:./image.jpg?as=webp',
+      specifierType: 'esm',
     };
 
     let result = getURLReplacement({
@@ -77,7 +78,8 @@ describe('replace bundle references', () => {
     // $FlowFixMe
     let dependency: Dependency = {
       id: '074b36596e3147e900a8ad17ceb5c90b',
-      moduleSpecifier: 'url:./image.jpg?as=webp',
+      specifier: 'url:./image.jpg?as=webp',
+      specifierType: 'esm',
     };
 
     let result = getURLReplacement({
@@ -121,7 +123,8 @@ describe('replace bundle references', () => {
     // $FlowFixMe
     let dependency: Dependency = {
       id: '074b36596e314797845a8ad17ceb5c9b',
-      moduleSpecifier: './image.jpg',
+      specifier: './image.jpg',
+      specifierType: 'esm',
     };
 
     let result = getURLReplacement({
@@ -165,7 +168,8 @@ describe('replace bundle references', () => {
     // $FlowFixMe
     let dependency: Dependency = {
       id: '074b36596e3147e900a8ad17ceb5c90b',
-      moduleSpecifier: 'url:./image.jpg?as=webp',
+      specifier: 'url:./image.jpg?as=webp',
+      specifierType: 'esm',
     };
 
     let result = getURLReplacement({

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -153,7 +153,7 @@ async function processCSSModule(
           },
         }),
         hints: [
-          `Instead do: import * as style from "${defaultImport.moduleSpecifier}";`,
+          `Instead do: import * as style from "${defaultImport.specifier}";`,
         ],
       });
     }

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -27,7 +27,18 @@ const metadataContent = new Set([
 ]);
 
 export default (new Packager({
-  async package({bundle, bundleGraph, getInlineBundleContents}) {
+  async loadConfig({config}) {
+    let posthtmlConfig = await config.getConfig(
+      ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
+      {
+        packageKey: 'posthtml',
+      },
+    );
+    config.setResult({
+      render: posthtmlConfig?.contents?.render,
+    });
+  },
+  async package({bundle, bundleGraph, getInlineBundleContents, config}) {
     let assets = [];
     bundle.traverseAssets(asset => {
       assets.push(asset);
@@ -46,13 +57,7 @@ export default (new Packager({
         new Set(bundleGraph.getReferencedBundles(bundle, {recursive: false})),
       ),
     ].filter(b => !b.isInline);
-    let posthtmlConfig = await asset.getConfig(
-      ['.posthtmlrc', '.posthtmlrc.js', 'posthtml.config.js'],
-      {
-        packageKey: 'posthtml',
-      },
-    );
-    let renderConfig = posthtmlConfig?.render;
+    let renderConfig = config?.render;
 
     let {html} = await posthtml([
       insertBundleReferences.bind(this, referencedBundles),

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -90,9 +90,7 @@ export class DevPackager {
             this.bundle,
           );
           if (resolved) {
-            deps[dep.moduleSpecifier] = this.bundleGraph.getAssetPublicId(
-              resolved,
-            );
+            deps[dep.specifier] = this.bundleGraph.getAssetPublicId(resolved);
           }
         }
 

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -498,7 +498,7 @@ ${code}
     let depMap = new Map();
     let replacements = new Map();
     for (let dep of deps) {
-      depMap.set(`${assetId}:${dep.moduleSpecifier}`, dep);
+      depMap.set(`${assetId}:${dep.specifier}`, dep);
 
       let asyncResolution = this.bundleGraph.resolveAsyncDependency(
         dep,
@@ -531,7 +531,7 @@ ${code}
             renamed = local;
           } else if (imported === 'default' || imported === '*') {
             renamed = this.getTopLevelName(
-              `$${this.bundle.publicId}$${dep.moduleSpecifier}`,
+              `$${this.bundle.publicId}$${dep.specifier}`,
             );
           } else {
             renamed = this.getTopLevelName(
@@ -568,7 +568,7 @@ ${code}
       // Async dependencies need a namespace object even if all used symbols were statically analyzed.
       // This is recorded in the promiseSymbol meta property set by the transformer rather than in
       // symbols so that we don't mark all symbols as used.
-      if (dep.isAsync && dep.meta.promiseSymbol) {
+      if (dep.priority === 'lazy' && dep.meta.promiseSymbol) {
         let promiseSymbol = dep.meta.promiseSymbol;
         invariant(typeof promiseSymbol === 'string');
         let symbol = this.resolveSymbol(asset, resolved, '*', dep);
@@ -616,11 +616,11 @@ ${code}
       });
     }
 
-    // Map of ModuleSpecifier -> Map<ExportedSymbol, Identifier>>
-    let external = this.externals.get(dep.moduleSpecifier);
+    // Map of DependencySpecifier -> Map<ExportedSymbol, Identifier>>
+    let external = this.externals.get(dep.specifier);
     if (!external) {
       external = new Map();
-      this.externals.set(dep.moduleSpecifier, external);
+      this.externals.set(dep.specifier, external);
     }
 
     return external;
@@ -893,7 +893,7 @@ ${code}
             if (!resolved) {
               // Re-exporting an external module. This should have already been handled in buildReplacements.
               let external = nullthrows(
-                nullthrows(this.externals.get(dep.moduleSpecifier)).get('*'),
+                nullthrows(this.externals.get(dep.specifier)).get('*'),
               );
               append += `$parcel$exportWildcard($${assetId}$exports, ${external});\n`;
               this.usedHelpers.add('$parcel$exportWildcard');

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -110,7 +110,7 @@ export default class HMRServer {
               bundle,
             );
             if (resolved) {
-              deps[dep.moduleSpecifier] = event.bundleGraph.getAssetPublicId(
+              deps[dep.specifier] = event.bundleGraph.getAssetPublicId(
                 resolved,
               );
             }

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -9,9 +9,9 @@ const WEBPACK_IMPORT_REGEX = /\S+-loader\S*!\S+/g;
 
 export default (new Resolver({
   resolve({dependency, options, filePath}) {
-    if (WEBPACK_IMPORT_REGEX.test(dependency.moduleSpecifier)) {
+    if (WEBPACK_IMPORT_REGEX.test(dependency.specifier)) {
       throw new Error(
-        `The import path: ${dependency.moduleSpecifier} is using webpack specific loader import syntax, which isn't supported by Parcel.`,
+        `The import path: ${dependency.specifier} is using webpack specific loader import syntax, which isn't supported by Parcel.`,
       );
     }
 
@@ -34,7 +34,7 @@ export default (new Resolver({
 
     return resolver.resolve({
       filename: filePath,
-      isURL: dependency.isURL,
+      isURL: dependency.specifierType === 'url',
       parent: dependency.resolveFrom,
       env: dependency.env,
     });

--- a/packages/resolvers/glob/src/GlobResolver.js
+++ b/packages/resolvers/glob/src/GlobResolver.js
@@ -20,7 +20,10 @@ export default (new Resolver({
     let error;
     if (sourceAssetType !== 'js' && sourceAssetType !== 'css') {
       error = `Glob imports are not supported in ${sourceAssetType} files.`;
-    } else if (dependency.isURL) {
+    } else if (
+      dependency.specifierType === 'url' &&
+      !dependency.meta?.isCSSImport
+    ) {
       error = 'Glob imports are not supported in URL dependencies.';
     }
 
@@ -72,7 +75,7 @@ export default (new Resolver({
         set(matches, parts, relative);
       }
 
-      let {value, imports} = generate(matches, dependency.isAsync);
+      let {value, imports} = generate(matches, dependency.priority === 'lazy');
       code = imports + 'module.exports = ' + value;
     } else if (sourceAssetType === 'css') {
       for (let [, relative] of results) {
@@ -88,7 +91,7 @@ export default (new Resolver({
       code,
       invalidateOnFileCreate: [{glob: normalized}],
       pipeline: null,
-      isAsync: false,
+      priority: 'sync',
     };
   },
 }): Resolver);

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -144,14 +144,12 @@ export default (new Runtime({
       // Otherwise, try to resolve the dependency to an external bundle group
       // and insert a URL to that bundle.
       let resolved = bundleGraph.resolveAsyncDependency(dependency, bundle);
-      if (dependency.isURL && resolved == null) {
+      if (dependency.specifierType === 'url' && resolved == null) {
         // If a URL dependency was not able to be resolved, add a runtime that
-        // exports the original moduleSpecifier.
+        // exports the original specifier.
         assets.push({
           filePath: __filename,
-          code: `module.exports = ${JSON.stringify(
-            dependency.moduleSpecifier,
-          )}`,
+          code: `module.exports = ${JSON.stringify(dependency.specifier)}`,
           dependency,
         });
         continue;
@@ -255,7 +253,10 @@ function getDependencies(
       }
 
       let dependency = node.value;
-      if (dependency.isAsync && !dependency.isURL) {
+      if (
+        dependency.priority === 'lazy' &&
+        dependency.specifierType !== 'url'
+      ) {
         asyncDependencies.push(dependency);
       } else {
         otherDependencies.push(dependency);

--- a/packages/runtimes/react-refresh/package.json
+++ b/packages/runtimes/react-refresh/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-beta.3.1",
+    "@parcel/utils": "2.0.0-beta.3.1",
     "react-refresh": "^0.9.0"
   }
 }

--- a/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
+++ b/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
 import {Runtime} from '@parcel/plugin';
+import {loadConfig} from '@parcel/utils';
 
 const CODE = `
 var Refresh = require('react-refresh/runtime');
@@ -27,11 +28,17 @@ export default (new Runtime({
 
     let entries = bundle.getEntryAssets();
     for (let entry of entries) {
-      let pkg = await entry.getPackage();
+      // TODO: do this in loadConfig - but it doesn't have access to the bundle...
+      let pkg = await loadConfig(
+        options.inputFS,
+        entry.filePath,
+        ['package.json'],
+        options.projectRoot,
+      );
       if (
-        pkg?.dependencies?.react ||
-        pkg?.devDependencies?.react ||
-        pkg?.peerDependencies?.react
+        pkg?.config?.dependencies?.react ||
+        pkg?.config?.devDependencies?.react ||
+        pkg?.config?.peerDependencies?.react
       ) {
         return {
           filePath: __filename,

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -72,7 +72,7 @@ export async function load(
     },
   );
   config.addDevDependency({
-    moduleSpecifier: '@babel/core',
+    specifier: '@babel/core',
     resolveFrom: config.searchPath,
     range: BABEL_CORE_RANGE,
   });
@@ -108,7 +108,7 @@ export async function load(
 
       // But also add the config as a dev dependency so we can at least attempt invalidation in watch mode.
       config.addDevDependency({
-        moduleSpecifier: relativePath(options.projectRoot, file),
+        specifier: relativePath(options.projectRoot, file),
         resolveFrom: path.join(options.projectRoot, 'index'),
         // Also invalidate @parcel/transformer-babel when the config or a dependency updates.
         // This ensures that the caches in @babel/core are also invalidated.
@@ -252,10 +252,7 @@ function definePluginDependencies(config, options) {
     // from the config location because configItem.file.request can be a shorthand
     // rather than a full package name.
     config.addDevDependency({
-      moduleSpecifier: relativePath(
-        options.projectRoot,
-        configItem.file.resolved,
-      ),
+      specifier: relativePath(options.projectRoot, configItem.file.resolved),
       resolveFrom: path.join(options.projectRoot, 'index'),
       // Also invalidate @parcel/transformer-babel when the plugin or a dependency updates.
       // This ensures that the caches in @babel/core are also invalidated.

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -134,6 +134,8 @@ export default (new Transformer({
           // Offset by 8 as it does not include `@import `
           loc: createLoc(nullthrows(rule.source.start), specifier, 0, 8),
           meta: {
+            // For the glob resolver to distinguish between `@import` and other URL dependencies.
+            isCSSImport: true,
             media,
           },
         };

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -99,7 +99,7 @@ export default (new Transformer({
     program.walkAtRules('import', rule => {
       let params = valueParser(rule.params);
       let [name, ...media] = params.nodes;
-      let moduleSpecifier;
+      let specifier;
       if (
         name.type === 'function' &&
         name.value === 'url' &&
@@ -108,14 +108,14 @@ export default (new Transformer({
         name = name.nodes[0];
       }
 
-      moduleSpecifier = name.value;
+      specifier = name.value;
 
-      if (!moduleSpecifier) {
+      if (!specifier) {
         throw new Error('Could not find import name for ' + String(rule));
       }
 
-      if (isURL(moduleSpecifier)) {
-        name.value = asset.addURLDependency(moduleSpecifier, {
+      if (isURL(specifier)) {
+        name.value = asset.addURLDependency(specifier, {
           loc: createLoc(nullthrows(rule.source.start), asset.filePath, 0, 8),
         });
       } else {
@@ -129,9 +129,10 @@ export default (new Transformer({
         // } else {
         media = valueParser.stringify(media).trim();
         let dep = {
-          moduleSpecifier,
+          specifier,
+          specifierType: 'url',
           // Offset by 8 as it does not include `@import `
-          loc: createLoc(nullthrows(rule.source.start), moduleSpecifier, 0, 8),
+          loc: createLoc(nullthrows(rule.source.start), specifier, 0, 8),
           meta: {
             media,
           },

--- a/packages/transformers/html/src/HTMLTransformer.js
+++ b/packages/transformers/html/src/HTMLTransformer.js
@@ -26,6 +26,7 @@ export default (new Transformer({
   async transform({asset, options}) {
     // Handle .htm
     asset.type = 'html';
+    asset.isIsolated = true;
     let ast = nullthrows(await asset.getAST());
     let hasScripts = collectDependencies(asset, ast);
 
@@ -44,9 +45,7 @@ export default (new Transformer({
         tag: 'script',
         attrs: {
           src: asset.addURLDependency('hmr.js', {
-            isAsync: false,
-            isEntry: false,
-            isIsolated: true,
+            priority: 'parallel',
           }),
         },
         content: [],

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -67,27 +67,23 @@ const META = {
 // Options to be passed to `addDependency` for certain tags + attributes
 const OPTIONS = {
   a: {
-    href: {isEntry: true},
+    href: {needsStableName: true},
   },
   iframe: {
-    src: {isEntry: true},
+    src: {needsStableName: true},
   },
   link(attrs) {
     if (attrs.rel === 'stylesheet') {
       return {
         // Keep in the same bundle group as the HTML.
-        isAsync: false,
-        isEntry: false,
-        isIsolated: true,
+        priority: 'parallel',
       };
     }
   },
   script(attrs, env: Environment) {
     return {
       // Keep in the same bundle group as the HTML.
-      isAsync: false,
-      isEntry: false,
-      isIsolated: true,
+      priority: 'parallel',
       env: {
         outputFormat:
           attrs.type === 'module' && env.shouldScopeHoist
@@ -155,7 +151,7 @@ export default function collectDependencies(
       attrs.href
     ) {
       attrs.href = asset.addURLDependency(attrs.href, {
-        isEntry: true,
+        needsStableName: true,
       });
       isDirty = true;
       return node;

--- a/packages/transformers/html/src/inline.js
+++ b/packages/transformers/html/src/inline.js
@@ -92,7 +92,8 @@ export default function extractInlineAssets(
         asset.setAST(ast); // mark dirty
 
         asset.addDependency({
-          moduleSpecifier: parcelKey,
+          specifier: parcelKey,
+          specifierType: 'esm',
         });
 
         parts.push({
@@ -100,6 +101,7 @@ export default function extractInlineAssets(
           content: value,
           uniqueKey: parcelKey,
           isInline: true,
+          isIsolated: false,
           env,
           meta: {
             type: 'tag',
@@ -119,7 +121,8 @@ export default function extractInlineAssets(
     let style = attrs?.style;
     if (attrs != null && style != null) {
       attrs.style = asset.addDependency({
-        moduleSpecifier: parcelKey,
+        specifier: parcelKey,
+        specifierType: 'esm',
       });
       asset.setAST(ast); // mark dirty
 
@@ -128,6 +131,7 @@ export default function extractInlineAssets(
         content: style,
         uniqueKey: parcelKey,
         isInline: true,
+        isIsolated: false,
         meta: {
           type: 'attr',
           // $FlowFixMe

--- a/packages/transformers/postcss/src/PostCSSTransformer.js
+++ b/packages/transformers/postcss/src/PostCSSTransformer.js
@@ -84,7 +84,8 @@ export default (new Transformer({
           parsed.walk(node => {
             if (node.type === 'string') {
               asset.addDependency({
-                moduleSpecifier: importPath,
+                specifier: importPath,
+                specifierType: 'url',
                 loc: {
                   filePath: asset.filePath,
                   start: decl.source.start,
@@ -129,12 +130,12 @@ export default (new Transformer({
       let cssModulesList = (Object.entries(cssModules): Array<
         [string, string],
       >);
-      let deps = asset.getDependencies().filter(dep => !dep.isURL);
+      let deps = asset.getDependencies().filter(dep => dep.priority === 'sync');
       let code: string;
       if (deps.length > 0) {
         code = `
           module.exports = Object.assign({}, ${deps
-            .map(dep => `require(${JSON.stringify(dep.moduleSpecifier)})`)
+            .map(dep => `require(${JSON.stringify(dep.specifier)})`)
             .join(', ')}, ${JSON.stringify(cssModules, null, 2)});
         `;
       } else {

--- a/packages/transformers/postcss/src/loadConfig.js
+++ b/packages/transformers/postcss/src/loadConfig.js
@@ -64,7 +64,7 @@ async function configHydrator(
   for (let p of pluginArray) {
     if (typeof p === 'string') {
       config.addDevDependency({
-        moduleSpecifier: p,
+        specifier: p,
         resolveFrom: nullthrows(resolveFrom),
       });
     }
@@ -98,7 +98,7 @@ export async function load({
   let contents = null;
   if (configFile) {
     config.addDevDependency({
-      moduleSpecifier: 'postcss',
+      specifier: 'postcss',
       resolveFrom: config.searchPath,
       range: POSTCSS_RANGE,
     });
@@ -117,7 +117,7 @@ export async function load({
 
       // Also add the config as a dev dependency so we attempt to reload in watch mode.
       config.addDevDependency({
-        moduleSpecifier: relativePath(
+        specifier: relativePath(
           path.dirname(config.searchPath),
           configFile.filePath,
         ),

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -34,7 +34,7 @@ export default (new Transformer({
 
         // Also add the config as a dev dependency so we attempt to reload in watch mode.
         config.addDevDependency({
-          moduleSpecifier: relativePath(
+          specifier: relativePath(
             path.dirname(config.searchPath),
             configFile.filePath,
           ),
@@ -56,7 +56,7 @@ export default (new Transformer({
       for (let p of pluginArray) {
         if (typeof p === 'string') {
           config.addDevDependency({
-            moduleSpecifier: p,
+            specifier: p,
             resolveFrom: configFile.filePath,
           });
         }

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -13,7 +13,7 @@ function shouldExclude(asset, options) {
     !asset.env.isBrowser() ||
     asset.env.isWorker() ||
     options.mode !== 'development' ||
-    !asset.getDependencies().find(v => v.moduleSpecifier === 'react')
+    !asset.getDependencies().find(v => v.specifier === 'react')
   );
 }
 
@@ -52,7 +52,8 @@ ${code}
 
     // The JSTransformer has already run, do it manually
     asset.addDependency({
-      moduleSpecifier: wrapperPath,
+      specifier: wrapperPath,
+      specifierType: 'esm',
     });
 
     return [asset];

--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -74,7 +74,7 @@ async function collectDependencies(
     }
     for (const locale of await fs.readdir(locales)) {
       asset.addURLDependency(`_locales/${locale}/messages.json`, {
-        isEntry: true,
+        needsStableName: true,
         pipeline: 'url',
       });
     }
@@ -87,7 +87,7 @@ async function collectDependencies(
         const assets = sc[k] || [];
         for (let j = 0; j < assets.length; ++j) {
           assets[j] = asset.addURLDependency(assets[j], {
-            isEntry: true,
+            needsStableName: true,
             loc: {
               filePath,
               ...getJSONSourceLocation(
@@ -139,11 +139,11 @@ async function collectDependencies(
         });
       }
       program.dictionaries[dict] = asset.addURLDependency(dictFile, {
-        isEntry: true,
+        needsStableName: true,
         loc,
       });
       asset.addURLDependency(dictFile.slice(0, -4) + '.aff', {
-        isEntry: true,
+        needsStableName: true,
         loc,
       });
     }
@@ -157,7 +157,7 @@ async function collectDependencies(
           'value',
         );
         themeIcon[k] = asset.addURLDependency(themeIcon[k], {
-          isEntry: true,
+          needsStableName: true,
           loc: {
             ...loc,
             filePath,
@@ -181,7 +181,7 @@ async function collectDependencies(
         )
       ).map(fp =>
         asset.addURLDependency(path.relative(path.dirname(filePath), fp), {
-          isEntry: true,
+          needsStableName: true,
           loc: {
             filePath,
             ...getJSONSourceLocation(ptrs[`/web_accessible_resources/${i}`]),
@@ -203,7 +203,7 @@ async function collectDependencies(
     const obj = parent[lastLoc];
     if (typeof obj == 'string')
       parent[lastLoc] = asset.addURLDependency(obj, {
-        isEntry: true,
+        needsStableName: true,
         loc: {
           filePath,
           ...getJSONSourceLocation(ptrs[location], 'value'),
@@ -213,7 +213,7 @@ async function collectDependencies(
     else {
       for (const k of Object.keys(obj)) {
         obj[k] = asset.addURLDependency(obj[k], {
-          isEntry: true,
+          needsStableName: true,
           loc: {
             filePath,
             ...getJSONSourceLocation(ptrs[location + '/' + k], 'value'),

--- a/packages/validators/typescript/src/TypeScriptValidator.js
+++ b/packages/validators/typescript/src/TypeScriptValidator.js
@@ -95,13 +95,14 @@ async function getConfig(
     asset.filePath,
   );
   let baseDir = configPath ? path.dirname(configPath) : options.projectRoot;
-  let configHash = (tsconfig ? hashObject(tsconfig) : '') + '-' + baseDir;
+  let configHash =
+    (tsconfig ? hashObject(tsconfig.config) : '') + '-' + baseDir;
 
   return {
     filepath: configPath,
     baseDir,
     configHash,
-    tsconfig,
+    tsconfig: tsconfig?.config,
   };
 }
 

--- a/packages/validators/typescript/src/TypeScriptValidator.js
+++ b/packages/validators/typescript/src/TypeScriptValidator.js
@@ -10,7 +10,7 @@ import type {LanguageService, Diagnostic} from 'typescript'; // eslint-disable-l
 import path from 'path';
 import ts from 'typescript';
 import {type DiagnosticCodeFrame, escapeMarkdown} from '@parcel/diagnostic';
-import {hashObject} from '@parcel/utils';
+import {hashObject, loadConfig} from '@parcel/utils';
 import {Validator} from '@parcel/plugin';
 import {LanguageServiceHost, ParseConfigHost} from '@parcel/ts-utils';
 
@@ -84,7 +84,12 @@ async function getConfig(
   resolveConfigWithPath,
 ): Promise<TSValidatorConfig> {
   let configNames = ['tsconfig.json'];
-  let tsconfig = await asset.getConfig(configNames);
+  let tsconfig = await loadConfig(
+    asset.fs,
+    asset.filePath,
+    configNames,
+    options.projectRoot,
+  );
   let configPath: ?string = await resolveConfigWithPath(
     configNames,
     asset.filePath,


### PR DESCRIPTION
Depends on #6379. T-859.

This is the start of our API updates, based on the notes in #5225. In this PR, there are two changes:

1. Remove `asset.getConfig` and `asset.getPackage`. These have been replaced by the config loading mechanism which properly supports caching.
2. Refactor the dependency options to have less boolean flags as discussed in our api audit meeting.