### PR TITLE
Fixed missing "Parcel" export member in Module "@parcel/core"

### DIFF
--- a/packages/core/core/index.d.ts
+++ b/packages/core/core/index.d.ts
@@ -2,7 +2,7 @@ import type {InitialParcelOptions, BuildEvent, BuildSuccessEvent, AsyncSubscript
 import type {FarmOptions} from '@parcel/workers';
 import type WorkerFarm from '@parcel/workers';
 
-export default class Parcel {
+export class Parcel {
   constructor(options: InitialParcelOptions);
   run(): Promise<BuildSuccessEvent>;
   watch(
@@ -11,3 +11,5 @@ export default class Parcel {
 }
 
 export declare function createWorkerFarm(options?: Partial<FarmOptions>): WorkerFarm;
+
+export default Parcel;


### PR DESCRIPTION
# ↪️ Pull Request

Fixes a typescript bug in the `@parcel/core`, and allowing examples from docs to work.

## 💻 Examples

As stated in the examples of https://parceljs.org/features/parcel-api/

It's possible to do `import { Parcel } from "@parcel/core";` but TypeScript will throw an error 
```Module '"node_modules/@parcel/core"' has no exported member 'Parcel'. Did you mean to use 'import Parcel from "node_modules/@parcel/core"' instead?```

Know that this will still work when building, but typescript just don't like it.

But when using `import Parcel from "@parcel/core";` it don't allow to be created due to the javascript code only have the constructor under `Parcel.default` now.