### PR TITLE
Fix cssnano integration test fixtures

### DIFF
--- a/packages/core/integration-tests/test/integration/html-inline-sass/index.html
+++ b/packages/core/integration-tests/test/integration/html-inline-sass/index.html
@@ -6,7 +6,7 @@
 <body>
   <style type="text/sass">
     .index
-      color: blue
+      color: #0000ff
   </style>
 </body>
 </html>

--- a/packages/core/integration-tests/test/integration/htmlnano-config/index.html
+++ b/packages/core/integration-tests/test/integration/htmlnano-config/index.html
@@ -3,7 +3,7 @@
 <head>
   <title>Test</title>
   <style>h1 { color: red }</style>
-  <style media="print">div { color: blue }</style>
+  <style media="print">div { color: #0000ff }</style>
 
   <style type="text/css" media="print">a {}</style>
   <style>div { font-size: 20px }</style>


### PR DESCRIPTION
Previously, cssnano "optimized" `blue` into `#00f` (which is just as big). Apparently, it doesn't do this anymore in never versions. This change forces an optimization from the 6 digit hex into the 3 digit hex representation.

Regression of https://github.com/parcel-bundler/parcel/pull/6447