### PR TITLE
Automatically mark 'electron' as a builtin module

### DIFF
--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -236,6 +236,11 @@ export default class NodeResolver {
       };
     }
 
+    let builtin = this.findBuiltin(filename, env);
+    if (builtin === null) {
+      return null;
+    }
+
     if (!this.shouldIncludeNodeModule(env, filename)) {
       if (sourcePath && env.isLibrary) {
         await this.checkExcludedDependency(sourcePath, filename, ctx);
@@ -243,8 +248,7 @@ export default class NodeResolver {
       return null;
     }
 
-    let builtin = this.findBuiltin(filename, env);
-    if (builtin || builtin === null) {
+    if (builtin) {
       return builtin;
     }
 
@@ -504,6 +508,10 @@ export default class NodeResolver {
         filename = filename.substr(5);
       }
       return {filePath: builtins[filename] || empty};
+    }
+
+    if (env.isElectron() && filename === 'electron') {
+      return null;
     }
   }
 

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -252,6 +252,24 @@ describe('resolver', function() {
       });
       assert.deepEqual(resolved, {isExcluded: true});
     });
+
+    it('should exclude the electron module in electron environments', async function() {
+      let resolved = await resolver.resolve({
+        env: new Environment(
+          createEnvironment({
+            context: 'electron-main',
+            isLibrary: true,
+          }),
+          DEFAULT_OPTIONS,
+        ),
+        filename: 'electron',
+        isURL: false,
+        parent: path.join(rootDir, 'foo.js'),
+        sourcePath: path.join(rootDir, 'foo.js'),
+      });
+
+      assert.deepEqual(resolved, {isExcluded: true});
+    });
   });
 
   describe('node_modules', function() {


### PR DESCRIPTION
Related to #6588.

Avoids the missing external dependency error for electron when in an electron environment.