### PR TITLE
Fix cache invalidation when shouldOptimize changes

### DIFF
--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -131,6 +131,7 @@ function getEnvironmentHash(env: Environment): string {
       env.outputFormat,
       env.sourceType,
       env.isLibrary,
+      env.shouldOptimize,
       env.shouldScopeHoist,
       env.sourceMap,
     ]),

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -563,7 +563,8 @@ export default class PackagerRunner {
         invalidationHash +
         bundle.target.publicUrl +
         bundleGraph.getHash(bundle) +
-        JSON.stringify(configResults),
+        JSON.stringify(configResults) +
+        this.options.mode,
     );
   }
 

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1016,7 +1016,7 @@ export default class RequestTracker {
   }
 
   async writeToCache() {
-    let cacheKey = `${PARCEL_VERSION}:${JSON.stringify(this.options.entries)}`;
+    let cacheKey = getCacheKey(this.options);
     let requestGraphKey = hashString(`${cacheKey}:requestGraph`);
     let snapshotKey = hashString(`${cacheKey}:snapshot`);
 
@@ -1072,12 +1072,16 @@ export function getWatcherOptions(options: ParcelOptions): WatcherOptions {
   return {ignore};
 }
 
+function getCacheKey(options) {
+  return `${PARCEL_VERSION}:${JSON.stringify(options.entries)}:${options.mode}`;
+}
+
 async function loadRequestGraph(options): Async<RequestGraph> {
   if (options.shouldDisableCache) {
     return new RequestGraph();
   }
 
-  let cacheKey = `${PARCEL_VERSION}:${JSON.stringify(options.entries)}`;
+  let cacheKey = getCacheKey(options);
   let requestGraphKey = hashString(`${cacheKey}:requestGraph`);
   let requestGraph = await options.cache.get<RequestGraph>(requestGraphKey);
 

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -132,7 +132,7 @@ export class AssetGraphBuilder {
     this.requestedAssetIds = requestedAssetIds ?? new Set();
     this.shouldBuildLazily = shouldBuildLazily ?? false;
     this.cacheKey = hashString(
-      `${PARCEL_VERSION}${name}${JSON.stringify(entries) ?? ''}`,
+      `${PARCEL_VERSION}${name}${JSON.stringify(entries) ?? ''}${options.mode}`,
     );
 
     this.queue = new PromiseQueue();

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -345,7 +345,8 @@ class BundlerRunner {
         assetGraph.getHash() +
         configs +
         devDepRequests +
-        invalidations,
+        invalidations +
+        this.options.mode,
     );
   }
 

--- a/packages/core/core/test/Environment.test.js
+++ b/packages/core/core/test/Environment.test.js
@@ -6,7 +6,7 @@ import {createEnvironment} from '../src/Environment';
 describe('Environment', () => {
   it('assigns a default environment with nothing passed', () => {
     assert.deepEqual(createEnvironment(), {
-      id: '28ff5688dfa7d45e',
+      id: 'c242f987e3544367',
       context: 'browser',
       engines: {
         browsers: ['> 0.25%'],
@@ -24,7 +24,7 @@ describe('Environment', () => {
 
   it('assigns a node context if a node engine is given', () => {
     assert.deepEqual(createEnvironment({engines: {node: '>= 10.0.0'}}), {
-      id: '3bae9fa4de65ce29',
+      id: '69e0ab7220ee8f7a',
       context: 'node',
       engines: {
         node: '>= 10.0.0',
@@ -44,7 +44,7 @@ describe('Environment', () => {
     assert.deepEqual(
       createEnvironment({engines: {browsers: ['last 1 version']}}),
       {
-        id: '0006b4816a385465',
+        id: '4b5c9005af8c5b19',
         context: 'browser',
         engines: {
           browsers: ['last 1 version'],
@@ -63,7 +63,7 @@ describe('Environment', () => {
 
   it('assigns default engines for node', () => {
     assert.deepEqual(createEnvironment({context: 'node'}), {
-      id: '5171f29d65a099c4',
+      id: 'f7c9644283a8698f',
       context: 'node',
       engines: {
         node: '>= 8.0.0',
@@ -81,7 +81,7 @@ describe('Environment', () => {
 
   it('assigns default engines for browsers', () => {
     assert.deepEqual(createEnvironment({context: 'browser'}), {
-      id: '28ff5688dfa7d45e',
+      id: 'c242f987e3544367',
       context: 'browser',
       engines: {
         browsers: ['> 0.25%'],

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -120,7 +120,7 @@ describe('TargetResolver', () => {
           publicUrl: '/',
           distDir: normalizeSeparators(path.resolve('customA')),
           env: {
-            id: '7185aca026a1ba43',
+            id: '1d40417b63734b32',
             context: 'browser',
             includeNodeModules: true,
             engines: {
@@ -141,7 +141,7 @@ describe('TargetResolver', () => {
           distEntry: 'b.js',
           distDir: normalizeSeparators(path.resolve('customB')),
           env: {
-            id: '923e2836f26d91cc',
+            id: '928f0d1c941b2e57',
             context: 'node',
             includeNodeModules: false,
             engines: {
@@ -172,7 +172,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: '5b90122270d806a3',
+            id: 'b552bd32da37fa8b',
             context: 'node',
             engines: {
               node: '>= 8.0.0',
@@ -206,7 +206,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: 'd569d73dba5024af',
+            id: '8804e4eb97e2703e',
             context: 'browser',
             engines: {
               browsers: ['last 1 version'],
@@ -242,7 +242,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/assets',
           env: {
-            id: 'f68e756a9f45b317',
+            id: 'a7ed3e73c53f1923',
             context: 'browser',
             engines: {
               browsers: ['last 1 version'],
@@ -288,7 +288,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: '5171f29d65a099c4',
+            id: 'f7c9644283a8698f',
             context: 'node',
             engines: {
               node: '>= 8.0.0',
@@ -331,7 +331,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: '5b90122270d806a3',
+            id: 'b552bd32da37fa8b',
             context: 'node',
             engines: {
               node: '>= 8.0.0',
@@ -365,7 +365,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: 'a06e3cc9e0541b70',
+            id: '1f28e9ceaf633d83',
             context: 'browser',
             engines: {
               browsers: ['last 1 version'],
@@ -399,7 +399,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: 'd9b90540ac44a9db',
+            id: '767bf6e6b675c4f3',
             context: 'browser',
             engines: {
               browsers: ['ie11'],
@@ -450,7 +450,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: '5b90122270d806a3',
+            id: 'b552bd32da37fa8b',
             context: 'node',
             engines: {
               node: '>= 8.0.0',
@@ -484,7 +484,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: 'a06e3cc9e0541b70',
+            id: 'ed7c0e65adee71c9',
             context: 'browser',
             engines: {
               browsers: ['last 1 version'],
@@ -518,7 +518,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: 'd9b90540ac44a9db',
+            id: 'f7692543e59e4c0a',
             context: 'browser',
             engines: {
               browsers: ['ie11'],
@@ -561,7 +561,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: 'www',
           env: {
-            id: '0d13493649c1b9ee',
+            id: 'ddb6ac7c9a3a9178',
             context: 'browser',
             engines: {
               browsers: '> 0.25%',
@@ -604,7 +604,7 @@ describe('TargetResolver', () => {
           distDir: normalizeSeparators(path.resolve('customB')),
           publicUrl: '/',
           env: {
-            id: '7185aca026a1ba43',
+            id: '1d40417b63734b32',
             context: 'browser',
             engines: {
               browsers: ['> 0.25%'],
@@ -646,7 +646,7 @@ describe('TargetResolver', () => {
           distDir: normalizeSeparators(path.resolve('customA')),
           publicUrl: '/',
           env: {
-            id: '7185aca026a1ba43',
+            id: '1d40417b63734b32',
             context: 'browser',
             engines: {
               browsers: ['> 0.25%'],
@@ -675,7 +675,7 @@ describe('TargetResolver', () => {
         distEntry: 'index.js',
         publicUrl: '/',
         env: {
-          id: 'b58d7c211621cd65',
+          id: 'bebcf0293c911f03',
           context: 'node',
           engines: {},
           includeNodeModules: false,
@@ -1046,7 +1046,7 @@ describe('TargetResolver', () => {
         distEntry: 'index.mjs',
         publicUrl: '/',
         env: {
-          id: '82a58acaebe4fd7c',
+          id: 'fa77701547623794',
           context: 'browser',
           engines: {},
           includeNodeModules: true,
@@ -1084,7 +1084,7 @@ describe('TargetResolver', () => {
         distEntry: 'index.js',
         publicUrl: '/',
         env: {
-          id: '82a58acaebe4fd7c',
+          id: 'fa77701547623794',
           context: 'browser',
           engines: {},
           includeNodeModules: true,
@@ -1126,7 +1126,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/',
           env: {
-            id: '5b90122270d806a3',
+            id: 'b552bd32da37fa8b',
             context: 'node',
             engines: {
               node: '>= 8.0.0',
@@ -1160,7 +1160,7 @@ describe('TargetResolver', () => {
           distEntry: 'index.js',
           publicUrl: '/assets',
           env: {
-            id: 'f68e756a9f45b317',
+            id: 'a7ed3e73c53f1923',
             context: 'browser',
             engines: {
               browsers: ['last 1 version'],
@@ -1208,7 +1208,7 @@ describe('TargetResolver', () => {
           distDir: '.parcel-cache/dist',
           publicUrl: '/',
           env: {
-            id: '69f74e7f31319ffd',
+            id: '4a236f9275d0a351',
             context: 'browser',
             engines: {},
             includeNodeModules: true,
@@ -1238,7 +1238,7 @@ describe('TargetResolver', () => {
           ),
           publicUrl: '/',
           env: {
-            id: '04e06037831229c5',
+            id: 'a9c07d094d038c73',
             context: 'browser',
             engines: {
               browsers: ['Chrome 80'],
@@ -1271,7 +1271,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: '/',
           env: {
-            id: '04e06037831229c5',
+            id: 'a9c07d094d038c73',
             context: 'browser',
             engines: {
               browsers: ['Chrome 80'],
@@ -1309,7 +1309,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: '/',
           env: {
-            id: 'a06e3cc9e0541b70',
+            id: '1f28e9ceaf633d83',
             context: 'browser',
             engines: {
               browsers: ['last 1 version'],
@@ -1337,7 +1337,7 @@ describe('TargetResolver', () => {
           distEntry: undefined,
           publicUrl: '/',
           env: {
-            id: '83bb584641584b67',
+            id: '824e113c03cab3c8',
             context: 'browser',
             engines: {
               browsers: ['IE 11'],

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -2235,19 +2235,21 @@ describe('cache', function() {
 
     it('should update when minify changes', async function() {
       let b = await testCache({
+        entries: ['src/index.html'],
         defaultTargetOptions: {
           shouldScopeHoist: true,
           shouldOptimize: false,
         },
         async update(b) {
           let contents = await overlayFS.readFile(
-            b.bundleGraph.getBundles()[0].filePath,
+            b.bundleGraph.getBundles()[1].filePath,
             'utf8',
           );
           assert(contents.includes('Test'), 'should include Test');
 
           return {
             defaultTargetOptions: {
+              shouldScopeHoist: true,
               shouldOptimize: true,
             },
           };
@@ -2255,7 +2257,7 @@ describe('cache', function() {
       });
 
       let contents = await overlayFS.readFile(
-        b.bundleGraph.getBundles()[0].filePath,
+        b.bundleGraph.getBundles()[1].filePath,
         'utf8',
       );
       assert(!contents.includes('Test'), 'should not include Test');

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -433,7 +433,7 @@ describe('sourcemaps', function() {
       source: inputs[0],
       generated: raw,
       str: 'const local',
-      generatedStr: 'const o',
+      generatedStr: 'const t',
       sourcePath: 'index.js',
     });
 
@@ -442,7 +442,7 @@ describe('sourcemaps', function() {
       source: inputs[0],
       generated: raw,
       str: 'local.a',
-      generatedStr: 'o.a',
+      generatedStr: 't.a',
       sourcePath: 'index.js',
     });
 
@@ -451,7 +451,7 @@ describe('sourcemaps', function() {
       source: inputs[1],
       generated: raw,
       str: 'exports.a',
-      generatedStr: 't.a',
+      generatedStr: 'o.a',
       sourcePath: 'local.js',
     });
 
@@ -460,7 +460,7 @@ describe('sourcemaps', function() {
       source: inputs[2],
       generated: raw,
       str: 'exports.count = function(a, b) {',
-      generatedStr: 't.count=function(e,n){',
+      generatedStr: 'o.count=function(e,n){',
       sourcePath: 'utils/util.js',
     });
   });


### PR DESCRIPTION
Fixes #6666. Fixes T-1121

shouldOptimize was missing from the environment hash. Sometimes it was working due to environment object deduplication, but other times not.

Also added `options.mode` to the cache key for the request graph, asset graph, bundle graph, and packager cache keys so that switching between `parcel serve` and `parcel build` doesn't overwrite the cache for the other.