### PR TITLE
Update all references to v2.parceljs.org to just parceljs.org

### DIFF
--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -308,7 +308,7 @@ async function processMap(
             },
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/dependency-resolution/#url-schemes',
+            'https://parceljs.org/features/dependency-resolution/#url-schemes',
         },
       });
     }

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -593,7 +593,7 @@ export class TargetResolver {
                 `The "${targetName}" field is meant for libraries. If you meant to output a ${ext} file, either remove the "${targetName}" field or choose a different target name.`,
               ],
               documentationURL:
-                'https://v2.parceljs.org/features/targets/#library-targets',
+                'https://parceljs.org/features/targets/#library-targets',
             },
           });
         }
@@ -625,7 +625,7 @@ export class TargetResolver {
                 `The "${targetName}" field is meant for libraries. The outputFormat must be either "commonjs" or "esmodule". Either change or remove the declared outputFormat.`,
               ],
               documentationURL:
-                'https://v2.parceljs.org/features/targets/#library-targets',
+                'https://parceljs.org/features/targets/#library-targets',
             },
           });
         }
@@ -684,7 +684,7 @@ export class TargetResolver {
                 `Either change the output file extension to .mjs, add "type": "module" to package.json, or remove the declared outputFormat.`,
               ],
               documentationURL:
-                'https://v2.parceljs.org/features/targets/#library-targets',
+                'https://parceljs.org/features/targets/#library-targets',
             },
           });
         }
@@ -716,7 +716,7 @@ export class TargetResolver {
                 `The "${targetName}" target is meant for libraries. Either remove the "scopeHoist" option, or use a different target name.`,
               ],
               documentationURL:
-                'https://v2.parceljs.org/features/targets/#library-targets',
+                'https://parceljs.org/features/targets/#library-targets',
             },
           });
         }
@@ -859,7 +859,7 @@ export class TargetResolver {
               ],
               hints: [`Either remove the "scopeHoist" or "isLibrary" option.`],
               documentationURL:
-                'https://v2.parceljs.org/features/targets/#library-targets',
+                'https://parceljs.org/features/targets/#library-targets',
             },
           });
         }
@@ -1027,7 +1027,7 @@ export class TargetResolver {
                 )}.`,
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       });
     }
@@ -1253,7 +1253,7 @@ function assertTargetsAreNotEntries(
               : '') +
               `Change the "${target.name}" field to point to an output file rather than your source code.`,
           ],
-          documentationURL: 'https://v2.parceljs.org/features/targets/',
+          documentationURL: 'https://parceljs.org/features/targets/',
         },
       });
     }

--- a/packages/core/core/test/ParcelConfig.test.js
+++ b/packages/core/core/test/ParcelConfig.test.js
@@ -312,7 +312,7 @@ describe('ParcelConfig', () => {
                 },
               ],
               documentationURL:
-                'https://v2.parceljs.org/features/dependency-resolution/#url-schemes',
+                'https://parceljs.org/features/dependency-resolution/#url-schemes',
             },
           ],
         },

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -737,7 +737,7 @@ describe('TargetResolver', () => {
             'The "main" field is meant for libraries. If you meant to output a .html file, either remove the "main" field or choose a different target name.',
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });
@@ -779,7 +779,7 @@ describe('TargetResolver', () => {
             'The "main" field is meant for libraries. The outputFormat must be either "commonjs" or "esmodule". Either change or remove the declared outputFormat.',
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });
@@ -832,7 +832,7 @@ describe('TargetResolver', () => {
             'Either change the output file extension to .mjs, add "type": "module" to package.json, or remove the declared outputFormat.',
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });
@@ -885,7 +885,7 @@ describe('TargetResolver', () => {
             'Either remove the target\'s declared "outputFormat" or change the extension to .mjs or .js.',
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });
@@ -938,7 +938,7 @@ describe('TargetResolver', () => {
             'Either remove the target\'s declared "outputFormat" or change the extension to .cjs or .js.',
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });
@@ -979,7 +979,7 @@ describe('TargetResolver', () => {
             'The "main" target is meant for libraries. Either remove the "scopeHoist" option, or use a different target name.',
           ],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });
@@ -1029,7 +1029,7 @@ describe('TargetResolver', () => {
           ],
           hints: ['Either remove the "scopeHoist" or "isLibrary" option.'],
           documentationURL:
-            'https://v2.parceljs.org/features/targets/#library-targets',
+            'https://parceljs.org/features/targets/#library-targets',
         },
       ],
     });

--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -613,7 +613,7 @@ describe('babel', function() {
               md`Delete __${path.relative(process.cwd(), babelrcPath)}__`,
             ],
             documentationURL:
-              'https://v2.parceljs.org/languages/javascript/#default-presets',
+              'https://parceljs.org/languages/javascript/#default-presets',
           },
           {
             origin: '@parcel/transformer-babel',
@@ -641,7 +641,7 @@ describe('babel', function() {
               "Either remove __@babel/preset-env__ to use Parcel's builtin transpilation, or replace with __@parcel/babel-preset-env__",
             ],
             documentationURL:
-              'https://v2.parceljs.org/languages/javascript/#custom-plugins',
+              'https://parceljs.org/languages/javascript/#custom-plugins',
           },
         ],
       },
@@ -697,7 +697,7 @@ describe('babel', function() {
               )}__`,
             ],
             documentationURL:
