### PR TITLE
Install curl in release workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install build tools
-        run: apk add --no-cache python3 make gcc g++ musl-dev
+        run: apk add --no-cache python3 make gcc g++ musl-dev curl
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install build tools
-        run: apk add --no-cache python3 make gcc g++ musl-dev
+        run: apk add --no-cache python3 make gcc g++ musl-dev curl
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
The new docker image from https://github.com/parcel-bundler/parcel/pull/6648 apparently doesn't have curl installed: https://github.com/parcel-bundler/parcel/runs/3177091128?check_suite_focus=true#logs