### PR TITLE
Always return new streams from asset.getStream()

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -24,7 +24,7 @@ import type {ConfigRequest} from './requests/ConfigRequest';
 import type {DevDepSpecifier} from './requests/DevDepRequest';
 
 import invariant from 'assert';
-import {blobToStream, TapStream} from '@parcel/utils';
+import {TapStream} from '@parcel/utils';
 import {PluginLogger} from '@parcel/logger';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 import {Readable} from 'stream';
@@ -606,12 +606,12 @@ export default class PackagerRunner {
     let hashReferences = [];
 
     // TODO: don't replace hash references in binary files??
-    if (contents instanceof Readable) {
+    if (typeof contents === 'function') {
       let boundaryStr = '';
       let h = new Hash();
       await this.options.cache.setStream(
         cacheKeys.content,
-        blobToStream(contents).pipe(
+        contents().pipe(
           new TapStream(buf => {
             let str = boundaryStr + buf.toString();
             hashReferences = hashReferences.concat(

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -462,9 +462,10 @@ export default class Transformation {
 
     return Promise.all(
       cachedAssets.map(async (value: AssetValue) => {
+        const contentKey = value.contentKey;
         let content =
-          value.contentKey != null
-            ? this.options.cache.getStream(value.contentKey)
+          contentKey != null
+            ? () => this.options.cache.getStream(contentKey)
             : null;
         let mapBuffer =
           value.astKey != null

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -22,7 +22,6 @@ import type {
 } from './types';
 import {objectSortedEntries} from '@parcel/utils';
 
-import {Readable} from 'stream';
 import {PluginLogger} from '@parcel/logger';
 import nullthrows from 'nullthrows';
 import CommittedAsset from './CommittedAsset';
@@ -167,8 +166,9 @@ async function _generateFromAST(asset: CommittedAsset | UncommittedAsset) {
 
   return {
     content:
-      content instanceof Readable
-        ? asset.options.cache.getStream(nullthrows(asset.value.contentKey))
+      typeof content === 'function'
+        ? () =>
+            asset.options.cache.getStream(nullthrows(asset.value.contentKey))
         : content,
     map,
   };

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -295,8 +295,8 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
     this.#asset.setCode(code);
   }
 
-  setStream(stream: Readable): void {
-    this.#asset.setStream(stream);
+  setStream(streamFactory: () => Readable): void {
+    this.#asset.setStream(streamFactory);
   }
 
   setAST(ast: AST): void {

--- a/packages/core/core/src/summarizeRequest.js
+++ b/packages/core/core/src/summarizeRequest.js
@@ -43,7 +43,7 @@ async function summarizeDiskRequest(
         hashStream(stream).then(
           hash =>
             resolve({
-              content: fs.createReadStream(req.filePath),
+              content: () => fs.createReadStream(req.filePath),
               hash,
               size,
             }),

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -732,8 +732,8 @@ export interface MutableAsset extends BaseAsset {
   setCode(string): void;
   /** Sets the asset contents as a buffer. */
   setBuffer(Buffer): void;
-  /** Sets the asset contents as a stream. */
-  setStream(Readable): void;
+  /** Sets the asset contents as a stream factory. */
+  setStream(() => Readable): void;
   /** Returns whether the AST has been modified. */
   setAST(AST): void;
   /** Sets the asset's AST. */

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -843,7 +843,7 @@ export type GenerateOutput = {|
   +map?: ?SourceMap,
 |};
 
-export type Blob = string | Buffer | Readable;
+export type Blob = string | Buffer | (() => Readable);
 
 /**
  * Transformers can return multiple result objects to create new assets.

--- a/packages/core/utils/src/blob.js
+++ b/packages/core/utils/src/blob.js
@@ -3,11 +3,10 @@
 import type {Blob} from '@parcel/types';
 
 import {bufferStream} from './';
-import {Readable} from 'stream';
 
 export function blobToBuffer(blob: Blob): Promise<Buffer> {
-  if (blob instanceof Readable) {
-    return bufferStream(blob);
+  if (typeof blob === 'function') {
+    return bufferStream(blob());
   } else if (blob instanceof Buffer) {
     return Promise.resolve(Buffer.from(blob));
   } else {
@@ -16,8 +15,8 @@ export function blobToBuffer(blob: Blob): Promise<Buffer> {
 }
 
 export async function blobToString(blob: Blob): Promise<string> {
-  if (blob instanceof Readable) {
-    return (await bufferStream(blob)).toString();
+  if (typeof blob === 'function') {
+    return (await bufferStream(blob())).toString();
   } else if (blob instanceof Buffer) {
     return blob.toString();
   } else {

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -10,10 +10,9 @@ import type {
   NamedBundle,
 } from '@parcel/types';
 
-import {Readable} from 'stream';
 import nullthrows from 'nullthrows';
 import URL from 'url';
-import {bufferStream, relativeBundlePath, urlJoin} from './';
+import {blobToString, relativeBundlePath, urlJoin} from './';
 
 type ReplacementMap = Map<
   string /* dependency id */,
@@ -127,16 +126,16 @@ export async function replaceInlineReferences({
       entryBundle,
       bundleGraph,
     );
-    let packagedContents = (packagedBundle.contents instanceof Readable
-      ? await bufferStream(packagedBundle.contents)
-      : packagedBundle.contents
-    ).toString();
 
     let inlineType = nullthrows(entryBundle.getMainEntry()).meta.inlineType;
     if (inlineType == null || inlineType === 'string') {
       replacements.set(
         dependency.id,
-        getInlineReplacement(dependency, inlineType, packagedContents),
+        getInlineReplacement(
+          dependency,
+          inlineType,
+          await blobToString(packagedBundle.contents),
+        ),
       );
     }
   }

--- a/packages/core/utils/src/stream.js
+++ b/packages/core/utils/src/stream.js
@@ -36,8 +36,8 @@ export function bufferStream(stream: Readable): Promise<Buffer> {
 }
 
 export function blobToStream(blob: Blob): Readable {
-  if (blob instanceof Readable) {
-    return blob;
+  if (typeof blob === 'function') {
+    return blob();
   }
 
   return readableFromStringOrBuffer(blob);
@@ -46,8 +46,8 @@ export function blobToStream(blob: Blob): Readable {
 export function streamFromPromise(promise: Promise<Blob>): Readable {
   const stream = new PassThrough();
   promise.then(blob => {
-    if (blob instanceof Readable) {
-      blob.pipe(stream);
+    if (typeof blob === 'function') {
+      blob().pipe(stream);
     } else {
       stream.end(blob);
     }

--- a/packages/packagers/raw/src/RawPackager.js
+++ b/packages/packagers/raw/src/RawPackager.js
@@ -11,6 +11,6 @@ export default (new Packager({
     });
 
     assert.equal(assets.length, 1, 'Raw bundles must only contain one asset');
-    return {contents: assets[0].getStream()};
+    return {contents: () => assets[0].getStream()};
   },
 }): Packager);

--- a/packages/transformers/image/src/ImageTransformer.js
+++ b/packages/transformers/image/src/ImageTransformer.js
@@ -48,7 +48,7 @@ export default (new Transformer({
         });
       }
 
-      asset.setStream(imagePipeline);
+      asset.setStream(() => imagePipeline);
     }
 
     return [asset];


### PR DESCRIPTION
Previously, there was only one stateful stream associated with an asset with stream content, and when called, `asset.getStream()` would return a reference to the stream and unset it on the asset. `asset.setStream()` now expects a stream-returning function.

This makes it possible to call `asset.getStream()` multiple times, each returning a new stream. For transformers that set streams, *this means that transformations may happen multiple times*, which seems safer than unsetting it.

Test Plan: `yarn test`