### PR TITLE
PNPM Workspaces, entry resolving for no input and accepting node_modules.

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -49,12 +49,18 @@ export default async function resolveOptions(
     entries = [path.resolve(inputCwd, initialOptions.entries)];
   }
 
-  let entryRoot = getRootDir(entries);
+  let entryRoot;
+  if(entries[0] === inputCwd) {
+    entryRoot = getRootDir([`${inputCwd}/package.json`])
+  } else {
+    entryRoot = getRootDir(entries);
+  }
+
   let projectRootFile =
     (await resolveConfig(
       inputFS,
       path.join(entryRoot, 'index'),
-      [...LOCK_FILE_NAMES, '.git', '.hg'],
+      [...LOCK_FILE_NAMES, '.git', '.hg', 'node_modules'],
       path.parse(entryRoot).root,
     )) || path.join(inputCwd, 'index'); // ? Should this just be rootDir
 


### PR DESCRIPTION
# ↪️ Pull Request
This pull request resolves issue #7063 and allows for Parcel to install dependencies in workspaces. It changes following things.
1. Adding `node_modules` to the list of acceptable names to identify a folder as a root folder.
2. Validating if the current directory could be the root directory if the current directory is the same as the entry.
e.g., `parcel build .`

## 💻 Examples
The test instructions tell an excellent example; the only difference is it's now supported to resolve the root dir as the folder where package.json lives in. (In case your current dir is the same as the entry in Parcel, e.g., running `parcel build .` would result in this).

## 🚨 Test instructions
1. Create a simple repository with pnpm as package manager, then add a project as workspace in the folder, e.g., `packages/playground.`
2. Add Parcel to the playground, and add the`"types"` field to trigger the auto module install function.
3. Parcel won't be able to find the playground as a project due to its missing lock files or .git

The result is the bundler is finding the root project and installing the dependencies in that folder, or it is simply failing to install in some cases.

## ✔️ PR Todo
- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs