### PR TITLE
Replace options.entryRoot with bundleGraph.getEntryRoot(target)

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1,8 +1,8 @@
 // @flow strict-local
 
 import type {
-  BundleGroup,
   GraphVisitor,
+  FilePath,
   Symbol,
   TraversalActions,
 } from '@parcel/types';
@@ -13,17 +13,20 @@ import type {
   AssetNode,
   Bundle,
   BundleGraphNode,
+  BundleGroup,
   Dependency,
   DependencyNode,
   NodeId,
   InternalSourceLocation,
+  Target,
 } from './types';
 import type AssetGraph from './AssetGraph';
+import type {ProjectPath} from './projectPath';
 
 import assert from 'assert';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
-import {objectSortedEntriesDeep} from '@parcel/utils';
+import {objectSortedEntriesDeep, getRootDir} from '@parcel/utils';
 import {Hash, hashString} from '@parcel/hash';
 import {Priority, BundleBehavior} from './types';
 
@@ -31,6 +34,7 @@ import {getBundleGroupId, getPublicId} from './utils';
 import {ALL_EDGE_TYPES, mapVisitor} from './Graph';
 import ContentGraph, {type SerializedContentGraph} from './ContentGraph';
 import {ISOLATED_ENVS} from './public/Environment';
+import {fromProjectPath} from './projectPath';
 
 type BundleGraphEdgeTypes =
   // A lack of an edge type indicates to follow the edge while traversing
