### PR TITLE
Handle module.require with scope-hoisting

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-require/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-require/a.js
@@ -1,0 +1,1 @@
+output = module.require("./b.js");

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-require/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/module-require/b.js
@@ -1,0 +1,1 @@
+module.exports.b = 2;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4371,6 +4371,18 @@ describe('scope hoisting', function() {
       assert.strictEqual(output, 'Say other');
     });
 
+    it('supports using module.require like require', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/module-require/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output.b, 2);
+    });
+
     it('support url imports in wrapped modules with interop', async function() {
       let b = await bundle(
         path.join(

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -429,7 +429,9 @@ impl<'a> Fold for DependencyCollector<'a> {
         }
       }
       Member(member) => {
-        if self.config.is_browser
+        if match_member_expr(member, vec!["module", "require"], self.decls) {
+          DependencyKind::Require
+        } else if self.config.is_browser
           && match_member_expr(
             member,
             vec!["navigator", "serviceWorker", "register"],

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1392,6 +1392,10 @@ impl Visit for Collect {
       return;
     }
 
+    if match_member_expr(node, vec!["module", "require"], &self.decls) {
+      return;
+    }
+
     let is_static = match &*node.prop {
       Expr::Ident(_) => !node.computed,
       Expr::Lit(Lit::Str(_)) => true,

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -114,6 +114,17 @@ pub fn match_require(
 
           None
         }
+        Expr::Member(member) => {
+          if match_member_expr(member, vec!["module", "require"], decls) {
+            if let Some(arg) = call.args.get(0) {
+              if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
+                return Some(str_.value.clone());
+              }
+            }
+          }
+
+          None
+        }
         _ => None,
       },
       _ => None,


### PR DESCRIPTION
If `module` declared as a local variable, it's equivalent to `require`