### PR TITLE
Revisit asset nodes on subsequent builds after symbol error

### DIFF
--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -710,7 +710,6 @@ export class AssetGraphBuilder {
           }
         }
         if (node.usedSymbolsUpDirty) {
-          node.usedSymbolsUpDirty = false;
           let e = visit(
             node,
             incoming,
@@ -721,8 +720,10 @@ export class AssetGraphBuilder {
             }),
           );
           if (e.length > 0) {
+            node.usedSymbolsUpDirty = true;
             errors.set(nodeId, e);
           } else {
+            node.usedSymbolsUpDirty = false;
             errors.delete(nodeId);
           }
         }
@@ -768,8 +769,10 @@ export class AssetGraphBuilder {
         if (node.usedSymbolsUpDirty) {
           let e = visit(node, incoming, outgoing);
           if (e.length > 0) {
+            node.usedSymbolsUpDirty = true;
             errors.set(queuedNodeId, e);
           } else {
+            node.usedSymbolsUpDirty = false;
             errors.delete(queuedNodeId);
           }
         }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -306,6 +306,7 @@ export type DependencyNode = {|
   hasDeferred?: boolean,
   usedSymbolsDown: Set<Symbol>,
   usedSymbolsUp: Set<Symbol>,
+  /** for the "down" pass, the dependency resolution asset needs to be updated */
   usedSymbolsDownDirty: boolean,
   /** for the "up" pass, the parent asset needs to be updated */
   usedSymbolsUpDirtyUp: boolean,

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-missing/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-missing/a.js
@@ -1,0 +1,3 @@
+import {foo} from "./b.js";
+
+output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-missing/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-missing/b.js
@@ -1,0 +1,1 @@
+export const bar = 1;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -576,6 +576,62 @@ describe('scope hoisting', function () {
       });
     });
 
+    it('throws when importing a missing symbol on cached builds without changes', async function () {
+      let entry = 'integration/scope-hoisting/es6/import-missing/a.js';
+      let message = md`${normalizePath(
+        'integration/scope-hoisting/es6/import-missing/b.js',
+        false,
+      )} does not export 'foo'`;
+      let error = {
+        name: 'BuildError',
+        message,
+        diagnostics: [
+          {
+            message,
+            origin: '@parcel/core',
+            codeFrames: [
+              {
+                filePath: path.join(__dirname, entry),
+                language: 'js',
+                codeHighlights: [
+                  {
+                    start: {
+                      line: 1,
+                      column: 9,
+                    },
+                    end: {
+                      line: 1,
+                      column: 11,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      let source = path.join(__dirname, entry);
+      await assert.rejects(
+        () =>
+          bundle(source, {
+            inputFS: overlayFS,
+            outputFS: overlayFS,
+            shouldDisableCache: false,
+          }),
+        error,
+      );
+      await assert.rejects(
+        () =>
+          bundle(source, {
+            inputFS: overlayFS,
+            outputFS: overlayFS,
+            shouldDisableCache: false,
+          }),
+        error,
+      );
+    });
+
     it('supports multiple exports of the same variable', async function () {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
Closes #7272

Mark asset node as dirty when a symbols error was determined for in that asset. This ensures that the node will be revisited on the next run (especially on no-change rebuilds) so that the error can be rethrown.