### PR TITLE
fixes #6658 (assertion error in BundleAnalyzer)

### DIFF
--- a/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
+++ b/packages/reporters/bundle-analyzer/src/BundleAnalyzerReporter.js
@@ -126,7 +126,7 @@ async function getBundleNode(bundle: PackagedBundle, options: PluginOptions) {
     let relativePath = path.relative(options.projectRoot, asset.filePath);
     let parts = relativePath.split(path.sep);
     let dirs = parts.slice(0, parts.length - 1);
-    let basename = parts[parts.length - 1];
+    let basename = path.basename(asset.filePath);
 
     let map = dirMap;
     for (let dir of dirs) {
@@ -136,7 +136,7 @@ async function getBundleNode(bundle: PackagedBundle, options: PluginOptions) {
 
     invariant(map instanceof DefaultMap);
     map.set(basename, {
-      basename: path.basename(asset.filePath),
+      basename,
       size: asset.size,
     });
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

The error occurs when `asset.filePath` is `''`. In that case `path.relative(options.projectRoot, asset.filePath)` doesn't return the right value. Thus the basename using `let basename = parts[parts.length - 1];` is not the fileName but the next folder in the Path which leads to assertion error subsequently. Fixing that using `path.baseName` fixes the error.

## 💻 Examples

For example, for example in `simple` package, `path.relative(options.projectRoot, asset.filePath)` returns `simple` and thus the basename using `let basename = parts[parts.length - 1];` doesn't return '' but returns `simple` which is wrong. Using `   let basename = path.basename(asset.filePath);` return the right value.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo
 For testing, you can run the bundleAnalyser in any of the example packages by passing this reporter. For example, 
```
"PARCEL_WORKERS=0 parcel build src/index.js --no-cache  --reporter @parcel/reporter-bundle-analyzer"
```
