### PR TITLE
Add missing C flags for SIMD support in build workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,67 +1,67 @@
 name: release-nightly
-on: push
-  # schedule:
-  #   - cron: '0 0 * * *'
-  # workflow_dispatch:
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 jobs:
-  # build:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-latest, windows-latest]
-  #   name: ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       if: ${{ matrix.os == 'macos-latest' }}
-  #       run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-${{ matrix.os }}
-  #         path: packages/*/*/*.node
-  #     - name: Smoke test
-  #       run: node -e "require('@parcel/fs-search')"
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-${{ matrix.os }}
+          path: packages/*/*/*.node
+      - name: Smoke test
+        run: node -e "require('@parcel/fs-search')"
 
-  # build-linux-gnu-x64:
-  #   name: linux-gnu-x64
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: docker.io/centos/nodejs-12-centos7
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install yarn
-  #       run: npm install --global yarn@1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       run: strip packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-linux-gnu-x64
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
-  #     - name: Smoke test
-  #       run: node -e 'require("@parcel/fs-search")'
+  build-linux-gnu-x64:
+    name: linux-gnu-x64
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/centos/nodejs-12-centos7
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install yarn
+        run: npm install --global yarn@1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-linux-gnu-x64
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        run: node -e 'require("@parcel/fs-search")'
 
   build-linux-gnu-arm:
     strategy:
@@ -72,9 +72,10 @@ jobs:
             arch: armhf
             strip: arm-linux-gnueabihf-strip
             cflags: -mfpu=neon
-          # - target: aarch64-unknown-linux-gnu
-          #   arch: arm64
-          #   strip: aarch64-linux-gnu-strip
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+            strip: aarch64-linux-gnu-strip
+            cflags: ''
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     steps:
@@ -114,110 +115,110 @@ jobs:
           options: -v ${{github.workspace}}:/work
           run: cd /work && node -e "require('@parcel/fs-search')"
 
