### PR TITLE
Fix `semver` version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mocha-multi-reporters": "^1.5.1",
     "prettier": "2.4.1",
     "rimraf": "^2.6.3",
-    "semver": "^5.4.1",
+    "semver": "^5.7.1",
     "sinon": "^7.3.1"
   },
   "engines": {

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -47,7 +47,7 @@
     "json5": "^1.0.1",
     "micromatch": "^4.0.2",
     "nullthrows": "^1.1.1",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "graphviz": "^0.0.9",

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -34,7 +34,7 @@
     "command-exists": "^1.2.6",
     "cross-spawn": "^6.0.4",
     "nullthrows": "^1.1.1",
-    "semver": "^5.4.1",
+    "semver": "^5.7.1",
     "split2": "^3.1.1"
   },
   "peerDependencies": {

--- a/packages/transformers/babel/src/utils.js
+++ b/packages/transformers/babel/src/utils.js
@@ -47,7 +47,7 @@ export function enginesToBabelTargets(env: Environment): BabelTargets {
     } else {
       invariant(typeof engineValue === 'string');
       if (!TargetNames.hasOwnProperty(engineName)) continue;
-      let minVersion = getMinSemver(engineValue);
+      let minVersion = semver.minVersion(engineValue)?.toString();
       targets[engineName] = minVersion ?? engineValue;
     }
   }
@@ -68,16 +68,4 @@ export function enginesToBabelTargets(env: Environment): BabelTargets {
   }
 
   return targets;
-}
-
-// TODO: Replace with `minVersion` (https://github.com/npm/node-semver#ranges-1)
-//       once semver has been upgraded across Parcel.
-export function getMinSemver(version: string): ?string {
-  try {
-    let range = new semver.Range(version);
-    let sorted = range.set.sort((a, b) => a[0].semver.compare(b[0].semver));
-    return sorted[0][0].semver.version;
-  } catch (err) {
-    return null;
-  }
 }

--- a/packages/transformers/coffeescript/package.json
+++ b/packages/transformers/coffeescript/package.json
@@ -25,6 +25,6 @@
     "@parcel/utils": "^2.0.1",
     "coffeescript": "^2.0.3",
     "nullthrows": "^1.1.1",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   }
 }

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -26,6 +26,6 @@
     "nullthrows": "^1.1.1",
     "postcss": "^8.3.0",
     "postcss-value-parser": "^4.1.0",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   }
 }

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -26,6 +26,6 @@
     "posthtml": "^0.16.5",
     "posthtml-parser": "^0.10.1",
     "posthtml-render": "^3.0.0",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   }
 }

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -40,7 +40,7 @@
     "micromatch": "^4.0.2",
     "nullthrows": "^1.1.1",
     "regenerator-runtime": "^0.13.7",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "1.0.4"

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -28,7 +28,7 @@
     "nullthrows": "^1.1.1",
     "postcss-modules": "^3.2.2",
     "postcss-value-parser": "^4.1.0",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "postcss": "^8.3.0"

--- a/packages/transformers/posthtml/package.json
+++ b/packages/transformers/posthtml/package.json
@@ -26,6 +26,6 @@
     "posthtml": "^0.16.5",
     "posthtml-parser": "^0.10.1",
     "posthtml-render": "^3.0.0",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   }
 }

--- a/packages/transformers/svg/package.json
+++ b/packages/transformers/svg/package.json
@@ -26,6 +26,6 @@
     "posthtml": "^0.16.5",
     "posthtml-parser": "^0.10.1",
     "posthtml-render": "^3.0.0",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   }
 }

--- a/packages/transformers/vue/package.json
+++ b/packages/transformers/vue/package.json
@@ -27,7 +27,7 @@
     "@vue/compiler-sfc": "^3.0.0",
     "consolidate": "^0.16.0",
     "nullthrows": "^1.1.1",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "vue": "^3.0.0"

--- a/packages/utils/babel-plugin-transform-runtime/package.json
+++ b/packages/utils/babel-plugin-transform-runtime/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.8.3",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.0",

--- a/packages/utils/babel-preset-env/package.json
+++ b/packages/utils/babel-preset-env/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@babel/preset-env": "^7.4.0",
-    "semver": "^5.4.1"
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.0"


### PR DESCRIPTION
The JS transformer was using `semver.minVersion` which was introduced in semver 5.7 while the semver dependency range was only `^5.4.1`.

I've bumped this range across all packages because to prevent this from happening in the future (using `semver.minVersion` but forgetting to bump the range).

https://github.com/parcel-bundler/parcel/issues/6720#issuecomment-974183404