### PR TITLE
Fix shaking for functions types with overload signatures

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/exporting-overload/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting-overload/expected.d.ts
@@ -1,0 +1,5 @@
+import { Named1, Named2 } from "external";
+export function overloaded(arg: string): Named1;
+export function overloaded(arg: number): Named2;
+
+//# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/exporting-overload/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting-overload/index.ts
@@ -1,0 +1,7 @@
+import {Named1, Named2} from 'external';
+
+export function overloaded(arg: string): Named1;
+export function overloaded(arg: number): Named2;
+export function overloaded(arg: unknown): unknown {
+  return {};
+}

--- a/packages/core/integration-tests/test/integration/ts-types/exporting-overload/package.json
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting-overload/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ts-types-exporting-overload",
+  "private": true,
+  "main": "dist/main.js",
+  "types": "dist/types.d.ts",
+  "dependencies": {
+    "external": "*"
+  }
+}

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -135,6 +135,41 @@ describe('typescript types', function() {
     assert.equal(dist, expected);
   });
 
+  it('should generate ts declarations with export of an overloaded function signature', async function() {
+    let b = await bundle(
+      path.join(__dirname, '/integration/ts-types/exporting-overload/index.ts'),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.ts'],
+      },
+      {
+        type: 'ts',
+        assets: ['index.ts'],
+      },
+    ]);
+
+    let dist = (
+      await outputFS.readFile(
+        path.join(
+          __dirname,
+          '/integration/ts-types/exporting-overload/dist/types.d.ts',
+        ),
+        'utf8',
+      )
+    ).replace(/\r\n/g, '\n');
+    let expected = await inputFS.readFile(
+      path.join(
+        __dirname,
+        '/integration/ts-types/exporting-overload/expected.d.ts',
+      ),
+      'utf8',
+    );
+    assert.equal(dist, expected);
+  });
+
   it('should generate ts declarations with externals', async function() {
     let b = await bundle(
       path.join(__dirname, '/integration/ts-types/externals/index.tsx'),

--- a/packages/transformers/typescript-types/src/TSModule.js
+++ b/packages/transformers/typescript-types/src/TSModule.js
@@ -8,7 +8,7 @@ export type Export =
 export class TSModule {
   imports: Map<string, Import>;
   exports: Array<Export>;
-  bindings: Map<string, any>;
+  bindings: Map<string, Set<any>>;
   names: Map<string, string>;
   used: Set<string>;
 
@@ -37,7 +37,9 @@ export class TSModule {
   }
 
   addLocal(name: string, node: any) {
-    this.bindings.set(name, node);
+    const bindings = this.bindings.get(name) ?? new Set();
+    bindings.add(node);
+    this.bindings.set(name, bindings);
     if (name !== 'default') {
       this.names.set(name, name);
     }

--- a/packages/transformers/typescript-types/src/TSModuleGraph.js
+++ b/packages/transformers/typescript-types/src/TSModuleGraph.js
@@ -64,9 +64,11 @@ export class TSModuleGraph {
       return ts.visitEachChild(node, visit, context);
     };
 
-    let node = module.bindings.get(name);
-    if (node) {
-      ts.visitEachChild(node, visit, context);
+    let bindings = module.bindings.get(name);
+    if (bindings) {
+      for (let node of bindings) {
+        ts.visitEachChild(node, visit, context);
+      }
     }
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

React Spectrum's `@react-aria/button` component has an issue where type imports used in an overload type are missing from the .d.ts bundle: https://github.com/adobe/react-spectrum/issues/1388

There's a general issue with the TSModule logic for collecting bindings on exported nodes. It currently makes an assumption that export declarations names can only only associate with one node. This PR updates that logic to create a set of bindings during traversal.

## 💻 Examples

Here's the current version of `@react-aria/button`'s type definition
https://cdn.jsdelivr.net/npm/@react-aria/button@3.3.4/dist/types.d.ts

Compare this to the source code and you'll see that the `*HTMLAttributes` imports used by the overload signatures are missing:
https://github.com/adobe/react-spectrum/blob/%40react-types/button%403.4.1/packages/@react-aria/button/src/useButton.ts

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
