### PR TITLE
Fix engines.parcel in SVG packager

### DIFF
--- a/packages/packagers/svg/package.json
+++ b/packages/packagers/svg/package.json
@@ -17,7 +17,7 @@
   "source": "src/SVGPackager.js",
   "engines": {
     "node": ">= 12.0.0",
-    "parcel": "^2.0.0-rc.0"
+    "parcel": "^2.0.0-beta.1"
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",


### PR DESCRIPTION
Use the same value as all the other plugins. Currently this error is thrown:
```
@parcel/core: The plugin "@parcel/packager-svg" is not compatible with the current version of Parcel. Requires "^2.0.0-rc.0" but the current version is
"2.0.0-nightly.824+80d7ae24".

  x/node_modules/@parcel/packager-svg/package.json:20:5
    19 |     "node": ">= 12.0.0",
  > 20 |     "parcel": "^2.0.0-rc.0"
  >    |     ^^^^^^^^^^^^^^^^^^^^^^^
    21 |   },
    22 |   "dependencies": {
```
if using `parcel@nightly` (because according to semver, the nightly versions are all older than rc)