### PR TITLE
Fix broken release workflows because the napi-rs docker image was moved

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -124,7 +124,7 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     container:
-      image: docker.pkg.github.com/napi-rs/napi-rs/rust-nodejs-alpine:lts
+      image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_TOKEN }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -123,7 +123,7 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     container:
-      image: docker.pkg.github.com/napi-rs/napi-rs/rust-nodejs-alpine:lts
+      image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_TOKEN }}


### PR DESCRIPTION
The nightly and release workflows are currently broken: https://github.com/parcel-bundler/parcel/actions/runs/1069341898

New names taken from https://github.com/napi-rs/package-template/blob/20c4ebb4e8d71b70f17b6897cd661b3270a84136/.github/workflows/CI.yaml#L77