### PR TITLE
Bug fixes

### DIFF
--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -154,10 +154,10 @@ export class TargetResolver {
       optionTargets = [exclusiveTarget];
     }
 
-    let packageTargets: Map<string, ?Target> = await this.resolvePackageTargets(
-      rootDir,
-      exclusiveTarget,
-    );
+    let packageTargets: Map<
+      string,
+      Target | null,
+    > = await this.resolvePackageTargets(rootDir, exclusiveTarget);
     let targets: Array<Target>;
     if (optionTargets) {
       if (Array.isArray(optionTargets)) {
@@ -348,7 +348,7 @@ export class TargetResolver {
   async resolvePackageTargets(
     rootDir: FilePath,
     exclusiveTarget?: string,
-  ): Promise<Map<string, ?Target>> {
+  ): Promise<Map<string, Target | null>> {
     let rootFile = path.join(rootDir, 'index');
     let conf = await loadConfig(
       this.fs,
@@ -460,7 +460,7 @@ export class TargetResolver {
       }
     }
 
-    let targets: Map<string, ?Target> = new Map();
+    let targets: Map<string, Target | null> = new Map();
     let node = pkgEngines.node;
     let browsers = pkgEngines.browsers;
 

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -154,7 +154,7 @@ export class TargetResolver {
       optionTargets = [exclusiveTarget];
     }
 
-    let packageTargets = await this.resolvePackageTargets(
+    let packageTargets: Map<string, ?Target> = await this.resolvePackageTargets(
       rootDir,
       exclusiveTarget,
     );
@@ -170,20 +170,29 @@ export class TargetResolver {
           });
         }
 
+        // Only build the intersection of the exclusive target and option targets.
+        if (exclusiveTarget != null) {
+          optionTargets = optionTargets.filter(
+            target => target === exclusiveTarget,
+          );
+        }
+
         // If an array of strings is passed, it's a filter on the resolved package
         // targets. Load them, and find the matching targets.
-        targets = optionTargets.map(target => {
-          let matchingTarget = packageTargets.get(target);
-          if (!matchingTarget) {
-            throw new ThrowableDiagnostic({
-              diagnostic: {
-                message: md`Could not find target with name "${target}"`,
-                origin: '@parcel/core',
-              },
-            });
-          }
-          return matchingTarget;
-        });
+        targets = optionTargets
+          .map(target => {
+            // null means skipped.
+            if (!packageTargets.has(target)) {
+              throw new ThrowableDiagnostic({
+                diagnostic: {
+                  message: md`Could not find target with name "${target}"`,
+                  origin: '@parcel/core',
+                },
+              });
+            }
+            return packageTargets.get(target);
+          })
+          .filter(Boolean);
       } else {
         // Otherwise, it's an object map of target descriptors (similar to those
         // in package.json). Adapt them to native targets.
@@ -322,13 +331,14 @@ export class TargetResolver {
           },
         ];
       } else {
-        targets = Array.from(packageTargets.values()).filter(descriptor => {
-          return !skipTarget(
-            descriptor.name,
-            exclusiveTarget,
-            descriptor.source,
-          );
-        });
+        targets = Array.from(packageTargets.values())
+          .filter(Boolean)
+          .filter(descriptor => {
+            return (
+              descriptor &&
+              !skipTarget(descriptor.name, exclusiveTarget, descriptor.source)
+            );
+          });
       }
     }
 
