### PR TITLE
BundleGraph refactor

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -76,7 +76,7 @@ export default (new Bundler({
         }
 
         let assets = bundleGraph.getDependencyAssets(dependency);
-        let resolution = bundleGraph.getDependencyResolution(dependency);
+        let resolution = bundleGraph.getResolvedAsset(dependency);
         let bundleGroup = context?.bundleGroup;
         // Create a new bundle for entries, lazy/parallel dependencies, isolated/inline assets.
         if (
@@ -232,7 +232,7 @@ export default (new Bundler({
         return;
       }
 
-      let candidates = bundleGraph.findBundlesWithAsset(mainEntry).filter(
+      let candidates = bundleGraph.getBundlesWithAsset(mainEntry).filter(
         containingBundle =>
           containingBundle.id !== bundle.id &&
           // Don't add to BundleGroups for entry bundles, as that would require
@@ -293,7 +293,7 @@ export default (new Bundler({
 
       let asset = node.value;
       let containingBundles = bundleGraph
-        .findBundlesWithAsset(asset)
+        .getBundlesWithAsset(asset)
         // Don't create shared bundles from entry bundles, as that would require
         // another entry bundle depending on these conditions, making it difficult
         // to predict and reference.
@@ -406,7 +406,7 @@ function deduplicate(bundleGraph: MutableBundleGraph) {
       let asset = node.value;
       // Search in reverse order, so bundles that are loaded keep the duplicated asset, not later ones.
       // This ensures that the earlier bundle is able to execute before the later one.
-      let bundles = bundleGraph.findBundlesWithAsset(asset).reverse();
+      let bundles = bundleGraph.getBundlesWithAsset(asset).reverse();
       for (let bundle of bundles) {
         if (
           bundle.hasAsset(asset) &&
@@ -500,7 +500,7 @@ function internalizeReachableAsyncDependencies(
       return;
     }
 
-    let resolution = bundleGraph.getDependencyResolution(dependency);
+    let resolution = bundleGraph.getResolvedAsset(dependency);
     if (resolution == null) {
       return;
     }
@@ -510,7 +510,7 @@ function internalizeReachableAsyncDependencies(
       asyncBundleGroups.add(externalResolution.value);
     }
 
-    for (let bundle of bundleGraph.findBundlesWithDependency(dependency)) {
+    for (let bundle of bundleGraph.getBundlesWithDependency(dependency)) {
       if (
         bundle.hasAsset(resolution) ||
         bundleGraph.isAssetReachableFromBundle(resolution, bundle)

--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -252,9 +252,7 @@ export default (new Bundler({
         if (
           Array.from(bundleGroups).every(
             group =>
-              bundleGraph
-                .getBundlesInBundleGroup(group)
-                .filter(b => b.bundleBehavior !== 'inline').length <
+              bundleGraph.getBundlesInBundleGroup(group).length <
               config.maxParallelRequests,
           )
         ) {
@@ -356,9 +354,7 @@ export default (new Bundler({
         if (
           bundleGroups.every(
             group =>
-              bundleGraph
-                .getBundlesInBundleGroup(group)
-                .filter(b => b.bundleBehavior !== 'inline').length <
+              bundleGraph.getBundlesInBundleGroup(group).length <
               config.maxParallelRequests,
           )
         ) {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -334,7 +334,7 @@ export default class BundleGraph {
 
       let resolved;
       if (referencedAssetNodeIds.length === 0) {
-        resolved = this.getDependencyResolution(dependency, bundle);
+        resolved = this.getResolvedAsset(dependency, bundle);
       } else if (referencedAssetNodeIds.length === 1) {
         let referencedAssetNode = this._graph.getNode(
           referencedAssetNodeIds[0],
@@ -608,7 +608,7 @@ export default class BundleGraph {
     );
   }
 
-  findBundlesWithAsset(asset: Asset): Array<Bundle> {
+  getBundlesWithAsset(asset: Asset): Array<Bundle> {
     return this._graph
       .getNodeIdsConnectedTo(
         this._graph.getNodeIdByContentKey(asset.id),
@@ -622,7 +622,7 @@ export default class BundleGraph {
       });
   }
 
-  findBundlesWithDependency(dependency: Dependency): Array<Bundle> {
+  getBundlesWithDependency(dependency: Dependency): Array<Bundle> {
     return this._graph
       .getNodeIdsConnectedTo(
         nullthrows(this._graph.getNodeIdByContentKey(dependency.id)),
@@ -647,7 +647,7 @@ export default class BundleGraph {
       });
   }
 
-  getDependencyResolution(dep: Dependency, bundle: ?Bundle): ?Asset {
+  getResolvedAsset(dep: Dependency, bundle: ?Bundle): ?Asset {
     let assets = this.getDependencyAssets(dep);
     let firstAsset = assets[0];
     let resolved =
@@ -697,7 +697,7 @@ export default class BundleGraph {
     );
   }
 
-  isAssetReferencedByDependant(bundle: Bundle, asset: Asset): boolean {
+  isAssetReferenced(bundle: Bundle, asset: Asset): boolean {
     let assetNodeId = nullthrows(this._graph.getNodeIdByContentKey(asset.id));
 
     if (
@@ -1189,7 +1189,7 @@ export default class BundleGraph {
     return this._graph.filteredTraverse(filter, visit, bundleNodeId);
   }
 
-  resolveSymbol(
+  getSymbolResolution(
     asset: Asset,
     symbol: Symbol,
     boundary: ?Bundle,
@@ -1222,7 +1222,7 @@ export default class BundleGraph {
       );
       let depSymbol = symbolLookup.get(identifier);
       if (depSymbol != null) {
-        let resolved = this.getDependencyResolution(dep);
+        let resolved = this.getResolvedAsset(dep);
         if (!resolved || resolved.id === asset.id) {
           // External module or self-reference
           return {
@@ -1250,7 +1250,7 @@ export default class BundleGraph {
           symbol: resolvedSymbol,
           exportSymbol,
           loc,
-        } = this.resolveSymbol(resolved, depSymbol, boundary);
+        } = this.getSymbolResolution(resolved, depSymbol, boundary);
 
         if (!loc) {
           // Remember how we got there
@@ -1272,11 +1272,11 @@ export default class BundleGraph {
         depSymbols.get('*')?.local === '*' &&
         symbol !== 'default'
       ) {
-        let resolved = this.getDependencyResolution(dep);
+        let resolved = this.getResolvedAsset(dep);
         if (!resolved) {
           continue;
         }
-        let result = this.resolveSymbol(resolved, symbol, boundary);
+        let result = this.getSymbolResolution(resolved, symbol, boundary);
 
         // We found the symbol
         if (result.symbol != undefined) {
@@ -1377,7 +1377,7 @@ export default class BundleGraph {
 
     for (let symbol of asset.symbols.keys()) {
       symbols.push({
-        ...this.resolveSymbol(asset, symbol, boundary),
+        ...this.getSymbolResolution(asset, symbol, boundary),
         exportAs: symbol,
       });
     }
@@ -1388,7 +1388,7 @@ export default class BundleGraph {
       if (!depSymbols) continue;
 
       if (depSymbols.get('*')?.local === '*') {
-        let resolved = this.getDependencyResolution(dep);
+        let resolved = this.getResolvedAsset(dep);
         if (!resolved) continue;
         let exported = this.getExportedSymbols(resolved, boundary)
           .filter(s => s.exportSymbol !== 'default')

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -62,7 +62,7 @@ export default async function applyRuntimes({
   let runtimes = await config.getRuntimes();
   let connections: Array<RuntimeConnection> = [];
 
-  for (let bundle of bundleGraph.getBundles()) {
+  for (let bundle of bundleGraph.getBundles({includeInline: true})) {
     for (let runtime of runtimes) {
       try {
         let applied = await runtime.plugin.apply({

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -169,7 +169,7 @@ export default async function applyRuntimes({
 
     let resolution =
       dependency &&
-      bundleGraph.getDependencyResolution(
+      bundleGraph.getResolvedAsset(
         dependencyToInternalDependency(dependency),
         bundle,
       );

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -80,8 +80,8 @@ export default class BundleGraph<TBundle: IBundle>
     return this.#graph.isDependencySkipped(dependencyToInternalDependency(dep));
   }
 
-  getDependencyResolution(dep: IDependency, bundle: ?IBundle): ?IAsset {
-    let resolution = this.#graph.getDependencyResolution(
+  getResolvedAsset(dep: IDependency, bundle: ?IBundle): ?IAsset {
+    let resolution = this.#graph.getResolvedAsset(
       dependencyToInternalDependency(dep),
       bundle && bundleToInternalBundle(bundle),
     );
@@ -173,8 +173,8 @@ export default class BundleGraph<TBundle: IBundle>
     );
   }
 
-  isAssetReferencedByDependant(bundle: IBundle, asset: IAsset): boolean {
-    return this.#graph.isAssetReferencedByDependant(
+  isAssetReferenced(bundle: IBundle, asset: IAsset): boolean {
+    return this.#graph.isAssetReferenced(
       bundleToInternalBundle(bundle),
       assetToAssetValue(asset),
     );
@@ -231,12 +231,12 @@ export default class BundleGraph<TBundle: IBundle>
       );
   }
 
-  resolveSymbol(
+  getSymbolResolution(
     asset: IAsset,
     symbol: Symbol,
     boundary: ?IBundle,
   ): SymbolResolution {
-    let res = this.#graph.resolveSymbol(
+    let res = this.#graph.getSymbolResolution(
       assetToAssetValue(asset),
       symbol,
       boundary ? bundleToInternalBundle(boundary) : null,
@@ -297,17 +297,17 @@ export default class BundleGraph<TBundle: IBundle>
     );
   }
 
-  findBundlesWithAsset(asset: IAsset): Array<TBundle> {
+  getBundlesWithAsset(asset: IAsset): Array<TBundle> {
     return this.#graph
-      .findBundlesWithAsset(assetToAssetValue(asset))
+      .getBundlesWithAsset(assetToAssetValue(asset))
       .map(bundle =>
         this.#createBundle.call(null, bundle, this.#graph, this.#options),
       );
   }
 
-  findBundlesWithDependency(dependency: IDependency): Array<TBundle> {
+  getBundlesWithDependency(dependency: IDependency): Array<TBundle> {
     return this.#graph
-      .findBundlesWithDependency(dependencyToInternalDependency(dependency))
+      .getBundlesWithDependency(dependencyToInternalDependency(dependency))
       .map(bundle =>
         this.#createBundle.call(null, bundle, this.#graph, this.#options),
       );

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -173,19 +173,6 @@ export default class BundleGraph<TBundle: IBundle>
     );
   }
 
-  findReachableBundleWithAsset(bundle: IBundle, asset: IAsset): ?TBundle {
-    let result = this.#graph.findReachableBundleWithAsset(
-      bundleToInternalBundle(bundle),
-      assetToAssetValue(asset),
-    );
-
-    if (result != null) {
-      return this.#createBundle.call(null, result, this.#graph, this.#options);
-    }
-
-    return null;
-  }
-
   isAssetReferencedByDependant(bundle: IBundle, asset: IAsset): boolean {
     return this.#graph.isAssetReferencedByDependant(
       bundleToInternalBundle(bundle),

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -113,18 +113,10 @@ export default class BundleGraph<TBundle: IBundle>
 
   getReferencedBundles(
     bundle: IBundle,
-    opts?: {|recursive: boolean|},
+    opts?: {|recursive?: boolean, includeInline?: boolean|},
   ): Array<TBundle> {
     return this.#graph
       .getReferencedBundles(bundleToInternalBundle(bundle), opts)
-      .map(bundle =>
-        this.#createBundle.call(null, bundle, this.#graph, this.#options),
-      );
-  }
-
-  getRequiredBundlesForBundle(bundle: IBundle): Array<TBundle> {
-    return this.#graph
-      .getReferencedBundles(bundleToInternalBundle(bundle))
       .map(bundle =>
         this.#createBundle.call(null, bundle, this.#graph, this.#options),
       );
@@ -208,17 +200,23 @@ export default class BundleGraph<TBundle: IBundle>
     );
   }
 
-  getBundlesInBundleGroup(bundleGroup: IBundleGroup): Array<TBundle> {
+  getBundlesInBundleGroup(
+    bundleGroup: IBundleGroup,
+    opts?: {|includeInline: boolean|},
+  ): Array<TBundle> {
     return this.#graph
-      .getBundlesInBundleGroup(bundleGroupToInternalBundleGroup(bundleGroup))
+      .getBundlesInBundleGroup(
+        bundleGroupToInternalBundleGroup(bundleGroup),
+        opts,
+      )
       .map(bundle =>
         this.#createBundle.call(null, bundle, this.#graph, this.#options),
       );
   }
 
-  getBundles(): Array<TBundle> {
+  getBundles(opts?: {|includeInline: boolean|}): Array<TBundle> {
     return this.#graph
-      .getBundles()
+      .getBundles(opts)
       .map(bundle =>
         this.#createBundle.call(null, bundle, this.#graph, this.#options),
       );

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -75,7 +75,7 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
 
     invariant(dependencyNode.type === 'dependency');
 
-    let resolved = this.#graph.getDependencyResolution(
+    let resolved = this.#graph.getResolvedAsset(
       dependencyToInternalDependency(dependency),
     );
     if (!resolved) {

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -315,7 +315,9 @@ class BundlerRunner {
 
   async nameBundles(bundleGraph: InternalBundleGraph): Promise<void> {
     let namers = await this.config.getNamers();
-    let bundles = bundleGraph.getBundles();
+    // inline bundles must still be named so the PackagerRunner
+    // can match them to the correct packager/optimizer plugins.
+    let bundles = bundleGraph.getBundles({includeInline: true});
     await Promise.all(
       bundles.map(bundle => this.nameBundle(namers, bundle, bundleGraph)),
     );

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -79,8 +79,7 @@ async function run({input, api, farm, options}: RunInput) {
       return false;
     }
 
-    // skip inline bundles, they will be processed via the parent bundle
-    return bundle.bundleBehavior !== BundleBehavior.inline;
+    return true;
   });
 
   try {

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -14,7 +14,6 @@ import nullthrows from 'nullthrows';
 import {hashString} from '@parcel/hash';
 import {createPackageRequest} from './PackageRequest';
 import createWriteBundleRequest from './WriteBundleRequest';
-import {BundleBehavior} from '../types';
 
 type WriteBundlesRequestInput = {|
   bundleGraph: BundleGraph,

--- a/packages/core/core/test/PublicMutableBundleGraph.test.js
+++ b/packages/core/core/test/PublicMutableBundleGraph.test.js
@@ -37,11 +37,11 @@ describe('PublicMutableBundleGraph', () => {
     mutableBundleGraph.traverse(node => {
       if (
         node.type === 'dependency' &&
-        mutableBundleGraph.getDependencyResolution(node.value)
+        mutableBundleGraph.getResolvedAsset(node.value)
       ) {
         let target = nullthrows(node.value.target);
         let group = mutableBundleGraph.createBundleGroup(node.value, target);
-        let resolved = mutableBundleGraph.getDependencyResolution(node.value);
+        let resolved = mutableBundleGraph.getResolvedAsset(node.value);
         if (resolved != null) {
           mutableBundleGraph.addBundleToBundleGroup(
             mutableBundleGraph.createBundle({
@@ -82,9 +82,7 @@ describe('PublicMutableBundleGraph', () => {
     let target = nullthrows(dependency.target);
     let bundleGroup = mutableBundleGraph.createBundleGroup(dependency, target);
     let bundle = mutableBundleGraph.createBundle({
-      entryAsset: nullthrows(
-        mutableBundleGraph.getDependencyResolution(dependency),
-      ),
+      entryAsset: nullthrows(mutableBundleGraph.getResolvedAsset(dependency)),
       target,
     });
 

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -2224,7 +2224,7 @@ describe('html', function() {
 
     bundleGraph.traverseBundles(bundle => {
       bundle.traverseAssets(asset => {
-        let bundles = bundleGraph.findBundlesWithAsset(asset);
+        let bundles = bundleGraph.getBundlesWithAsset(asset);
         assert.equal(
           bundles.length,
           1,

--- a/packages/core/integration-tests/test/integration/resolver-canDefer/node_modules/parcel-bundler-no-defer/index.js
+++ b/packages/core/integration-tests/test/integration/resolver-canDefer/node_modules/parcel-bundler-no-defer/index.js
@@ -53,7 +53,7 @@ module.exports = (new Bundler({
         // }
 
         let assets = bundleGraph.getDependencyAssets(dependency);
-        let resolution = bundleGraph.getDependencyResolution(dependency);
+        let resolution = bundleGraph.getResolvedAsset(dependency);
         let bundleGroup = context && context.bundleGroup;
         // Create a new bundle for entries, lazy/parallel dependencies, isolated/inline assets.
         if (
@@ -178,7 +178,7 @@ module.exports = (new Bundler({
     for (let [bundle, rootAssets] of bundleRoots) {
       for (let asset of rootAssets) {
         bundleGraph.addEntryToBundle(asset, bundle, dependency => {
-          let resolution = bundleGraph.getDependencyResolution(dependency);
+          let resolution = bundleGraph.getResolvedAsset(dependency);
           return (
             bundleGraph.isDependencySkipped(dependency) &&
             (!resolution || path.basename(resolution.filePath) !== 'b.js')

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -281,7 +281,7 @@ describe('scope hoisting', function() {
         new Set(['add']),
       );
 
-      // resolveSymbol is broken
+      // getSymbolResolution is broken
       // let output = await run(b);
       // assert.equal(output, 3);
     });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -416,7 +416,7 @@ export async function runBundle(
       lowerCaseAttributeNames: true,
     });
 
-    let bundles = bundleGraph.getBundles();
+    let bundles = bundleGraph.getBundles({includeInline: true});
     let scripts = [];
     postHtml().walk.call(ast, node => {
       if (node.attrs?.nomodule != null) {

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1366,13 +1366,13 @@ export interface BundleGraph<TBundle: Bundle> {
   /** If a dependency was excluded since it's unused based on symbol data. */
   isDependencySkipped(dependency: Dependency): boolean;
   /** Find out which asset the dependency resolved to. */
-  getDependencyResolution(dependency: Dependency, bundle: ?Bundle): ?Asset;
+  getResolvedAsset(dependency: Dependency, bundle: ?Bundle): ?Asset;
   getReferencedBundle(dependency: Dependency, bundle: Bundle): ?TBundle;
-  findBundlesWithAsset(Asset): Array<TBundle>;
-  findBundlesWithDependency(Dependency): Array<TBundle>;
+  getBundlesWithAsset(Asset): Array<TBundle>;
+  getBundlesWithDependency(Dependency): Array<TBundle>;
   /** Whether the asset is already included in a compatible (regarding EnvironmentContext) parent bundle. */
   isAssetReachableFromBundle(asset: Asset, bundle: Bundle): boolean;
-  isAssetReferencedByDependant(bundle: Bundle, asset: Asset): boolean;
+  isAssetReferenced(bundle: Bundle, asset: Asset): boolean;
   hasParentBundleOfType(bundle: Bundle, type: string): boolean;
   /**
    * Resolve the export `symbol` of `asset` to the source,
@@ -1385,7 +1385,7 @@ export interface BundleGraph<TBundle: Bundle> {
    * corresponding variable lives (resolves re-exports). Stop resolving transitively once \
    * <code>boundary</code> was left (<code>bundle.hasAsset(asset) === false</code>), then <code>result.symbol</code> is undefined.
    */
-  resolveSymbol(
+  getSymbolResolution(
     asset: Asset,
     symbol: Symbol,
     boundary: ?Bundle,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1372,7 +1372,6 @@ export interface BundleGraph<TBundle: Bundle> {
   findBundlesWithDependency(Dependency): Array<TBundle>;
   /** Whether the asset is already included in a compatible (regarding EnvironmentContext) parent bundle. */
   isAssetReachableFromBundle(asset: Asset, bundle: Bundle): boolean;
-  findReachableBundleWithAsset(bundle: Bundle, asset: Asset): ?TBundle;
   isAssetReferencedByDependant(bundle: Bundle, asset: Asset): boolean;
   hasParentBundleOfType(bundle: Bundle, type: string): boolean;
   /**

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1317,18 +1317,33 @@ export interface MutableBundleGraph extends BundleGraph<Bundle> {
  * @section bundler
  */
 export interface BundleGraph<TBundle: Bundle> {
+  /** Retrieves an asset by id. */
   getAssetById(id: string): Asset;
+  /** Returns the public (short) id for an asset. */
   getAssetPublicId(asset: Asset): string;
-  getBundles(): Array<TBundle>;
+  /** Returns a list of bundles in the bundle graph. By default, inline bundles are excluded. */
+  getBundles(opts?: {|includeInline: boolean|}): Array<TBundle>;
+  /** Traverses the assets and dependencies in the bundle graph, in depth first order. */
+  traverse<TContext>(GraphVisitor<BundleGraphTraversable, TContext>): ?TContext;
+  /** Traverses all bundles in the bundle graph, including inline bundles, in depth first order. */
+  traverseBundles<TContext>(
+    visit: GraphVisitor<TBundle, TContext>,
+    startBundle: ?Bundle,
+  ): ?TContext;
+  /** Returns a list of bundle groups that load the given bundle. */
   getBundleGroupsContainingBundle(bundle: Bundle): Array<BundleGroup>;
-  getBundlesInBundleGroup(bundleGroup: BundleGroup): Array<TBundle>;
+  /** Returns a list of bundles that load together in the given bundle group. */
+  getBundlesInBundleGroup(
+    bundleGroup: BundleGroup,
+    opts?: {|includeInline: boolean|},
+  ): Array<TBundle>;
   /** Child bundles are Bundles that might be loaded by an asset in the bundle */
   getChildBundles(bundle: Bundle): Array<TBundle>;
   getParentBundles(bundle: Bundle): Array<TBundle>;
-  /** Bundles that are referenced (by filename) */
+  /** Returns a list of bundles that are referenced by this bundle. By default, inline bundles are excluded. */
   getReferencedBundles(
     bundle: Bundle,
-    opts?: {|recursive: boolean|},
+    opts?: {|recursive?: boolean, includeInline?: boolean|},
   ): Array<TBundle>;
   /** Get the dependencies that the asset requires */
   getDependencies(asset: Asset): Array<Dependency>;
@@ -1381,11 +1396,6 @@ export interface BundleGraph<TBundle: Bundle> {
     asset: Asset,
     boundary: ?Bundle,
   ): Array<ExportSymbolResolution>;
-  traverse<TContext>(GraphVisitor<BundleGraphTraversable, TContext>): ?TContext;
-  traverseBundles<TContext>(
-    visit: GraphVisitor<TBundle, TContext>,
-    startBundle: ?Bundle,
-  ): ?TContext;
   getUsedSymbols(Asset | Dependency): $ReadOnlySet<Symbol>;
   getEntryRoot(target: Target): FilePath;
 }

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -16,7 +16,9 @@ const ALLOWED_EXTENSIONS = {
 export default (new Namer({
   name({bundle, bundleGraph}) {
     let bundleGroup = bundleGraph.getBundleGroupsContainingBundle(bundle)[0];
-    let bundleGroupBundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
+    let bundleGroupBundles = bundleGraph.getBundlesInBundleGroup(bundleGroup, {
+      includeInline: true,
+    });
     let isEntry = bundleGraph.isEntryBundleGroup(bundleGroup);
 
     if (bundle.needsStableName) {

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -56,7 +56,7 @@ export default (new Packager({
         new Set(bundleGraph.getReferencedBundles(bundle)),
         new Set(bundleGraph.getReferencedBundles(bundle, {recursive: false})),
       ),
-    ].filter(b => b.bundleBehavior !== 'inline');
+    ];
     let renderConfig = config?.render;
 
     let {html} = await posthtml([

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -61,7 +61,7 @@ export class DevPackager {
       let wrapped = first ? '' : ',';
 
       if (node.type === 'dependency') {
-        let resolved = this.bundleGraph.getDependencyResolution(
+        let resolved = this.bundleGraph.getResolvedAsset(
           node.value,
           this.bundle,
         );
@@ -97,10 +97,7 @@ export class DevPackager {
         let deps = {};
         let dependencies = this.bundleGraph.getDependencies(asset);
         for (let dep of dependencies) {
-          let resolved = this.bundleGraph.getDependencyResolution(
-            dep,
-            this.bundle,
-          );
+          let resolved = this.bundleGraph.getResolvedAsset(dep, this.bundle);
           if (resolved) {
             deps[getSpecifier(dep)] = this.bundleGraph.getAssetPublicId(
               resolved,

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -120,9 +120,7 @@ export class ScopeHoistingPackager {
       this.bundle.env.isLibrary ||
       this.bundle.env.outputFormat === 'commonjs'
     ) {
-      let bundles = this.bundleGraph
-        .getReferencedBundles(this.bundle)
-        .filter(b => b.bundleBehavior !== 'inline');
+      let bundles = this.bundleGraph.getReferencedBundles(this.bundle);
       for (let b of bundles) {
         this.externals.set(relativeBundlePath(this.bundle, b), new Map());
       }

--- a/packages/packagers/js/src/utils.js
+++ b/packages/packagers/js/src/utils.js
@@ -27,7 +27,7 @@ export function replaceScriptDependencies(
     }
 
     let dep = nullthrows(dependencies.find(d => getSpecifier(d) === s));
-    let resolved = nullthrows(bundleGraph.getDependencyResolution(dep, bundle));
+    let resolved = nullthrows(bundleGraph.getResolvedAsset(dep, bundle));
     let publicId = bundleGraph.getAssetPublicId(resolved);
     let replacement = `${parcelRequireName}("${publicId}")`;
     if (map) {

--- a/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
+++ b/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
@@ -19,9 +19,7 @@ export default (new Reporter({
       Array<PackagedBundle>,
     > = new DefaultMap(() => []);
     for (let bundle of event.bundleGraph.getBundles()) {
-      if (bundle.bundleBehavior !== 'inline') {
-        bundlesByTarget.get(bundle.target.name).push(bundle);
-      }
+      bundlesByTarget.get(bundle.target.name).push(bundle);
     }
 
     let reportsDir = path.join(options.projectRoot, 'parcel-bundle-reports');

--- a/packages/reporters/bundle-buddy/src/BundleBuddyReporter.js
+++ b/packages/reporters/bundle-buddy/src/BundleBuddyReporter.js
@@ -11,15 +11,13 @@ export default (new Reporter({
 
     let bundlesByTarget: Map<string, Array<PackagedBundle>> = new Map();
     for (let bundle of event.bundleGraph.getBundles()) {
-      if (bundle.bundleBehavior !== 'inline') {
-        let bundles = bundlesByTarget.get(bundle.target.distDir);
-        if (!bundles) {
-          bundles = [];
-          bundlesByTarget.set(bundle.target.distDir, bundles);
-        }
-
-        bundles.push(bundle);
+      let bundles = bundlesByTarget.get(bundle.target.distDir);
+      if (!bundles) {
+        bundles = [];
+        bundlesByTarget.set(bundle.target.distDir, bundles);
       }
+
+      bundles.push(bundle);
     }
 
     for (let [targetDir, bundles] of bundlesByTarget) {

--- a/packages/reporters/bundle-buddy/src/BundleBuddyReporter.js
+++ b/packages/reporters/bundle-buddy/src/BundleBuddyReporter.js
@@ -27,7 +27,7 @@ export default (new Reporter({
         bundle.traverseAssets(asset => {
           let deps = event.bundleGraph.getDependencies(asset);
           for (let dep of deps) {
-            let resolved = event.bundleGraph.getDependencyResolution(dep);
+            let resolved = event.bundleGraph.getResolvedAsset(dep);
             if (!resolved) {
               continue;
             }

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -24,9 +24,7 @@ export default async function bundleReport(
   projectRoot: FilePath,
   assetCount: number = 0,
 ) {
-  let bundleList = bundleGraph
-    .getBundles()
-    .filter(b => b.bundleBehavior !== 'inline');
+  let bundleList = bundleGraph.getBundles();
 
   // Get a list of bundles sorted by size
   let {bundles} =

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -102,13 +102,10 @@ export default class HMRServer {
       queue.add(async () => {
         let dependencies = event.bundleGraph.getDependencies(asset);
         let depsByBundle = {};
-        for (let bundle of event.bundleGraph.findBundlesWithAsset(asset)) {
+        for (let bundle of event.bundleGraph.getBundlesWithAsset(asset)) {
           let deps = {};
           for (let dep of dependencies) {
-            let resolved = event.bundleGraph.getDependencyResolution(
-              dep,
-              bundle,
-            );
+            let resolved = event.bundleGraph.getResolvedAsset(dep, bundle);
             if (resolved) {
               deps[dep.specifier] = event.bundleGraph.getAssetPublicId(
                 resolved,

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -217,7 +217,6 @@ export default class Server {
       let requestedPath = path.normalize(pathname.slice(1));
       let bundle = bundleGraph
         .getBundles()
-        .filter(b => b.bundleBehavior !== 'inline')
         .find(
           b =>
             path.relative(this.options.distDir, b.filePath) === requestedPath,

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -195,9 +195,7 @@ export default (new Runtime({
     // know about all of the sibling bundles of a child when it is written for the first time.
     // Therefore, we need to also ensure that the siblings are loaded when the child loads.
     if (options.shouldBuildLazily && bundle.env.outputFormat === 'global') {
-      let referenced = bundleGraph
-        .getReferencedBundles(bundle)
-        .filter(b => b.bundleBehavior !== 'inline');
+      let referenced = bundleGraph.getReferencedBundles(bundle);
       for (let referencedBundle of referenced) {
         let loaders = getLoaders(bundle.env);
         if (!loaders) {
@@ -294,10 +292,7 @@ function getLoaderRuntime({
     return;
   }
 
-  let externalBundles = bundleGraph
-    .getBundlesInBundleGroup(bundleGroup)
-    .filter(bundle => bundle.bundleBehavior !== 'inline');
-
+  let externalBundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
   let mainBundle = nullthrows(
     externalBundles.find(
       bundle => bundle.getMainEntry()?.id === bundleGroup.entryAssetId,


### PR DESCRIPTION
* Excludes inline bundles by default from most bundle graph methods that return an array of them. An `includeInline` option can be set to change that. Fixes T-950.
* Removes unused methods.
* Renames methods according to #5225.
* Adds docs

I tried to replace `resolveAsyncDependency` but was not successful. Main problem is that `getResolvedAsset` (née `getDependencyResolution`) resolves to runtimes, whereas `resolveAsyncDependency` resolves to the underlying asset. And we would need to add a `getResolvedBundleGroup` as well. Open to suggestions.

Also didn't remove `getChildBundles` and `getParentBundles` as discussed, along with the bundle group related methods. I think we were thinking of getting rid of bundle groups completely but I don't really want to tackle that right now.