### PR TITLE
Add support for more types of dependencies in SVG

### DIFF
--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -319,7 +319,7 @@ describe('css', () => {
     assert.equal(
       css.trim(),
       `.svg-img {
-  background-image: url('data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%27120%27%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%2F%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%23blur-_.%21~%2a%29%22%20%2F%3E%0A%3C%2Fsvg%3E%0A');
+  background-image: url('data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%3E%3C%2FfeGaussianBlur%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%27%23blur-_.%21~%2a%27%29%22%3E%3C%2Fcircle%3E%0A%3C%2Fsvg%3E%0A');
 }`,
     );
   });

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -2432,7 +2432,7 @@ describe('html', function() {
     );
     assert.equal(
       contents.trim(),
-      `<img src="data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%27120%27%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%2F%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%23blur-_.%21~%2a%29%22%20%2F%3E%0A%3C%2Fsvg%3E%0A">`,
+      `<img src="data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%3E%3C%2FfeGaussianBlur%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%27%23blur-_.%21~%2a%27%29%22%3E%3C%2Fcircle%3E%0A%3C%2Fsvg%3E%0A">`,
     );
   });
 

--- a/packages/core/integration-tests/test/integration/svg/circle.svg
+++ b/packages/core/integration-tests/test/integration/svg/circle.svg
@@ -5,4 +5,12 @@
     <use href="#circle" x="10" fill="blue"/>
   </a>
   <use xlink:href="square.svg#square" x="20" fill="white" stroke="red"/>
+  <circle cx="5" cy="5" r="4" fill="url(gradient.svg#myGradient)" />
+  <text>
+    <textPath href="path.svg#MyPath">
+      Quick brown fox jumps over the lazy dog.
+    </textPath>
+  </text>
+  <script xlink:href="script.js" />
+  <script type="module" href="module.js" />
 </svg>

--- a/packages/core/integration-tests/test/integration/svg/gradient.svg
+++ b/packages/core/integration-tests/test/integration/svg/gradient.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="myGradient">
+      <stop offset="10%" stop-color="gold" />
+      <stop offset="95%" stop-color="red" />
+    </radialGradient>
+  </defs>
+</svg>

--- a/packages/core/integration-tests/test/integration/svg/module.js
+++ b/packages/core/integration-tests/test/integration/svg/module.js
@@ -1,0 +1,2 @@
+import './script';
+console.log('module');

--- a/packages/core/integration-tests/test/integration/svg/path.svg
+++ b/packages/core/integration-tests/test/integration/svg/path.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <path id="MyPath" fill="none" stroke="red"
+        d="M10,90 Q90,90 90,45 Q90,10 50,10 Q10,10 10,40 Q10,70 45,70 Q70,70 75,50" />
+  </defs>
+</svg>

--- a/packages/core/integration-tests/test/integration/svg/script.js
+++ b/packages/core/integration-tests/test/integration/svg/script.js
@@ -1,0 +1,1 @@
+console.log('script');

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4134,7 +4134,7 @@ describe('javascript', function() {
 
     assert.equal(
       (await run(b)).default,
-      'data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%27120%27%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%2F%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%23blur-_.%21~%2a%29%22%20%2F%3E%0A%3C%2Fsvg%3E%0A',
+      'data:image/svg+xml,%3Csvg%20width%3D%22120%22%20height%3D%22120%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%3Cfilter%20id%3D%22blur-_.%21~%2a%22%3E%0A%20%20%20%20%3CfeGaussianBlur%20stdDeviation%3D%225%22%3E%3C%2FfeGaussianBlur%3E%0A%20%20%3C%2Ffilter%3E%0A%20%20%3Ccircle%20cx%3D%2260%22%20cy%3D%2260%22%20r%3D%2250%22%20fill%3D%22green%22%20filter%3D%22url%28%27%23blur-_.%21~%2a%27%29%22%3E%3C%2Fcircle%3E%0A%3C%2Fsvg%3E%0A',
     );
   });
 

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -23,7 +23,58 @@ describe('svg', function() {
         name: 'other2.html',
         assets: ['other2.html'],
       },
+      {
+        type: 'svg',
+        assets: ['path.svg'],
+      },
+      {
+        type: 'svg',
+        assets: ['gradient.svg'],
+      },
+      {
+        type: 'js',
+        assets: ['script.js'],
+      },
+      {
+        type: 'js',
+        assets: ['module.js', 'script.js'],
+      },
     ]);
