### PR TITLE
Parse babel config as json5

### DIFF
--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -32,6 +32,7 @@
     "@parcel/utils": "2.0.0-rc.0",
     "browserslist": "^4.6.6",
     "core-js": "^3.2.1",
+    "json5": "^2.1.0",
     "nullthrows": "^1.1.1",
     "semver": "^5.7.0"
   },

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -5,6 +5,7 @@ import typeof * as BabelCore from '@babel/core';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {BabelConfig} from './types';
 
+import json5 from 'json5';
 import path from 'path';
 import * as internalBabelCore from '@babel/core';
 import {hashObject, relativePath, resolveConfig} from '@parcel/utils';
@@ -397,7 +398,7 @@ async function getCodeHighlights(fs, filePath, redundantPresets) {
   let ext = path.extname(filePath);
   if (ext !== '.js' && ext !== '.cjs' && ext !== '.mjs') {
     let contents = await fs.readFile(filePath, 'utf8');
-    let json = JSON.parse(contents);
+    let json = json5.parse(contents);
 
     let presets = json.presets || [];
     let pointers = [];
@@ -410,7 +411,12 @@ async function getCodeHighlights(fs, filePath, redundantPresets) {
     }
 
     if (pointers.length > 0) {
-      return generateJSONCodeHighlights(contents, pointers);
+      try {
+        return generateJSONCodeHighlights(contents, pointers);
+      } catch {
+        // TODO: support code highlights for json5 sources.
+        // Babel supports json5 syntax, but json-source-map does not.
+      }
     }
   }
 


### PR DESCRIPTION
In #6747, Parcel gained the ability to emit warnings when a Babel config has redundant presets. However, this currently errors when the Babel config contains json5 syntax (which Babel supports):

```shell
@parcel/transformer-babel: Unexpected token / in JSON at position 4

  SyntaxError: Unexpected token / in JSON at position 4
  at JSON.parse (<anonymous>)
  at getCodeHighlights
````

This PR is a stop-gap solution until #6921 is addressed. It:
 
- Uses `json5.parse()` instead of `JSON.parse()` when generating code highlights for Babel config warnings
- Fails silently when trying to generate a code frame from a json5 source 
