### PR TITLE
Properly visit member expressions

### DIFF
--- a/packages/core/integration-tests/test/integration/js-import-member/foo.js
+++ b/packages/core/integration-tests/test/integration/js-import-member/foo.js
@@ -1,0 +1,6 @@
+export const foo = {
+	a: "b",
+  bar: "bar"
+};
+
+export const bar = "a";

--- a/packages/core/integration-tests/test/integration/js-import-member/index.js
+++ b/packages/core/integration-tests/test/integration/js-import-member/index.js
@@ -1,0 +1,3 @@
+import { foo, bar } from "./foo.js";
+
+export default [bar, foo[bar], foo.bar];

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4982,6 +4982,14 @@ describe('javascript', function () {
     assert.deepEqual(res.default, 123);
   });
 
+  it('should replace imported values in member expressions', async function () {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-import-member/index.js'),
+    );
+    let res = await run(b);
+    assert.deepEqual(res.default, ['a', 'b', 'bar']);
+  });
+
   it('should not freeze live default imports', async function () {
     let b = await bundle(
       path.join(__dirname, 'integration/js-import-default-live/index.js'),

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -317,11 +317,10 @@ macro_rules! fold_member_expr_skip_prop {
       &mut self,
       mut node: swc_ecmascript::ast::MemberExpr,
     ) -> swc_ecmascript::ast::MemberExpr {
-      node.obj = node.obj.fold_children_with(self);
+      node.obj = node.obj.fold_with(self);
 
-      // To ensure that fold_expr doesn't replace `require` in non-computed member expressions
       if node.computed {
-        node.prop = node.prop.fold_children_with(self);
+        node.prop = node.prop.fold_with(self);
       }
 
       node


### PR DESCRIPTION
Calling `node.prop.fold_children_with` if `node.prop` is an `Expr` means that `fold_expr` was never called, because it's only the `Expr`'s children that are visited.

ak-editor was broken without scope hoisting because

```js
import { foo, bar } from "./other";

print(foo[bar]);
```
was transformed into
```js
var _other = require("./other");
print(_other.foo[bar]);
```

---