+
+    let file = await outputFS.readFile(
+      b.getBundles().find(b => b.type === 'svg').filePath,
+      'utf-8',
+    );
+    assert(file.includes('<a href="/other1.html">'));
+    assert(file.includes('<use href="#circle"'));
+    assert(
+      file.includes(
+        `<use xlink:href="/${path.basename(
+          b.getBundles().find(b => b.name.startsWith('square')).filePath,
+        )}#square"`,
+      ),
+    );
+    assert(
+      file.includes(
+        `fill="url('/${path.basename(
+          b.getBundles().find(b => b.name.startsWith('gradient')).filePath,
+        )}#myGradient')"`,
+      ),
+    );
+    assert(
+      file.includes(
+        `<script xlink:href="/${path.basename(
+          b.getBundles().find(b => b.name.startsWith('script')).filePath,
+        )}"`,
+      ),
+    );
+    assert(
+      file.includes(
+        `<script href="/${path.basename(
+          b.getBundles().find(b => b.name.startsWith('module')).filePath,
+        )}"`,
+      ),
+    );
   });
 
   it('should minify SVG bundles', async function() {

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -64,14 +64,20 @@ describe('svg', function() {
     assert(
       file.includes(
         `<script xlink:href="/${path.basename(
-          b.getBundles().find(b => b.name.startsWith('script')).filePath,
+          b
+            .getBundles()
+            .find(b => b.type === 'js' && b.env.sourceType === 'script')
+            .filePath,
         )}"`,
       ),
     );
     assert(
       file.includes(
         `<script href="/${path.basename(
-          b.getBundles().find(b => b.name.startsWith('module')).filePath,
+          b
+            .getBundles()
+            .find(b => b.type === 'js' && b.env.sourceType === 'module')
+            .filePath,
         )}"`,
       ),
     );

--- a/packages/transformers/svg/src/dependencies.js
+++ b/packages/transformers/svg/src/dependencies.js
@@ -57,7 +57,7 @@ const FUNC_IRI_ATTRS = new Set([
 // https://www.w3.org/TR/css3-values/#urls
 const FUNC_IRI_RE = /^url\((?:((['"])(.*?)\2(\s+.*)?)|((?:\\[\s'"]|[^\s'"])+))\)$/;
 const ESCAPE_RE = /\\(.|\n|\r|\u2028|\u2029)/;
-export function parseFuncIRI(value: string) {
+export function parseFuncIRI(value: string): ?[string, string] {
   let m = value.match(FUNC_IRI_RE);
   if (m) {
     let url = (m[3] || m[5]).replace(ESCAPE_RE, '$1');

--- a/packages/transformers/svg/src/dependencies.js
+++ b/packages/transformers/svg/src/dependencies.js
@@ -5,10 +5,66 @@ import PostHTML from 'posthtml';
 
 // A list of all attributes that may produce a dependency
 // Based on https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+// See also https://www.w3.org/TR/SVG/attindex.html and https://www.w3.org/TR/SVG11/attindex.html
+// SVG animation elements are excluded because they may only reference elements in the same document: https://www.w3.org/TR/SVG/linking.html#processingURL-fetch
+const HREF_ATTRS = [
+  'a',
+  'use',
+  'feImage',
+  'image',
+  'linearGradient',
+  'radialGradient',
+  'pattern',
+  'mpath',
+  'textPath',
+  'script',
+];
 const ATTRS = {
-  href: ['a', 'use'],
-  'xlink:href': ['a', 'use'],
+  href: HREF_ATTRS,
+  'xlink:href': [
+    ...HREF_ATTRS,
+    'altGlyph',
+    'cursor',
+    'filter',
+    'font-face-uri',
+    'glyphRef',
+    'tref',
+    'color-profile',
+  ],
 };
+
+// Attributes that allow url() to reference another element, either in the same document or a different one.
+// https://www.w3.org/TR/SVG11/linking.html#processingIRI
+const FUNC_IRI_ATTRS = new Set([
+  'fill',
+  'stroke',
+  'clip-path',
+  'color-profile',
+  'cursor',
+  'filter',
+  'marker',
+  'marker-start',
+  'marker-mid',
+  'marker-end',
+  'mask',
+
+  // SVG2 - https://www.w3.org/TR/SVG/linking.html#processingURL-validity
+  'shape-inside',
+  'shape-subtract',
+  'mask-image',
+]);
+
+// https://www.w3.org/TR/css3-values/#urls
+const FUNC_IRI_RE = /^url\((?:((['"])(.*?)\2(\s+.*)?)|((?:\\[\s'"]|[^\s'"])+))\)$/;
+const ESCAPE_RE = /\\(.|\n|\r|\u2028|\u2029)/;
+export function parseFuncIRI(value: string) {
+  let m = value.match(FUNC_IRI_RE);
+  if (m) {
+    let url = (m[3] || m[5]).replace(ESCAPE_RE, '$1');
+    let modifier = m[4] ?? '';
+    return [url, modifier];
+  }
+}
 
 // Options to be passed to `addDependency` for certain tags + attributes
 const OPTIONS = {
@@ -42,8 +98,36 @@ export default function collectDependencies(asset: MutableAsset, ast: AST) {
 
       const elements = ATTRS[attr];
       if (elements && elements.includes(node.tag)) {
-        attrs[attr] = asset.addURLDependency(attrs[attr], OPTIONS[tag]?.[attr]);
+        let options = OPTIONS[tag]?.[attr];
+        if (node.tag === 'script') {
+          options = {
+            priority: 'parallel',
+            env: {
+              sourceType: attrs.type === 'module' ? 'module' : 'script',
+              // SVG script elements do not support type="module" natively yet.
+              outputFormat: 'global',
+              loc: node.location
+                ? {
+                    filePath: asset.filePath,
+                    start: node.location.start,
+                    end: node.location.end,
+                  }
+                : undefined,
+            },
+          };
+          delete attrs.type;
+        }
+        attrs[attr] = asset.addURLDependency(attrs[attr], options);
         isDirty = true;
+      }
+
+      if (FUNC_IRI_ATTRS.has(attr)) {
+        let parsed = parseFuncIRI(attrs[attr]);
+        if (parsed) {
+          let depId = asset.addURLDependency(parsed[0], {});
+          attrs[attr] = `url('${depId}'${parsed[1]})`;
+          isDirty = true;
+        }
       }
     }
 

--- a/packages/transformers/svg/test/parseFuncIRI.test.js
+++ b/packages/transformers/svg/test/parseFuncIRI.test.js
@@ -1,0 +1,24 @@
+import {parseFuncIRI} from '../src/dependencies';
+import assert from 'assert';
+
+describe('parseFuncIRI', () => {
+  it('should parse unquoted url()', () => {
+    assert.deepEqual(parseFuncIRI('url(test)'), ['test', '']);
+    assert.deepEqual(parseFuncIRI('url(test hi)'), null);
+    assert.deepEqual(parseFuncIRI('url(test"hi)'), null);
+    assert.deepEqual(parseFuncIRI('url(test\\ hi)'), ['test hi', '']);
+    assert.deepEqual(parseFuncIRI('url(test\\"hi)'), ['test"hi', '']);
+    assert.deepEqual(parseFuncIRI('url(test\nhi)'), null);
+    assert.deepEqual(parseFuncIRI('url(test\\\nhi)'), ['test\nhi', '']);
+  });
+
+  it('should parse quoted url()', () => {
+    assert.deepEqual(parseFuncIRI('url("test")'), ['test', '']);
+    assert.deepEqual(parseFuncIRI("url('test')"), ['test', '']);
+    assert.deepEqual(parseFuncIRI('url(\'test")'), null);
+    assert.deepEqual(parseFuncIRI('url("test\')'), null);
+    assert.deepEqual(parseFuncIRI('url("test)'), null);
+    assert.deepEqual(parseFuncIRI('url("test" hi)'), ['test', ' hi']);
+    assert.deepEqual(parseFuncIRI('url("te\\"st" hi)'), ['te"st', ' hi']);
+  });
+});


### PR DESCRIPTION
Adds support for more elements that support `href` and `xlink:href`, as well as presentational attributes that support function references (e.g. `url(other.svg#foo)`). Also supports external scripts. Currently `type="module"` scripts are not natively supported in SVG, but Parcel still supports that attribute to distinguish between source types. We always generate global script output for compatibility. Support for inline scripts can be handled separately once #6743 is merged.

cc. @thewilkybarkid