### PR TITLE
Don't attempt to resolve URLs starting with '#'

### DIFF
--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -168,12 +168,15 @@ export class ResolverRunner {
         }
       }
     } else {
-      if (
-        dep.specifierType === 'url' &&
-        dependency.specifier.startsWith('//')
-      ) {
-        // A protocol-relative URL, e.g `url('//example.com/foo.png')`
-        return null;
+      if (dep.specifierType === 'url') {
+        if (dependency.specifier.startsWith('//')) {
+          // A protocol-relative URL, e.g `url('//example.com/foo.png')`
+          return null;
+        }
+        if (dependency.specifier.startsWith('#')) {
+          // An ID-only URL, e.g. `url(#clip-path)` for CSS rules
+          return null;
+        }
       }
       filePath = dependency.specifier;
     }

--- a/packages/core/integration-tests/test/integration/stylus-id-url/index.js
+++ b/packages/core/integration-tests/test/integration/stylus-id-url/index.js
@@ -1,0 +1,5 @@
+require('./index.styl');
+
+module.exports = function () {
+  return 2;
+};

--- a/packages/core/integration-tests/test/integration/stylus-id-url/index.styl
+++ b/packages/core/integration-tests/test/integration/stylus-id-url/index.styl
@@ -1,0 +1,2 @@
+.svg-background .clip-1
+  clip-path: url("#clip-path")

--- a/packages/core/integration-tests/test/stylus.js
+++ b/packages/core/integration-tests/test/stylus.js
@@ -96,6 +96,31 @@ describe('stylus', function() {
     );
   });
 
+  it('should ignore paths starting with "#" when resolving with stylus url()', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/stylus-id-url/index.js'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js'],
+      },
+      {
+        name: 'index.css',
+        assets: ['index.styl'],
+      },
+    ]);
+
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 2);
+
+    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
+    assert(css.includes('#clip-path'));
+    assert(css.includes('.svg-background'));
+  });
+
   it('should support transforming stylus with css modules', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/stylus-postcss/index.js'),


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This resolves the issue I came across in #6471 where Stylus files containing a rule like `clip-path: url('#clip-path')` caused the build to fail and throw an error (`Received URL without a pathname #clip-path`).

At first I thought the issue was coming from the `@parcel/transformer-stylus` package, but after digging into it I discovered the error is being thrown _before_ the stylus transformer is hit.

After looking around I came across this [issue](https://github.com/parcel-bundler/parcel/issues/5175) with `#` in paths of SVG files which was solved in #5188. I chose to update `PathRequest.js` to check if a path starts with `#` and return `null` if so.

I can't think of any cases where we would want Parcel to attempt resolving a path starting with `#`, but I could be wrong.

Let me know if there's a different path I should take or if there's any issues with my proposed fix.

Thanks!

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

This is an example of a Stylus rule that causes Parcel to fail and is fixed by this PR:
```
.svg-background .cls-1
  clip-path: url('#clip-path')
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
