### PR TITLE
Chore: update examples/html html script attributes

### DIFF
--- a/packages/examples/html/src/index.html
+++ b/packages/examples/html/src/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <title>HTML Example</title>
-    <script nomodule src="./index.js"></script>
     <script type="module" src="./index.js"></script>
   </head>
   <body>

--- a/packages/examples/html/src/other.html
+++ b/packages/examples/html/src/other.html
@@ -6,6 +6,6 @@
   <body>
     <h1>Other page</h1>
     <a href="index.html">Back to index</a>
-    <script src="index.js"></script>
+    <script type="module" src="index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Now, `parcel` supports module/no-module pattern differential serving as default behavior, and `parcel` throws an error when importing modules without `type=module` or with `nomodule`, but `examples/html` is not updated so building `example/html` causes an error. 

I fixed this.


![スクリーンショット 2021-11-22 18 41 21](https://user-images.githubusercontent.com/42742053/142847508-14e07ff2-d618-43ec-8ff6-f6f747e1711f.png)

