### PR TITLE
Show 'Code from unknown source files' in bundle analyzer

### DIFF
--- a/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
+++ b/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
@@ -144,7 +144,7 @@ async function getBundleNode(bundle: PackagedBundle, options: PluginOptions) {
   }
 
   return {
-    label: nullthrows(bundle.name),
+    label: bundle.filePath,
     weight: bundle.stats.size,
     groups: generateGroups(dirMap),
   };
@@ -181,7 +181,10 @@ function generateGroups(dirMap: DirMap): Array<Group> {
     } else {
       // file
       groups.push({
-        label: contents.basename,
+        label:
+          contents.basename === ''
+            ? 'Code from unknown source files'
+            : contents.basename,
         weight: contents.size,
       });
     }


### PR DESCRIPTION
This makes the bundle analyzer show "Code from unknown source files" instead of an empty string as an asset label in the visualization.

It also changes bundles to display as their complete filepaths, rather than names, which include HASH_REFs.

**Question:** Maybe we can return a special type (a sentinel value such as a singleton object or null) for this instead of expressing it with an empty string? Took me a while to figure out what this was 😅 cc @DeMoorJasper 

Test Plan: Tested in a large app that previously showed empty labels for assets.