### PR TITLE
fix: getRootDir behaviour for single directory causing wrong project root

### DIFF
--- a/packages/core/utils/src/getRootDir.js
+++ b/packages/core/utils/src/getRootDir.js
@@ -4,6 +4,8 @@ import type {FilePath} from '@parcel/types';
 import {isGlob} from './glob';
 import path from 'path';
 
+// Returns the common root of the given paths.
+// If there is no common root, returns the current working directory.
 export default function getRootDir(files: Array<FilePath>): FilePath {
   let cur = null;
 
@@ -27,10 +29,16 @@ export default function getRootDir(files: Array<FilePath>): FilePath {
       }
 
       cur.dir = i > 1 ? curParts.slice(0, i).join(path.sep) : cur.root;
+      cur.name = '';
+      cur.base = '';
     }
   }
 
-  return cur ? cur.dir : process.cwd();
+  if (!cur) {
+    return process.cwd();
+  }
+
+  return path.join(cur.dir, cur.name);
 }
 
 // Transforms a path like `packages/*/src/index.js` to the root of the glob, `packages/`

--- a/packages/core/utils/test/getRootDir.test.js
+++ b/packages/core/utils/test/getRootDir.test.js
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import getRootDir from '../src/getRootDir';
+import path from 'path';
+
+describe('getRootDir', () => {
+  it('Should return the common parts if provided a file list', () => {
+    const rootPath = process.cwd();
+    const fileList = [
+      path.join(rootPath, 'foo', 'bar'),
+      path.join(rootPath, 'foo', 'bar', 'baz', 'qux'),
+      path.join(rootPath, 'foo.js'),
+    ];
+    assert.equal(getRootDir(fileList), rootPath);
+  });
+  it('Should return the passsed path if its a directory', () => {
+    const rootPath = process.cwd();
+    assert.equal(getRootDir([rootPath]), rootPath);
+  });
+});


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

Linked issue: #7145 

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The getProjectRoot command was returning a wrong root when passed in a folder value. This caused the wrong project root to be determined when running in watch mode. In some cases this caused the entire filesystem to be watched.

The reason this is a draft is that this change breaks about ~100 integration tests, I'm happy to look into fixing those as well, but I'd like to first get feedback and confirm that my change aligns with the intended behaviour of the `getProjectRoot` function.

I tested this on a repo that was not working due to this bug, and now the .proxyrc.js file was loaded correctly and the site could be loaded. In fact some extra config files (.babelrc) also got loaded thanks to this.

Even if this is the intended change it's probably a huge breaking change, so please advise on how should I proceed.

Thank you for the amazing work on this project, adding a new test and making this fix was a breeze.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
Loading .proxyrc.js from project didn't work and explicitly setting the path for it wasn't possible.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
