### PR TITLE
Add type for WorkerFarm.end()

### DIFF
--- a/packages/core/workers/index.d.ts
+++ b/packages/core/workers/index.d.ts
@@ -15,6 +15,8 @@ export type FarmOptions = {
 
 declare class WorkerFarm {
   constructor(options: FarmOptions);
+
+  end(): Promise<void>;
 }
 
 export default WorkerFarm; 


### PR DESCRIPTION
Related to #6686, it seems important to call `WorkerFarm.end()` when using a `MemoryFS`. I was getting from Jest 'A worker process has failed to exit gracefully and has been force exited' otherwise.

This method didn't have a TypeScript definition, so I've added it. (There's clearly a lot more that need typing, I've not gone down that rabbit hole. 😅)