### PR TITLE
Fix hash collision in generated variable names

### DIFF
--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
+use std::hash::Hasher;
 use swc_atoms::JsWord;
 use swc_common::{sync::Lrc, Mark, Span, SyntaxContext, DUMMY_SP};
 use swc_ecmascript::ast::*;
@@ -22,7 +22,7 @@ macro_rules! id {
 macro_rules! hash {
   ($str:expr) => {{
     let mut hasher = DefaultHasher::new();
-    $str.hash(&mut hasher);
+    hasher.write($str.as_bytes());
     hasher.finish()
   }};
 }

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -559,7 +559,7 @@ impl<'a> Fold for Hoist<'a> {
           match &**expr {
             Expr::Ident(ident) => {
               // import * as y from 'x'; OR const y = require('x'); OR const y = await import('x');
-              // y.foo -> $id$import$10b1f2ceae7ab64e$y
+              // y.foo -> $id$import$d141bba7fdc215a3$y
               if let Some(Import {
                 source,
                 specifier,
@@ -568,7 +568,7 @@ impl<'a> Fold for Hoist<'a> {
               }) = self.collect.imports.get(&id!(ident))
               {
                 // If there are any non-static accesses of the namespace, don't perform any replacement.
-                // This will be handled in the Ident visitor below, which replaces y -> $id$import$10b1f2ceae7ab64e.
+                // This will be handled in the Ident visitor below, which replaces y -> $id$import$d141bba7fdc215a3.
                 if specifier == "*"
                   && !self.collect.non_static_access.contains_key(&id!(ident))
                   && !self.collect.non_const_bindings.contains_key(&id!(ident))
@@ -2537,7 +2537,7 @@ mod tests {
     let $abc$var$test = {
         bar: 3
     };
-    console.log($abc$import$558d6cfb8af8a010$ba02ad2230917043, $abc$var$test.bar);
+    console.log($abc$import$70a00e0a8474f72a$6a5cdcad01c973fa, $abc$var$test.bar);
     "#}
     );
 
@@ -2552,7 +2552,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    console.log($abc$import$558d6cfb8af8a010$3705fc5f2281438d);
+    console.log($abc$import$70a00e0a8474f72a$d927737047eb3867);
     "#}
     );
 
@@ -2567,7 +2567,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    console.log($abc$import$558d6cfb8af8a010$9099ad97b570f7c, $abc$import$558d6cfb8af8a010$9099ad97b570f7c.bar);
+    console.log($abc$import$70a00e0a8474f72a$2e2bcd8739ae039, $abc$import$70a00e0a8474f72a$2e2bcd8739ae039.bar);
     "#}
     );
   }
@@ -2588,8 +2588,8 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     import "abc:bar";
-    console.log($abc$import$558d6cfb8af8a010$9099ad97b570f7c);
-    console.log($abc$import$3705fc5f2281438d$9099ad97b570f7c);
+    console.log($abc$import$70a00e0a8474f72a$2e2bcd8739ae039);
+    console.log($abc$import$d927737047eb3867$2e2bcd8739ae039);
     "#}
     );
 
@@ -2609,10 +2609,10 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     import "abc:bar";
-    console.log($abc$import$558d6cfb8af8a010$9099ad97b570f7c);
+    console.log($abc$import$70a00e0a8474f72a$2e2bcd8739ae039);
     import "abc:x";
-    console.log($abc$import$10b1f2ceae7ab64e);
-    console.log($abc$import$3705fc5f2281438d$9099ad97b570f7c);
+    console.log($abc$import$d141bba7fdc215a3);
+    console.log($abc$import$d927737047eb3867$2e2bcd8739ae039);
     "#}
     );
   }
@@ -2631,7 +2631,7 @@ mod tests {
       indoc! {r#"
     const $abc$var$x = 4;
     import "abc:other";
-    var $abc$require$bar = $abc$import$558d6cfb8af8a010$3705fc5f2281438d;
+    var $abc$require$bar = $abc$import$70a00e0a8474f72a$d927737047eb3867;
     const $abc$var$baz = 3;
     console.log($abc$require$bar);
     "#}
@@ -2650,7 +2650,7 @@ mod tests {
     const $abc$var$x = 3;
     import "abc:other";
     const $abc$var$bar = 2;
-    console.log($abc$import$558d6cfb8af8a010$3705fc5f2281438d);
+    console.log($abc$import$70a00e0a8474f72a$d927737047eb3867);
     "#}
     );
   }
@@ -2668,7 +2668,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    const { foo: $abc$var$foo , ...$abc$var$bar } = $abc$import$558d6cfb8af8a010;
+    const { foo: $abc$var$foo , ...$abc$var$bar } = $abc$import$70a00e0a8474f72a;
     console.log($abc$var$foo, $abc$var$bar);
     "#}
     );
