### PR TITLE
Unify BundleGraph traversal

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -317,7 +317,7 @@ export default (new Bundler({
       |},
     > = new Map();
 
-    bundleGraph.traverseContents((node, ctx, actions) => {
+    bundleGraph.traverse((node, ctx, actions) => {
       if (node.type !== 'asset') {
         return;
       }

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -968,13 +968,21 @@ export default class BundleGraph {
     });
   }
 
-  traverseContents<TContext>(
+  traverse<TContext>(
     visit: GraphVisitor<AssetNode | DependencyNode, TContext>,
   ): ?TContext {
-    return this._graph.filteredTraverse(nodeId => {
-      let node = nullthrows(this._graph.getNode(nodeId));
-      return node.type === 'asset' || node.type === 'dependency' ? node : null;
-    }, visit);
+    return this._graph.filteredTraverse(
+      nodeId => {
+        let node = nullthrows(this._graph.getNode(nodeId));
+        if (node.type === 'asset' || node.type === 'dependency') {
+          return node;
+        }
+      },
+      visit,
+      undefined, // start with root
+      // $FlowFixMe
+      ALL_EDGE_TYPES,
+    );
   }
 
   getChildBundles(bundle: Bundle): Array<Bundle> {

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -535,23 +535,26 @@ export function mapVisitor<NodeId, TValue, TContext>(
   filter: (NodeId, TraversalActions) => ?TValue,
   visit: GraphVisitor<TValue, TContext>,
 ): GraphVisitor<NodeId, TContext> {
-  return {
-    enter: (nodeId, context, actions) => {
-      let enter = typeof visit === 'function' ? visit : visit.enter;
-      if (!enter) {
-        return;
-      }
-
+  function makeEnter(visit) {
+    return function mappedEnter(nodeId, context, actions) {
       let value = filter(nodeId, actions);
       if (value != null) {
-        return enter(value, context, actions);
+        return visit(value, context, actions);
       }
-    },
-    exit: (nodeId, context, actions) => {
-      if (typeof visit === 'function') {
-        return;
-      }
+    };
+  }
 
+  if (typeof visit === 'function') {
+    return makeEnter(visit);
+  }
+
+  let mapped = {};
+  if (visit.enter != null) {
+    mapped.enter = makeEnter(visit.enter);
+  }
+
+  if (visit.exit != null) {
+    mapped.exit = function mappedExit(nodeId, context, actions) {
       let exit = visit.exit;
       if (!exit) {
         return;
@@ -561,8 +564,10 @@ export function mapVisitor<NodeId, TValue, TContext>(
       if (value != null) {
         return exit(value, context, actions);
       }
-    },
-  };
+    };
+  }
+
+  return mapped;
 }
 
 type AdjacencyListMap<TEdgeType> = Map<NodeId, Map<TEdgeType, Set<NodeId>>>;

--- a/packages/core/core/src/Graph.js
+++ b/packages/core/core/src/Graph.js
@@ -422,7 +422,12 @@ export default class Graph<TNode: Node, TEdgeType: string | null = null> {
         }
       }
 
-      if (typeof visit !== 'function' && visit.exit) {
+      if (
+        typeof visit !== 'function' &&
+        visit.exit &&
+        // Make sure the graph still has the node: it may have been removed between enter and exit
+        this.hasNode(nodeId)
+      ) {
         let newContext = visit.exit(nodeId, context, actions);
         if (typeof newContext !== 'undefined') {
           // $FlowFixMe[reassign-const]

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -4,6 +4,7 @@ import type {
   Asset as IAsset,
   Bundle as IBundle,
   BundleGraph as IBundleGraph,
+  BundleGraphTraversable,
   BundleGroup,
   Dependency as IDependency,
   ExportSymbolResolution,
@@ -268,6 +269,23 @@ export default class BundleGraph<TBundle: IBundle>
       loc: e.loc,
       exportAs: e.exportAs,
     }));
+  }
+
+  traverse<TContext>(
+    visit: GraphVisitor<BundleGraphTraversable, TContext>,
+  ): ?TContext {
+    return this.#graph.traverse(
+      mapVisitor(
+        node =>
+          node.type === 'asset'
+            ? {type: 'asset', value: assetFromValue(node.value, this.#options)}
+            : {
+                type: 'dependency',
+                value: new Dependency(node.value),
+              },
+        visit,
+      ),
+    );
   }
 
   traverseBundles<TContext>(

--- a/packages/core/core/test/BundleGraph.test.js
+++ b/packages/core/core/test/BundleGraph.test.js
@@ -34,7 +34,7 @@ describe('BundleGraph', () => {
 
 function getAssets(bundleGraph) {
   let assets = [];
-  bundleGraph.traverseContents(node => {
+  bundleGraph.traverse(node => {
     if (node.type === 'asset') {
       assets.push(node.value);
     }

--- a/packages/core/integration-tests/test/BundleGraph.js
+++ b/packages/core/integration-tests/test/BundleGraph.js
@@ -1,0 +1,64 @@
+// @flow strict-local
+
+import assert from 'assert';
+import path from 'path';
+import {bundle} from '@parcel/test-utils';
+
+describe('BundleGraph', () => {
+  it('can traverse assets across bundles and contexts', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/worker-shared/index.js'),
+    );
+
+    let assets = [];
+    b.traverse(node => {
+      if (node.type === 'asset') {
+        assets.push({
+          type: node.type,
+          value: path.basename(
+            node.value.filePath.replace(/runtime-[0-9a-f]*/g, 'runtime'),
+          ),
+        });
+      }
+    });
+
+    assert.deepEqual(assets, [
+      {
+        type: 'asset',
+        value: 'index.js',
+      },
+      {
+        type: 'asset',
+        value: 'lodash.js',
+      },
+      {
+        type: 'asset',
+        value: 'worker-a.js',
+      },
+      {
+        type: 'asset',
+        value: 'worker-b.js',
+      },
+      {
+        type: 'asset',
+        value: 'esmodule-helpers.js',
+      },
+      {
+        type: 'asset',
+        value: 'runtime.js',
+      },
+      {
+        type: 'asset',
+        value: 'get-worker-url.js',
+      },
+      {
+        type: 'asset',
+        value: 'bundle-url.js',
+      },
+      {
+        type: 'asset',
+        value: 'runtime.js',
+      },
+    ]);
+  });
+});

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -4270,7 +4270,7 @@ describe('cache', function() {
                   ?.filePath,
                 'utf8',
               );
-              assert.equal(html.match(/<script/g)?.length, 5);
+              assert.equal(html.match(/<script/g)?.length, 7);
 
               let pkgFile = path.join(inputDir, 'package.json');
               let pkg = JSON.parse(await overlayFS.readFile(pkgFile));
@@ -4292,7 +4292,7 @@ describe('cache', function() {
           b.bundleGraph.getBundles().find(b => b.name === 'b.html')?.filePath,
           'utf8',
         );
-        assert.equal(html.match(/<script/g)?.length, 4);
+        assert.equal(html.match(/<script/g)?.length, 5);
       });
 
       it('should support updating bundler config', async function() {
@@ -4306,7 +4306,7 @@ describe('cache', function() {
                   ?.filePath,
                 'utf8',
               );
-              assert.equal(html.match(/<script/g)?.length, 4);
+              assert.equal(html.match(/<script/g)?.length, 5);
 
               let pkgFile = path.join(inputDir, 'package.json');
               let pkg = JSON.parse(await overlayFS.readFile(pkgFile));
@@ -4328,7 +4328,7 @@ describe('cache', function() {
           b.bundleGraph.getBundles().find(b => b.name === 'b.html')?.filePath,
           'utf8',
         );
-        assert.equal(html.match(/<script/g)?.length, 5);
+        assert.equal(html.match(/<script/g)?.length, 7);
       });
 
       it('should support removing bundler config', async function() {
@@ -4342,7 +4342,7 @@ describe('cache', function() {
                   ?.filePath,
                 'utf8',
               );
-              assert.equal(html.match(/<script/g)?.length, 4);
+              assert.equal(html.match(/<script/g)?.length, 5);
 
               let pkgFile = path.join(inputDir, 'package.json');
               let pkg = JSON.parse(await overlayFS.readFile(pkgFile));
@@ -4362,7 +4362,7 @@ describe('cache', function() {
           b.bundleGraph.getBundles().find(b => b.name === 'b.html')?.filePath,
           'utf8',
         );
-        assert.equal(html.match(/<script/g)?.length, 5);
+        assert.equal(html.match(/<script/g)?.length, 7);
       });
     });
   });

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1542,26 +1542,26 @@ describe('html', function() {
     });
 
     let html = await outputFS.readFile(path.join(distDir, 'a.html'), 'utf8');
-    assert.equal(html.match(/<script/g).length, 2);
-
-    html = await outputFS.readFile(path.join(distDir, 'b.html'), 'utf8');
     assert.equal(html.match(/<script/g).length, 4);
 
+    html = await outputFS.readFile(path.join(distDir, 'b.html'), 'utf8');
+    assert.equal(html.match(/<script/g).length, 5);
+
     html = await outputFS.readFile(path.join(distDir, 'c.html'), 'utf8');
-    assert.equal(html.match(/<script/g).length, 3);
+    assert.equal(html.match(/<script/g).length, 5);
 
     html = await outputFS.readFile(path.join(distDir, 'd.html'), 'utf8');
-    assert.equal(html.match(/<script/g).length, 2);
+    assert.equal(html.match(/<script/g).length, 4);
 
     html = await outputFS.readFile(path.join(distDir, 'e.html'), 'utf8');
-    assert.equal(html.match(/<script/g).length, 1);
+    assert.equal(html.match(/<script/g).length, 2);
 
     html = await outputFS.readFile(path.join(distDir, 'f.html'), 'utf8');
-    assert.equal(html.match(/<script/g).length, 1);
+    assert.equal(html.match(/<script/g).length, 3);
 
     // b.html hitting the parallel request limit should not prevent g.html from being optimized
     html = await outputFS.readFile(path.join(distDir, 'g.html'), 'utf8');
-    assert.equal(html.match(/<script/g).length, 2);
+    assert.equal(html.match(/<script/g).length, 5);
   });
 
   it('should not add CSS to a worker bundle group', async function() {

--- a/packages/core/integration-tests/test/integration/internalize-no-bundle-split/bar.js
+++ b/packages/core/integration-tests/test/integration/internalize-no-bundle-split/bar.js
@@ -1,0 +1,1 @@
+export default import('./foo').then(mod => mod.default);

--- a/packages/core/integration-tests/test/integration/internalize-no-bundle-split/foo.js
+++ b/packages/core/integration-tests/test/integration/internalize-no-bundle-split/foo.js
@@ -1,0 +1,1 @@
+export default 3;

--- a/packages/core/integration-tests/test/integration/internalize-no-bundle-split/index.js
+++ b/packages/core/integration-tests/test/integration/internalize-no-bundle-split/index.js
@@ -1,0 +1,4 @@
+import bar from './bar';
+import foo from './foo';
+
+export default Promise.all([foo, bar]);

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1061,6 +1061,21 @@ describe('javascript', function() {
     assert.deepEqual(await Promise.all((await run(b)).default), [5, 4]);
   });
 
+  it('does not create bundles for dynamic imports when assets are available up the graph', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/internalize-no-bundle-split/index.js'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'bar.js', 'foo.js', 'esmodule-helpers.js'],
+      },
+    ]);
+
+    assert.deepEqual(await (await run(b)).default, [3, 3]);
+  });
+
   it('async dependency internalization successfully removes unneeded bundlegroups and their bundles', async () => {
     let b = await bundle(
       path.join(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -841,7 +841,7 @@ export type BundleTraversable =
 /**
  * @section bundler
  */
-export type BundlerBundleGraphTraversable =
+export type BundleGraphTraversable =
   | {|+type: 'asset', value: Asset|}
   | {|+type: 'dependency', value: Dependency|};
 
@@ -993,12 +993,6 @@ export interface MutableBundleGraph extends BundleGraph<Bundle> {
   removeBundleGroup(bundleGroup: BundleGroup): void;
   /** Turns a dependency to a different bundle into a dependency to an asset inside <code>bundle</code>. */
   internalizeAsyncDependency(bundle: Bundle, dependency: Dependency): void;
-  traverse<TContext>(
-    GraphVisitor<BundlerBundleGraphTraversable, TContext>,
-  ): ?TContext;
-  traverseContents<TContext>(
-    GraphVisitor<BundlerBundleGraphTraversable, TContext>,
-  ): ?TContext;
 }
 
 /**
@@ -1070,6 +1064,7 @@ export interface BundleGraph<TBundle: Bundle> {
     asset: Asset,
     boundary: ?Bundle,
   ): Array<ExportSymbolResolution>;
+  traverse<TContext>(GraphVisitor<BundleGraphTraversable, TContext>): ?TContext;
   traverseBundles<TContext>(
     visit: GraphVisitor<TBundle, TContext>,
     startBundle: ?Bundle,


### PR DESCRIPTION
This:

* Unifies BundleGraph traversal as `BundleGraph#traverse()`, removing `MutableBundleGraph#traverseContents()`, which would only reach nodes along untyped edges.
* Lifts `.traverse()` to the public `BundleGraph`, where it can be used by reporter plugins.


Test Plan:
* Added a test for `BundleGraph#traverse()` reaching assets across bundles and contexts.
* Adjusted tests. It appears that since `DefaultBundler#optimize` could not reach certain assets via traverseContents, shared bundles were sub-optimal.

cc @MonicaOlejniczak