-              'https://v2.parceljs.org/languages/javascript/#default-presets',
+              'https://parceljs.org/languages/javascript/#default-presets',
           },
         ],
       },

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1320,7 +1320,7 @@ describe('html', function() {
           ],
           hints: ['Add the type="module" attribute to the <script> tag.'],
           documentationURL:
-            'https://v2.parceljs.org/languages/javascript/#classic-scripts',
+            'https://parceljs.org/languages/javascript/#classic-scripts',
         },
       ]);
 
@@ -1601,7 +1601,7 @@ describe('html', function() {
           ],
           hints: ['Add the type="module" attribute to the <script> tag.'],
           documentationURL:
-            'https://v2.parceljs.org/languages/javascript/#classic-scripts',
+            'https://parceljs.org/languages/javascript/#classic-scripts',
         },
       ]);
 

--- a/packages/core/integration-tests/test/integration/webextension/manifest.json
+++ b/packages/core/integration-tests/test/integration/webextension/manifest.json
@@ -22,7 +22,7 @@
     "default_popup": "src/popup.html"
   },
   "content_scripts": [{
-    "matches": ["https://v2.parceljs.org/*"],
+    "matches": ["https://parceljs.org/*"],
     "js": ["src/content.js"],
     "css": ["src/content.css"]
   }],

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1262,7 +1262,7 @@ describe('javascript', function() {
             "Add {type: 'module'} as a second argument to the Worker constructor.",
           ],
           documentationURL:
-            'https://v2.parceljs.org/languages/javascript/#classic-scripts',
+            'https://parceljs.org/languages/javascript/#classic-scripts',
         },
       ]);
     }
@@ -1367,7 +1367,7 @@ describe('javascript', function() {
                   : 'navigator.serviceWorker.register() call.'),
             ],
             documentationURL:
-              'https://v2.parceljs.org/languages/javascript/#classic-script-workers',
+              'https://parceljs.org/languages/javascript/#classic-script-workers',
           },
         ]);
       }
@@ -1585,7 +1585,7 @@ describe('javascript', function() {
             "Add {type: 'module'} as a second argument to the navigator.serviceWorker.register() call.",
           ],
           documentationURL:
-            'https://v2.parceljs.org/languages/javascript/#classic-scripts',
+            'https://parceljs.org/languages/javascript/#classic-scripts',
         },
       ]);
     }

--- a/packages/core/parcel/README.md
+++ b/packages/core/parcel/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://v2.parceljs.org/" target="_blank">
+  <a href="https://parceljs.org/" target="_blank">
     <img alt="Parcel" src="https://user-images.githubusercontent.com/19409/135924939-03845d0b-e7bb-414b-89b6-e627dfa9f614.png" width="749">
   </a>
 </p>
@@ -25,13 +25,13 @@ Parcel is a zero configuration build tool for the web. It combines a great out-o
 
 See the following guides in our documentation on how to get started with Parcel.
 
