### PR TITLE
Support multiple dependency types on the same specifier in the same file

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -798,7 +798,13 @@ export default class BundleGraph {
       // If the asset is in any sibling bundles of the original bundle, it is reachable.
       let bundles = this.getBundlesInBundleGroup(bundleGroup);
       if (
-        bundles.some(b => b.id !== bundle.id && this.bundleHasAsset(b, asset))
+        bundles.some(
+          b =>
+            b.id !== bundle.id &&
+            b.bundleBehavior !== BundleBehavior.isolated &&
+            b.bundleBehavior !== BundleBehavior.inline &&
+            this.bundleHasAsset(b, asset),
+        )
       ) {
         return true;
       }
@@ -814,7 +820,8 @@ export default class BundleGraph {
         let bundleNode = nullthrows(this._graph.getNode(bundleNodeId));
         if (
           bundleNode.type !== 'bundle' ||
-          bundleNode.value.bundleBehavior === BundleBehavior.isolated
+          bundleNode.value.bundleBehavior === BundleBehavior.isolated ||
+          bundleNode.value.bundleBehavior === BundleBehavior.inline
         ) {
           return false;
         }
@@ -843,6 +850,7 @@ export default class BundleGraph {
                   b =>
                     b.id !== bundle.id &&
                     b.bundleBehavior !== BundleBehavior.isolated &&
+                    b.bundleBehavior !== BundleBehavior.inline &&
                     this.bundleHasAsset(b, asset),
                 )
               ) {

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -48,7 +48,9 @@ export function createDependency(
         opts.specifier +
         opts.env.id +
         (opts.target ? JSON.stringify(opts.target) : '') +
-        (opts.pipeline ?? ''),
+        (opts.pipeline ?? '') +
+        opts.specifierType +
+        (opts.priority ?? 'sync'),
     );
 
   return {

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -155,7 +155,8 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
     let bundleId = hashString(
       'bundle:' +
         (opts.entryAsset ? opts.entryAsset.id : opts.uniqueKey) +
-        fromProjectPathRelative(target.distDir),
+        fromProjectPathRelative(target.distDir) +
+        (opts.bundleBehavior ?? ''),
     );
 
     let existing = this.#graph._graph.getNodeByContentKey(bundleId);

--- a/packages/core/integration-tests/test/blob-url.js
+++ b/packages/core/integration-tests/test/blob-url.js
@@ -44,7 +44,7 @@ describe('blob urls', () => {
       path.join(distDir, 'index.js'),
       'utf8',
     );
-    assert(bundleContent.includes('new Worker(require("blob-url:./worker"))'));
+    assert(bundleContent.includes('new Worker(require('));
     assert(
       bundleContent.includes(
         'module.exports = URL.createObjectURL(new Blob(["// modules are defined as an array\\n',
@@ -87,7 +87,7 @@ describe('blob urls', () => {
       path.join(distDir, 'index.js'),
       'utf8',
     );
-    assert(bundleContent.match(/new Worker\([^(]*\("blob-url:.\/worker"\)\)/));
+    assert(bundleContent.includes('new Worker('));
     assert(
       bundleContent.includes(
         ".exports=URL.createObjectURL(new Blob(['!function(",

--- a/packages/core/integration-tests/test/integration/multiple-import-types/dynamic-inline.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/dynamic-inline.js
@@ -1,0 +1,4 @@
+import t from 'bundle-text:./other';
+
+export const lazy = import('./other').then(({default: LazyFoo}) => LazyFoo);
+export const text = t;

--- a/packages/core/integration-tests/test/integration/multiple-import-types/dynamic-url.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/dynamic-url.js
@@ -1,0 +1,2 @@
+export const lazy = import('./other').then(({default: LazyFoo}) => LazyFoo);
+export const url = new URL('./other', import.meta.url).toString();

--- a/packages/core/integration-tests/test/integration/multiple-import-types/other.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/other.js
@@ -1,0 +1,1 @@
+export default class Foo {}

--- a/packages/core/integration-tests/test/integration/multiple-import-types/static-dynamic-url.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/static-dynamic-url.js
@@ -1,0 +1,5 @@
+import Foo from './other';
+
+export {Foo};
+export const LazyFoo = import('./other').then(({default: LazyFoo}) => LazyFoo);
+export const url = new URL('./other', import.meta.url).toString();

--- a/packages/core/integration-tests/test/integration/multiple-import-types/static-dynamic.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/static-dynamic.js
@@ -1,0 +1,4 @@
+import Foo from './other';
+
+export {Foo};
+export const LazyFoo = import('./other').then(({default: LazyFoo}) => LazyFoo);

--- a/packages/core/integration-tests/test/integration/multiple-import-types/static-inline.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/static-inline.js
@@ -1,0 +1,6 @@
+import Foo from './other';
+import text from 'bundle-text:./other';
+
+// Get around bug with exports of symbols with bailouts...
+const t = text;
+export {Foo, t as text};

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -664,8 +664,7 @@ describe('javascript', function() {
       mainBundle.filePath,
       'utf8',
     );
-    assert(mainBundleContent.includes("require('./async')"));
-    assert(mainBundleContent.includes(`require('./async2')`));
+    assert(!mainBundleContent.includes('foo:'));
   });
 
   it('should split bundles when a dynamic import is used with a node environment', async function() {
@@ -4475,5 +4474,329 @@ describe('javascript', function() {
         ],
       },
     );
+  });
+
+  describe('multiple import types', function() {
+    it('supports both static and dynamic imports to the same specifier in the same file', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-dynamic.js',
+        ),
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-dynamic.js', 'other.js', 'esmodule-helpers.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.LazyFoo, 'object');
+      assert.equal(res.Foo, await res.LazyFoo);
+    });
+
+    it('supports both static and dynamic imports to the same specifier in the same file with scope hoisting', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-dynamic.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-dynamic.js', 'other.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.LazyFoo, 'object');
+      assert.equal(res.Foo, await res.LazyFoo);
+    });
+
+    it('supports static, dynamic, and url to the same specifier in the same file', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-dynamic-url.js',
+        ),
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: [
+            'static-dynamic-url.js',
+            'other.js',
+            'esmodule-helpers.js',
+            'bundle-url.js',
+          ],
+        },
+        {
+          type: 'js',
+          assets: ['other.js', 'esmodule-helpers.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.LazyFoo, 'object');
+      assert.equal(res.Foo, await res.LazyFoo);
+      assert.equal(
+        res.url,
+        'http://localhost/' + path.basename(b.getBundles()[1].filePath),
+      );
+    });
+
+    it('supports static, dynamic, and url to the same specifier in the same file with scope hoisting', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-dynamic-url.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-dynamic-url.js', 'other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.LazyFoo, 'object');
+      assert.equal(res.Foo, await res.LazyFoo);
+      assert.equal(
+        res.url,
+        'http://localhost/' + path.basename(b.getBundles()[1].filePath),
+      );
+    });
+
+    it('supports dynamic import and url to the same specifier in the same file', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/dynamic-url.js',
+        ),
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: [
+            'dynamic-url.js',
+            'esmodule-helpers.js',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
+          ],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js', 'esmodule-helpers.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.lazy, 'object');
+      assert.equal(typeof (await res.lazy), 'function');
+      assert.equal(
+        res.url,
+        'http://localhost/' + path.basename(b.getBundles()[1].filePath),
+      );
+    });
+
+    it('supports dynamic import and url to the same specifier in the same file with scope hoisting', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/dynamic-url.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['dynamic-url.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.lazy, 'object');
+      assert.equal(typeof (await res.lazy), 'function');
+      assert.equal(
+        res.url,
+        'http://localhost/' + path.basename(b.getBundles()[1].filePath),
+      );
+    });
+
+    it('supports static import and inline bundle for the same asset', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-inline.js',
+        ),
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-inline.js', 'other.js', 'esmodule-helpers.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js', 'esmodule-helpers.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.text, 'string');
+    });
+
+    it('supports static import and inline bundle for the same asset with scope hoisting', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-inline.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-inline.js', 'other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.text, 'string');
+    });
+
+    it('supports dynamic import and inline bundle for the same asset', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/dynamic-inline.js',
+        ),
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: [
+            'dynamic-inline.js',
+            'esmodule-helpers.js',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
+          ],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js', 'esmodule-helpers.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.lazy, 'object');
+      assert.equal(typeof (await res.lazy), 'function');
+      assert.equal(typeof res.text, 'string');
+    });
+
+    it('supports dynamic import and inline bundle for the same asset with scope hoisting', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/dynamic-inline.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['dynamic-inline.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+      ]);
+
+      let res = await run(b);
+      assert.equal(typeof res.lazy, 'object');
+      assert.equal(typeof (await res.lazy), 'function');
+      assert.equal(typeof res.text, 'string');
+    });
   });
 });

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -6,7 +6,7 @@ import SourceMap from '@parcel/source-map';
 import invariant from 'assert';
 import path from 'path';
 import fs from 'fs';
