### PR TITLE
Set macOS deployment target

### DIFF
--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -50,4 +50,5 @@ function setupMacBuild() {
     encoding: 'utf8',
   }).trim();
   process.env.CFLAGS = `-isysroot ${sysRoot} -isystem ${sysRoot}`;
+  process.env.MACOSX_DEPLOYMENT_TARGET = '10.9';
 }


### PR DESCRIPTION
Previously, running on macOS 10.13 could fail with
```
Symbol not found: ____chkstk_darwin
  Referenced from: @parcel/transformer-js/parcel-swc.darwin-x64.node (which was built for Mac OS X 10.15)
  Expected in: /usr/lib/libSystem.B.dylib
```
This change makes the binary compile with older versions than the SDK used for building (currently 10.15).

Similar to https://github.com/parcel-bundler/source-map/issues/71