### PR TITLE
Fix importing shared bundles in ESM workers

### DIFF
--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -825,7 +825,7 @@ describe('output formats', function() {
         .find(b => !b.filePath.includes('async'));
       assert(
         workerBundleContents.includes(
-          `importScripts("./${path.basename(syncBundle.filePath)}")`,
+          `import "./${path.basename(syncBundle.filePath)}"`,
         ),
       );
       assert(

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1047,10 +1047,15 @@ ${code}
       let importScripts = '';
       let bundles = this.bundleGraph.getReferencedBundles(this.bundle);
       for (let b of bundles) {
-        importScripts += `importScripts("${relativeBundlePath(
-          this.bundle,
-          b,
-        )}");\n`;
+        if (this.bundle.env.outputFormat === 'esmodule') {
+          // importScripts() is not allowed in native ES module workers.
+          importScripts += `import "${relativeBundlePath(this.bundle, b)}";\n`;
+        } else {
+          importScripts += `importScripts("${relativeBundlePath(
+            this.bundle,
+            b,
+          )}");\n`;
+        }
       }
 
       res += importScripts;


### PR DESCRIPTION
Native ESM workers don't support `importScripts()`, so use a normal `import` for shared bundles instead.