### PR TITLE
Make Webpack loader detection regex dramatically faster

### DIFF
--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -382,4 +382,20 @@ describe('resolver', function () {
     let output = await run(b);
     assert.strictEqual(output.default, 2);
   });
+
+  it('should support very long dependency specifiers', async function () {
+    this.timeout(8000);
+
+    let inputDir = path.join(__dirname, 'input');
+
+    await outputFS.mkdirp(inputDir);
+    await outputFS.writeFile(
+      path.join(inputDir, 'index.html'),
+      `<img src="data:image/jpeg;base64,/9j/${'A'.repeat(200000)}">`,
+    );
+
+    await bundle(path.join(inputDir, 'index.html'), {
+      inputFS: overlayFS,
+    });
+  });
 });

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -5,7 +5,7 @@ import NodeResolver from '@parcel/node-resolver-core';
 
 // Throw user friendly errors on special webpack loader syntax
 // ex. `imports-loader?$=jquery!./example.js`
-const WEBPACK_IMPORT_REGEX = /\S+-loader\S*!\S+/g;
+const WEBPACK_IMPORT_REGEX = /^\w+-loader(?:\?\S*)?!/;
 
 export default (new Resolver({
   resolve({dependency, options, specifier}) {


### PR DESCRIPTION
That regex took way too long on an 2mb input string. The new one should be equivalent (and take <1ms on 2mb)

Closes https://github.com/parcel-bundler/parcel/issues/6760