### PR TITLE
Default reexports of a CommonJS asset on namespace object are undefined

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-commonjs-namespace/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-commonjs-namespace/a.js
@@ -1,0 +1,2 @@
+import * as x from './b.js';
+output = sideEffectNoop(x).foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-commonjs-namespace/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-commonjs-namespace/b.js
@@ -1,0 +1,1 @@
+export {default as foo} from './c.js'

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-commonjs-namespace/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-commonjs-namespace/c.js
@@ -1,0 +1,1 @@
+module.exports = 'foo';

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1775,6 +1775,18 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, 'foo');
     });
 
+    it('support accessing default reexports of a CommonJS asset on namespace object', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-commonjs-namespace/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'foo');
+    });
+
     it('concatenates in the correct order when re-exporting assets were excluded', async function() {
       let b = await bundle(
         path.join(

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -327,7 +327,7 @@ export async function runBundles(
 
   // A utility to prevent optimizers from removing side-effect-free code needed for testing
   // $FlowFixMe[prop-missing]
-  ctx.sideEffectNoop = () => {};
+  ctx.sideEffectNoop = v => v;
 
   vm.createContext(ctx);
   let esmOutput;


### PR DESCRIPTION
The reproduction from https://github.com/parcel-bundler/parcel/issues/6361#issuecomment-873494221 would still fail even after fixing #6361 because of this bug.

The problem is that c.js is treated as ESM and "default" isn't translated to the namespace exports object. The output contains

```js
// 42309d7075d0fd86 is the reexporting b.js
// 89f40be4dd9522be is the CJS file c.js

$parcel$export($42309d7075d0fd86$exports, "foo", () => $89f40be4dd9522be$exports.default);
```



The invalid call comes from here:

https://github.com/parcel-bundler/parcel/blob/9aa20cf0135a831c161d9cf6105d9869b5ef403f/packages/packagers/js/src/ScopeHoistingPackager.js#L938-L945

probably because `getSymbolResolution` isn't passed the optional `dep` (which isn't really available here anyway) and then `dep?.meta.kind === "Imported"` is false:
https://github.com/parcel-bundler/parcel/blob/9aa20cf0135a831c161d9cf6105d9869b5ef403f/packages/packagers/js/src/ScopeHoistingPackager.js#L740-L747