@@ -2684,7 +2684,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:x";
-    const { x: { y: $abc$var$z  }  } = $abc$import$10b1f2ceae7ab64e;
+    const { x: { y: $abc$var$z  }  } = $abc$import$d141bba7fdc215a3;
     console.log($abc$var$z);
     "#}
     );
@@ -2700,7 +2700,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    console.log($abc$import$558d6cfb8af8a010[bar]);
+    console.log($abc$import$70a00e0a8474f72a[bar]);
     "#}
     );
 
@@ -2715,7 +2715,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    console.log($abc$import$558d6cfb8af8a010[bar], $abc$import$558d6cfb8af8a010.baz);
+    console.log($abc$import$70a00e0a8474f72a[bar], $abc$import$70a00e0a8474f72a.baz);
     "#}
     );
   }
@@ -2741,7 +2741,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    var $abc$require$foo = $abc$import$558d6cfb8af8a010$ba02ad2230917043;
+    var $abc$require$foo = $abc$import$70a00e0a8474f72a$6a5cdcad01c973fa;
     console.log($abc$require$foo);
     "#}
     );
@@ -2757,7 +2757,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    const $abc$var$foo = $abc$import$558d6cfb8af8a010[bar];
+    const $abc$var$foo = $abc$import$70a00e0a8474f72a[bar];
     console.log($abc$var$foo);
     "#}
     );
@@ -2773,7 +2773,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    const { foo: $abc$var$foo  } = $abc$import$558d6cfb8af8a010$ba02ad2230917043;
+    const { foo: $abc$var$foo  } = $abc$import$70a00e0a8474f72a$6a5cdcad01c973fa;
     console.log($abc$var$foo);
     "#}
     );
@@ -2796,7 +2796,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     function $abc$var$x() {
-        const foo = $abc$import$558d6cfb8af8a010;
+        const foo = $abc$import$70a00e0a8474f72a;
         console.log(foo.bar);
     }
     import "abc:bar";
@@ -2823,7 +2823,7 @@ mod tests {
     import "abc:other";
     var $abc$var$foo = (function() {
         if (Date.now() < 0) {
-            var bar = $abc$import$558d6cfb8af8a010;
+            var bar = $abc$import$70a00e0a8474f72a;
         }
     })();
     "#}
@@ -2847,7 +2847,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     function $abc$var$x() {
-        const foo = $abc$import$558d6cfb8af8a010$ba02ad2230917043;
+        const foo = $abc$import$70a00e0a8474f72a$6a5cdcad01c973fa;
         console.log(foo);
     }
     "#}
@@ -2866,7 +2866,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     function $abc$var$x() {
-        console.log($abc$import$558d6cfb8af8a010$ba02ad2230917043);
+        console.log($abc$import$70a00e0a8474f72a$6a5cdcad01c973fa);
     }
     "#}
     );
@@ -2885,7 +2885,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     function $abc$var$x() {
-        const foo = $abc$import$558d6cfb8af8a010[test];
+        const foo = $abc$import$70a00e0a8474f72a[test];
         console.log(foo);
     }
     "#}
@@ -2905,7 +2905,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     function $abc$var$x() {
-        const { foo: foo  } = $abc$import$558d6cfb8af8a010;
+        const { foo: foo  } = $abc$import$70a00e0a8474f72a;
         console.log(foo);
     }
     "#}
