### PR TITLE
Don't rename export default declarations when wrapping the asset

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-class-wrapped/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-class-wrapped/a.js
@@ -1,0 +1,3 @@
+import b from "./b.js";
+
+output = b;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-class-wrapped/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-class-wrapped/b.js
@@ -1,0 +1,4 @@
+export default class Log {}
+Log.VERSION = 1234;
+
+sideEffectNoop(module)

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-function-wrapped/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-function-wrapped/a.js
@@ -1,0 +1,3 @@
+import b from "./b.js";
+
+output = b;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-function-wrapped/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/export-default-function-wrapped/b.js
@@ -1,0 +1,4 @@
+export default function log(){}
+log.VERSION = 1234;
+
+sideEffectNoop(module)

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -626,6 +626,30 @@ describe('scope hoisting', function() {
       assert.deepEqual(output, ['test']);
     });
 
+    it('should default export classes when wrapped', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/export-default-class-wrapped/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output.VERSION, 1234);
+    });
+
+    it('should default export functions when wrapped', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/export-default-function-wrapped/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output.VERSION, 1234);
+    });
+
     it('should default export globals', async function() {
       let b = await bundle(
         path.join(

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -308,12 +308,20 @@ impl<'a> Fold for Hoist<'a> {
             ModuleDecl::ExportDefaultDecl(export) => {
               let decl = match export.decl {
                 DefaultDecl::Class(class) => Decl::Class(ClassDecl {
-                  ident: self.get_export_ident(DUMMY_SP, &"default".into()),
+                  ident: if self.collect.should_wrap && class.ident.is_some() {
+                    class.ident.unwrap()
+                  } else {
+                    self.get_export_ident(DUMMY_SP, &"default".into())
+                  },
                   declare: false,
                   class: class.class.fold_with(self),
                 }),
                 DefaultDecl::Fn(func) => Decl::Fn(FnDecl {
-                  ident: self.get_export_ident(DUMMY_SP, &"default".into()),
+                  ident: if self.collect.should_wrap && func.ident.is_some() {
+                    func.ident.unwrap()
+                  } else {
+                    self.get_export_ident(DUMMY_SP, &"default".into())
+                  },
                   declare: false,
                   function: func.function.fold_with(self),
                 }),

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -3065,6 +3065,23 @@ mod tests {
     "#}
     );
 
+    let (_collect, code, hoist) = parse(
+      r#"
+    console.log(module);
+    export default class X {}
+    "#,
+    );
+
+    assert!(hoist.should_wrap);
+    assert_eq!(
+      code,
+      indoc! {r#"
+    console.log(module);
+    class X {
+    }
+    "#}
+    );
+
     let (_collect, code, _hoist) = parse(
       r#"
     export var x = 2, y = 3;


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/6712

When the asset is wrapped, we don't rename identifiers. But for export default declarations, it was still renamed, leading to the mismatch in the linked issue