@@ -338,7 +348,7 @@ export class TargetResolver {
   async resolvePackageTargets(
     rootDir: FilePath,
     exclusiveTarget?: string,
-  ): Promise<Map<string, Target>> {
+  ): Promise<Map<string, ?Target>> {
     let rootFile = path.join(rootDir, 'index');
     let conf = await loadConfig(
       this.fs,
@@ -450,7 +460,7 @@ export class TargetResolver {
       }
     }
 
-    let targets: Map<string, Target> = new Map();
+    let targets: Map<string, ?Target> = new Map();
     let node = pkgEngines.node;
     let browsers = pkgEngines.browsers;
 
@@ -542,6 +552,7 @@ export class TargetResolver {
         );
 
         if (skipTarget(targetName, exclusiveTarget, descriptor.source)) {
+          targets.set(targetName, null);
           continue;
         }
 
@@ -798,6 +809,7 @@ export class TargetResolver {
         );
         let pkgDir = path.dirname(nullthrows(pkgFilePath));
         if (skipTarget(targetName, exclusiveTarget, descriptor.source)) {
+          targets.set(targetName, null);
           continue;
         }
 
@@ -1103,6 +1115,10 @@ function assertNoDuplicateTargets(options, targets, pkgFilePath, pkgContents) {
   // Without this, an assertion is thrown much later after naming the bundles and finding duplicates.
   let targetsByPath: Map<string, Array<string>> = new Map();
   for (let target of targets.values()) {
+    if (!target) {
+      continue;
+    }
+
     let {distEntry} = target;
     if (distEntry != null) {
       let distPath = path.join(

--- a/packages/core/integration-tests/test/integration/mdx-react-17/index.mdx
+++ b/packages/core/integration-tests/test/integration/mdx-react-17/index.mdx
@@ -1,0 +1,9 @@
+# heading1
+
+content content content
+
+# Below is a JSX block
+
+<div style={{ padding: '10px 30px', backgroundColor: 'tomato' }}>
+  <h2>This is a red heading</h2>
+</div>

--- a/packages/core/integration-tests/test/integration/mdx-react-17/package.json
+++ b/packages/core/integration-tests/test/integration/mdx-react-17/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "react": "17"
+  }
+}

--- a/packages/core/integration-tests/test/mdx.js
+++ b/packages/core/integration-tests/test/mdx.js
@@ -10,4 +10,14 @@ describe('mdx', function() {
     assert.equal(typeof output.default, 'function');
     assert(output.default.isMDXComponent);
   });
+
+  it('should support bundling MDX with React 17', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/mdx-react-17/index.mdx'),
+    );
+
+    let output = await run(b);
+    assert.equal(typeof output.default, 'function');
+    assert(output.default.isMDXComponent);
+  });
 });

--- a/packages/core/integration-tests/test/monorepos.js
+++ b/packages/core/integration-tests/test/monorepos.js
@@ -91,6 +91,57 @@ describe('monorepos', function() {
     }
   });
 
+  it('should compile packages with target source overrides and --target option', async function() {
+    let fixture = path.join(__dirname, '/integration/target-source');
+    let oldcwd = inputFS.cwd();
+    inputFS.chdir(fixture);
+
+    try {
+      let b = await bundle(
+        [
+          path.join(fixture, 'packages/package-a'),
+          path.join(fixture, 'packages/package-b'),
+        ],
+        {
+          targets: ['alternate'],
+          defaultTargetOptions: {
+            shouldScopeHoist: true,
+            distDir,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          name: 'indexAlternate.js',
+          assets: ['bar.js', 'indexAlternate.js'],
+        },
+        {
+          name: 'indexAlternate.js',
+          assets: ['bar.js', 'indexAlternate.js'],
+        },
+        {
+          name: 'indexAlternate2.js',
+          assets: ['foo.js', 'indexAlternate2.js'],
+        },
+      ]);
+
+      let contents = await outputFS.readFile(
+        path.join(distDir, '/package-a/src/indexAlternate.js'),
+        'utf8',
+      );
+      assert(contents.includes('hello bar'));
+
+      contents = await outputFS.readFile(
+        path.join(distDir, '/package-a/src/indexAlternate2.js'),
+        'utf8',
+      );
+      assert(contents.includes('hello foo'));
+    } finally {
+      inputFS.chdir(oldcwd);
+    }
+  });
+
   it('should build using root targets with entry files inside packages and cwd at project root', async function() {
     let fixture = path.join(__dirname, '/integration/monorepo');
     let oldcwd = inputFS.cwd();

--- a/packages/transformers/mdx/src/MDXTransformer.js
+++ b/packages/transformers/mdx/src/MDXTransformer.js
@@ -8,7 +8,8 @@ export default (new Transformer({
     let compiled = await mdx(code);
 
     asset.type = 'js';
-    asset.setCode(`/* @jsx mdx */
+    asset.setCode(`/* @jsxRuntime classic */
+/* @jsx mdx */
 import React from 'react';
 import { mdx } from '@mdx-js/react'
 ${compiled}


### PR DESCRIPTION
Fixes #6605. Fixes #6199.

* Always adds `@jsxRuntime classic` to compiled MDX
* Fixes the `--target` option when combined with targets that have a `source` field.