### PR TITLE
Fix named export with different export name for wrapped assets

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename-wrapped/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename-wrapped/a.js
@@ -1,0 +1,3 @@
+import {foo} from './b';
+
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename-wrapped/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename-wrapped/b.js
@@ -1,0 +1,2 @@
+var bar = module && 2;
+export {bar as foo};

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename/a.js
@@ -1,0 +1,3 @@
+import {foo} from './b';
+
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/named-export-variable-rename/b.js
@@ -1,0 +1,2 @@
+var bar = 2;
+export {bar as foo};

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -123,6 +123,29 @@ describe('scope hoisting', function() {
       assert.equal(output, 2);
     });
 
+    it('supports named exports of variables with a different name', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/named-export-variable-rename/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 2);
+    });
+    it('supports named exports of variables with a different name when wrapped', async function() {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/named-export-variable-rename-wrapped/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.equal(output, 2);
+    });
+
     it('supports renaming non-ASCII identifiers', async function() {
       let b = await bundle(
         path.join(

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -268,14 +268,15 @@ impl<'a> Fold for Hoist<'a> {
                       // A variable will appear only once in the `exports` mapping but
                       // could be exported multiple times with different names.
                       // Find the original exported name, and remap.
-                      let orig_exported = self.collect.exports.get(&id).unwrap();
                       let id = if self.collect.should_wrap {
-                        Ident::new(orig_exported.clone(), DUMMY_SP)
+                        id.0
                       } else {
-                        self.get_export_ident(DUMMY_SP, orig_exported)
+                        self
+                          .get_export_ident(DUMMY_SP, self.collect.exports.get(&id).unwrap())
+                          .sym
                       };
                       self.exported_symbols.push(ExportedSymbol {
-                        local: id.sym,
+                        local: id,
                         exported,
                         loc: SourceLocation::from(&self.collect.source_map, named.span),
                       });


### PR DESCRIPTION
Somehow a regression from https://github.com/parcel-bundler/parcel/pull/7021