### PR TITLE
Don't include the default export in static reexports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/a.js
@@ -1,0 +1,5 @@
+export {default} from './b.js';
+export * from './b.js';
+
+export {default as other} from './c.js';
+export * from './c.js';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/async.js
@@ -1,0 +1,5 @@
+import _default, {other} from './a.js';
+
+sideEffectNoop(_default, other);
+
+export default _default;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/b.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/c.js
@@ -1,0 +1,1 @@
+export default 99;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-default/index.js
@@ -1,0 +1,3 @@
+import _default, {other} from './a.js';
+
+output = import('./async').then(mod => mod.default);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-esmodule/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-esmodule/a.js
@@ -1,0 +1,2 @@
+module.exports.foo = 42;
+module.exports.__esModule = true;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-esmodule/async.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-esmodule/async.js
@@ -1,0 +1,1 @@
+export * from './a';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-esmodule/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/no-reexport-esmodule/index.js
@@ -1,0 +1,3 @@
+import * as a from './a.js';
+
+output = import('./async').then(mod => mod.__esModule);

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3725,6 +3725,17 @@ describe('scope hoisting', function() {
 
       assert.equal(await run(b), 42);
     });
+
+    it('should not include __esModule when reexporting * without $parcel$exportWildcard', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/scope-hoisting/es6/no-reexport-esmodule/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), undefined);
+    });
   });
 
   describe('commonjs', function() {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3714,6 +3714,17 @@ describe('scope hoisting', function() {
       let test = await run(b);
       assert.equal(test({foo: 2}), 2);
     });
+
+    it('should not include default when reexporting * without $parcel$exportWildcard', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/scope-hoisting/es6/no-reexport-default/index.js',
+        ),
+      );
+
+      assert.equal(await run(b), 42);
+    });
   });
 
   describe('commonjs', function() {

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -983,6 +983,12 @@ ${code}
               this.usedHelpers.add('$parcel$exportWildcard');
             } else {
               for (let symbol of this.bundleGraph.getUsedSymbols(dep)) {
+                if (
+                  symbol === 'default' // `export * as ...` does not include the default export
+                ) {
+                  continue;
+                }
+
                 let resolvedSymbol = this.getSymbolResolution(
                   asset,
                   resolved,

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -984,7 +984,8 @@ ${code}
             } else {
               for (let symbol of this.bundleGraph.getUsedSymbols(dep)) {
                 if (
-                  symbol === 'default' // `export * as ...` does not include the default export
+                  symbol === 'default' || // `export * as ...` does not include the default export
+                  symbol === '__esModule'
                 ) {
                   continue;
                 }


### PR DESCRIPTION
Previously, if a re-exporting module didn't use `$parcel$exportWildcard`, we would enumerate and re-export all symbols, but `export * as ...` should not reexport the default export.

Test Plan: Added integration test