### PR TITLE
More bugs

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -660,19 +660,13 @@ export default class Transformation {
     const logger = new PluginLogger({origin: transformerName});
 
     const resolve = async (from: FilePath, to: string): Promise<FilePath> => {
-      let result: {|
-        assetGroup: AssetGroup,
-        invalidateOnFileCreate?: Array<FileCreateInvalidation>,
-        invalidateOnFileChange?: Array<FilePath>,
-      |} = nullthrows(
-        await pipeline.resolverRunner.resolve(
-          createDependency(this.options.projectRoot, {
-            env: asset.value.env,
-            specifier: to,
-            specifierType: 'esm', // ???
-            sourcePath: from,
-          }),
-        ),
+      let result = await pipeline.resolverRunner.resolve(
+        createDependency(this.options.projectRoot, {
+          env: asset.value.env,
+          specifier: to,
+          specifierType: 'esm', // ???
+          sourcePath: from,
+        }),
       );
 
       if (result.invalidateOnFileCreate) {
@@ -694,9 +688,13 @@ export default class Transformation {
         }
       }
 
+      if (result.diagnostics && result.diagnostics.length > 0) {
+        throw new ThrowableDiagnostic({diagnostic: result.diagnostics});
+      }
+
       return fromProjectPath(
         this.options.projectRoot,
-        result.assetGroup.filePath,
+        nullthrows(result.assetGroup).filePath,
       );
     };
 

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -2,7 +2,6 @@
 
 import type {
   FilePath,
-  FileCreateInvalidation,
   GenerateOutput,
   Transformer,
   TransformerResult,
@@ -12,7 +11,6 @@ import type {
 import type {WorkerApi} from '@parcel/workers';
 import type {
   Asset as AssetValue,
-  AssetGroup,
   TransformationRequest,
   RequestInvalidation,
   Config,

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -5,7 +5,6 @@ import type {
   FileCreateInvalidation,
   FilePath,
   QueryParameters,
-  ResolveResult,
 } from '@parcel/types';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {AssetGroup, Dependency, ParcelOptions} from '../types';

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2037,7 +2037,7 @@ describe('javascript', function() {
     let output = await run(b);
     assert(/^http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.default));
     let stats = await outputFS.stat(
-      path.join(distDir, url.parse(output.default).pathname),
+      path.join(distDir, output.default.pathname),
     );
     assert.equal(stats.size, 9);
   });
@@ -2064,7 +2064,7 @@ describe('javascript', function() {
     let output = await run(b);
     assert(/^http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.default));
     let stats = await outputFS.stat(
-      path.join(distDir, url.parse(output.default).pathname),
+      path.join(distDir, output.default.pathname),
     );
     assert.equal(stats.size, 9);
   });

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -100,15 +100,12 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
       let assets = data.assets.filter(asset => asset.envHash === HMR_ENV_HASH);
 
       // Handle HMR Update
-      var handled = false;
-      assets.forEach(asset => {
-        var didAccept =
+      let handled = assets.every(asset => {
+        return (
           asset.type === 'css' ||
           (asset.type === 'js' &&
-            hmrAcceptCheck(module.bundle.root, asset.id, asset.depsByBundle));
-        if (didAccept) {
-          handled = true;
-        }
+            hmrAcceptCheck(module.bundle.root, asset.id, asset.depsByBundle))
+        );
       });
 
       if (handled) {

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -14,7 +14,9 @@ function shouldExclude(asset, options) {
     asset.env.isWorker() ||
     asset.env.isWorklet() ||
     options.mode !== 'development' ||
-    !asset.getDependencies().find(v => v.specifier === 'react')
+    !asset
+      .getDependencies()
+      .find(v => v.specifier === 'react' || v.specifier === 'react/jsx-runtime')
   );
 }
 

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -186,6 +186,8 @@ export default class NodeResolver {
       if (err instanceof ThrowableDiagnostic) {
         return {
           diagnostics: err.diagnostics,
+          invalidateOnFileCreate: ctx.invalidateOnFileCreate,
+          invalidateOnFileChange: [...ctx.invalidateOnFileChange],
         };
       } else {
         throw err;


### PR DESCRIPTION
* Reloads the page if multiple assets changed and not all of them were accepted by HMR. This happens e.g. when changing an HTML file with Tailwind. The CSS gets accepted, but the HTML does not, and the page doesn't get reloaded currently. Fixes #6393.
* Fixes React Fast Refresh runtime not being applied with the new automatic JSX runtime, which doesn't require a dependency on `"react"` to be in the file. Now we also look for `"react/jsx-runtime"`.
* If the resolver failed but then the error was fixed (e.g. file didn't exist and it was created), we didn't trigger a rebuild and you had to restart Parcel. This was because the invalidations were never added to the graph. Now we do this before throwing the error.
* `new URL('something', import.meta.url)` was getting transformed into a require of a runtime and returning a string instead of an actual URL object. Now it's transformed into `new URL(require('something'))` instead.