### PR TITLE
fix: add @parcel/diagnostic as dependency of @parcel/transformer-typescript-types

### DIFF
--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -20,6 +20,7 @@
     "parcel": "^2.0.0"
   },
   "dependencies": {
+    "@parcel/diagnostic": "^2.0.0",
     "@parcel/plugin": "^2.0.0",
     "@parcel/source-map": "^2.0.0",
     "@parcel/ts-utils": "^2.0.0",


### PR DESCRIPTION
# ↪️ Pull Request

Fixes missing `@parcel/diagnostic` dependency in `@parcel/transformer-typescript-types`. Otherwise, it produces unexpected behavior with modern package managers (such as yarn v2+).  

Specifically, in yarn berry, it can be solved using `packageExtensions` like so:

```yml
packageExtensions:
  "@parcel/transformer-typescript-types@*":
    dependencies:
      "@parcel/diagnostic": "^2.0.0"
```

However, it's better when packages themselves list their dependencies for more fluent DX and stability.