### PR TITLE
Ignore `data:` and external URLs in CSS

### DIFF
--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -11,11 +11,11 @@ import nullthrows from 'nullthrows';
 import valueParser from 'postcss-value-parser';
 import semver from 'semver';
 
-const URL_RE = /url\s*\("?(?![a-z]+:)/;
+const URL_RE = /data:|:?\/\//;
 const IMPORT_RE = /@import/;
 
 function canHaveDependencies(filePath: FilePath, code: string) {
-  return !/\.css$/.test(filePath) || IMPORT_RE.test(code) || URL_RE.test(code);
+  return !/\.css$/.test(filePath) || IMPORT_RE.test(code) || !URL_RE.test(code);
 }
 
 export default (new Transformer({
@@ -131,7 +131,7 @@ export default (new Transformer({
     });
 
     program.walkDecls(decl => {
-      if (URL_RE.test(decl.value)) {
+      if (!URL_RE.test(decl.value)) {
         let parsed = valueParser(decl.value);
         let isDeclDirty = false;
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Fix #6898

I believe this regex supposed to be used for ignoring URLs with protocols but it doesn't work in that way. I thought eliminating invalid URLs are easier than testing if it's valid URL.

## 🚨 Test instructions

```ts
// ignored urls
url("data:xxx") 
url("https://example.com/a.png")
url("//a.png")

// allowed urls
url("/a.png")
url("./a.png")
url("../a.png")
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