-* [Building a webapp with Parcel](https://v2.parceljs.org/getting-started/webapp/)
-* [Building a library with Parcel](https://v2.parceljs.org/getting-started/library/)
-* [Migrating from Parcel v1](https://v2.parceljs.org/getting-started/migration/)
+* [Building a webapp with Parcel](https://parceljs.org/getting-started/webapp/)
+* [Building a library with Parcel](https://parceljs.org/getting-started/library/)
+* [Migrating from Parcel v1](https://parceljs.org/getting-started/migration/)
 
 ## Documentation
 
-Read the docs at https://v2.parceljs.org/docs/.
+Read the docs at https://parceljs.org/docs/.
 
 ## Community
 

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -177,7 +177,7 @@ async function processCSSModule(
         hints: [
           `Instead do: import * as style from "${defaultImport.specifier}";`,
         ],
-        documentationURL: 'https://v2.parceljs.org/languages/css/#tree-shaking',
+        documentationURL: 'https://parceljs.org/languages/css/#tree-shaking',
       });
     }
   }

--- a/packages/packagers/xml/src/XMLPackager.js
+++ b/packages/packagers/xml/src/XMLPackager.js
@@ -29,7 +29,7 @@ export default (new Packager({
     let dom = parser.parseFromString(code);
 
     let inlineElements = dom.getElementsByTagNameNS(
-      'https://v2.parceljs.org',
+      'https://parceljs.org',
       'inline',
     );
     if (inlineElements.length > 0) {

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -342,7 +342,7 @@ async function warnOnRedundantPlugins(fs, babelConfig, logger) {
       ],
       hints: [md`Delete __${filePath}__`],
       documentationURL:
-        'https://v2.parceljs.org/languages/javascript/#default-presets',
+        'https://parceljs.org/languages/javascript/#default-presets',
     });
   } else if (foundRedundantPresets.size > 0) {
     diagnostics.push({
@@ -363,7 +363,7 @@ async function warnOnRedundantPlugins(fs, babelConfig, logger) {
       ],
       hints: [md`Remove the above presets from __${filePath}__`],
       documentationURL:
-        'https://v2.parceljs.org/languages/javascript/#default-presets',
+        'https://parceljs.org/languages/javascript/#default-presets',
     });
   }
 
@@ -385,7 +385,7 @@ async function warnOnRedundantPlugins(fs, babelConfig, logger) {
         `Either remove __@babel/preset-env__ to use Parcel's builtin transpilation, or replace with __@parcel/babel-preset-env__`,
       ],
       documentationURL:
-        'https://v2.parceljs.org/languages/javascript/#custom-plugins',
+        'https://parceljs.org/languages/javascript/#custom-plugins',
     });
   }
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -208,7 +208,7 @@ impl<'a> DependencyCollector<'a> {
       show_environment: true,
       severity: DiagnosticSeverity::Error,
       documentation_url: Some(String::from(
-        "https://v2.parceljs.org/languages/javascript/#classic-scripts",
+        "https://parceljs.org/languages/javascript/#classic-scripts",
       )),
     });
   }
@@ -394,7 +394,7 @@ impl<'a> Fold for DependencyCollector<'a> {
                 show_environment: self.config.source_type == SourceType::Script,
                 severity: DiagnosticSeverity::Error,
                 documentation_url: Some(String::from(
-                  "https://v2.parceljs.org/languages/javascript/#classic-script-workers",
+                  "https://parceljs.org/languages/javascript/#classic-script-workers",
                 )),
               });
             }
