### PR TITLE
Fix type generation when tsconfig's "incremental" option is true

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/composite/tsconfig.json
+++ b/packages/core/integration-tests/test/integration/ts-types/composite/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
+    "incremental": true
   },
   "files": [
     "index.ts",

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -306,7 +306,7 @@ describe('typescript types', function () {
     assert(/import\s*{\s*B\s*}\s*from\s*"b";/.test(dist));
   });
 
-  it('should generate a typescript declaration file even when composite is true', async function () {
+  it('should generate a typescript declaration file even when composite and incremental true', async function () {
     await bundle(
       path.join(__dirname, '/integration/ts-types/composite/index.ts'),
     );

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -306,7 +306,7 @@ describe('typescript types', function () {
     assert(/import\s*{\s*B\s*}\s*from\s*"b";/.test(dist));
   });
 
-  it('should generate a typescript declaration file even when composite and incremental true', async function () {
+  it('should generate a typescript declaration file even when composite and incremental are true', async function () {
     await bundle(
       path.join(__dirname, '/integration/ts-types/composite/index.ts'),
     );

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -36,6 +36,7 @@ export default (new Transformer({
       moduleResolution: ts.ModuleResolutionKind.NodeJs,
       // createProgram doesn't support incremental mode
       composite: false,
+      incremental: false,
     };
 
     let host = new CompilerHost(options.inputFS, ts, logger);


### PR DESCRIPTION
# ↪️ Pull Request

This fixes #7351

The issue is that `@parcel/transformer-typescript-types` will output blank `.d.ts` files when the user supplies a `tsconfig.json` with `"incremental": true`. The solution is to override this to ensure that we always set it to false before trying to generate types.

It's a follow up to #5346 and tweaks the unit test from that PR to cover both the original case, and this one.

## 💻 Examples

Examples are in the original bug (#7351).

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
