### PR TITLE
Require sharp from the main thread to prevent issues on worker exit

### DIFF
--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
+    "@parcel/workers": "2.0.0-rc.0",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/transformers/image/src/ImageTransformer.js
+++ b/packages/transformers/image/src/ImageTransformer.js
@@ -2,6 +2,7 @@
 import {validateConfig} from './validateConfig';
 import {Transformer} from '@parcel/plugin';
 import nullthrows from 'nullthrows';
+import WorkerFarm from '@parcel/workers';
 
 // from https://github.com/lovell/sharp/blob/df7b8ba73808fc494be413e88cfb621b6279218c/lib/output.js#L6-L17
 const FORMATS = new Map([
@@ -17,6 +18,8 @@ const FORMATS = new Map([
 ]);
 
 const SHARP_RANGE = '^0.29.1';
+
+let isSharpLoadedOnMainThread = false;
 
 export default (new Transformer({
   async loadConfig({config}) {
@@ -61,6 +64,18 @@ export default (new Transformer({
     const outputOptions = config[format];
 
     if (width || height || quality || targetFormat || outputOptions) {
+      // Sharp must be required from the main thread as well to prevent errors when workers exit
+      // See https://sharp.pixelplumbing.com/install#worker-threads and https://github.com/lovell/sharp/issues/2263
+      if (WorkerFarm.isWorker() && !isSharpLoadedOnMainThread) {
+        let api = WorkerFarm.getWorkerApi();
+        await api.callMaster({
+          location: __dirname + '/loadSharp.js',
+          args: [],
+        });
+
+        isSharpLoadedOnMainThread = true;
+      }
+
       let inputBuffer = await asset.getBuffer();
       let sharp = await options.packageManager.require(
         'sharp',

--- a/packages/transformers/image/src/loadSharp.js
+++ b/packages/transformers/image/src/loadSharp.js
@@ -1,5 +1,23 @@
+// @flow
+import type {PackageManager} from '@parcel/package-manager';
+import type {FilePath} from '@parcel/types';
+
+const SHARP_RANGE = '^0.29.1';
+
 // This is used to load sharp on the main thread, which prevents errors when worker threads exit
 // See https://sharp.pixelplumbing.com/install#worker-threads and https://github.com/lovell/sharp/issues/2263
-module.exports = () => {
-  require('sharp');
+module.exports = async (
+  packageManager: PackageManager,
+  filePath: FilePath,
+  shouldAutoInstall: boolean,
+  shouldReturn: boolean,
+): Promise<any> => {
+  let sharp = await packageManager.require('sharp', filePath, {
+    range: SHARP_RANGE,
+    shouldAutoInstall: shouldAutoInstall,
+  });
+
+  if (shouldReturn) {
+    return sharp;
+  }
 };

--- a/packages/transformers/image/src/loadSharp.js
+++ b/packages/transformers/image/src/loadSharp.js
@@ -1,0 +1,5 @@
+// This is used to load sharp on the main thread, which prevents errors when worker threads exit
+// See https://sharp.pixelplumbing.com/install#worker-threads and https://github.com/lovell/sharp/issues/2263
+module.exports = () => {
+  require('sharp');
+};


### PR DESCRIPTION
Potentially fixes #5961

Sharp doesn't play nice with Node worker_threads, because on thread exit it may unload a shared library that is still being used. So this tries to require it from the main thread before using it in a worker. See https://sharp.pixelplumbing.com/install#worker-threads and https://github.com/lovell/sharp/issues/2263