### PR TITLE
Fix Elm transform showing compiler errors twice

### DIFF
--- a/packages/transformers/elm/src/ElmTransformer.js
+++ b/packages/transformers/elm/src/ElmTransformer.js
@@ -56,8 +56,19 @@ export default (new Transformer({
     // this can be removed after https://github.com/isaacs/node-graceful-fs/pull/200 was mergend and used in parcel
     // $FlowFixMe[method-unbinding]
     process.chdir.disabled = isWorker;
+    let code;
+    try {
+      code = await compileToString(elm, elmBinary, asset, compilerConfig);
+    } catch (e) {
+      throw new ThrowableDiagnostic({
+        diagnostic: {
+          message: 'Compilation failed',
+          origin: '@parcel/elm-transformer',
+          stack: e.toString(),
+        },
+      });
+    }
 
-    let code = await compileToString(elm, elmBinary, asset, compilerConfig);
     if (options.hmrOptions) {
       code = elmHMR.inject(code);
     }


### PR DESCRIPTION
# ↪️ Pull Request

Fix for #6703 by wrapping the Exception thrown by `compileToString` in a ThrowableDiagnostic.
Unfortunately this doesn't seem to fix #6124.

I looked into using codeframes to get syntax highlighting. Running the elm compiler with `--report=json` gives usable diagnostic location information, but the error message is still quite verbose, including code snippets (again) and hints. It just didn't look right, so I've left it at printing the stack trace.

## 💻 Examples

### Before
![image](https://user-images.githubusercontent.com/23027708/142491250-52990d56-d740-4666-9144-24ca27fb979c.png)

### After
![image](https://user-images.githubusercontent.com/23027708/142491398-59f73846-0df7-43e9-86c0-1fe679439232.png)


## 🚨 Test instructions
Start parcel v2 with any broken Elm code, e.g.
Main.elm:
```elm
module Main exposing (main)
main =
   i-am-broken
```

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
