### PR TITLE
Fix react-refresh runtime with inline scripts

### DIFF
--- a/packages/core/integration-tests/test/integration/react-refresh-inline-script/index.html
+++ b/packages/core/integration-tests/test/integration/react-refresh-inline-script/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<script>
+  /*asdf */
+</script>
+<script type="module" src="index.js"></script>

--- a/packages/core/integration-tests/test/integration/react-refresh-inline-script/index.js
+++ b/packages/core/integration-tests/test/integration/react-refresh-inline-script/index.js
@@ -1,0 +1,3 @@
+function App() {
+  return <div>test</div>;
+}

--- a/packages/core/integration-tests/test/integration/react-refresh-inline-script/package.json
+++ b/packages/core/integration-tests/test/integration/react-refresh-inline-script/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "*"
+  }
+}

--- a/packages/core/integration-tests/test/react-refresh.js
+++ b/packages/core/integration-tests/test/react-refresh.js
@@ -3,10 +3,12 @@ import assert from 'assert';
 import invariant from 'assert';
 import path from 'path';
 import {
+  bundle,
   bundler,
   getNextBuild,
   overlayFS as fs,
   sleep,
+  run,
 } from '@parcel/test-utils';
 import getPort from 'get-port';
 import type {BuildEvent} from '@parcel/types';
@@ -157,6 +159,23 @@ if (MessageChannel) {
       afterEach(async () => {
         await cleanup({subscription, window});
       });
+    });
+
+    it('does not error on inline scripts', async () => {
+      let port = await getPort();
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/react-refresh-inline-script/index.html',
+        ),
+        {
+          hmrOptions: {
+            port,
+          },
+        },
+      );
+
+      await run(b, {}, {require: false});
     });
   });
 }

--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -40,6 +40,9 @@ export default (new Runtime({
         `module.bundle.HMR_BUNDLE_ID = ${JSON.stringify(bundle.id)};` +
         HMR_RUNTIME,
       isEntry: true,
+      env: {
+        sourceType: 'module',
+      },
     };
   },
 }): Runtime);

--- a/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
+++ b/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
@@ -22,7 +22,8 @@ export default (new Runtime({
       !bundle.env.isBrowser() ||
       bundle.env.isWorker() ||
       bundle.env.isWorklet() ||
-      options.mode !== 'development'
+      options.mode !== 'development' ||
+      bundle.env.sourceType !== 'module'
     ) {
       return;
     }

--- a/packages/transformers/html/src/inline.js
+++ b/packages/transformers/html/src/inline.js
@@ -70,14 +70,31 @@ export default function extractInlineAssets(
             sourceType = 'module';
           }
 
+          let loc = node.location
+            ? {
+                filePath: asset.filePath,
+                start: node.location.start,
+                end: node.location.end,
+              }
+            : undefined;
+
           env = {
             sourceType,
             outputFormat,
+            loc,
           };
         } else {
+          let loc = node.location
+            ? {
+                filePath: asset.filePath,
+                start: node.location.start,
+                end: node.location.end,
+              }
+            : undefined;
           type = 'js';
           env = {
             sourceType: 'script',
+            loc,
           };
         }
 

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -435,7 +435,6 @@ export default (new Transformer({
             codeFrames: [
               {
                 filePath: asset.filePath,
-                code: code.toString(),
                 codeHighlights: diagnostic.code_highlights?.map(highlight => {
                   let {start, end} = convertLoc(highlight.loc);
                   return {
@@ -450,7 +449,7 @@ export default (new Transformer({
           };
 
           if (diagnostic.show_environment) {
-            if (asset.env.loc) {
+            if (asset.env.loc && asset.env.loc.filePath !== asset.filePath) {
               res.codeFrames.push({
                 filePath: asset.env.loc.filePath,
                 codeHighlights: [

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -435,6 +435,7 @@ export default (new Transformer({
             codeFrames: [
               {
                 filePath: asset.filePath,
+                code: code.toString(),
                 codeHighlights: diagnostic.code_highlights?.map(highlight => {
                   let {start, end} = convertLoc(highlight.loc);
                   return {


### PR DESCRIPTION
Fixes #4858. Fixes #6586.

Appeared to already work with inline `<script type="module">`, but this fixes a few problems with inline non-module scripts. Underlying error was that the react-refresh runtime was being added, and it was erroring on the `require`. Now we don't add the react-refresh runtime when sourceType is "script".

While finding the cause, I also fixed CLI error output for virtual assets, e.g. runtimes. We were trying to read the runtime file from disk, but it obviously doesn't exist. So now the diagnostic has a `code` property. And also added location info to the environment for inline scripts for nicer output.