@@ -553,7 +553,7 @@ impl<'a> Fold for DependencyCollector<'a> {
           let (msg, docs) = if kind == DependencyKind::ServiceWorker {
             (
               "Registering service workers with a string literal is not supported.",
-              "https://v2.parceljs.org/languages/javascript/#service-workers",
+              "https://parceljs.org/languages/javascript/#service-workers",
             )
           } else {
             (
@@ -741,7 +741,7 @@ impl<'a> Fold for DependencyCollector<'a> {
             show_environment: false,
             severity: DiagnosticSeverity::Error,
             documentation_url: Some(String::from(
-              "https://v2.parceljs.org/languages/javascript/#web-workers",
+              "https://parceljs.org/languages/javascript/#web-workers",
             )),
           });
           return node;
@@ -1228,7 +1228,7 @@ impl<'a> DependencyCollector<'a> {
             show_environment: true,
             severity: DiagnosticSeverity::Error,
             documentation_url: Some(String::from(
-              "https://v2.parceljs.org/languages/javascript/#classic-scripts",
+              "https://parceljs.org/languages/javascript/#classic-scripts",
             )),
           })
         }

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -267,47 +267,47 @@ impl BailoutReason {
     match self {
       BailoutReason::NonTopLevelRequire => (
         "Conditional or non-top-level `require()` call. This causes the resolved module and all dependendencies to be wrapped.",
-        "https://v2.parceljs.org/features/scope-hoisting/#avoid-conditional-require()"
+        "https://parceljs.org/features/scope-hoisting/#avoid-conditional-require()"
       ),
       BailoutReason::NonStaticDestructuring => (
         "Non-static destructuring of `require` or dynamic `import()`. This causes all exports of the resolved module to be included.",
-        "https://v2.parceljs.org/features/scope-hoisting/#commonjs"
+        "https://parceljs.org/features/scope-hoisting/#commonjs"
       ),
       BailoutReason::TopLevelReturn => (
         "Module contains a top-level `return` statement. This causes the module to be wrapped in a function and tree shaking to be disabled.",
-        "https://v2.parceljs.org/features/scope-hoisting/#avoid-top-level-return"
+        "https://parceljs.org/features/scope-hoisting/#avoid-top-level-return"
       ),
       BailoutReason::Eval => (
         "Module contains usage of `eval`. This causes the module to be wrapped in a function and minification to be disabled.",
-        "https://v2.parceljs.org/features/scope-hoisting/#avoid-eval"
+        "https://parceljs.org/features/scope-hoisting/#avoid-eval"
       ),
       BailoutReason::NonStaticExports => (
         "Non-static access of CommonJS `exports` object. This causes tree shaking to be disabled for the module.",
-        "https://v2.parceljs.org/features/scope-hoisting/#commonjs"
+        "https://parceljs.org/features/scope-hoisting/#commonjs"
       ),
       BailoutReason::FreeModule => (
         "Unknown usage of CommonJS `module` object. This causes the module to be wrapped, and tree shaking to be disabled.",
-        "https://v2.parceljs.org/features/scope-hoisting/#commonjs"
+        "https://parceljs.org/features/scope-hoisting/#commonjs"
       ),
       BailoutReason::FreeExports => (
         "Unknown usage of CommonJS `exports` object. This causes tree shaking to be disabled.",
-        "https://v2.parceljs.org/features/scope-hoisting/#commonjs"
+        "https://parceljs.org/features/scope-hoisting/#commonjs"
       ),
       BailoutReason::ExportsReassignment => (
         "Module contains a reassignment of the CommonJS `exports` object. This causes the module to be wrapped and tree-shaking to be disabled.",
-        "https://v2.parceljs.org/features/scope-hoisting/#avoid-module-and-exports-re-assignment"
+        "https://parceljs.org/features/scope-hoisting/#avoid-module-and-exports-re-assignment"
       ),
       BailoutReason::ModuleReassignment => (
         "Module contains a reassignment of the CommonJS `module` object. This causes the module to be wrapped and tree-shaking to be disabled.",
-        "https://v2.parceljs.org/features/scope-hoisting/#avoid-module-and-exports-re-assignment"
+        "https://parceljs.org/features/scope-hoisting/#avoid-module-and-exports-re-assignment"
       ),
       BailoutReason::NonStaticDynamicImport => (
         "Unknown dynamic import usage. This causes tree shaking to be disabled for the resolved module.",
-        "https://v2.parceljs.org/features/scope-hoisting/#dynamic-imports"
+        "https://parceljs.org/features/scope-hoisting/#dynamic-imports"
       ),
       BailoutReason::NonStaticAccess => (
         "Non-static access of an `import` or `require`. This causes tree shaking to be disabled for the resolved module.",
-        "https://v2.parceljs.org/features/scope-hoisting/#dynamic-member-accesses"
+        "https://parceljs.org/features/scope-hoisting/#dynamic-member-accesses"
       ),
     }
   }

--- a/packages/transformers/xml/src/atom.js
+++ b/packages/transformers/xml/src/atom.js
@@ -50,7 +50,7 @@ export function content(
   if (contents) {
     let parcelKey = `${asset.id}:${parts.length}`;
     let el = element.ownerDocument.createElementNS(
-      'https://v2.parceljs.org',
+      'https://parceljs.org',
       'inline',
     );
     el.setAttribute('key', parcelKey);

--- a/packages/transformers/xml/src/rss.js
+++ b/packages/transformers/xml/src/rss.js
@@ -44,7 +44,7 @@ export function description(
   }
 
   let el = element.ownerDocument.createElementNS(
-    'https://v2.parceljs.org',
+    'https://parceljs.org',
     'inline',
   );
   el.setAttribute('key', parcelKey);


### PR DESCRIPTION
v2 is now the default docs on parceljs.org