### PR TITLE
Read error stack without throwing in getBundleURL

### DIFF
--- a/packages/runtimes/js/src/helpers/bundle-url.js
+++ b/packages/runtimes/js/src/helpers/bundle-url.js
@@ -10,18 +10,16 @@ function getBundleURLCached(id) {
 }
 
 function getBundleURL() {
-  try {
-    throw new Error();
-  } catch (err) {
-    var matches = ('' + err.stack).match(/(https?|file|ftp):\/\/[^)\n]+/g);
-    if (matches) {
-      // The first two stack frames will be this function and getBundleURLCached.
-      // Use the 3rd one, which will be a runtime in the original bundle.
-      return getBaseURL(matches[2]);
-    }
+  var matches = String(new Error().stack).match(
+    /(https?|file|ftp):\/\/[^)\n]+/g,
+  );
+  if (matches) {
+    // The first two stack frames will be this function and getBundleURLCached.
+    // Use the 3rd one, which will be a runtime in the original bundle.
+    return getBaseURL(matches[2]);
+  } else {
+    return '/';
   }
-
-  return '/';
 }
 
 function getBaseURL(url) {


### PR DESCRIPTION
The error's stack information is captured/initialized when creating the error object, so throwing and catching it shouldn't change anything. 

Closes https://github.com/parcel-bundler/parcel/issues/6858