@@ -98,6 +102,7 @@ export default class BundleGraph {
   // It needs to be exposed in BundlerRunner for now based on how applying runtimes works and the
   // BundlerRunner takes care of invalidating hashes when runtimes are applied, but this is not ideal.
   _bundleContentHashes: Map<string, string>;
+  _targetEntryRoots: Map<ProjectPath, FilePath> = new Map();
   _graph: ContentGraph<BundleGraphNode, BundleGraphEdgeTypes>;
 
   constructor({
@@ -1597,5 +1602,37 @@ export default class BundleGraph {
       )
       .map(id => nullthrows(this._graph.getNode(id)))
       .some(n => n.type === 'root');
+  }
+
+  getEntryRoot(projectRoot: FilePath, target: Target): FilePath {
+    let cached = this._targetEntryRoots.get(target.distDir);
+    if (cached != null) {
+      return cached;
+    }
+
+    let entryBundleGroupIds = this._graph.getNodeIdsConnectedFrom(
+      nullthrows(this._graph.rootNodeId),
+      'bundle',
+    );
+
+    let entries = [];
+    for (let bundleGroupId of entryBundleGroupIds) {
+      let bundleGroupNode = this._graph.getNode(bundleGroupId);
+      invariant(bundleGroupNode?.type === 'bundle_group');
+
+      if (bundleGroupNode.value.target.distDir === target.distDir) {
+        let entryAssetNode = this._graph.getNodeByContentKey(
+          bundleGroupNode.value.entryAssetId,
+        );
+        invariant(entryAssetNode?.type === 'asset');
+        entries.push(
+          fromProjectPath(projectRoot, entryAssetNode.value.filePath),
+        );
+      }
+    }
+
+    let root = getRootDir(entries);
+    this._targetEntryRoots.set(target.distDir, root);
+    return root;
   }
 }

--- a/packages/core/core/src/public/BundleGroup.js
+++ b/packages/core/core/src/public/BundleGroup.js
@@ -1,0 +1,52 @@
+// @flow
+import type {
+  BundleGroup as IBundleGroup,
+  Target as ITarget,
+} from '@parcel/types';
+import type {BundleGroup as InternalBundleGroup, ParcelOptions} from '../types';
+
+import nullthrows from 'nullthrows';
+import Target from './Target';
+
+const internalBundleGroupToBundleGroup: WeakMap<
+  InternalBundleGroup,
+  BundleGroup,
+> = new WeakMap();
+const _bundleGroupToInternalBundleGroup: WeakMap<
+  IBundleGroup,
+  InternalBundleGroup,
+> = new WeakMap();
+export function bundleGroupToInternalBundleGroup(
+  target: IBundleGroup,
+): InternalBundleGroup {
+  return nullthrows(_bundleGroupToInternalBundleGroup.get(target));
+}
+
+export default class BundleGroup implements IBundleGroup {
+  #bundleGroup /*: InternalBundleGroup */;
+  #options /*: ParcelOptions */;
+
+  constructor(
+    bundleGroup: InternalBundleGroup,
+    options: ParcelOptions,
+  ): BundleGroup {
+    let existing = internalBundleGroupToBundleGroup.get(bundleGroup);
+    if (existing != null) {
+      return existing;
+    }
+
+    this.#bundleGroup = bundleGroup;
+    this.#options = options;
+    _bundleGroupToInternalBundleGroup.set(this, bundleGroup);
+    internalBundleGroupToBundleGroup.set(bundleGroup, this);
+    return this;
+  }
+
+  get target(): ITarget {
+    return new Target(this.#bundleGroup.target, this.#options);
+  }
+
+  get entryAssetId(): string {
+    return this.#bundleGroup.entryAssetId;
+  }
+}

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -13,8 +13,6 @@ import type {FileSystem} from '@parcel/fs';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ParcelOptions} from '../types';
 
-import {fromProjectPath} from '../projectPath';
-
 let parcelOptionsToPluginOptions: WeakMap<
   ParcelOptions,
   PluginOptions,
@@ -64,10 +62,6 @@ export default class PluginOptions implements IPluginOptions {
 
   get logLevel(): LogLevel {
     return this.#options.logLevel;
-  }
-
-  get entryRoot(): FilePath {
-    return fromProjectPath(this.#options.projectRoot, this.#options.entryRoot);
   }
 
   get cacheDir(): FilePath {

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -49,11 +49,7 @@ export default async function resolveOptions(
     entries = [path.resolve(inputCwd, initialOptions.entries)];
   }
 
-  let entryRoot =
-    initialOptions.entryRoot != null
-      ? path.resolve(inputCwd, initialOptions.entryRoot)
-      : getRootDir(entries);
-
+  let entryRoot = getRootDir(entries);
   let projectRootFile =
     (await resolveConfig(
       inputFS,
@@ -137,7 +133,6 @@ export default async function resolveOptions(
     shouldProfile: initialOptions.shouldProfile ?? false,
     cacheDir,
     entries: entries.map(e => toProjectPath(projectRoot, e)),
-    entryRoot: toProjectPath(projectRoot, entryRoot),
     targets: initialOptions.targets,
     logLevel: initialOptions.logLevel ?? 'info',
     projectRoot,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -3,7 +3,6 @@
 import type {
   ASTGenerator,
   BuildMode,
-  BundleGroup,
   Engines,
   EnvironmentContext,
   EnvMap,
@@ -243,7 +242,6 @@ export type DevDepRequest = {|
 
 export type ParcelOptions = {|
   entries: Array<ProjectPath>,
-  entryRoot: ProjectPath,
   config?: DependencySpecifier,
   defaultConfig?: DependencySpecifier,
   env: EnvMap,
@@ -501,6 +499,11 @@ export type BundleNode = {|
   id: ContentKey,
   +type: 'bundle',
   value: Bundle,
+|};
+
+export type BundleGroup = {|
+  target: Target,
+  entryAssetId: string,
 |};
 
 export type BundleGroupNode = {|

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -2,12 +2,12 @@
 
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import type {
-  BundleGroup,
   FilePath,
   FileCreateInvalidation,
   SourceLocation,
 } from '@parcel/types';
 import type {
+  BundleGroup,
   ParcelOptions,
   InternalFileCreateInvalidation,
   InternalSourceLocation,

--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -19,7 +19,6 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
   cacheDir: path.join(__dirname, '.parcel-cache'),
   entries: [],
   logLevel: 'info',
-  entryRoot: toProjectPath('/', __dirname),
   targets: undefined,
   projectRoot: __dirname,
   shouldAutoInstall: false,

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -109,18 +109,8 @@ describe('html', function() {
       },
     ]);
 
-    assert(
-      await outputFS.exists(
-        path.join(distDir, 'html-pkg-source-array/a.html'),
-        'utf8',
-      ),
-    );
-    assert(
-      await outputFS.exists(
-        path.join(distDir, 'html-pkg-source-array/b.html'),
-        'utf8',
-      ),
-    );
+    assert(await outputFS.exists(path.join(distDir, 'a.html'), 'utf8'));
+    assert(await outputFS.exists(path.join(distDir, 'b.html'), 'utf8'));
   });
 
   it('should find href attr when not first', async function() {

--- a/packages/core/integration-tests/test/integration/namer-dir/package.json
+++ b/packages/core/integration-tests/test/integration/namer-dir/package.json
@@ -1,0 +1,3 @@
+{
+  "source": "src/index.html"
+}

--- a/packages/core/integration-tests/test/integration/namer-dir/src/index.html
+++ b/packages/core/integration-tests/test/integration/namer-dir/src/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<a href="nested/other.html">Other</a>

--- a/packages/core/integration-tests/test/integration/namer-dir/src/nested/other.html
+++ b/packages/core/integration-tests/test/integration/namer-dir/src/nested/other.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<p>Other</p>

--- a/packages/core/integration-tests/test/integration/packager-loadConfig/node_modules/parcel-packager-config/index.js
+++ b/packages/core/integration-tests/test/integration/packager-loadConfig/node_modules/parcel-packager-config/index.js
@@ -7,7 +7,7 @@ const {loadConfig} = require('@parcel/utils');
 
 module.exports = (new Packager({
   async loadConfig({options, config}) {
-    let result = await config.getConfigFrom(path.join(options.entryRoot, 'index'), ['foo.config.json']);
+    let result = await config.getConfigFrom(path.join(options.projectRoot, 'index'), ['foo.config.json']);
     return result && result.contents;
   },
   package({bundle, config}) {

--- a/packages/core/integration-tests/test/namer.js
+++ b/packages/core/integration-tests/test/namer.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import path from 'path';
+import {bundle, outputFS, distDir} from '@parcel/test-utils';
+
+describe('namer', function() {
+  it('should determine correct entry root when building a directory', async function() {
+    await bundle(path.join(__dirname, 'integration/namer-dir'));
+
+    assert(await outputFS.exists(path.join(distDir, 'index.html')));
+    assert(await outputFS.exists(path.join(distDir, 'nested/other.html')));
+  });
+});

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -278,7 +278,6 @@ export type DetailedReportOptions = {|
 
 export type InitialParcelOptions = {|
   +entries?: FilePath | Array<FilePath>,
-  +entryRoot?: FilePath,
   +config?: DependencySpecifier,
   +defaultConfig?: DependencySpecifier,
   +env?: EnvMap,
@@ -338,7 +337,6 @@ export interface PluginOptions {
   +shouldBuildLazily: boolean;
   +shouldAutoInstall: boolean;
   +logLevel: LogLevel;
-  +entryRoot: FilePath;
   +projectRoot: FilePath;
   +cacheDir: FilePath;
   +inputFS: FileSystem;
@@ -1274,12 +1272,12 @@ export interface PackagedBundle extends NamedBundle {
  * A collection of sibling bundles (which are stored in the BundleGraph) that should be loaded together (in order).
  * @section bundler
  */
-export type BundleGroup = {|
+export interface BundleGroup {
   /** The target of the bundle group. */
-  +target: Target,
+  +target: Target;
   /** The id of the entry asset in the bundle group, which is executed immediately when the bundle group is loaded. */
-  +entryAssetId: string,
-|};
+  +entryAssetId: string;
+}
 
 /**
  * A BundleGraph in the Bundler that can be modified
@@ -1388,6 +1386,7 @@ export interface BundleGraph<TBundle: Bundle> {
     startBundle: ?Bundle,
   ): ?TContext;
   getUsedSymbols(Asset | Dependency): $ReadOnlySet<Symbol>;
+  getEntryRoot(target: Target): FilePath;
 }
 
 /**

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -14,7 +14,7 @@ const ALLOWED_EXTENSIONS = {
 };
 
 export default (new Namer({
-  name({bundle, bundleGraph, options}) {
+  name({bundle, bundleGraph}) {
     let bundleGroup = bundleGraph.getBundleGroupsContainingBundle(bundle)[0];
     let bundleGroupBundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
     let isEntry = bundleGraph.isEntryBundleGroup(bundleGroup);
@@ -91,7 +91,7 @@ export default (new Namer({
       mainBundle,
       isEntry,
       bundleGroup.entryAssetId,
-      options.entryRoot,
+      bundleGraph.getEntryRoot(bundle.target),
     );
     if (!bundle.needsStableName) {
       name += '.' + bundle.hashReference;

--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -12,7 +12,7 @@ import {extendDefaultPlugins} from 'svgo';
 export default (new Optimizer({
   async loadConfig({config, options}) {
     let userConfig = await config.getConfigFrom(
-      path.join(options.entryRoot, 'index.html'),
+      path.join(options.projectRoot, 'index.html'),
       ['.htmlnanorc', '.htmlnanorc.js'],
     );
 

--- a/packages/optimizers/terser/src/TerserOptimizer.js
+++ b/packages/optimizers/terser/src/TerserOptimizer.js
@@ -12,7 +12,7 @@ import path from 'path';
 export default (new Optimizer({
   async loadConfig({config, options}) {
     let userConfig = await config.getConfigFrom(
-      path.join(options.entryRoot, 'index'),
+      path.join(options.projectRoot, 'index'),
       ['.terserrc', '.terserrc.js'],
     );
 

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -14,7 +14,7 @@ export default (new Packager({
     // Generate a name for the global parcelRequire function that is unique to this project.
     // This allows multiple parcel builds to coexist on the same page.
     let pkg = await config.getConfigFrom(
-      path.join(options.entryRoot, 'index'),
+      path.join(options.projectRoot, 'index'),
       ['package.json'],
     );
     let name = pkg?.contents?.name ?? '';

--- a/packages/reporters/cli/test/CLIReporter.test.js
+++ b/packages/reporters/cli/test/CLIReporter.test.js
@@ -12,7 +12,6 @@ const EMPTY_OPTIONS = {
   cacheDir: '.parcel-cache',
   entries: [],
   logLevel: 'info',
-  entryRoot: __dirname,
   targets: [],
   projectRoot: '',
   distDir: 'dist',


### PR DESCRIPTION
Fixes #6458.

`options.entryRoot` is used during naming as a common root directory from which to determine relative paths for non-hashed bundles. However, this is computed before entry resolution, so if an entry resolves to a directory, the computed root will be wrong. In addition, if entries have different targets, it will also be incorrect. This PR replaces this with a `bundleGraph.getEntryRoot` method, which receives a target, finds all of the entries associated with that target distDir, and computes the common root dir from there. This is memoized per target dist dir for performance.

In addition, it seems we were exposing internal bundle group objects with project paths instead of full file paths. This adds a public wrapper class for bundle groups like we have for all of our other public objects.