### PR TITLE
Don't emit runtime manifest for inline child bundles

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4045,6 +4045,53 @@ describe('javascript', function() {
       path.join(__dirname, '/integration/bundle-text/index.js'),
     );
 
+    assertBundles(b, [{type: 'js', assets: ['index.js']}]);
+
+    let jsBundle = b.getBundles().find(b => b.type === 'js');
+    console.log(await outputFS.readFile(jsBundle.filePath, 'utf8'));
+
+    let cssBundleContent = (await run(b)).default;
+
+    assert(
+      cssBundleContent.startsWith(
+        `body {
+  background-color: #000000;
+}
+
+.svg-img {
+  background-image: url("data:image/svg+xml,%3Csvg%3E%0A%0A%3C%2Fsvg%3E%0A");
+}`,
+      ),
+    );
+
+    assert(!cssBundleContent.includes('sourceMappingURL'));
+  });
+
+  it('should not include the runtime manifest for `bundle-text`', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/bundle-text/index.js'),
+      {
+        mode: 'production',
+        defaultTargetOptions: {shouldScopeHoist: false, shouldOptimize: false},
+      },
+    );
+
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        type: 'js',
+        assets: ['esmodule-helpers.js', 'index.js'],
+      },
+      {
+        type: 'svg',
+        assets: ['img.svg'],
+      },
+      {
+        type: 'css',
+        assets: ['text.scss'],
+      },
+    ]);
+
     let cssBundleContent = (await run(b)).default;
 
     assert(

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4045,11 +4045,6 @@ describe('javascript', function() {
       path.join(__dirname, '/integration/bundle-text/index.js'),
     );
 
-    assertBundles(b, [{type: 'js', assets: ['index.js']}]);
-
-    let jsBundle = b.getBundles().find(b => b.type === 'js');
-    console.log(await outputFS.readFile(jsBundle.filePath, 'utf8'));
-
     let cssBundleContent = (await run(b)).default;
 
     assert(

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -226,7 +226,9 @@ export default (new Runtime({
 
     if (
       shouldUseRuntimeManifest(bundle, options) &&
-      bundleGraph.getChildBundles(bundle).length > 0 &&
+      bundleGraph
+        .getChildBundles(bundle)
+        .some(b => b.bundleBehavior !== 'inline') &&
       isNewContext(bundle, bundleGraph)
     ) {
       assets.push({


### PR DESCRIPTION
AFAICT, only non-inline bundles are registered into the runtime manifest. So including the manifest if there are only inline child bundles doesn't make sense?

Closes https://github.com/parcel-bundler/parcel/issues/6775