### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.0",
   "private": true,
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git",
+    "directory": "packages/dev/babel-preset"
+  },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.4.4",

--- a/packages/utils/babylon-walk/package.json
+++ b/packages/utils/babylon-walk/package.json
@@ -10,6 +10,11 @@
     "url": "https://opencollective.com/parcel"
   },
   "description": "Lightweight Babylon AST traversal",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git",
+    "directory": "packages/utils/babylon-walk"
+  },
   "main": "lib/index.js",
   "source": "src/index.js",
   "engines": {

--- a/packages/utils/create-react-app/package.json
+++ b/packages/utils/create-react-app/package.json
@@ -5,6 +5,11 @@
     "parcel-create-react-app": "src/bin.js"
   },
   "main": "lib/bin.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git",
+    "directory": "packages/utils/create-react-app"
+  },
   "source": "src/bin.js",
   "files": [
     "templates",

--- a/packages/utils/fs-write-stream-atomic/package.json
+++ b/packages/utils/fs-write-stream-atomic/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.0",
   "description": "Like `fs.createWriteStream(...)`, but atomic.",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git",
+    "directory": "packages/utils/fs-write-stream-atomic"
+  },
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @parcel/babel-preset
* @parcel/babylon-walk
* @parcel/create-react-app
* @parcel/fs-write-stream-atomic