### PR TITLE
Update watcher and source-map library to 2.0.0

### DIFF
--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -33,7 +33,7 @@
     "@parcel/logger": "2.0.0-rc.0",
     "@parcel/package-manager": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/types": "2.0.0-rc.0",
     "@parcel/utils": "2.0.0-rc.0",
     "@parcel/workers": "2.0.0-rc.0",

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -29,7 +29,7 @@
     "@parcel/fs-write-stream-atomic": "2.0.0-rc.0",
     "@parcel/types": "2.0.0-rc.0",
     "@parcel/utils": "2.0.0-rc.0",
-    "@parcel/watcher": "2.0.0-alpha.10",
+    "@parcel/watcher": "^2.0.0",
     "@parcel/workers": "2.0.0-rc.0",
     "graceful-fs": "^4.2.4",
     "mkdirp": "^0.5.1",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -20,7 +20,7 @@
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/fs": "2.0.0-rc.0",
     "@parcel/package-manager": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/workers": "2.0.0-rc.0",
     "utility-types": "^3.10.0"
   }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -26,7 +26,7 @@
     "@parcel/hash": "2.0.0-rc.0",
     "@parcel/logger": "2.0.0-rc.0",
     "@parcel/markdown-ansi": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "ansi-html-community": "0.0.8",
     "chalk": "^4.1.0",
     "clone": "^2.1.1",

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "cssnano": "^5.0.5",
     "postcss": "^8.3.0"
   }

--- a/packages/optimizers/esbuild/package.json
+++ b/packages/optimizers/esbuild/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "esbuild": "^0.8.11",
     "nullthrows": "^1.1.1"

--- a/packages/optimizers/terser/package.json
+++ b/packages/optimizers/terser/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "nullthrows": "^1.1.1",
     "terser": "^5.2.0"

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "nullthrows": "^1.1.1",
     "postcss": "^8.3.0"

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -23,7 +23,7 @@
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/hash": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "globals": "^13.2.0",
     "nullthrows": "^1.1.1"

--- a/packages/shared/babel-ast-utils/package.json
+++ b/packages/shared/babel-ast-utils/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@babel/parser": "^7.0.0",
     "@parcel/babylon-walk": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "astring": "^1.6.2"
   }

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -28,7 +28,7 @@
     "@parcel/babel-ast-utils": "2.0.0-rc.0",
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "browserslist": "^4.6.6",
     "core-js": "^3.2.1",

--- a/packages/transformers/coffeescript/package.json
+++ b/packages/transformers/coffeescript/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "coffeescript": "^2.0.3",
     "nullthrows": "^1.1.1",

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "nullthrows": "^1.1.1",
     "postcss": "^8.3.0",

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "@swc/helpers": "^0.2.11",
     "browserslist": "^4.6.6",

--- a/packages/transformers/less/package.json
+++ b/packages/transformers/less/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "less": "^4.1.1"
   }
 }

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "sass": "^1.38.0"
   }
 }

--- a/packages/transformers/stylus/package.json
+++ b/packages/transformers/stylus/package.json
@@ -22,6 +22,6 @@
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
     "@parcel/utils": "2.0.0-rc.0",
-    "stylus": "^0.54.5"
+    "stylus": "^0.55.0"
   }
 }

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/ts-utils": "2.0.0-rc.0",
     "nullthrows": "^1.1.1"
   },

--- a/packages/transformers/vue/package.json
+++ b/packages/transformers/vue/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@parcel/diagnostic": "2.0.0-rc.0",
     "@parcel/plugin": "2.0.0-rc.0",
-    "@parcel/source-map": "2.0.0-rc.7",
+    "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.0.0-rc.0",
     "@vue/compiler-sfc": "^3.0.0",
     "consolidate": "^0.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,21 +2129,21 @@
     detect-libc "^1.0.3"
     globby "^11.0.3"
 
-"@parcel/source-map@2.0.0-rc.7":
-  version "2.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0-rc.7.tgz#73e3251c2169abf733f28b5d6649eb440e39995f"
-  integrity sha512-LFTvZz8wSOfQAHtczr2PVMBa2gSBeWTivJf4TPQ7neHqECIgAL2GvuCGhETZqU1OYXlnzuxdsiWvDKQtrLiWgA==
+"@parcel/source-map@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0.tgz#41cf004109bbf277ceaf096a58838ff6a59af774"
+  integrity sha512-njoUJpj2646NebfHp5zKJeYD1KwhsfQIoU9TnCTHmF9fGOaPbClmeq12G6/4ZqGASftRq+YhhukFBi/ncWKGvw==
   dependencies:
     detect-libc "^1.0.3"
     globby "^11.0.3"
 
