### PR TITLE
Upgrade the ejs version for the dev-server reporter

### DIFF
--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -24,7 +24,7 @@
     "@parcel/plugin": "2.0.0-rc.0",
     "@parcel/utils": "2.0.0-rc.0",
     "connect": "^3.7.0",
-    "ejs": "^2.6.1",
+    "ejs": "^3.1.6",
     "http-proxy-middleware": "^1.0.0",
     "nullthrows": "^1.1.1",
     "serve-handler": "^6.0.0",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

The `ejs` package used by the bundler seems to have a critical security vulnerability: https://www.whitesourcesoftware.com/vulnerability-database/WS-2021-0153

Even though the usage here seems to be not impacted by this issue in any way, it is still triggering alerts in security checkers, and requiring people to look into it. In this PR, I have attempted to upgrade the version that is used in the dev-server reporter.

I have never contributed to Parcel before, and I don't really know how to validate my changes, therefore I wanted to validate at least that the contract hasn't changed for the new major version, and for that I have created a small reproduction that runs and compares outputs of the both versions side by side: https://replit.com/@BurakKarakan/EjsUpgradeTest

## 🚨 Test instructions

Please see: https://replit.com/@BurakKarakan/EjsUpgradeTest

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
