### PR TITLE
Fix ESM output from CJS input

### DIFF
--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -1401,6 +1401,7 @@ describe('cache', function() {
               targets: {
                 esmodule: {
                   outputFormat: 'esmodule',
+                  isLibrary: true,
                 },
               },
             }),
@@ -1563,6 +1564,7 @@ describe('cache', function() {
               targets: {
                 esmodule: {
                   outputFormat: 'esmodule',
+                  isLibrary: true,
                 },
               },
             }),
@@ -1679,6 +1681,7 @@ describe('cache', function() {
               targets: {
                 modern: {
                   outputFormat: 'esmodule',
+                  isLibrary: true,
                 },
                 legacy: {
                   outputFormat: 'commonjs',
@@ -1883,6 +1886,7 @@ describe('cache', function() {
               targets: {
                 modern: {
                   outputFormat: 'esmodule',
+                  isLibrary: true,
                 },
               },
             }),
@@ -1912,6 +1916,7 @@ describe('cache', function() {
               targets: {
                 modern: {
                   outputFormat: 'esmodule',
+                  isLibrary: true,
                 },
               },
             }),

--- a/packages/core/integration-tests/test/integration/formats/esm-cjs/a.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-cjs/a.js
@@ -1,0 +1,1 @@
+exports.test = true;

--- a/packages/core/integration-tests/test/integration/formats/esm-cjs/package.json
+++ b/packages/core/integration-tests/test/integration/formats/esm-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "module": "dist/test.js"
+}

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1108,6 +1108,16 @@ describe('output formats', function() {
       let ns = await run(b);
       assert.strictEqual(ns.fib(5), 8);
     });
+
+    it('should support ESM output from CJS input', async function() {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/esm-cjs/a.js'),
+      );
+
+      let ns = await run(b);
+      assert.deepEqual(ns.test, true);
+      assert.deepEqual(ns.default, {test: true});
+    });
   });
 
   it('should support generating ESM from universal module wrappers', async function() {

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -845,7 +845,10 @@ ${code}
       // If a symbol is imported (used) from a CJS asset but isn't listed in the symbols,
       // we fallback on the namespace object.
       (asset.symbols.hasExportSymbol('*') &&
-        [...usedSymbols].some(s => !asset.symbols.hasExportSymbol(s)));
+        [...usedSymbols].some(s => !asset.symbols.hasExportSymbol(s))) ||
+      // If the exports has this asset's namespace (e.g. ESM output from CJS input),
+      // include the namespace object for the default export.
+      this.exportedSymbols.has(`$${assetId}$exports`);
 
     // If the asset doesn't have static exports, should wrap, the namespace is used,
     // or we need default interop, then we need to synthesize a namespace object for

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -268,7 +268,11 @@ export class ScopeHoistingPackager {
   }
 
   buildExportedSymbols() {
-    if (this.isAsyncBundle || this.bundle.env.outputFormat !== 'esmodule') {
+    if (
+      this.isAsyncBundle ||
+      !this.bundle.env.isLibrary ||
+      this.bundle.env.outputFormat !== 'esmodule'
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fixes #6454. Fixes #6103.

When outputting ESM from an entry CJS asset, we include a `default` export with the CJS namespace in addition to any statically analyzable exports. But this was not working because the namespace object might not have been declared if the asset wasn't wrapped. This also resulted in any assets that don't contain any ESM imports or exports (treated as CJS) in adding an extra default export pointing to an undefined variable.

Separately, I've disabled ESM exports for non library builds since we don't use them.