-  # build-linux-musl:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - target: x86_64-unknown-linux-musl
-  #           strip: strip
-  #           cflags: -msse4.2
-  #         - target: aarch64-unknown-linux-musl
-  #           strip: aarch64-linux-musl-strip
-  #           cflags: ''
-  #   name: ${{ matrix.target }}
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-  #     credentials:
-  #       username: ${{ github.actor }}
-  #       password: ${{ secrets.GHCR_TOKEN }}
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install build tools
-  #       run: apk add --no-cache python3 make gcc g++ musl-dev curl
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #         target: ${{ matrix.target }}
-  #     - name: Install cross compile toolchains
-  #       if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
-  #       run: |
-  #         curl -O http://musl.cc/aarch64-linux-musl-cross.tgz
-  #         tar xzf aarch64-linux-musl-cross.tgz
-  #         cp -R aarch64-linux-musl-cross/* /usr
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #       env:
-  #         RUST_TARGET: ${{ matrix.target }}
-  #         CFLAGS: ${{ matrix.cflags }}
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       run: ${{ matrix.strip }} packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-linux-musl
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
-  #     - name: Smoke test
-  #       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
-  #       run: node -e 'require("@parcel/fs-search")'
+  build-linux-musl:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            strip: strip
+            cflags: -msse4.2
+          - target: aarch64-unknown-linux-musl
+            strip: aarch64-linux-musl-strip
+            cflags: ''
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install build tools
+        run: apk add --no-cache python3 make gcc g++ musl-dev curl
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+      - name: Install cross compile toolchains
+        if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
+        run: |
+          curl -O http://musl.cc/aarch64-linux-musl-cross.tgz
+          tar xzf aarch64-linux-musl-cross.tgz
+          cp -R aarch64-linux-musl-cross/* /usr
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+          CFLAGS: ${{ matrix.cflags }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: ${{ matrix.strip }} packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-linux-musl
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        run: node -e 'require("@parcel/fs-search")'
 
-  # build-apple-silicon:
-  #   name: aarch64-apple-darwin
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: nightly
-  #         profile: minimal
-  #         override: true
-  #         target: aarch64-apple-darwin
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #       env:
-  #         RUST_TARGET: aarch64-apple-darwin
-  #         JEMALLOC_SYS_WITH_LG_PAGE: 14
-  #     - name: Strip debug symbols
-  #       run: strip -x packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-apple-aarch64
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
+  build-apple-silicon:
+    name: aarch64-apple-darwin
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+          target: aarch64-apple-darwin
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: aarch64-apple-darwin
+          JEMALLOC_SYS_WITH_LG_PAGE: 14
+      - name: Strip debug symbols
+        run: strip -x packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: bindings-apple-aarch64
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
 
-  # build-and-release:
-  #   runs-on: ubuntu-latest
-  #   name: Build and release nightly
-  #   needs:
-  #     - build
-  #     - build-linux-musl
-  #     - build-linux-gnu-arm
-  #     - build-apple-silicon
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #     - name: Download artifacts
-  #       uses: actions/download-artifact@v2
-  #       with:
-  #         path: artifacts
-  #     - name: Move artifacts
-  #       run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
-  #     - name: Debug
-  #       run: ls -l packages/*/*/*.node
-  #     - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-  #       env:
-  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  #     - run: yarn nightly:release
+  build-and-release:
+    runs-on: ubuntu-latest
+    name: Build and release nightly
+    needs:
+      - build
+      - build-linux-musl
+      - build-linux-gnu-arm
+      - build-apple-silicon
+    steps:
+      - uses: actions/checkout@v1
+      - uses: bahmutov/npm-install@v1.1.0
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+      - name: Move artifacts
+        run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+      - name: Debug
+        run: ls -l packages/*/*/*.node
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: yarn nightly:release

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,116 +1,116 @@
 name: release-nightly
-on:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
+on: push
+  # schedule:
+  #   - cron: '0 0 * * *'
+  # workflow_dispatch:
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-${{ matrix.os }}
-          path: packages/*/*/*.node
-      - name: Smoke test
-        run: node -e "require('@parcel/fs-search')"
+  # build:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-latest, windows-latest]
+  #   name: ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       if: ${{ matrix.os == 'macos-latest' }}
+  #       run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-${{ matrix.os }}
+  #         path: packages/*/*/*.node
+  #     - name: Smoke test
+  #       run: node -e "require('@parcel/fs-search')"
 
-  build-linux-gnu-x64:
-    name: linux-gnu-x64
-    runs-on: ubuntu-latest
-    container:
-      image: docker.io/centos/nodejs-12-centos7
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install yarn
-        run: npm install --global yarn@1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: strip packages/*/*/*.node
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-linux-gnu-x64
-          path: packages/*/*/*.node
-      - name: debug
-        run: ls -l packages/*/*/*.node
-      - name: Smoke test
-        run: node -e 'require("@parcel/fs-search")'
+  # build-linux-gnu-x64:
+  #   name: linux-gnu-x64
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: docker.io/centos/nodejs-12-centos7
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install yarn
+  #       run: npm install --global yarn@1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       run: strip packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-linux-gnu-x64
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
+  #     - name: Smoke test
+  #       run: node -e 'require("@parcel/fs-search")'
 
-  build-linux-gnu-arm:
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: arm-unknown-linux-gnueabihf
-            arch: armhf
-            strip: arm-linux-gnueabihf-strip
-          - target: aarch64-unknown-linux-gnu
-            arch: arm64
-            strip: aarch64-linux-gnu-strip
-    name: ${{ matrix.target }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
-      - name: Install cross compile toolchains
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-        env:
-          RUST_TARGET: ${{ matrix.target }}
-      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-        run: ${{ matrix.strip }} packages/*/*/*.node
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-${{ matrix.target }}
-          path: packages/*/*/*.node
-      - name: debug
-        run: ls -l packages/*/*/*.node
-      - name: Configure binfmt-support
-        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      - name: Smoke test
-        uses: addnab/docker-run-action@v1
-        with:
-          image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
-          options: -v ${{github.workspace}}:/work
-          run: cd /work && node -e "require('@parcel/fs-search')"
+  # build-linux-gnu-arm:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - target: arm-unknown-linux-gnueabihf
+  #           arch: armhf
+  #           strip: arm-linux-gnueabihf-strip
+  #         - target: aarch64-unknown-linux-gnu
+  #           arch: arm64
+  #           strip: aarch64-linux-gnu-strip
+  #   name: ${{ matrix.target }}
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #         target: ${{ matrix.target }}
+  #     - name: Install cross compile toolchains
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #       env:
+  #         RUST_TARGET: ${{ matrix.target }}
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       run: ${{ matrix.strip }} packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-${{ matrix.target }}
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
+  #     - name: Configure binfmt-support
+  #       run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+  #     - name: Smoke test
+  #       uses: addnab/docker-run-action@v1
+  #       with:
+  #         image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
+  #         options: -v ${{github.workspace}}:/work
+  #         run: cd /work && node -e "require('@parcel/fs-search')"
 
   build-linux-musl:
     strategy:
@@ -119,8 +119,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             strip: strip
-          - target: aarch64-unknown-linux-musl
-            strip: aarch64-linux-musl-strip
+          # - target: aarch64-unknown-linux-musl
+          #   strip: aarch64-linux-musl-strip
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     container:
@@ -150,6 +150,7 @@ jobs:
         run: yarn build-native-release
         env:
           RUST_TARGET: ${{ matrix.target }}
+          CFLAGS: -msse4.2
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts
@@ -163,56 +164,56 @@ jobs:
         if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         run: node -e 'require("@parcel/fs-search")'
 
-  build-apple-silicon:
-    name: aarch64-apple-darwin
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-          target: aarch64-apple-darwin
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-        env:
-          RUST_TARGET: aarch64-apple-darwin
-          JEMALLOC_SYS_WITH_LG_PAGE: 14
-      - name: Strip debug symbols
-        run: strip -x packages/*/*/*.node
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: bindings-apple-aarch64
-          path: packages/*/*/*.node
-      - name: debug
-        run: ls -l packages/*/*/*.node
+  # build-apple-silicon:
+  #   name: aarch64-apple-darwin
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #         profile: minimal
+  #         override: true
+  #         target: aarch64-apple-darwin
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #       env:
+  #         RUST_TARGET: aarch64-apple-darwin
+  #         JEMALLOC_SYS_WITH_LG_PAGE: 14
+  #     - name: Strip debug symbols
+  #       run: strip -x packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-apple-aarch64
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
 
-  build-and-release:
-    runs-on: ubuntu-latest
-    name: Build and release nightly
-    needs:
-      - build
-      - build-linux-musl
-      - build-linux-gnu-arm
-      - build-apple-silicon
-    steps:
-      - uses: actions/checkout@v1
-      - uses: bahmutov/npm-install@v1.1.0
-      - name: Build native packages
-        run: yarn build-native-release
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-      - name: Move artifacts
-        run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
-      - name: Debug
-        run: ls -l packages/*/*/*.node
-      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: yarn nightly:release
+  # build-and-release:
+  #   runs-on: ubuntu-latest
+  #   name: Build and release nightly
+  #   needs:
+  #     - build
+  #     - build-linux-musl
+  #     - build-linux-gnu-arm
+  #     - build-apple-silicon
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         path: artifacts
+  #     - name: Move artifacts
+  #       run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+  #     - name: Debug
+  #       run: ls -l packages/*/*/*.node
+  #     - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+  #       env:
+  #         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  #     - run: yarn nightly:release

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -63,75 +63,22 @@ jobs:
   #     - name: Smoke test
   #       run: node -e 'require("@parcel/fs-search")'
 
-  # build-linux-gnu-arm:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - target: arm-unknown-linux-gnueabihf
-  #           arch: armhf
-  #           strip: arm-linux-gnueabihf-strip
-  #         - target: aarch64-unknown-linux-gnu
-  #           arch: arm64
-  #           strip: aarch64-linux-gnu-strip
-  #   name: ${{ matrix.target }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: stable
-  #         profile: minimal
-  #         override: true
-  #         target: ${{ matrix.target }}
-  #     - name: Install cross compile toolchains
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
-  #     - uses: bahmutov/npm-install@v1.1.0
-  #     - name: Build native packages
-  #       run: yarn build-native-release
-  #       env:
-  #         RUST_TARGET: ${{ matrix.target }}
-  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
-  #       run: ${{ matrix.strip }} packages/*/*/*.node
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v2
-  #       with:
-  #         name: bindings-${{ matrix.target }}
-  #         path: packages/*/*/*.node
-  #     - name: debug
-  #       run: ls -l packages/*/*/*.node
-  #     - name: Configure binfmt-support
-  #       run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
-  #     - name: Smoke test
-  #       uses: addnab/docker-run-action@v1
-  #       with:
-  #         image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
-  #         options: -v ${{github.workspace}}:/work
-  #         run: cd /work && node -e "require('@parcel/fs-search')"
-
-  build-linux-musl:
+  build-linux-gnu-arm:
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-musl
-            strip: strip
-          # - target: aarch64-unknown-linux-musl
-          #   strip: aarch64-linux-musl-strip
+          - target: arm-unknown-linux-gnueabihf
+            arch: armhf
+            strip: arm-linux-gnueabihf-strip
+            cflags: -mfpu=neon
+          # - target: aarch64-unknown-linux-gnu
+          #   arch: arm64
+          #   strip: aarch64-linux-gnu-strip
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GHCR_TOKEN }}
     steps:
       - uses: actions/checkout@v1
-      - name: Install build tools
-        run: apk add --no-cache python3 make gcc g++ musl-dev curl
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -140,29 +87,86 @@ jobs:
           override: true
           target: ${{ matrix.target }}
       - name: Install cross compile toolchains
-        if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
         run: |
-          curl -O http://musl.cc/aarch64-linux-musl-cross.tgz
-          tar xzf aarch64-linux-musl-cross.tgz
-          cp -R aarch64-linux-musl-cross/* /usr
+          sudo apt-get update
+          sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
       - uses: bahmutov/npm-install@v1.1.0
       - name: Build native packages
         run: yarn build-native-release
         env:
           RUST_TARGET: ${{ matrix.target }}
-          CFLAGS: -msse4.2
+          CFLAGS: ${{ matrix.cflags }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: bindings-linux-musl
+          name: bindings-${{ matrix.target }}
           path: packages/*/*/*.node
       - name: debug
         run: ls -l packages/*/*/*.node
+      - name: Configure binfmt-support
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - name: Smoke test
-        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
-        run: node -e 'require("@parcel/fs-search")'
+        uses: addnab/docker-run-action@v1
+        with:
+          image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
+          options: -v ${{github.workspace}}:/work
+          run: cd /work && node -e "require('@parcel/fs-search')"
+
+  # build-linux-musl:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - target: x86_64-unknown-linux-musl
+  #           strip: strip
+  #           cflags: -msse4.2
+  #         - target: aarch64-unknown-linux-musl
+  #           strip: aarch64-linux-musl-strip
+  #           cflags: ''
+  #   name: ${{ matrix.target }}
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+  #     credentials:
+  #       username: ${{ github.actor }}
+  #       password: ${{ secrets.GHCR_TOKEN }}
+  #   steps:
+  #     - uses: actions/checkout@v1
+  #     - name: Install build tools
+  #       run: apk add --no-cache python3 make gcc g++ musl-dev curl
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: stable
+  #         profile: minimal
+  #         override: true
+  #         target: ${{ matrix.target }}
+  #     - name: Install cross compile toolchains
+  #       if: ${{ matrix.target == 'aarch64-unknown-linux-musl' }}
+  #       run: |
+  #         curl -O http://musl.cc/aarch64-linux-musl-cross.tgz
+  #         tar xzf aarch64-linux-musl-cross.tgz
+  #         cp -R aarch64-linux-musl-cross/* /usr
+  #     - uses: bahmutov/npm-install@v1.1.0
+  #     - name: Build native packages
+  #       run: yarn build-native-release
+  #       env:
+  #         RUST_TARGET: ${{ matrix.target }}
+  #         CFLAGS: ${{ matrix.cflags }}
+  #     - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+  #       run: ${{ matrix.strip }} packages/*/*/*.node
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v2
+  #       with:
+  #         name: bindings-linux-musl
+  #         path: packages/*/*/*.node
+  #     - name: debug
+  #       run: ls -l packages/*/*/*.node
+  #     - name: Smoke test
+  #       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+  #       run: node -e 'require("@parcel/fs-search")'
 
   # build-apple-silicon:
   #   name: aarch64-apple-darwin

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -70,9 +70,11 @@ jobs:
           - target: arm-unknown-linux-gnueabihf
             arch: armhf
             strip: arm-linux-gnueabihf-strip
+            cflags: -mfpu=neon
           - target: aarch64-unknown-linux-gnu
             arch: arm64
             strip: aarch64-linux-gnu-strip
+            cflags: ''
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +95,7 @@ jobs:
         run: yarn build-native-release
         env:
           RUST_TARGET: ${{ matrix.target }}
+          CFLAGS: ${{ matrix.cflags }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts
@@ -118,8 +121,10 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             strip: strip
+            cflags: -msse4.2
           - target: aarch64-unknown-linux-musl
             strip: aarch64-linux-musl-strip
+            cflags: ''
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     container:
@@ -149,6 +154,7 @@ jobs:
         run: yarn build-native-release
         env:
           RUST_TARGET: ${{ matrix.target }}
+          CFLAGS: ${{ matrix.cflags }}
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,15 @@
-jobs: []
-# - template: azure-pipelines-template.yml
-#   parameters:
-#     name: macOS
-#     vmImage: macOS-latest
+jobs:
+- template: azure-pipelines-template.yml
+  parameters:
+    name: macOS
+    vmImage: macOS-latest
 
-# - template: azure-pipelines-template.yml
-#   parameters:
-#     name: Linux
-#     vmImage: ubuntu-latest
+- template: azure-pipelines-template.yml
+  parameters:
+    name: Linux
+    vmImage: ubuntu-latest
 
-# - template: azure-pipelines-template.yml
-#   parameters:
-#    name: Windows
-#    vmImage: windows-latest
+- template: azure-pipelines-template.yml
+  parameters:
+   name: Windows
+   vmImage: windows-latest

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,15 @@
-jobs:
-- template: azure-pipelines-template.yml
-  parameters:
-    name: macOS
-    vmImage: macOS-latest
+jobs: []
+# - template: azure-pipelines-template.yml
+#   parameters:
+#     name: macOS
+#     vmImage: macOS-latest
 
-- template: azure-pipelines-template.yml
-  parameters:
-    name: Linux
-    vmImage: ubuntu-latest
+# - template: azure-pipelines-template.yml
+#   parameters:
+#     name: Linux
+#     vmImage: ubuntu-latest
 
-- template: azure-pipelines-template.yml
-  parameters:
-   name: Windows
-   vmImage: windows-latest
+# - template: azure-pipelines-template.yml
+#   parameters:
+#    name: Windows
+#    vmImage: windows-latest


### PR DESCRIPTION
This fixes the native build on arm-unknown-linux-gnueabihf and x86_64-unknown-linux-musl. We needed to enable some flags for the C compiler on those platforms for SIMD support.

Related #6962. Fixes #6934.