-"@parcel/watcher@2.0.0-alpha.10":
-  version "2.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.0-alpha.10.tgz#99266189f5193512dbdf6b0faca20400c519a16e"
-  integrity sha512-8uA7Tmx/1XvmUdGzksg0+oN7uj24pXFFnKJqZr3L3mgYjdrL7CMs3PRIHv1k3LUz/hNRsb/p3qxztSkWz1IGZA==
+"@parcel/watcher@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@parcel/watcher/-/watcher-2.0.0.tgz#ebe992a4838b35c3da9a568eb95a71cb26ddf551"
+  integrity sha512-ByalKmRRXNNAhwZ0X1r0XeIhh1jG8zgdlvjgHk9ZV3YxiersEGNQkwew+RfqJbIL4gOJfvC2ey6lg5kaeRainw==
   dependencies:
-    node-addon-api "^3.0.2"
-    node-gyp-build "^4.2.3"
+    node-addon-api "^3.2.1"
+    node-gyp-build "^4.3.0"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0", "@sinonjs/commons@^1.7.0":
   version "1.7.0"
@@ -9083,7 +9083,7 @@ node-addon-api@^1.7.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
   integrity sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==
 
-node-addon-api@^3.0.2:
+node-addon-api@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
@@ -9126,6 +9126,11 @@ node-gyp-build@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
+
+node-gyp-build@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
 node-gyp@^5.0.2:
   version "5.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,13 +4344,6 @@ css-parse@1.7.x:
   resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-1.7.0.tgz#321f6cf73782a6ff751111390fc05e2c657d8c9b"
   integrity sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=
 
-css-parse@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/css-parse/-/css-parse-2.0.0.tgz#a468ee667c16d81ccf05c58c38d2a97c780dbfd4"
-  integrity sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=
-  dependencies:
-    css "^2.0.0"
-
 css-select-base-adapter@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
@@ -4412,15 +4405,14 @@ css-what@^5.0.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
   integrity sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==
 
-css@^2.0.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
   dependencies:
-    inherits "^2.0.3"
+    inherits "^2.0.4"
     source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
+    source-map-resolve "^0.6.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -8834,12 +8826,12 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@^1.0.4:
+mkdirp@*, mkdirp@^1.0.4, mkdirp@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1, mkdirp@~0.5.x:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -11937,7 +11929,7 @@ source-map-js@^0.6.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
@@ -11947,6 +11939,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.16, source-map-support@~0.5.19:
   version "0.5.19"
@@ -12382,18 +12382,18 @@ stylus@0.54.5:
     sax "0.5.x"
     source-map "0.1.x"
 
-stylus@^0.54.5:
-  version "0.54.7"
-  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.54.7.tgz#c6ce4793965ee538bcebe50f31537bfc04d88cd2"
-  integrity sha512-Yw3WMTzVwevT6ZTrLCYNHAFmanMxdylelL3hkWNgPMeTCpMwpV3nXjpOHuBXtFv7aiO2xRuQS6OoAdgkNcSNug==
+stylus@^0.55.0:
+  version "0.55.0"
+  resolved "https://registry.yarnpkg.com/stylus/-/stylus-0.55.0.tgz#bd404a36dd93fa87744a9dd2d2b1b8450345e5fc"
+  integrity sha512-MuzIIVRSbc8XxHH7FjkvWqkIcr1BvoMZoR/oFuAJDlh7VSaNJzrB4uJ38GRQa+mWjLXODAMzeDe0xi9GYbGwnw==
   dependencies:
-    css-parse "~2.0.0"
+    css "^3.0.0"
     debug "~3.1.0"
-    glob "^7.1.3"
-    mkdirp "~0.5.x"
+    glob "^7.1.6"
+    mkdirp "~1.0.4"
     safer-buffer "^2.1.2"
     sax "~1.2.4"
-    semver "^6.0.0"
+    semver "^6.3.0"
     source-map "^0.7.3"
 
 sugarss@^3.0.3:


### PR DESCRIPTION
Also updates stylus to latest major, because previous one had deprecated dependencies.