### PR TITLE
Update sharp and use buffers instead of streams

### DIFF
--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -20,6 +20,6 @@
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "sharp": "^0.28.3"
+    "sharp": "^0.29.1"
   }
 }

--- a/packages/transformers/image/src/ImageTransformer.js
+++ b/packages/transformers/image/src/ImageTransformer.js
@@ -89,7 +89,9 @@ export default (new Transformer({
       });
 
       asset.type = format;
-      asset.setStream(imagePipeline);
+
+      let buffer = await imagePipeline.toBuffer();
+      asset.setBuffer(buffer);
     }
 
     return [asset];

--- a/packages/transformers/image/src/ImageTransformer.js
+++ b/packages/transformers/image/src/ImageTransformer.js
@@ -16,7 +16,7 @@ const FORMATS = new Map([
   ['heif', 'heif'],
 ]);
 
-const SHARP_RANGE = '^0.28.3';
+const SHARP_RANGE = '^0.29.1';
 
 export default (new Transformer({
   async loadConfig({config}) {


### PR DESCRIPTION
Updates sharp to the latest "major" (otherwise Parcel complains that the dependency people add to their project doesn't match the required version).

Also switches to using buffers instead of streams for output. Not sure if it's a bug on the Sharp side or the Parcel side, but I noticed that sometimes when using streams we get zero-byte output. Maybe the stream is somehow already read or something. Anyway, buffers fixes it for now.