### PR TITLE
Only use error overlay if there's a document

### DIFF
--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -95,7 +95,9 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
 
     if (data.type === 'update') {
       // Remove error overlay if there is one
-      removeErrorOverlay();
+      if (typeof document !== 'undefined') {
+        removeErrorOverlay();
+      }
 
       let assets = data.assets.filter(asset => asset.envHash === HMR_ENV_HASH);
 
@@ -143,11 +145,13 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
         );
       }
 
-      // Render the fancy html overlay
-      removeErrorOverlay();
-      var overlay = createErrorOverlay(data.diagnostics.html);
-      // $FlowFixMe
-      document.body.appendChild(overlay);
+      if (typeof document !== 'undefined') {
+        // Render the fancy html overlay
+        removeErrorOverlay();
+        var overlay = createErrorOverlay(data.diagnostics.html);
+        // $FlowFixMe
+        document.body.appendChild(overlay);
+      }
     }
   };
   ws.onerror = function(e) {


### PR DESCRIPTION
# ↪️ Pull Request

This is a first step towards making HMR work within workers in some situations, namely that an update can be applied cleanly (because there is no `location.reload()` in workers).

If an update cannot be applied, you now get "window is not defined" (because of `window.location.reload`) instead of "document is not defined", so we still need to figure that out.

## 💻 Examples

This works correctly now when editing the worker to change the response:
```js
// main.js
let worker = new Worker(new URL("worker.js", import.meta.url), {
	type: "module",
});

setInterval(() => {
	worker.postMessage(null);
}, 1000);

worker.onmessage = (d) => console.log("response from worker:", d);
```
```js
// worker.js
console.log("worker started");

self.onmessage = () => self.postMessage("pong2"); // <----------

module.hot.accept();
```
