### PR TITLE
Adds '@parcel/diagnostic' to dependencies

### DIFF
--- a/packages/validators/typescript/package.json
+++ b/packages/validators/typescript/package.json
@@ -20,6 +20,7 @@
     "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
+    "@parcel/diagnostic": "2.0.0-beta.3.1",
     "@parcel/plugin": "2.0.0-beta.3.1",
     "@parcel/ts-utils": "2.0.0-beta.3.1",
     "@parcel/types": "2.0.0-beta.3.1",


### PR DESCRIPTION
# ↪️ Pull Request

An import to '@parcel/diagnostic' was added to TypeScriptValidator, but wasn't added to the dependency list.

The resulted in the falling build error when using `nightly`.

```
🚨 Build failed.

@parcel/validator-typescript: Could not resolve module "@parcel/diagnostic" ... /node_modules/@parcel/validator-typescript/lib/TypeScriptValidator.js"
```