### PR TITLE
Export core class in TypeScript

### DIFF
--- a/packages/core/core/index.d.ts
+++ b/packages/core/core/index.d.ts
@@ -2,7 +2,7 @@ import type {InitialParcelOptions, BuildEvent, BuildSuccessEvent, AsyncSubscript
 import type {FarmOptions} from '@parcel/workers';
 import type WorkerFarm from '@parcel/workers';
 
-declare class Parcel {
+export default class Parcel {
   constructor(options: InitialParcelOptions);
   run(): Promise<BuildSuccessEvent>;
   watch(


### PR DESCRIPTION
Working on a small test suite for turning https://github.com/parcel-bundler/parcel/pull/6544 into an independent library, and found the core class isn't currently exported in the TypeScript definitions.