-import {replaceScriptDependencies} from './utils';
+import {replaceScriptDependencies, getSpecifier} from './utils';
 
 const PRELUDE = fs
   .readFileSync(path.join(__dirname, 'dev-prelude.js'), 'utf8')
@@ -102,7 +102,9 @@ export class DevPackager {
             this.bundle,
           );
           if (resolved) {
-            deps[dep.specifier] = this.bundleGraph.getAssetPublicId(resolved);
+            deps[getSpecifier(dep)] = this.bundleGraph.getAssetPublicId(
+              resolved,
+            );
           }
         }
 

--- a/packages/packagers/js/src/ESMOutputFormat.js
+++ b/packages/packagers/js/src/ESMOutputFormat.js
@@ -74,11 +74,27 @@ export class ESMOutputFormat implements OutputFormat {
     let res = '';
     let lines = 0;
     let exportSpecifiers = [];
-    for (let exported of this.packager.exportedSymbols.values()) {
-      for (let {exportAs, local} of exported) {
+    for (let {
+      asset,
+      exportSymbol,
+      local,
+      exportAs,
+    } of this.packager.exportedSymbols.values()) {
+      if (this.packager.wrappedAssets.has(asset.id)) {
+        let obj = `parcelRequire("${this.packager.bundleGraph.getAssetPublicId(
+          asset,
+        )}")`;
+        res += `\nvar ${local} = ${this.packager.getPropertyAccess(
+          obj,
+          exportSymbol,
+        )};`;
+        lines++;
+      }
+
+      for (let as of exportAs) {
         let specifier = local;
         if (exportAs !== local) {
-          specifier += ` as ${exportAs}`;
+          specifier += ` as ${as}`;
         }
 
         exportSpecifiers.push(specifier);

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -19,7 +19,7 @@ import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
 import {GlobalOutputFormat} from './GlobalOutputFormat';
 import {prelude, helpers} from './helpers';
-import {replaceScriptDependencies} from './utils';
+import {replaceScriptDependencies, getSpecifier} from './utils';
 
 // https://262.ecma-international.org/6.0/#sec-names-and-keywords
 const IDENTIFIER_RE = /^[$_\p{ID_Start}][$_\u200C\u200D\p{ID_Continue}]*$/u;
@@ -535,7 +535,7 @@ ${code}
     let depMap = new Map();
     let replacements = new Map();
     for (let dep of deps) {
-      depMap.set(`${assetId}:${dep.specifier}`, dep);
+      depMap.set(`${assetId}:${getSpecifier(dep)}`, dep);
 
       let asyncResolution = this.bundleGraph.resolveAsyncDependency(
         dep,

--- a/packages/packagers/js/src/utils.js
+++ b/packages/packagers/js/src/utils.js
@@ -1,5 +1,5 @@
 // @flow
-import type {BundleGraph, NamedBundle} from '@parcel/types';
+import type {BundleGraph, Dependency, NamedBundle} from '@parcel/types';
 import type SourceMap from '@parcel/source-map';
 import nullthrows from 'nullthrows';
 
@@ -26,7 +26,7 @@ export function replaceScriptDependencies(
       return '\n';
     }
 
-    let dep = nullthrows(dependencies.find(d => d.specifier === s));
+    let dep = nullthrows(dependencies.find(d => getSpecifier(d) === s));
     let resolved = nullthrows(bundleGraph.getDependencyResolution(dep, bundle));
     let publicId = bundleGraph.getAssetPublicId(resolved);
     let replacement = `${parcelRequireName}("${publicId}")`;
@@ -46,4 +46,12 @@ export function replaceScriptDependencies(
   });
 
   return code;
+}
+
+export function getSpecifier(dep: Dependency): string {
+  if (typeof dep.meta.placeholder === 'string') {
+    return dep.meta.placeholder;
+  }
+
+  return dep.specifier;
 }

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -561,6 +561,10 @@ export default (new Transformer({
           meta.importAttributes = dep.attributes;
         }
 
+        if (dep.placeholder) {
+          meta.placeholder = dep.placeholder;
+        }
+
         let env;
         if (dep.kind === 'DynamicImport') {
           if (asset.env.isWorklet()) {
@@ -650,7 +654,9 @@ export default (new Transformer({
       }
 
       let deps = new Map(
-        asset.getDependencies().map(dep => [dep.specifier, dep]),
+        asset
+          .getDependencies()
+          .map(dep => [dep.meta.placeholder ?? dep.specifier, dep]),
       );
       for (let dep of deps.values()) {
         dep.symbols.ensure();


### PR DESCRIPTION
Fixes #5016.

This adds support for importing the same specifier in multiple ways within the same file. For example, a static and dynamic import, or a url import. Previously this was not possible because we used the specifier as the key of an object in the dev packager. Now, the specifier is replaced with a hash of the original specifier and the import kind. In addition, some bundler bugs were fixed so that assets/dependencies with different `bundleBehavior` settings are not merged.