### PR TITLE
Preserve hash in replaced URL dependencies

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -76,6 +76,16 @@ describe('html', function() {
       }
     }
 
+    assert(html.includes('#hash_link'));
+    assert(html.includes('mailto:someone@acme.com'));
+    assert(html.includes('tel:+33636757575'));
+    assert(html.includes('https://unpkg.com/parcel-bundler'));
+
+    let iconsBundle = b.getBundles().find(b => b.name.startsWith('icons'));
+    assert(
+      html.includes('/' + path.basename(iconsBundle.filePath) + '#icon-code'),
+    );
+
     let value = null;
     await run(b, {
       alert: v => (value = v),

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -161,19 +161,20 @@ export function getURLReplacement({
 |}): {|from: string, to: string|} {
   let to;
 
+  let orig = URL.parse(dependency.specifier);
+
   if (relative) {
-    to = URL.format(
-      URL.parse(
-        relativeBundlePath(fromBundle, toBundle, {
-          leadingDotSlash: false,
-        }),
-      ),
+    let parsed = URL.parse(
+      relativeBundlePath(fromBundle, toBundle, {
+        leadingDotSlash: false,
+      }),
     );
+    parsed.hash = orig.hash;
+    to = URL.format(parsed);
   } else {
-    to = urlJoin(
-      toBundle.target.publicUrl,
-      URL.format(URL.parse(nullthrows(toBundle.name))),
-    );
+    let parsed = URL.parse(nullthrows(toBundle.name));
+    parsed.hash = orig.hash;
+    to = urlJoin(toBundle.target.publicUrl, URL.format(parsed));
   }
 
   let placeholder = dependency.meta?.placeholder ?? dependency.id;


### PR DESCRIPTION
Fixes #6048. Fixes #4346.

When a URL dependency has a hash, e.g. `<a href="somepage.html#hash">`, it should be preserved after the final url is replaced. This also breaks things like SVG sprite sheets.

I wondered if we should do this for query params too? But how would we know if the query params were meant for Parcel transformers or not?