### PR TITLE
Docs and API consistency for bundles

### DIFF
--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -117,7 +117,7 @@ export default async function dumpGraphToGraphViz(
       // $FlowFixMe
     } else if (node.type === 'bundle') {
       let parts = [];
-      if (node.value.isEntry) parts.push('entry');
+      if (node.value.needsStableName) parts.push('stable name');
       if (node.value.isInline) parts.push('inline');
       if (parts.length) label += ' (' + parts.join(', ') + ')';
       if (node.value.env) label += ` (${getEnvDescription(node.value.env)})`;

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -115,8 +115,8 @@ export class Bundle implements IBundle {
     return new Environment(this.#bundle.env);
   }
 
-  get isEntry(): ?boolean {
-    return this.#bundle.isEntry;
+  get needsStableName(): ?boolean {
+    return this.#bundle.needsStableName;
   }
 
   get isInline(): ?boolean {

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -156,7 +156,7 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
     let target = targetToInternalTarget(opts.target);
     let bundleId = hashString(
       'bundle:' +
-        (opts.uniqueKey ?? nullthrows(entryAsset?.id)) +
+        (opts.entryAsset ? opts.entryAsset.id : opts.uniqueKey) +
         path.relative(this.#options.projectRoot, target.distDir),
     );
 
@@ -186,16 +186,20 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
       value: {
         id: bundleId,
         hashReference: HASH_REF_PREFIX + bundleId,
-        type: opts.type ?? nullthrows(entryAsset).type,
+        type: opts.entryAsset ? opts.entryAsset.type : opts.type,
         env: opts.env
           ? environmentToInternalEnvironment(opts.env)
           : nullthrows(entryAsset).env,
         entryAssetIds: entryAsset ? [entryAsset.id] : [],
         mainEntryId: entryAsset?.id,
-        pipeline: opts.pipeline ?? entryAsset?.pipeline,
-        isEntry: opts.isEntry,
-        isInline: opts.isInline,
-        isSplittable: opts.isSplittable ?? entryAsset?.isBundleSplittable,
+        pipeline: opts.entryAsset ? opts.entryAsset.pipeline : opts.pipeline,
+        needsStableName: opts.needsStableName,
+        isInline: opts.entryAsset
+          ? opts.entryAsset.bundleBehavior === 'inline'
+          : opts.isInline,
+        isSplittable: opts.entryAsset
+          ? opts.entryAsset.isBundleSplittable
+          : opts.isSplittable,
         isPlaceholder,
         target,
         name: null,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -434,7 +434,7 @@ export type Bundle = {|
   env: Environment,
   entryAssetIds: Array<ContentKey>,
   mainEntryId: ?ContentKey,
-  isEntry: ?boolean,
+  needsStableName: ?boolean,
   isInline: ?boolean,
   isSplittable: ?boolean,
   isPlaceholder?: boolean,

--- a/packages/core/core/test/PublicBundle.test.js
+++ b/packages/core/core/test/PublicBundle.test.js
@@ -23,7 +23,7 @@ describe('Public Bundle', () => {
       displayName: null,
       publicId: null,
       pipeline: null,
-      isEntry: null,
+      needsStableName: null,
       isInline: null,
       isSplittable: true,
       target: {

--- a/packages/core/integration-tests/test/integration/cache/node_modules/parcel-bundler-test/index.js
+++ b/packages/core/integration-tests/test/integration/cache/node_modules/parcel-bundler-test/index.js
@@ -15,7 +15,7 @@ module.exports = new Bundler({
       for (let asset of assets) {
         let bundle = bundleGraph.createBundle({
           entryAsset: asset,
-          isEntry: Boolean(dependency.isEntry),
+          needsStableName: Boolean(dependency.isEntry),
           target: bundleGroup.target,
         });
 

--- a/packages/core/integration-tests/test/integration/commonjs-bundle-require/node_modules/parcel-bundler-splitable/index.js
+++ b/packages/core/integration-tests/test/integration/commonjs-bundle-require/node_modules/parcel-bundler-splitable/index.js
@@ -67,7 +67,7 @@ var _default = new _plugin.Bundler({
           for (let asset of assets) {
             let bundle = bundleGraph.createBundle({
               entryAsset: asset,
-              isEntry: asset.isIsolated ? false : Boolean(dependency.isEntry),
+              needsStableName: asset.isIsolated ? false : Boolean(dependency.isEntry),
               isInline: asset.isInline,
               target: bundleGroup.target,
             });
@@ -133,7 +133,7 @@ var _default = new _plugin.Bundler({
             let bundle = bundleGraph.createBundle({
               entryAsset: asset,
               target: bundleGroup.target,
-              isEntry: bundleGroupDependency.isEntry,
+              needsStableName: bundleGroupDependency.isEntry,
               isInline: asset.isInline,
             });
             bundleByType.set(bundle.type, bundle);

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -425,7 +425,7 @@ describe('javascript', function() {
       path.join(__dirname, '/integration/dynamic-import-attributes/index.js'),
     );
 
-    let mainBundle = b.getBundles().find(b => b.isEntry);
+    let mainBundle = b.getBundles()[0];
     let mainBundleContent = await outputFS.readFile(
       mainBundle.filePath,
       'utf8',
@@ -1006,10 +1006,7 @@ describe('javascript', function() {
       },
     ]);
 
-    let contents = await outputFS.readFile(
-      b.getBundles().find(b => b.isEntry).filePath,
-      'utf8',
-    );
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(!contents.includes('import.meta.url'));
   });
 
@@ -1082,10 +1079,7 @@ describe('javascript', function() {
       },
     ]);
 
-    let contents = await outputFS.readFile(
-      b.getBundles().find(b => b.isEntry).filePath,
-      'utf8',
-    );
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(!contents.includes('import.meta.url'));
   });
 
@@ -3565,7 +3559,9 @@ describe('javascript', function() {
     );
 
     let bundles = b.getBundles();
-    let asyncJsBundles = bundles.filter(b => !b.isEntry && b.type === 'js');
+    let asyncJsBundles = bundles.filter(
+      b => !b.needsStableName && b.type === 'js',
+    );
     assert.equal(asyncJsBundles.length, 2);
 
     // Every bundlegroup with an async js bundle should have the corresponding css

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -659,7 +659,7 @@ describe('output formats', function() {
       ]);
 
       let dist = await outputFS.readFile(
-        b.getBundles().find(b => !b.isEntry).filePath,
+        b.getBundles().find(b => !b.needsStableName).filePath,
         'utf8',
       );
       assert(dist.includes('$parcel$interopDefault'));
@@ -715,7 +715,7 @@ describe('output formats', function() {
       );
 
       let async = await outputFS.readFile(
-        b.getChildBundles(b.getBundles().find(b => b.isEntry))[0].filePath,
+        b.getChildBundles(b.getBundles()[0])[0].filePath,
         'utf8',
       );
       assert(!async.includes('$import$'));

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4333,14 +4333,7 @@ describe('scope hoisting', function() {
         ),
       );
 
-      let entryBundle;
-      b.traverseBundles((bundle, ctx, traversal) => {
-        if (bundle.isEntry) {
-          entryBundle = bundle;
-          traversal.stop();
-        }
-      });
-      let entryAsset = entryBundle.getMainEntry();
+      let entryAsset = b.getBundles()[0].getMainEntry();
 
       // TODO: this test doesn't currently work in older browsers since babel
       // replaces the typeof calls before we can get to them.
@@ -5426,10 +5419,7 @@ describe('scope hoisting', function() {
       ),
     );
 
-    let contents = await outputFS.readFile(
-      b.getBundles().find(bundle => bundle.isEntry).filePath,
-      'utf8',
-    );
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(contents.includes('=>'));
 
     let calls = [];

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1046,27 +1046,43 @@ export type CreateBundleOpts =
   // If an entryAsset is provided, a bundle id, type, and environment will be
   // inferred from the entryAsset.
   | {|
-      +uniqueKey?: string,
+      /** The entry asset of the bundle. If provided, many bundle properties will be inferred from it. */
       +entryAsset: Asset,
+      /** The target of the bundle. Should come from the dependency that created the bundle. */
       +target: Target,
-      +isEntry?: ?boolean,
-      +isInline?: ?boolean,
-      +isSplittable?: ?boolean,
-      +type?: ?string,
-      +env?: ?Environment,
-      +pipeline?: ?string,
+      /**
+       * Indicates that the bundle's file name should be stable over time, even when the content of the bundle
+       * changes. This is useful for entries that a user would manually enter the URL for, as well as for things
+       * like service workers or RSS feeds, where the URL must remain consistent over time.
+       */
+      +needsStableName?: ?boolean,
     |}
   // If an entryAsset is not provided, a bundle id, type, and environment must
   // be provided.
   | {|
-      +uniqueKey: string,
-      +entryAsset?: Asset,
-      +target: Target,
-      +isEntry?: ?boolean,
-      +isInline?: ?boolean,
-      +isSplittable?: ?boolean,
+      /** The type of the bundle. */
       +type: string,
+      /** The environment of the bundle. */
       +env: Environment,
+      /** A unique value for the bundle to be used in its id. */
+      +uniqueKey: string,
+      /** The target of the bundle. Should come from the dependency that created the bundle. */
+      +target: Target,
+      /**
+       * Indicates that the bundle's file name should be stable over time, even when the content of the bundle
+       * changes. This is useful for entries that a user would manually enter the URL for, as well as for things
+       * like service workers or RSS feeds, where the URL must remain consistent over time.
+       */
+      +needsStableName?: ?boolean,
+      /** Whether this bundle should be inlined into the parent bundle(s), */
+      +isInline?: ?boolean,
+      /**
+       * Whether the bundle can be split. If false, then all dependencies of the bundle will be kept
+       * internal to the bundle, rather than referring to other bundles. This may result in assets
+       * being duplicated between multiple bundles, but can be useful for things like server side rendering.
+       */
+      +isSplittable?: ?boolean,
+      /** The bundle's pipeline, to be used for optimization. Usually based on the pipeline of the entry asset. */
       +pipeline?: ?string,
     |};
 
@@ -1099,26 +1115,50 @@ export type ExportSymbolResolution = {|
  * @section bundler
  */
 export interface Bundle {
+  /** The bundle id. */
   +id: string;
-  /** Whether this value is inside <code>filePath</code> it will be replace with the real hash at the end. */
-  +hashReference: string;
+  /** The type of the bundle. */
   +type: string;
+  /** The environment of the bundle. */
   +env: Environment;
-  /** Whether this is an entry (e.g. should not be hashed). */
-  +isEntry: ?boolean;
+  /** The bundle's target. */
+  +target: Target;
+  /**
+   * Indicates that the bundle's file name should be stable over time, even when the content of the bundle
+   * changes. This is useful for entries that a user would manually enter the URL for, as well as for things
+   * like service workers or RSS feeds, where the URL must remain consistent over time.
+   */
+  +needsStableName: ?boolean;
   /** Whether this bundle should be inlined into the parent bundle(s), */
   +isInline: ?boolean;
+  /**
+   * Whether the bundle can be split. If false, then all dependencies of the bundle will be kept
+   * internal to the bundle, rather than referring to other bundles. This may result in assets
+   * being duplicated between multiple bundles, but can be useful for things like server side rendering.
+   */
   +isSplittable: ?boolean;
-  +target: Target;
-  /** Assets that run when the bundle is loaded (e.g. runtimes could be added). VERIFY */
+  /**
+   * A placeholder for the bundle's content hash that can be used in the bundle's name or the contents of another
+   * bundle. Hash references are replaced with a content hash of the bundle after packaging and optimizing.
+   */
+  +hashReference: string;
+  /**
+   * Returns the assets that are executed immediately when the bundle is loaded.
+   * Some bundles may not have any entry assets, for example, shared bundles.
+   */
   getEntryAssets(): Array<Asset>;
-  /** The actual entry (which won't be a runtime). */
+  /**
+   * Returns the main entry of the bundle, which will provide the bundle's exports.
+   * Some bundles do not have a main entry, for example, shared bundles.
+   */
   getMainEntry(): ?Asset;
+  /** Returns whether the bundle includes the given asset. */
   hasAsset(Asset): boolean;
+  /** Returns whether the bundle includes the given dependency. */
   hasDependency(Dependency): boolean;
   /** Traverses the assets in the bundle. */
   traverseAssets<TContext>(visit: GraphVisitor<Asset, TContext>): ?TContext;
-  /** Traverses assets and dependencies (see BundleTraversable). */
+  /** Traverses assets and dependencies in the bundle. */
   traverse<TContext>(
     visit: GraphVisitor<BundleTraversable, TContext>,
   ): ?TContext;
@@ -1129,13 +1169,21 @@ export interface Bundle {
  * @section bundler
  */
 export interface NamedBundle extends Bundle {
+  /** A shortened version of the bundle id that is used to refer to the bundle at runtime. */
   +publicId: string;
+  /**
+   * The bundle's name. This is a file path relative to the bundle's target directory.
+   * The bundle name may include a hash reference, but not the final content hash.
+   */
   +name: string;
+  /** A version of the bundle's name with hash references removed for display. */
   +displayName: string;
 }
 
 export interface PackagedBundle extends NamedBundle {
+  /** The absolute file path of the written bundle, including the final content hash if any. */
   +filePath: FilePath;
+  /** Statistics about the bundle. */
   +stats: Stats;
 }
 
@@ -1144,7 +1192,9 @@ export interface PackagedBundle extends NamedBundle {
  * @section bundler
  */
 export type BundleGroup = {|
+  /** The target of the bundle group. */
   +target: Target,
+  /** The id of the entry asset in the bundle group, which is executed immediately when the bundle group is loaded. */
   +entryAssetId: string,
 |};
 

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -15,9 +15,9 @@ export default (new Namer({
     let bundleGroup = bundleGraph.getBundleGroupsContainingBundle(bundle)[0];
     let bundleGroupBundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
 
-    if (bundle.isEntry) {
+    if (bundle.needsStableName) {
       let entryBundlesOfType = bundleGroupBundles.filter(
-        b => b.isEntry && b.type === bundle.type,
+        b => b.needsStableName && b.type === bundle.type,
       );
       assert(
         entryBundlesOfType.length === 1,
@@ -34,7 +34,7 @@ export default (new Namer({
 
     if (
       bundle.id === mainBundle.id &&
-      bundle.isEntry &&
+      bundle.needsStableName &&
       bundle.target &&
       bundle.target.distEntry != null
     ) {
@@ -87,7 +87,7 @@ export default (new Namer({
       bundleGroup.entryAssetId,
       options.entryRoot,
     );
-    if (!bundle.isEntry) {
+    if (!bundle.needsStableName) {
       name += '.' + bundle.hashReference;
     }
 
@@ -106,7 +106,7 @@ function nameFromContent(
   let name = basenameWithoutExtension(entryFilePath);
 
   // If this is an entry bundle, use the original relative path.
-  if (bundle.isEntry) {
+  if (bundle.needsStableName) {
     // Match name of target entry if possible, but with a different extension.
     if (bundle.target.distEntry != null) {
       return basenameWithoutExtension(bundle.target.distEntry);

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -163,7 +163,7 @@ export default class Server {
       // If the main asset is an HTML file, serve it
       let htmlBundleFilePaths = [];
       this.bundleGraph.traverseBundles(bundle => {
-        if (bundle.type === 'html' && bundle.isEntry) {
+        if (bundle.type === 'html' && !bundle.isInline) {
           htmlBundleFilePaths.push(bundle.filePath);
         }
       });

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -480,8 +480,11 @@ function isNewContext(
   bundleGraph: BundleGraph<NamedBundle>,
 ): boolean {
   let parents = bundleGraph.getParentBundles(bundle);
+  let isInEntryBundleGroup = bundleGraph
+    .getBundleGroupsContainingBundle(bundle)
+    .some(g => bundleGraph.isEntryBundleGroup(g));
   return (
-    bundle.isEntry ||
+    isInEntryBundleGroup ||
     parents.length === 0 ||
     parents.some(
       parent =>


### PR DESCRIPTION
Renames `bundle.isEntry` to `bundle.needsStableName` to match dependencies. Also adjusts the options for creating bundles, and adds docs for bundle properties.