### PR TITLE
Chore: fix typo initialise -> initialize in core/core/src/Parcel.js

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -399,7 +399,7 @@ export default class Parcel {
   _getResolvedParcelOptions(): ParcelOptions {
     return nullthrows(
       this.#resolvedOptions,
-      'Resolved options is null, please let parcel initialise before accessing this.',
+      'Resolved options is null, please let parcel initialize before accessing this.',
     );
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Hi team! 👋

When I read parcel's code, and I noticed a typo in `core/core/src/Parcel.js`.

`resolvedOptions`, nullchecked in here, is initialized in `_init` method and This error message should be shown when parcel is not initialized, so I thought this phrase should be `initialize`, not `initialise`.

Not a really important change at all but I will be happy if this will help you.

## 💻 Examples

This change will not cause any change in behavior.

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

This change will not cause any change in behavior.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] ~Added/updated unit tests for this change~ This change will not cause any change in behavior.
- [x] ~Filled out test instructions (In case there aren't any unit tests)~ This change will not cause any change in behavior.
- [x] ~Included links to related issues/PRs
