### PR TITLE
Use automatic react runtime for v18.0.0

### DIFF
--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -22,7 +22,7 @@ const JSX_PRAGMA = {
   react: {
     pragma: 'React.createElement',
     pragmaFrag: 'React.Fragment',
-    automatic: '>= 17.0.0',
+    automatic: '>= 17.0.0 || >= 18.0.0',
   },
   preact: {
     pragma: 'h',


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

When using `react@next` and `react-dom@next`, NPM installs `v18.0.0-alpha-XXXXXXX`. Parcel uses `>= 17.0.0` to determine whether to use automatic runtime or React.createElement. The check fails for v18.x probably because of semver: `>=17.0.0` does not go beyond the major release.


## 🚨 Test instructions

Using a fresh nightly build `parcel@^2.0.0-nightly.838` with `react@^18.0.0-alpha-a8cabb564-20210915` (and similar `react-dom`, or simply `react@next`), writing any JSX without `import React from 'react'` throws an error `React is not defined` in browser.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