@@ -2922,7 +2922,7 @@ mod tests {
       indoc! {r#"
     import "abc:a";
     import "abc:b";
-    let $abc$var$x = $abc$import$7ac649919d1c80a6 + $abc$import$a91ade93898ecc38;
+    let $abc$var$x = $abc$import$407448d2b89b1813 + $abc$import$8b22cf2602fb60ce;
     "#}
     );
 
@@ -2937,7 +2937,7 @@ mod tests {
       indoc! {r#"
     import "abc:a";
     import "abc:b";
-    let $abc$var$x = (!$abc$import$7ac649919d1c80a6, $abc$import$a91ade93898ecc38);
+    let $abc$var$x = (!$abc$import$407448d2b89b1813, $abc$import$8b22cf2602fb60ce);
     "#}
     );
 
@@ -2952,7 +2952,7 @@ mod tests {
       indoc! {r#"
     import "abc:a";
     import "abc:b";
-    let $abc$var$x = $abc$import$7ac649919d1c80a6 || $abc$import$a91ade93898ecc38;
+    let $abc$var$x = $abc$import$407448d2b89b1813 || $abc$import$8b22cf2602fb60ce;
     "#}
     );
 
@@ -2967,7 +2967,7 @@ mod tests {
       indoc! {r#"
     import "abc:a";
     import "abc:b";
-    let $abc$var$x = condition ? $abc$import$7ac649919d1c80a6 : $abc$import$a91ade93898ecc38;
+    let $abc$var$x = condition ? $abc$import$407448d2b89b1813 : $abc$import$8b22cf2602fb60ce;
     "#}
     );
 
@@ -2981,7 +2981,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:a";
-    if (condition) $abc$import$7ac649919d1c80a6;
+    if (condition) $abc$import$407448d2b89b1813;
     "#}
     );
 
@@ -2995,7 +2995,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:y";
-    for(let x = $abc$import$57bbd0ca114c72e; x < 5; x++){
+    for(let x = $abc$import$4a5767248b18ef41; x < 5; x++){
     }
     "#}
     );
@@ -3015,8 +3015,8 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    let $abc$export$10b1f2ceae7ab64e = 3;
-    let $abc$export$57bbd0ca114c72e = 4;
+    let $abc$export$d141bba7fdc215a3 = 3;
+    let $abc$export$4a5767248b18ef41 = 4;
     let $abc$var$z = 6;
     "#}
     );
@@ -3030,7 +3030,7 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$9099ad97b570f7c = 3;
+    var $abc$export$2e2bcd8739ae039 = 3;
     "#}
     );
 
@@ -3045,7 +3045,7 @@ mod tests {
       code,
       indoc! {r#"
     let $abc$var$x = 3;
-    var $abc$export$9099ad97b570f7c = $abc$var$x;
+    var $abc$export$2e2bcd8739ae039 = $abc$var$x;
     "#}
     );
 
@@ -3058,7 +3058,7 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    function $abc$export$9099ad97b570f7c() {
+    function $abc$export$2e2bcd8739ae039() {
     }
     "#}
     );
@@ -3072,7 +3072,7 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    class $abc$export$9099ad97b570f7c {
+    class $abc$export$2e2bcd8739ae039 {
     }
     "#}
     );
@@ -3103,7 +3103,7 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$10b1f2ceae7ab64e = 2, $abc$export$57bbd0ca114c72e = 3;
+    var $abc$export$d141bba7fdc215a3 = 2, $abc$export$4a5767248b18ef41 = 3;
     "#}
     );
 
@@ -3118,9 +3118,9 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var { x: $abc$export$10b1f2ceae7ab64e , ...$abc$export$57bbd0ca114c72e } = something;
-    var [$abc$export$e809c7c5e035fc81, ...$abc$export$51cf687b896afa97] = something;
-    var { x: $abc$export$10b1f2ceae7ab64e = 3  } = something;
+    var { x: $abc$export$d141bba7fdc215a3 , ...$abc$export$4a5767248b18ef41 } = something;
+    var [$abc$export$ffb5f4729a158638, ...$abc$export$9e5f44173e64f162] = something;
+    var { x: $abc$export$d141bba7fdc215a3 = 3  } = something;
     "#}
     );
 
@@ -3133,7 +3133,7 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    function $abc$export$fdd70aeca3bc8cbb() {
+    function $abc$export$e0969da9b8fb378d() {
     }
     "#}
     );
@@ -3147,7 +3147,7 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    class $abc$export$785fc6237f113e49 {
+    class $abc$export$1b16fc9eb974a84d {
     }
     "#}
     );
@@ -3190,8 +3190,8 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
-    $abc$export$ba02ad2230917043 = 2;
+    var $abc$export$6a5cdcad01c973fa;
+    $abc$export$6a5cdcad01c973fa = 2;
     "#}
     );
 
@@ -3204,8 +3204,8 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
-    $abc$export$ba02ad2230917043 = 2;
+    var $abc$export$6a5cdcad01c973fa;
+    $abc$export$6a5cdcad01c973fa = 2;
     "#}
     );
 
@@ -3220,9 +3220,9 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
+    var $abc$export$6a5cdcad01c973fa;
     function $abc$var$init() {
-        $abc$export$ba02ad2230917043 = 2;
+        $abc$export$6a5cdcad01c973fa = 2;
     }
     "#}
     );
@@ -3236,8 +3236,8 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
-    $abc$export$ba02ad2230917043 = 2;
+    var $abc$export$6a5cdcad01c973fa;
+    $abc$export$6a5cdcad01c973fa = 2;
     "#}
     );
 
@@ -3250,8 +3250,8 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
-    $abc$export$ba02ad2230917043 = 2;
+    var $abc$export$6a5cdcad01c973fa;
+    $abc$export$6a5cdcad01c973fa = 2;
     "#}
     );
 
