### PR TITLE
Fix `src` tag for Vue SFCs

### DIFF
--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -207,7 +207,7 @@ async function processPipeline({
             await resolve(asset.filePath, template.src),
           )
         ).toString();
-        template.lang = extname(template.src);
+        template.lang = extname(template.src).slice(1);
       }
       let content = template.content;
       if (template.lang && !['htm', 'html'].includes(template.lang)) {
@@ -267,7 +267,7 @@ ${
             await resolve(asset.filePath, script.src),
           )
         ).toString();
-        script.lang = extname(script.src);
+        script.lang = extname(script.src).slice(1);
       }
       let type;
       switch (script.lang || 'js') {
@@ -323,7 +323,7 @@ ${
             if (!style.module) {
               style.module = MODULE_BY_NAME_RE.test(style.src);
             }
-            style.lang = extname(style.src);
+            style.lang = extname(style.src).slice(1);
           }
           switch (style.lang) {
             case 'less':


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes the `src` tag in Vue SFCs, which previously didn't work because the `type` was detected as `.js` instead of `js`.

## 💻 Examples

`App.vue`:
```js
<script src="./other.tsx" />
```

`other.tsx`:
```js
import { defineComponent, h } from 'vue'

export default defineComponent({
  render() {
    return <h1>Hi there!</h1>
  }
})
```

Just noticed this while testing out the v2.0.0 stable release (Congrats! 🎉) I'd prefer to make a PR for tests later, though a regression test could be nice.