### PR TITLE
Remove 'Name already registered with serializer' error

### DIFF
--- a/packages/core/core/src/serializer.js
+++ b/packages/core/core/src/serializer.js
@@ -11,10 +11,6 @@ const nameToCtor: Map<string, Class<*>> = new Map();
 const ctorToName: Map<Class<*>, string> = new Map();
 
 export function registerSerializableClass(name: string, ctor: Class<*>) {
-  if (nameToCtor.has(name)) {
-    throw new Error('Name already registered with serializer');
-  }
-
   if (ctorToName.has(ctor)) {
     throw new Error('Class already registered with serializer');
   }


### PR DESCRIPTION
Fixes #4064.

This issue seems to come up a lot because npm/yarn don't always deduplicate packages properly. It should be safe to not error because the version is part of the key being registered. The only case where it wouldn't work is if we relied on `instanceof`, but I didn't find any places where that's the case. So let's try just removing this error and see where it takes us. 🤷 