### PR TITLE
Fix scope resolution for TS enums

### DIFF
--- a/packages/core/integration-tests/test/integration/typescript-enum/index.ts
+++ b/packages/core/integration-tests/test/integration/typescript-enum/index.ts
@@ -1,0 +1,19 @@
+export enum A {
+  X = 'X',
+  Y = 'Y',
+}
+
+export enum B {
+  X = 'X',
+  Y = 'Y',
+}
+
+export enum C {
+  X = 'X',
+  Y = 'Y',
+}
+
+export const z = {
+  a: A.X,
+  c: C.Y,
+};

--- a/packages/core/integration-tests/test/typescript.js
+++ b/packages/core/integration-tests/test/typescript.js
@@ -203,5 +203,36 @@ describe('typescript', function() {
         {config},
       );
     });
+
+    it('should handle compile enums correctly', async function() {
+      if (config != null) {
+        return;
+      }
+      let b = await bundle(
+        path.join(__dirname, '/integration/typescript-enum/index.ts'),
+        {config},
+      );
+
+      let output = await run(b);
+
+      assert.deepEqual(output, {
+        A: {
+          X: 'X',
+          Y: 'Y',
+        },
+        B: {
+          X: 'X',
+          Y: 'Y',
+        },
+        C: {
+          X: 'X',
+          Y: 'Y',
+        },
+        z: {
+          a: 'X',
+          c: 'Y',
+        },
+      });
+    });
   }
 });


### PR DESCRIPTION
TypeScript pass needs to be called _before_ the resolver. This matches how SWC core does it: https://github.com/swc-project/swc/commit/edc4cb432e0fbe01061cbda00a2636a77492839d#diff-b0ba3e54b6f5ef1fa6aed8075e352a68fda66067fbafa8421042a2347801338aL251-R304