### PR TITLE
Ensure atom and rss links have stable names

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -170,6 +170,40 @@ describe('html', function() {
     assert(/<link rel="canonical" href="\.?\/index.html">/.test(html));
   });
 
+  it('should support RSS feed links', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/html-feed/rss.html'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'rss.html',
+        assets: ['rss.html'],
+      },
+      {
+        name: 'feed.xml',
+        assets: ['feed.xml'],
+      },
+    ]);
+  });
+
+  it('should support atom feed links', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/html-feed/atom.html'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'atom.html',
+        assets: ['atom.html'],
+      },
+      {
+        name: 'feed.xml',
+        assets: ['feed.xml'],
+      },
+    ]);
+  });
+
   it('should support meta tags', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/html-meta/index.html'),

--- a/packages/core/integration-tests/test/integration/html-feed/atom.html
+++ b/packages/core/integration-tests/test/integration/html-feed/atom.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+  <link href="feed.xml" rel="alternate" type="application/atom+xml" title="Blog RSS" />
+</head>
+<body>
+</body>
+</html>

--- a/packages/core/integration-tests/test/integration/html-feed/rss.html
+++ b/packages/core/integration-tests/test/integration/html-feed/rss.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<head>
+  <link href="feed.xml" rel="alternate" type="application/rss+xml" title="Blog RSS" />
+</head>
+<body>
+</body>
+</html>

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -65,6 +65,8 @@ const META = {
   ],
 };
 
+const FEED_TYPES = new Set(['application/rss+xml', 'application/atom+xml']);
+
 // Options to be passed to `addDependency` for certain tags + attributes
 const OPTIONS = {
   a: {
@@ -146,7 +148,9 @@ export default function collectDependencies(
 
     if (
       tag === 'link' &&
-      (attrs.rel === 'canonical' || attrs.rel === 'manifest') &&
+      (attrs.rel === 'canonical' ||
+        attrs.rel === 'manifest' ||
+        (attrs.rel === 'alternate' && FEED_TYPES.has(attrs.type))) &&
       attrs.href
     ) {
       let href = attrs.href;


### PR DESCRIPTION
Noticed the new feed link on the parcel website has a hashed name, which obviously won't work in feed readers.