### PR TITLE
Resolve GLSL relative to the importer, not the asset

### DIFF
--- a/packages/core/integration-tests/test/glsl.js
+++ b/packages/core/integration-tests/test/glsl.js
@@ -22,4 +22,23 @@ describe('glsl', function () {
       }, true),
     );
   });
+
+  it('should correctly resolve relative GLSL imports', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/glsl-relative-import/index.js'),
+    );
+
+    let output = await run(b);
+    assert.strictEqual(
+      output.trim(),
+      `#define GLSLIFY 1
+float b(float p) { return p*2.0; }
+
+float c(float p) { return b(p)*3.0; }
+
+varying float x;
+
+void main() { gl_FragColor = vec4(c(x)); }`,
+    );
+  });
 });

--- a/packages/core/integration-tests/test/integration/glsl-relative-import/frag.glsl
+++ b/packages/core/integration-tests/test/integration/glsl-relative-import/frag.glsl
@@ -1,0 +1,5 @@
+#pragma glslify: c = require('./sub/other');
+
+varying float x;
+
+void main() { gl_FragColor = vec4(c(x)); }

--- a/packages/core/integration-tests/test/integration/glsl-relative-import/index.js
+++ b/packages/core/integration-tests/test/integration/glsl-relative-import/index.js
@@ -1,0 +1,3 @@
+import frag from "./frag.glsl";
+
+module.exports = frag;

--- a/packages/core/integration-tests/test/integration/glsl-relative-import/sub/other.glsl
+++ b/packages/core/integration-tests/test/integration/glsl-relative-import/sub/other.glsl
@@ -1,0 +1,5 @@
+#pragma glslify: b = require('./other2');
+
+float c(float p) { return b(p)*3.0; }
+
+#pragma glslify: export(c);

--- a/packages/core/integration-tests/test/integration/glsl-relative-import/sub/other2.glsl
+++ b/packages/core/integration-tests/test/integration/glsl-relative-import/sub/other2.glsl
@@ -1,0 +1,3 @@
+float b(float p) { return p*2.0; }
+
+#pragma glslify: export(b);

--- a/packages/transformers/glsl/package.json
+++ b/packages/transformers/glsl/package.json
@@ -22,6 +22,6 @@
   "dependencies": {
     "@parcel/plugin": "^2.0.0",
     "glslify-bundle": "^5.1.1",
-    "glslify-deps": "^1.3.1"
+    "glslify-deps": "^1.3.2"
   }
 }

--- a/packages/transformers/glsl/src/GLSLTransformer.js
+++ b/packages/transformers/glsl/src/GLSLTransformer.js
@@ -1,5 +1,4 @@
 // @flow
-
 import path from 'path';
 import {promisify} from 'util';
 import {Transformer} from '@parcel/plugin';
@@ -8,15 +7,16 @@ import glslifyBundle from 'glslify-bundle';
 
 export default (new Transformer({
   async transform({asset, resolve}) {
-    asset.type = 'js';
-
     // Parse and collect dependencies with glslify-deps
     let cwd = path.dirname(asset.filePath);
     let depper = glslifyDeps({
       cwd,
       resolve: async (target, opts, next) => {
         try {
-          let filePath = await resolve(asset.filePath, target);
+          let filePath = await resolve(
+            path.join(opts.basedir, 'index.glsl'),
+            target,
+          );
 
           next(null, filePath);
         } catch (err) {
@@ -36,6 +36,7 @@ export default (new Transformer({
     let glsl = await glslifyBundle(ast);
 
     asset.setCode(`module.exports=${JSON.stringify(glsl)};`);
+    asset.type = 'js';
 
     return [asset];
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5694,15 +5694,10 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
   integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
 
-events@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
-  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
-
-events@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
-  integrity sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==
+events@^3.1.0, events@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -6706,13 +6701,13 @@ glslify-bundle@^5.1.1:
     murmurhash-js "^1.0.0"
     shallow-copy "0.0.1"
 
-glslify-deps@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/glslify-deps/-/glslify-deps-1.3.1.tgz#dfa6962322454a91ecc4de25b5e710415b0c89ad"
-  integrity sha512-Ogm179MCazwIRyEqs3g3EOY4Y3XIAa0yl8J5RE9rJC6QH1w8weVOp2RZu0mvnYy/2xIas1w166YR2eZdDkWQxg==
+glslify-deps@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/glslify-deps/-/glslify-deps-1.3.2.tgz#c09ee945352bfc07ac2d8a1cc9e3de776328c72b"
+  integrity sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==
   dependencies:
     "@choojs/findup" "^0.2.0"
-    events "^1.0.2"
+    events "^3.2.0"
     glsl-resolve "0.0.1"
     glsl-tokenizer "^2.0.0"
     graceful-fs "^4.1.2"


### PR DESCRIPTION
With `index.js` imports `a.glsl` imports `sub/a.glsl` imports `sub/b.glsl`,
the last import (using `require(./b)`) should be relative to `sub`, not `asset.filePath` (which is in the parent folder.

Closes https://github.com/parcel-bundler/parcel/issues/7253