### PR TITLE
Handle mutations of process.env

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1242,9 +1242,7 @@ describe('html', function() {
               ],
             },
           ],
-          hints: [
-            'Add type="module" as a second argument to the <script> tag.',
-          ],
+          hints: ['Add the type="module" attribute to the <script> tag.'],
         },
       ]);
 
@@ -1523,9 +1521,7 @@ describe('html', function() {
               ],
             },
           ],
-          hints: [
-            'Add type="module" as a second argument to the <script> tag.',
-          ],
+          hints: ['Add the type="module" attribute to the <script> tag.'],
         },
       ]);
 

--- a/packages/core/integration-tests/test/integration/env-computed/index.js
+++ b/packages/core/integration-tests/test/integration/env-computed/index.js
@@ -1,3 +1,2 @@
 let name = "ABC";
-process.env[name] = "abc";
 module.exports = process.env[name];

--- a/packages/core/integration-tests/test/integration/env-mutate/index.js
+++ b/packages/core/integration-tests/test/integration/env-mutate/index.js
@@ -1,0 +1,4 @@
+process.env.SOMETHING = "foo";
+process.env.SOMETHING += "foo";
+delete process.env.SOMETHING;
+process.env.SOMETHING++;

--- a/packages/core/integration-tests/test/integration/env-mutate/node_modules/foo/index.js
+++ b/packages/core/integration-tests/test/integration/env-mutate/node_modules/foo/index.js
@@ -1,0 +1,3 @@
+output(process.env.SOMETHING = 'foo');
+output(delete process.env.SOMETHING)
+output(process.env.SOMETHING++);

--- a/packages/core/integration-tests/test/integration/env-mutate/warn.js
+++ b/packages/core/integration-tests/test/integration/env-mutate/warn.js
@@ -1,0 +1,1 @@
+import 'foo';

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -206,6 +206,7 @@ impl<'a> DependencyCollector<'a> {
       }]),
       hints: None,
       show_environment: true,
+      severity: DiagnosticSeverity::Error,
     });
   }
 }
@@ -380,6 +381,7 @@ impl<'a> Fold for DependencyCollector<'a> {
                   "Use a static `import`, or dynamic `import()` instead.",
                 )]),
                 show_environment: self.config.source_type == SourceType::Script,
+                severity: DiagnosticSeverity::Error,
               });
             }
 
@@ -549,6 +551,7 @@ impl<'a> Fold for DependencyCollector<'a> {
                 str_.value,
               )]),
               show_environment: false,
+              severity: DiagnosticSeverity::Error,
             });
             return node;
           } else {
@@ -719,6 +722,7 @@ impl<'a> Fold for DependencyCollector<'a> {
                 str_.value
               )]),
               show_environment: false,
+              severity: DiagnosticSeverity::Error,
             });
             return node;
           } else {
@@ -1221,6 +1225,7 @@ impl<'a> DependencyCollector<'a> {
             }]),
             hints: None,
             show_environment: true,
+            severity: DiagnosticSeverity::Error,
           })
         }
         true

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -7,6 +7,7 @@ use swc_ecmascript::ast;
 use swc_ecmascript::visit::{Fold, FoldWith};
 
 use crate::utils::*;
+use ast::*;
 
 pub struct EnvReplacer<'a> {
   pub replace_env: bool,
@@ -14,35 +15,35 @@ pub struct EnvReplacer<'a> {
   pub env: &'a HashMap<swc_atoms::JsWord, swc_atoms::JsWord>,
   pub decls: &'a HashSet<(JsWord, SyntaxContext)>,
   pub used_env: &'a mut HashSet<JsWord>,
