### PR TITLE
Add `@section` to Compressor type

### DIFF
--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1595,6 +1595,9 @@ export type Optimizer<ConfigType> = {|
   |}): Async<BundleResult>,
 |};
 
+/**
+ * @section compressor
+ */
 export type Compressor = {|
   compress({|
     stream: stream$Readable,


### PR DESCRIPTION
This is used to generated the "Relevant API" section like here: https://v2.parceljs.org/plugin-system/optimizer/ (which is currently missing for compressors)