### PR TITLE
HMR fixes for URL dependencies

### DIFF
--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -19,7 +19,7 @@ import path from 'path';
 import assert from 'assert';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
-import AssetGraph, {nodeFromAssetGroup} from './AssetGraph';
+import {nodeFromAssetGroup} from './AssetGraph';
 import BundleGraph from './public/BundleGraph';
 import InternalBundleGraph, {bundleGraphEdgeTypes} from './BundleGraph';
 import {NamedBundle} from './public/Bundle';
@@ -249,7 +249,7 @@ export default async function applyRuntimes({
   return changedAssets;
 }
 
-async function reconcileNewRuntimes(
+function reconcileNewRuntimes(
   api: RunAPI,
   connections: Array<RuntimeConnection>,
   optionsRef: SharedReference,
@@ -262,5 +262,5 @@ async function reconcileNewRuntimes(
   });
 
   // rebuild the graph
-  return await api.runRequest(request, {force: true});
+  return api.runRequest(request, {force: true});
 }

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -191,7 +191,9 @@ export default class MutableBundleGraph extends BundleGraph<IBundle>
       id: bundleId,
       value: {
         id: bundleId,
-        hashReference: HASH_REF_PREFIX + bundleId,
+        hashReference: this.#options.shouldContentHash
+          ? HASH_REF_PREFIX + bundleId
+          : bundleId.slice(-8),
         type: opts.entryAsset ? opts.entryAsset.type : opts.type,
         env: opts.env
           ? environmentToInternalEnvironment(opts.env)

--- a/packages/core/core/src/requests/ParcelBuildRequest.js
+++ b/packages/core/core/src/requests/ParcelBuildRequest.js
@@ -73,7 +73,12 @@ async function run({input, api, options}: RunInput) {
     optionsRef,
   });
 
-  let bundleGraph = await api.runRequest(bundleGraphRequest);
+  let {bundleGraph, changedAssets: changedRuntimeAssets} = await api.runRequest(
+    bundleGraphRequest,
+  );
+  for (let [id, asset] of changedRuntimeAssets) {
+    changedAssets.set(id, asset);
+  }
 
   // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381 (Windows only)
   dumpGraphToGraphViz(bundleGraph._graph, 'BundleGraph', bundleGraphEdgeTypes);

--- a/packages/optimizers/image/src/ImageOptimizer.js
+++ b/packages/optimizers/image/src/ImageOptimizer.js
@@ -5,6 +5,10 @@ import {optimize} from '../native';
 
 export default (new Optimizer({
   async optimize({bundle, contents}) {
+    if (!bundle.env.shouldOptimize) {
+      return {contents};
+    }
+
     let buffer = await blobToBuffer(contents);
     let optimized = optimize(bundle.type, buffer);
     return {

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -108,7 +108,7 @@ export default class HMRServer {
           for (let dep of dependencies) {
             let resolved = event.bundleGraph.getResolvedAsset(dep, bundle);
             if (resolved) {
-              deps[dep.specifier] = event.bundleGraph.getAssetPublicId(
+              deps[getSpecifier(dep)] = event.bundleGraph.getAssetPublicId(
                 resolved,
               );
             }
@@ -152,4 +152,12 @@ export default class HMRServer {
       ws.send(json);
     }
   }
+}
+
+function getSpecifier(dep: Dependency): string {
+  if (typeof dep.meta.placeholder === 'string') {
+    return dep.meta.placeholder;
+  }
+
+  return dep.specifier;
 }

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {BuildSuccessEvent, PluginOptions} from '@parcel/types';
+import type {BuildSuccessEvent, Dependency, PluginOptions} from '@parcel/types';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {AnsiDiagnosticResult} from '@parcel/utils';
 import type {ServerError, HMRServerOptions} from './types.js.flow';
@@ -95,11 +95,35 @@ export default class HMRServer {
   async emitUpdate(event: BuildSuccessEvent) {
     this.unresolvedError = null;
 
-    let changedAssets = Array.from(event.changedAssets.values());
-    if (changedAssets.length === 0) return;
+    let changedAssets = new Set(event.changedAssets.values());
+    if (changedAssets.size === 0) return;
 
     let queue = new PromiseQueue({maxConcurrent: FS_CONCURRENCY});
     for (let asset of changedAssets) {
+      if (asset.type !== 'js') {
+        // If all of the incoming dependencies of the asset actually resolve to a JS asset
+        // rather than the original, we can mark the runtimes as changed instead. URL runtimes
+        // have a cache busting query param added with HMR enabled which will trigger a reload.
+        let runtimes = new Set();
+        let incomingDeps = event.bundleGraph.getIncomingDependencies(asset);
+        let isOnlyReferencedByRuntimes = incomingDeps.every(dep => {
+          let resolved = event.bundleGraph.getResolvedAsset(dep);
+          let isRuntime = resolved?.type === 'js' && resolved !== asset;
+          if (resolved && isRuntime) {
+            runtimes.add(resolved);
+          }
+          return isRuntime;
+        });
+
+        if (isOnlyReferencedByRuntimes) {
+          for (let runtime of runtimes) {
+            changedAssets.add(runtime);
+          }
+
+          continue;
+        }
+      }
+
       queue.add(async () => {
         let dependencies = event.bundleGraph.getDependencies(asset);
         let depsByBundle = {};
@@ -119,7 +143,8 @@ export default class HMRServer {
         return {
           id: event.bundleGraph.getAssetPublicId(asset),
           type: asset.type,
-          output: await asset.getCode(),
+          // No need to send the contents of non-JS assets to the client.
+          output: asset.type === 'js' ? await asset.getCode() : '',
           envHash: asset.env.id,
           depsByBundle,
         };

--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -15,7 +15,8 @@ export default (new Runtime({
       bundle.type !== 'js' ||
       !options.hmrOptions ||
       bundle.env.isLibrary ||
-      bundle.env.isWorklet()
+      bundle.env.isWorklet() ||
+      bundle.env.sourceType === 'script'
     ) {
       return;
     }

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -589,7 +589,12 @@ function getRelativePathExpr(
     );
   }
 
-  return JSON.stringify(relativePath);
+  let res = JSON.stringify(relativePath);
+  if (options.hmrOptions) {
+    res += ' + "?" + Date.now()';
+  }
+
+  return res;
 }
 
 function getAbsoluteUrlExpr(relativePathExpr: string, bundle: NamedBundle) {


### PR DESCRIPTION
Fixes T-1106.

* Fixes saving a file containing a URL dependency. This previously uses the wrong specifier since we changed to allow multiple dependencies with the same specifier in the same file.
* Fixes adding a URL or async dependency in JS which previously used a hash reference that wasn't replaced. Now we just use the bundle id as the hash reference in development to begin with so there's nothing to replace and it works in HMR.
* Ensures added/changed runtimes are included in the list of `changedAssets` returned by core.
* Prevents the page from being reloaded when adding/updating a URL dependency in JS. For example, now if you add or modify an image it will be reloaded in place without reloading the whole page. This is done by adding a cache busting query param based on the current date to the URL runtime when HMR is enabled. If a changed asset is only depended on by runtimes, then we skip sending the original file over HMR (as that would cause the page to be reloaded), and instead mark the runtime as "changed" which will cause it to be re-executed and the timestamp in the query param to be updated.

Also prevented the image optimizer from running in development which was kinda slow.

Note: inline bundles are still broken with HMR, but that's a much bigger issue so I didn't tackle it yet.