### PR TITLE
Revert adding COEP/COOP headers

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -40,8 +40,6 @@ function setHeaders(res: Response) {
     'Access-Control-Allow-Headers',
     'Origin, X-Requested-With, Content-Type, Accept, Content-Type',
   );
-  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
-  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
 }
 
 const SOURCES_ENDPOINT = '/__parcel_source_root';


### PR DESCRIPTION
Revert #6404

There are many more people using third-party resources than SharedArrayBuffer... https://github.com/parcel-bundler/parcel/issues/6561

Related: https://github.com/parcel-bundler/website/issues/884