### PR TITLE
Parcel API improvements

### DIFF
--- a/packages/core/core/src/index.js
+++ b/packages/core/core/src/index.js
@@ -12,6 +12,7 @@ export {
 
 export {
   default,
+  default as Parcel,
   BuildError,
   createWorkerFarm,
   INTERNAL_RESOLVE,

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -106,8 +106,7 @@ export default async function resolveOptions(
       projectRoot,
       initialOptions.defaultConfig,
     ),
-    shouldPatchConsole:
-      initialOptions.shouldPatchConsole ?? process.env.NODE_ENV !== 'test',
+    shouldPatchConsole: initialOptions.shouldPatchConsole ?? false,
     env: {
       ...process.env,
       ...initialOptions.env,


### PR DESCRIPTION
Exposes `Parcel` as a named export rather than a default export from `@parcel/core`. This makes it a bit nicer to consume from CommonJS, as well as Node ESM.

Also disables console patching by default, which is already enabled in the CLI. When using the API, it appears broken unless you have a reporter added.