@@ -3265,9 +3265,9 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
-    $abc$export$ba02ad2230917043 = 2;
-    console.log($abc$export$ba02ad2230917043);
+    var $abc$export$6a5cdcad01c973fa;
+    $abc$export$6a5cdcad01c973fa = 2;
+    console.log($abc$export$6a5cdcad01c973fa);
     "#}
     );
 
@@ -3281,9 +3281,9 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var $abc$export$ba02ad2230917043;
-    $abc$export$ba02ad2230917043 = 2;
-    console.log($abc$export$ba02ad2230917043);
+    var $abc$export$6a5cdcad01c973fa;
+    $abc$export$6a5cdcad01c973fa = 2;
+    console.log($abc$export$6a5cdcad01c973fa);
     "#}
     );
   }
@@ -3444,13 +3444,13 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
@@ -3458,7 +3458,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     async function $abc$var$test() {
-        const x = await $abc$importAsync$558d6cfb8af8a010;
+        const x = await $abc$importAsync$70a00e0a8474f72a;
         console.log(x.foo);
     }
     "#}
@@ -3475,13 +3475,13 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => (w!("other"), w!("*"))
+        w!("$abc$importAsync$70a00e0a8474f72a") => (w!("other"), w!("*"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
@@ -3489,7 +3489,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     async function $abc$var$test() {
-        const x = await $abc$importAsync$558d6cfb8af8a010;
+        const x = await $abc$importAsync$70a00e0a8474f72a;
         console.log(x[foo]);
     }
     "#}
@@ -3506,13 +3506,13 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
@@ -3520,7 +3520,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     async function $abc$var$test() {
-        const { foo: foo  } = await $abc$importAsync$558d6cfb8af8a010;
+        const { foo: foo  } = await $abc$importAsync$70a00e0a8474f72a;
         console.log(foo);
     }
     "#}
@@ -3537,13 +3537,13 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
@@ -3551,7 +3551,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     async function $abc$var$test() {
-        const { foo: bar  } = await $abc$importAsync$558d6cfb8af8a010;
+        const { foo: bar  } = await $abc$importAsync$70a00e0a8474f72a;
         console.log(bar);
     }
     "#}
@@ -3565,20 +3565,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then((x)=>x.foo
+    $abc$importAsync$70a00e0a8474f72a.then((x)=>x.foo
     );
     "#}
     );
@@ -3591,20 +3591,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => (w!("other"), w!("*"))
+        w!("$abc$importAsync$70a00e0a8474f72a") => (w!("other"), w!("*"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then((x)=>x
+    $abc$importAsync$70a00e0a8474f72a.then((x)=>x
     );
     "#}
     );
@@ -3617,20 +3617,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then(({ foo: foo  })=>foo
+    $abc$importAsync$70a00e0a8474f72a.then(({ foo: foo  })=>foo
     );
     "#}
     );
@@ -3643,20 +3643,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then(({ foo: bar  })=>bar
+    $abc$importAsync$70a00e0a8474f72a.then(({ foo: bar  })=>bar
     );
     "#}
     );
@@ -3669,20 +3669,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then(function(x) {
+    $abc$importAsync$70a00e0a8474f72a.then(function(x) {
         return x.foo;
     });
     "#}
@@ -3696,20 +3696,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => (w!("other"), w!("*"))
+        w!("$abc$importAsync$70a00e0a8474f72a") => (w!("other"), w!("*"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then(function(x) {
+    $abc$importAsync$70a00e0a8474f72a.then(function(x) {
         return x;
     });
     "#}
@@ -3723,20 +3723,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then(function({ foo: foo  }) {
+    $abc$importAsync$70a00e0a8474f72a.then(function({ foo: foo  }) {
     });
     "#}
     );
@@ -3749,20 +3749,20 @@ mod tests {
     assert_eq_imported_symbols!(
       hoist.imported_symbols,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010$ba02ad2230917043") => (w!("other"), w!("foo"))
+        w!("$abc$importAsync$70a00e0a8474f72a$6a5cdcad01c973fa") => (w!("other"), w!("foo"))
       }
     );
     assert_eq!(
       hoist.dynamic_imports,
       map! {
-        w!("$abc$importAsync$558d6cfb8af8a010") => w!("other")
+        w!("$abc$importAsync$70a00e0a8474f72a") => w!("other")
       }
     );
     assert_eq!(
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$558d6cfb8af8a010.then(function({ foo: bar  }) {
+    $abc$importAsync$70a00e0a8474f72a.then(function({ foo: bar  }) {
     });
     "#}
     );


### PR DESCRIPTION
Fixes #6708.

`JsWord` is derived from the [string-cache](https://github.com/servo/string-cache) crate. This implements the `hash` method, and in [some cases](https://github.com/servo/string-cache/issues/224#issuecomment-934089828) uses a very poor hash function. This replaces that by writing the actual string bytes to the hasher instead.