### PR TITLE
Bug fixes

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -485,7 +485,7 @@ describe('html', function() {
     // minifySvg is false
     assert(
       html.includes(
-        '<svg version=1.1 width=300 height=200 xmlns=http://www.w3.org/2000/svg baseProfile=full><rect width=100% height=100% fill=red></rect><circle cx=150 cy=100 r=80 fill=green></circle><text x=150 y=125 font-size=60 text-anchor=middle fill=white>SVG</text></svg>',
+        '<svg version=1.1 baseprofile=full width=300 height=200 xmlns=http://www.w3.org/2000/svg><rect width=100% height=100% fill=red></rect><circle cx=150 cy=100 r=80 fill=green></circle><text x=150 y=125 font-size=60 text-anchor=middle fill=white>SVG</text></svg>',
       ),
     );
   });
@@ -791,6 +791,9 @@ describe('html', function() {
   it('should ignore svgs referencing local symbols via <use xlink:href="#">', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-svg-local-symbol/index.html'),
+      {
+        mode: 'production',
+      },
     );
 
     assertBundles(b, [
@@ -799,6 +802,13 @@ describe('html', function() {
         assets: ['index.html'],
       },
     ]);
+
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(
+      contents.includes(
+        '<svg><symbol id="all"><rect width="100" height="100"/></symbol></svg><svg xmlns:xlink="http://www.w3.org/1999/xlink"><use xlink:href="#all" href="#all"/></svg>',
+      ),
+    );
   });
 
   it('should bundle svg files using <image xlink:href=""> correctly', async function() {

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -348,7 +348,7 @@ describe('html', function() {
     );
 
     assert(
-      /^<link rel="stylesheet" href="[/\\]index\.[a-f0-9]+\.css">\s*<script src="[/\\]index\.[a-f0-9]+\.js"><\/script>\s*<h1>Hello/m.test(
+      /^<link rel="stylesheet" href="[/\\]index\.[a-f0-9]+\.css">\s*<script src="[/\\]index\.[a-f0-9]+\.js" defer=""><\/script>\s*<h1>Hello/m.test(
         html,
       ),
     );
@@ -391,7 +391,8 @@ describe('html', function() {
     );
 
     assert.equal(
-      html.match(/<script src="[/\\]{1}index\.[a-f0-9]+?\.js">/g).length,
+      html.match(/<script src="[/\\]{1}index\.[a-f0-9]+?\.js" defer="">/g)
+        .length,
       2,
     );
   });

--- a/packages/core/integration-tests/test/integration/html-svg-local-symbol/index.html
+++ b/packages/core/integration-tests/test/integration/html-svg-local-symbol/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<svg xmlns:xlink="http://www.w3.org/1999/xlink">
-	<use xlink:href="#all" href="#all"/>
-</svg>
-<svg xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg>
 	<symbol id="all">
 		<rect width="100" height="100" x="0" y="0"/>
 	</symbol>
+</svg>
+<svg>
+	<use xlink:href="#all" href="#all"/>
 </svg>

--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import type {PostHTMLNode, PostHTMLTree} from 'posthtml';
+import type {PostHTMLNode} from 'posthtml';
 
 import htmlnano from 'htmlnano';
 import {Optimizer} from '@parcel/plugin';

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -173,6 +173,10 @@ export default function collectDependencies(
       if (attrs.type === 'module' && asset.env.shouldScopeHoist) {
         outputFormat = 'esmodule';
       } else {
+        if (attrs.type === 'module') {
+          attrs.defer = '';
+        }
+
         delete attrs.type;
       }
 

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -2,9 +2,6 @@
 
 import path from 'path';
 import {Transformer} from '@parcel/plugin';
-import {relativePath} from '@parcel/utils';
-
-const WRAPPER = path.join(__dirname, 'helpers', 'helpers.js');
 
 function shouldExclude(asset, options) {
   return (

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -26,22 +26,22 @@ export default (new Transformer({
       return [asset];
     }
 
-    let wrapperPath = relativePath(path.dirname(asset.filePath), WRAPPER);
-    if (!wrapperPath.startsWith('.')) {
-      wrapperPath = './' + wrapperPath;
-    }
+    let wrapperPath = `@parcel/transformer-react-refresh-wrap/${path.basename(
+      __dirname,
+    )}/helpers/helpers.js`;
 
     let code = await asset.getCode();
     let map = await asset.getMap();
+    let name = `$parcel$ReactRefreshHelpers$${asset.id.slice(-4)}`;
 
-    code = `var helpers = require(${JSON.stringify(wrapperPath)});
+    code = `var ${name} = require(${JSON.stringify(wrapperPath)});
 var prevRefreshReg = window.$RefreshReg$;
 var prevRefreshSig = window.$RefreshSig$;
-helpers.prelude(module);
+${name}.prelude(module);
 
 try {
 ${code}
-  helpers.postlude(module);
+  ${name}.postlude(module);
 } finally {
   window.$RefreshReg$ = prevRefreshReg;
   window.$RefreshSig$ = prevRefreshSig;
@@ -57,6 +57,7 @@ ${code}
     asset.addDependency({
       specifier: wrapperPath,
       specifierType: 'esm',
+      resolveFrom: __filename,
     });
 
     return [asset];


### PR DESCRIPTION
* Adds `defer` to `<script type="module">` elements in development, since we remove the `type="module"`.
* Generates a unique variable name for react refresh helpers in the wrapper transform so it won't conflict with variables set by the user. Also resolves the helper using a node_modules specifier rather than a relative path. Fixes #6507.
* Fixes some issues related to inline SVGs. Fixes #6629.
  1. SVGO is too aggressive about removing unused symbols from SVGs. When embedded within an HTML document, those symbols can be referenced by another SVG element on the page. We now disable that plugin.
  2. SVGs without an `xmlns` or `xmlns:xlink` attribute failed to parse. These are required in standalone SVG files but optional in HTML. We now add these if they are missing in a pre-pass before running htmlnano, and SVGO strips them (`xmlns:xlink` will be once https://github.com/svg/svgo/pull/1508 is merged).