### PR TITLE
Add optimizer plugin for new CSS compiler

### DIFF
--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -177,7 +177,10 @@ export function errorToDiagnostic(
       origin: defaultValues?.origin ?? 'Error',
       message: escapeMarkdown(error.message),
       name: error.name,
-      stack: error.highlightedCodeFrame ?? error.codeFrame ?? error.stack,
+      stack:
+        codeFrames == null
+          ? error.highlightedCodeFrame ?? error.codeFrame ?? error.stack
+          : undefined,
       codeFrames,
     },
   ];

--- a/packages/optimizers/css/package.json
+++ b/packages/optimizers/css/package.json
@@ -20,7 +20,7 @@
     "parcel": "^2.0.1"
   },
   "dependencies": {
-    "@parcel/css": "1.0.0-alpha.3",
+    "@parcel/css": "1.0.0-alpha.4",
     "@parcel/plugin": "^2.0.1",
     "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "^2.0.1",

--- a/packages/optimizers/css/package.json
+++ b/packages/optimizers/css/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@parcel/optimizer-css",
+  "version": "2.0.1",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "lib/CSSOptimizer.js",
+  "source": "src/CSSOptimizer.js",
+  "engines": {
+    "node": ">= 12.0.0",
+    "parcel": "^2.0.1"
+  },
+  "dependencies": {
+    "@parcel/css": "1.0.0-alpha.3",
+    "@parcel/plugin": "^2.0.1",
+    "@parcel/source-map": "^2.0.0",
+    "@parcel/utils": "^2.0.1",
+    "browserslist": "^4.6.6"
+  }
+}

--- a/packages/optimizers/css/src/CSSOptimizer.js
+++ b/packages/optimizers/css/src/CSSOptimizer.js
@@ -1,0 +1,110 @@
+// @flow strict-local
+
+import SourceMap from '@parcel/source-map';
+import {Optimizer} from '@parcel/plugin';
+// $FlowFixMe
+import {transform} from '@parcel/css';
+import {blobToBuffer} from '@parcel/utils';
+import browserslist from 'browserslist';
+
+export default (new Optimizer({
+  async optimize({
+    bundle,
+    contents: prevContents,
+    getSourceMapReference,
+    map: prevMap,
+    options,
+  }) {
+    if (!bundle.env.shouldOptimize) {
+      return {contents: prevContents, map: prevMap};
+    }
+
+    let targets = getTargets(bundle.env.engines.browsers);
+    let code = await blobToBuffer(prevContents);
+    let result = transform({
+      filename: bundle.name,
+      code,
+      minify: true,
+      source_map: !!bundle.env.sourceMap,
+      targets,
+    });
+
+    let map;
+    if (result.map != null) {
+      map = new SourceMap(options.projectRoot);
+      map.addVLQMap(JSON.parse(result.map));
+    }
+
+    let contents = result.code;
+    if (bundle.env.sourceMap) {
+      let reference = await getSourceMapReference(map);
+      if (reference != null) {
+        contents += '\n' + '/*# sourceMappingURL=' + reference + ' */\n';
+      }
+    }
+
+    return {
+      contents,
+      map,
+    };
+  },
+}): Optimizer);
+
+const BROWSER_MAPPING = {
+  and_chr: 'chrome',
+  and_ff: 'firefox',
+  ie_mob: 'ie',
+  op_mob: 'opera',
+  and_qq: null,
+  and_uc: null,
+  baidu: null,
+  bb: null,
+  kaios: null,
+  op_mini: null,
+};
+
+let cache = new Map();
+
+function getTargets(browsers) {
+  if (browsers == null) {
+    return undefined;
+  }
+
+  let cached = cache.get(browsers);
+  if (cached != null) {
+    return cached;
+  }
+
+  let targets = {};
+  for (let browser of browserslist(browsers)) {
+    let [name, v] = browser.split(' ');
+    if (BROWSER_MAPPING[name] === null) {
+      continue;
+    }
+
+    let version = parseVersion(v);
+    if (version == null) {
+      continue;
+    }
+
+    if (targets[name] == null || version < targets[name]) {
+      targets[name] = version;
+    }
+  }
+
+  cache.set(browsers, targets);
+  return targets;
+}
+
+function parseVersion(version) {
+  let [major, minor = 0, patch = 0] = version
+    .split('-')[0]
+    .split('.')
+    .map(v => parseInt(v, 10));
+
+  if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+    return null;
+  }
+
+  return (major << 16) | (minor << 8) | patch;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,6 +2133,11 @@
   dependencies:
     "@octokit/openapi-types" "^6.2.0"
 
+"@parcel/css@1.0.0-alpha.3":
+  version "1.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@parcel/css/-/css-1.0.0-alpha.3.tgz#1a444d0c361a53cc54cf3c06ca437e926c427fc8"
+  integrity sha512-Aeu1+CABHXgKwI2omxV3/sV3EmoTY3RrqxL7j0LAwagS5fLFjqcmbdbZIkYT0wDhcaufqXsaEg3ijdHiHNLDgA==
+
 "@parcel/source-map@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@parcel/source-map/-/source-map-2.0.0.tgz#41cf004109bbf277ceaf096a58838ff6a59af774"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,10 +2133,12 @@
   dependencies:
     "@octokit/openapi-types" "^6.2.0"
 
-"@parcel/css@1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@parcel/css/-/css-1.0.0-alpha.3.tgz#1a444d0c361a53cc54cf3c06ca437e926c427fc8"
-  integrity sha512-Aeu1+CABHXgKwI2omxV3/sV3EmoTY3RrqxL7j0LAwagS5fLFjqcmbdbZIkYT0wDhcaufqXsaEg3ijdHiHNLDgA==
+"@parcel/css@1.0.0-alpha.4":
+  version "1.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@parcel/css/-/css-1.0.0-alpha.4.tgz#967520401053f8eb0d5f23ed58b4afbcebc6c9de"
+  integrity sha512-/wd7WWesAekEexrL7slIkb1gNXX/XYF8bMZUEcEKjDdkfne5SyINLTGbV3WzvsEjzRwgBL5kBET5nX59GJ3JVg==
+  dependencies:
+    detect-libc "^1.0.3"
 
 "@parcel/source-map@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This adds a `@parcel/optimizer-css` plugin, which uses [@parcel/css](https://github.com/parcel-bundler/parcel-css), our new CSS minifier written in Rust. It's significantly faster than cssnano (see readme linked above for benchmarks). For now, it's experimental, so not included in the default config.

I'm actually not sure if we want this to eventually be a transformer rather than an optimizer. Eventually it will also perform the work of the current CSS transformer, e.g. extracting dependencies, and there aren't many CSS minification opportunities that will be effective cross file, so probably ok to perform minification in the transformer as well. For now, I put it in an optimizer because minification is the first target.