### PR TITLE
Add url:*.{filename} patterns to transformers.

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -34,7 +34,20 @@
     "script:*.vue": ["@parcel/transformer-vue"],
     "style:*.vue": ["@parcel/transformer-vue"],
     "custom:*.vue": ["@parcel/transformer-vue"],
+    "url:*.{js,mjs,jsm,jsx,es6,cjs,ts,tsx}": [
+      "@parcel/transformer-babel",
+      "@parcel/transformer-js",
+      "@parcel/transformer-react-refresh-wrap"
+    ],
     "url:*.{png,jpg,jpeg,webp}": ["@parcel/transformer-image"],
+    "url:*.{styl,stylus}": ["@parcel/transformer-stylus"],
+    "url:*.{sass,scss}": ["@parcel/transformer-sass"],
+    "url:*.less": ["@parcel/transformer-less"],
+    "url:*.{css,pcss}": [
+      "@parcel/transformer-postcss",
+      "@parcel/transformer-css"
+    ],
+    "url:*.sss": ["@parcel/transformer-sugarss"],
     "url:*": ["@parcel/transformer-raw"]
   },
   "namers": ["@parcel/namer-default"],


### PR DESCRIPTION
Fixes #6456
Close #6456

# ↪️ Pull Request

So, inspired by the comment in #6156 I figured out how to fix the issue I posted some days ago (#6456).

It works when I put the pattern in my local `.parcelrc`.

In the PR I've added all extension that I know it make sense to import as urls. I don't understand what's the reason of importing `.html` file in javascript, therefore I didn't add it there.


## 🚨 Test instructions

See #6456 

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
