### PR TITLE
Use imported Readable flow type instead of global

### DIFF
--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1600,11 +1600,11 @@ export type Optimizer<ConfigType> = {|
  */
 export type Compressor = {|
   compress({|
-    stream: stream$Readable,
+    stream: Readable,
     options: PluginOptions,
     logger: PluginLogger,
   |}): Async<{|
-    stream: stream$Readable,
+    stream: Readable,
     type?: string,
   |}>,
 |};


### PR DESCRIPTION
The last successful nightly release was 10 days ago, because the automatically generated TS definitions used `stream$Readable` (which isn't valid) and therefore the `check-ts` scripts failed.

Instead use the `Readable` import as we do everywhere else