### PR TITLE
Ensure named exports are prioritized over wildcard re-exports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/a.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/a.mjs
@@ -1,0 +1,2 @@
+export const foo = 2;
+export * from './foo.mjs'

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/b.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/b.mjs
@@ -1,0 +1,2 @@
+export * from './foo.mjs'
+export const foo = 2;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/entry-a.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/entry-a.mjs
@@ -1,0 +1,2 @@
+import {foo} from './a.mjs';
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/entry-b.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/entry-b.mjs
@@ -1,0 +1,2 @@
+import {foo} from './b.mjs';
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/foo.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/foo.mjs
@@ -1,0 +1,1 @@
+export const foo = 3;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/namespace-a.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/namespace-a.mjs
@@ -1,0 +1,2 @@
+import * as a from './a.mjs';
+output = a;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/namespace-b.mjs
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-priority/namespace-b.mjs
@@ -1,0 +1,2 @@
+import * as b from './b.mjs';
+output = b;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4843,6 +4843,30 @@ describe('javascript', function() {
     assert.equal(typeof res.c, 'function');
   });
 
+  it('should prioritize named exports before re-exports withput scope hoisting (before)', async () => {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        'integration/scope-hoisting/es6/re-export-priority/entry-a.mjs',
+      ),
+    );
+
+    let res = await run(b, null, {require: false});
+    assert.equal(res.output, 2);
+  });
+
+  it('should prioritize named exports before re-exports without scope hoisting (after)', async () => {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        'integration/scope-hoisting/es6/re-export-priority/entry-b.mjs',
+      ),
+    );
+
+    let res = await run(b, null, {require: false});
+    assert.equal(res.output, 2);
+  });
+
   it('should exclude default from export all declaration', async function() {
     let b = await bundle(
       path.join(__dirname, 'integration/js-export-all/index.js'),

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3774,6 +3774,54 @@ describe('scope hoisting', function() {
         test: 'foo',
       });
     });
+
+    it('should prioritize named exports before re-exports (before)', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/scope-hoisting/es6/re-export-priority/entry-a.mjs',
+        ),
+      );
+
+      let res = await run(b);
+      assert.equal(res, 2);
+    });
+
+    it('should prioritize named exports before re-exports (after)', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/scope-hoisting/es6/re-export-priority/entry-b.mjs',
+        ),
+      );
+
+      let res = await run(b);
+      assert.equal(res, 2);
+    });
+
+    it('should prioritize named exports before re-exports in namespace (before)', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/scope-hoisting/es6/re-export-priority/namespace-a.mjs',
+        ),
+      );
+
+      let res = await run(b);
+      assert.deepEqual(res, {foo: 2});
+    });
+
+    it('should prioritize named exports before re-exports in namespace (after)', async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/scope-hoisting/es6/re-export-priority/namespace-b.mjs',
+        ),
+      );
+
+      let res = await run(b);
+      assert.deepEqual(res, {foo: 2});
+    });
   });
 
   describe('commonjs', function() {

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -38,7 +38,7 @@ export const helpers = {
 `,
   $parcel$exportWildcard: `function $parcel$exportWildcard(dest, source) {
   Object.keys(source).forEach(function(key) {
-    if (key === 'default' || key === '__esModule') {
+    if (key === 'default' || key === '__esModule' || dest.hasOwnProperty(key)) {
       return;
     }
 

--- a/packages/transformers/js/src/esmodule-helpers.js
+++ b/packages/transformers/js/src/esmodule-helpers.js
@@ -8,12 +8,7 @@ exports.defineInteropFlag = function(a) {
 
 exports.exportAll = function(source, dest) {
   Object.keys(source).forEach(function(key) {
-    if (key === 'default' || key === '__esModule') {
-      return;
-    }
-
-    // Skip duplicate re-exports when they have the same value.
-    if (key in dest && dest[key] === source[key]) {
+    if (key === 'default' || key === '__esModule' || dest.hasOwnProperty(key)) {
       return;
     }
 


### PR DESCRIPTION
Fixes #6344. Fixes #6970.

The ES module spec says that named exports should be prioritized over wildcard re-exports. This updates our helpers to skip keys that are already defined when performing a wildcard re-export. This is safe because we hoist named exports to the top of the module, so by the time the helper is called, all named exports are already defined.

Previously, we either errored when trying to read the previous value (non scope-hoisting), errored when trying to re-define the property (scope hoisting with multiple re-exports), or overwrote the value with the later one (scope hoisting). Now the value is consistent across all cases.

Note: duplicate wildcard re-exports is still not fully spec compliant, but we can address this separately. According to the spec, ambiguous re-exports should be completely omitted from the namespace object, but should error when performing a named import. We currently will return the first value instead. Unfortunately, it seems most tools are inconsistent in this regard.