### PR TITLE
DefaultResolver: always prefer module field over main field

### DIFF
--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -15,21 +15,11 @@ export default (new Resolver({
       );
     }
 
-    let mainFields = ['source', 'browser'];
-
-    // If scope hoisting is enabled, we can get smaller builds using esmodule input, so choose `module` over `main`.
-    // Otherwise, we'd be wasting time transforming esmodules to commonjs, so choose `main` over `module`.
-    if (dependency.env.shouldScopeHoist) {
-      mainFields.push('module', 'main');
-    } else {
-      mainFields.push('main', 'module');
-    }
-
     const resolver = new NodeResolver({
       fs: options.inputFS,
       projectRoot: options.projectRoot,
       extensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'css', 'styl', 'vue'],
-      mainFields,
+      mainFields: ['source', 'browser', 'module', 'main'],
     });
 
     return resolver.resolve({


### PR DESCRIPTION
Closes #4879, Closes https://github.com/parcel-bundler/website/issues/755

Now that swc transforms esm modules to CommonJS, the performance impact of preferring `main` to `module` to skip this transformation is negligible. This should also better align non-scope-hoisted builds with scope-hoisted builds.

Test Plan: Ran in development mode in a large app. Verified consistent behavior and that build times were essentially the same as without this change.