### PR TITLE
Fix @parcel/validator-typescript with ts 4.4+

### DIFF
--- a/packages/utils/ts-utils/src/FSHost.js
+++ b/packages/utils/ts-utils/src/FSHost.js
@@ -101,6 +101,7 @@ export class FSHost {
       depth,
       dirPath => this.getAccessibleFileSystemEntries(dirPath),
       filePath => this.realpath(filePath),
+      dirPath => this.directoryExists(dirPath),
     );
   }
 }


### PR DESCRIPTION
# ↪️ Pull Request

This fixes #6779. Typescript 4.4+ added a new required parameter called `directoryExists` to their `matchFiles` utility function - see [this PR](https://github.com/microsoft/TypeScript/pull/44710/files#diff-1516c8349f7a625a2e4a2aa60f6bbe84e4b1a499128e8705d3087d893e01d367).

We call this function in the `FSHost` class in the `ts-utils` package. Without this change, using typescript 4.4+ with `@parcel/-validator-typescript` would blow up.

## 💻 Examples

See #6779 for repro instructions.

## 🚨 Test instructions

See [this repo](https://github.com/astegmaier/parcel-typescript-validator-broken) for an environment where you can test these changes. Without this PR, you'll see an error, and with this PR, it is fixed.

I've validated that this change will work with both TS `4.4.3` and `4.3.5` (i.e. before and after the ts API change).

## ✔️ PR Todo

- [x] Added/updated unit tests for this change. **I didn't modify any tests, because the existing tests should cover this case, once internal versions of typescript within parcel are upgraded to 4.4+**
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