+  pub source_map: &'a swc_common::SourceMap,
+  pub diagnostics: &'a mut Vec<Diagnostic>,
 }
 
 impl<'a> Fold for EnvReplacer<'a> {
-  fn fold_expr(&mut self, node: ast::Expr) -> ast::Expr {
-    use ast::{Bool, Expr::*, ExprOrSuper::*, Ident, Lit, MemberExpr, Str};
-
+  fn fold_expr(&mut self, node: Expr) -> Expr {
     // Replace assignments to process.browser with `true`
     // TODO: this seems questionable but we did it in the JS version??
-    if let Assign(ref assign) = node {
-      if let ast::PatOrExpr::Pat(ref pat) = assign.left {
-        if let ast::Pat::Expr(ref expr) = &**pat {
-          if let Member(ref member) = &**expr {
+    if let Expr::Assign(ref assign) = node {
+      if let PatOrExpr::Pat(ref pat) = assign.left {
+        if let Pat::Expr(ref expr) = &**pat {
+          if let Expr::Member(ref member) = &**expr {
             if self.is_browser && match_member_expr(member, vec!["process", "browser"], self.decls)
             {
               let mut res = assign.clone();
-              res.right = Box::new(Lit(Lit::Bool(Bool {
+              res.right = Box::new(Expr::Lit(Lit::Bool(Bool {
                 value: true,
                 span: DUMMY_SP,
               })));
-              return Assign(res);
+              return Expr::Assign(res);
             }
           }
         }
       }
     }
 
-    if let Member(ref member) = node {
+    if let Expr::Member(ref member) = node {
       if self.is_browser && match_member_expr(member, vec!["process", "browser"], self.decls) {
-        return Lit(Lit::Bool(Bool {
+        return Expr::Lit(Lit::Bool(Bool {
           value: true,
           span: DUMMY_SP,
         }));
@@ -53,19 +54,19 @@ impl<'a> Fold for EnvReplacer<'a> {
       }
 
       if let MemberExpr {
-        obj: Expr(ref expr),
+        obj: ExprOrSuper::Expr(ref expr),
         ref prop,
         computed,
         ..
       } = member
       {
-        if let Member(member) = &**expr {
+        if let Expr::Member(member) = &**expr {
           if match_member_expr(member, vec!["process", "env"], self.decls) {
-            if let Lit(Lit::Str(Str { value: ref sym, .. })) = &**prop {
+            if let Expr::Lit(Lit::Str(Str { value: ref sym, .. })) = &**prop {
               if let Some(replacement) = self.replace(sym, true) {
                 return replacement;
               }
-            } else if let Ident(Ident { ref sym, .. }) = &**prop {
+            } else if let Expr::Ident(Ident { ref sym, .. }) = &**prop {
               if !computed {
                 if let Some(replacement) = self.replace(sym, true) {
                   return replacement;
@@ -77,53 +78,98 @@ impl<'a> Fold for EnvReplacer<'a> {
       }
     }
 
-    if let Assign(assign) = &node {
-      if !self.replace_env || assign.op != ast::AssignOp::Assign {
+    if let Expr::Assign(assign) = &node {
+      if !self.replace_env {
         return node.fold_children_with(self);
       }
 
-      if let ast::PatOrExpr::Pat(pat) = &assign.left {
-        if let ast::Expr::Member(member) = &*assign.right {
+      let expr = match &assign.left {
+        PatOrExpr::Pat(pat) => {
+          if let Pat::Expr(expr) = &**pat {
+            Some(&**expr)
+          } else if let Expr::Member(member) = &*assign.right {
+            if assign.op == AssignOp::Assign
+              && match_member_expr(member, vec!["process", "env"], self.decls)
+            {
+              let mut decls = vec![];
+              self.collect_pat_bindings(&pat, &mut decls);
+
+              let mut exprs: Vec<Box<Expr>> = decls
+                .iter()
+                .map(|decl| {
+                  Box::new(Expr::Assign(AssignExpr {
+                    span: DUMMY_SP,
+                    op: AssignOp::Assign,
+                    left: PatOrExpr::Pat(Box::new(decl.name.clone())),
+                    right: Box::new(if let Some(init) = &decl.init {
+                      *init.clone()
+                    } else {
+                      Expr::Ident(Ident::new(js_word!("undefined"), DUMMY_SP))
+                    }),
+                  }))
+                })
+                .collect();
+
+              exprs.push(Box::new(Expr::Object(ObjectLit {
+                span: DUMMY_SP,
+                props: vec![],
+              })));
+
+              return Expr::Seq(SeqExpr {
+                span: assign.span,
+                exprs,
+              });
+            }
+            None
+          } else {
+            None
+          }
+        }
+        PatOrExpr::Expr(expr) => Some(&**expr),
+        _ => None,
+      };
+
+      if let Some(Expr::Member(MemberExpr {
+        obj: ExprOrSuper::Expr(ref obj),
+        ..
+      })) = expr
+      {
+        if let Expr::Member(member) = &**obj {
           if match_member_expr(member, vec!["process", "env"], self.decls) {
-            let mut decls = vec![];
-            self.collect_pat_bindings(&pat, &mut decls);
-
-            let mut exprs: Vec<Box<ast::Expr>> = decls
-              .iter()
-              .map(|decl| {
-                Box::new(Assign(ast::AssignExpr {
-                  span: DUMMY_SP,
-                  op: ast::AssignOp::Assign,
-                  left: ast::PatOrExpr::Pat(Box::new(decl.name.clone())),
-                  right: Box::new(if let Some(init) = &decl.init {
-                    *init.clone()
-                  } else {
-                    Ident(Ident::new(js_word!("undefined"), DUMMY_SP))
-                  }),
-                }))
-              })
-              .collect();
-
-            exprs.push(Box::new(Object(ast::ObjectLit {
-              span: DUMMY_SP,
-              props: vec![],
-            })));
-
-            return Seq(ast::SeqExpr {
-              span: assign.span,
-              exprs,
-            });
+            self.emit_mutating_error(assign.span);
+            return *assign.right.clone().fold_with(self);
           }
         }
       }
     }
 
-    swc_ecmascript::visit::fold_expr(self, node)
+    if self.replace_env {
+      match &node {
+        // e.g. delete process.env.SOMETHING
+        Expr::Unary(UnaryExpr { op: UnaryOp::Delete, arg, span, .. }) |
+        // e.g. process.env.UPDATE++
+        Expr::Update(UpdateExpr { arg, span, .. }) => {
+          if let Expr::Member(MemberExpr { obj: ExprOrSuper::Expr(ref obj), .. }) = &**arg {
+            if let Expr::Member(member) = &**obj {
+              if match_member_expr(member, vec!["process", "env"], self.decls) {
+                self.emit_mutating_error(*span);
+                return match &node {
+                  Expr::Unary(_) => Expr::Lit(Lit::Bool(Bool { span: *span, value: true })),
+                  Expr::Update(_) => *arg.clone().fold_with(self),
+                  _ => unreachable!()
+                }
+              }
+            }
+          }
+        },
+        _ => {}
+      }
+    }
+
+    node.fold_children_with(self)
   }
 
-  fn fold_var_decl(&mut self, node: ast::VarDecl) -> ast::VarDecl {
-    use ast::*;
-
+  fn fold_var_decl(&mut self, node: VarDecl) -> VarDecl {
     if !self.replace_env {
       return node.fold_children_with(self);
     }
@@ -152,16 +198,14 @@ impl<'a> Fold for EnvReplacer<'a> {
 }
 
 impl<'a> EnvReplacer<'a> {
-  fn replace(&mut self, sym: &JsWord, fallback_undefined: bool) -> Option<ast::Expr> {
-    use ast::{Expr::*, Ident, Lit};
-
+  fn replace(&mut self, sym: &JsWord, fallback_undefined: bool) -> Option<Expr> {
     if let Some(val) = self.env.get(sym) {
       self.used_env.insert(sym.clone());
-      return Some(Lit(Lit::Str(ast::Str {
+      return Some(Expr::Lit(Lit::Str(Str {
         span: DUMMY_SP,
         value: val.into(),
         has_escape: false,
-        kind: ast::StrKind::Synthesized,
+        kind: StrKind::Synthesized,
       })));
     } else if fallback_undefined {
       match sym as &str {
@@ -175,16 +219,14 @@ impl<'a> EnvReplacer<'a> {
         | "valueOf" => {}
         _ => {
           self.used_env.insert(sym.clone());
-          return Some(Ident(Ident::new(js_word!("undefined"), DUMMY_SP)));
+          return Some(Expr::Ident(Ident::new(js_word!("undefined"), DUMMY_SP)));
         }
       };
     }
     None
   }
 
-  fn collect_pat_bindings(&mut self, pat: &ast::Pat, decls: &mut Vec<ast::VarDeclarator>) {
-    use ast::*;
-
+  fn collect_pat_bindings(&mut self, pat: &Pat, decls: &mut Vec<VarDeclarator>) {
     match pat {
       Pat::Object(object) => {
         for prop in &object.props {
@@ -252,5 +294,18 @@ impl<'a> EnvReplacer<'a> {
       }),
       _ => {}
     }
+  }
+
+  fn emit_mutating_error(&mut self, span: swc_common::Span) {
+    self.diagnostics.push(Diagnostic {
+      message: "Mutating process.env is not supported".into(),
+      code_highlights: Some(vec![CodeHighlight {
+        message: None,
+        loc: SourceLocation::from(self.source_map, span),
+      }]),
+      hints: None,
+      show_environment: false,
+      severity: DiagnosticSeverity::SourceError,
+    });
   }
 }

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -8,7 +8,8 @@ use swc_ecmascript::ast::*;
 use swc_ecmascript::visit::{Fold, FoldWith, Node, Visit, VisitWith};
 
 use crate::utils::{
-  match_import, match_member_expr, match_require, CodeHighlight, Diagnostic, SourceLocation,
+  match_import, match_member_expr, match_require, CodeHighlight, Diagnostic, DiagnosticSeverity,
+  SourceLocation,
 };
 
 type IdentId = (JsWord, SyntaxContext);
@@ -168,6 +169,7 @@ impl<'a> Fold for Hoist<'a> {
                     code_highlights: Some(highlights),
                     hints: None,
                     show_environment: false,
+                    severity: DiagnosticSeverity::Error,
                   })
                 }
               }

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -2,7 +2,7 @@ use inflector::Inflector;
 use std::collections::{HashMap, HashSet};
 use swc_atoms::JsWord;
 use swc_common::{Mark, Span, SyntaxContext, DUMMY_SP};
-use swc_ecma_preset_env::{preset_env, Feature, Mode::Entry, Targets, Version, Versions};
+use swc_ecma_preset_env::{Feature, Versions};
 use swc_ecmascript::ast::*;
 use swc_ecmascript::visit::{Fold, FoldWith};
 

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -186,6 +186,17 @@ pub struct Diagnostic {
   pub code_highlights: Option<Vec<CodeHighlight>>,
   pub hints: Option<Vec<String>>,
   pub show_environment: bool,
+  pub severity: DiagnosticSeverity,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub enum DiagnosticSeverity {
+  /// Fails the build with an error.
+  Error,
+  /// Logs a warning, but the build does not fail.
+  Warning,
+  /// An error if this is source code in the project, or a warning if in node_modules.
+  SourceError,
 }
 
 #[derive(Serialize, Debug, Deserialize, Eq, PartialEq, Clone, Copy)]

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -111,7 +111,7 @@ type PackageJSONConfig = {|
 const SCRIPT_ERRORS = {
   browser: {
     message: 'Browser scripts cannot have imports or exports.',
-    hint: 'Add type="module" as a second argument to the <script> tag.',
+    hint: 'Add the type="module" attribute to the <script> tag.',
   },
   'web-worker': {
     message:

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -279,7 +279,7 @@ export default (new Transformer({
       decorators,
     };
   },
-  async transform({asset, config, options}) {
+  async transform({asset, config, options, logger}) {
     let [code, originalMap] = await Promise.all([
       asset.getBuffer(),
       asset.getMap(),
@@ -423,59 +423,75 @@ export default (new Transformer({
     };
 
     if (diagnostics) {
-      throw new ThrowableDiagnostic({
-        diagnostic: diagnostics.map(diagnostic => {
-          let message = diagnostic.message;
-          if (message === 'SCRIPT_ERROR') {
-            let err = SCRIPT_ERRORS[(asset.env.context: string)];
-            message = err?.message || SCRIPT_ERRORS.browser.message;
+      let errors = diagnostics.filter(
+        d =>
+          d.severity === 'Error' ||
+          (d.severity === 'SourceError' && asset.isSource),
+      );
+      let warnings = diagnostics.filter(
+        d =>
+          d.severity === 'Warning' ||
+          (d.severity === 'SourceError' && !asset.isSource),
+      );
+      let convertDiagnostic = diagnostic => {
+        let message = diagnostic.message;
+        if (message === 'SCRIPT_ERROR') {
+          let err = SCRIPT_ERRORS[(asset.env.context: string)];
+          message = err?.message || SCRIPT_ERRORS.browser.message;
+        }
+
+        let res = {
+          message,
+          codeFrames: [
+            {
+              filePath: asset.filePath,
+              codeHighlights: diagnostic.code_highlights?.map(highlight => {
+                let {start, end} = convertLoc(highlight.loc);
+                return {
+                  message: highlight.message,
+                  start,
+                  end,
+                };
+              }),
+            },
+          ],
+          hints: diagnostic.hints,
+        };
+
+        if (diagnostic.show_environment) {
+          if (asset.env.loc && asset.env.loc.filePath !== asset.filePath) {
+            res.codeFrames.push({
+              filePath: asset.env.loc.filePath,
+              codeHighlights: [
+                {
+                  start: asset.env.loc.start,
+                  end: asset.env.loc.end,
+                  message: 'The environment was originally created here',
+                },
+              ],
+            });
           }
 
-          let res = {
-            message,
-            codeFrames: [
-              {
-                filePath: asset.filePath,
-                codeHighlights: diagnostic.code_highlights?.map(highlight => {
-                  let {start, end} = convertLoc(highlight.loc);
-                  return {
-                    message: highlight.message,
-                    start,
-                    end,
-                  };
-                }),
-              },
-            ],
-            hints: diagnostic.hints,
-          };
-
-          if (diagnostic.show_environment) {
-            if (asset.env.loc && asset.env.loc.filePath !== asset.filePath) {
-              res.codeFrames.push({
-                filePath: asset.env.loc.filePath,
-                codeHighlights: [
-                  {
-                    start: asset.env.loc.start,
-                    end: asset.env.loc.end,
-                    message: 'The environment was originally created here',
-                  },
-                ],
-              });
-            }
-
-            let err = SCRIPT_ERRORS[(asset.env.context: string)];
-            if (err) {
-              if (!res.hints) {
-                res.hints = [err.hint];
-              } else {
-                res.hints.push(err.hint);
-              }
+          let err = SCRIPT_ERRORS[(asset.env.context: string)];
+          if (err) {
+            if (!res.hints) {
+              res.hints = [err.hint];
+            } else {
+              res.hints.push(err.hint);
             }
           }
+        }
 
-          return res;
-        }),
-      });
+        return res;
+      };
+
+      if (errors.length > 0) {
+        throw new ThrowableDiagnostic({
+          diagnostic: errors.map(convertDiagnostic),
+        });
+      }
+
+      logger.warn(warnings.map(convertDiagnostic));
     }
 
     if (shebang) {


### PR DESCRIPTION
Fixes #5493. Fixes T-1036.

Mutating process.env properties can't be supported if we still want to statically replace them with their values at build time. In source code this is flagged as an error. In node_modules it is a warning in case the code isn't actually used at runtime. In that case, the behavior won't be as expected but at least it will compile.

In order to do this, the diagnostics in Rust now have a severity property, which can be `Error`, `Warning`, or `SourceError`. `SourceError` means error if `asset.isSource` and warning otherwise.

Also fixed an error message for script tags which had a copy/paste mistake I noticed.