### PR TITLE
Readme.md: Make summary about parcel more accurate

### DIFF
--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -14,7 +14,7 @@
 
 - 🚀 **Blazing fast** bundle times - multicore compilation, and a filesystem cache for fast rebuilds even after a restart.
 - 📦 Out of the box support for JS, CSS, HTML, file assets, and more - **no plugins to install**.
-- 🐠 **Automatically transforms modules** using Babel, PostCSS, and PostHTML when needed - even `node_modules`.
+- 🐠 **Automatically transforms modules** using Babel, PostCSS, and PostHTML when needed.
 - ✂️ Zero configuration **code splitting** using dynamic `import()` statements.
 - 🔥 Built in support for **hot module replacement**
 - 🚨 Friendly error logging experience - syntax highlighted code frames help pinpoint the problem.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

`node_modules` can't be transpiled, see https://github.com/parcel-bundler/parcel/issues/1655 and https://github.com/parcel-bundler/parcel/issues/6306#issuecomment-846641326

Yet the readme claimed they could. I propose to remove that claim.

## 💻 Examples

Me right now that needs solid-js to not make my scripts throw syntax errors in older browsers because they contain arrow functions because parcel refuses to transpile them

## 🚨 Test instructions

Clone solid-js, import something from it, add something like this to package.json

```
"targets": {
    "ie11": {
      "engines": {
        "browsers": "ie 11"
      }
    }
  }
```
and build -> you have arrow functions

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X ] Filled out test instructions (In case there aren't any unit tests)
- [ X] Included links to related issues/PRs
