### PR TITLE
Fixed the hmr connection with host 0.0.0.0

### DIFF
--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -25,7 +25,9 @@ export default (new Runtime({
     return {
       filePath: __filename,
       code:
-        `var HMR_HOST = ${JSON.stringify((host != null && host !== '0.0.0.0') ? host : null)};` +
+        `var HMR_HOST = ${JSON.stringify(
+          host != null && host !== '0.0.0.0' ? host : null,
+        )};` +
         `var HMR_PORT = ${JSON.stringify(
           port != null &&
             // Default to the HTTP port in the browser, only override

--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -25,7 +25,7 @@ export default (new Runtime({
     return {
       filePath: __filename,
       code:
-        `var HMR_HOST = ${JSON.stringify(host != null ? host : null)};` +
+        `var HMR_HOST = ${JSON.stringify((host != null && host !== '0.0.0.0') ? host : null)};` +
         `var HMR_PORT = ${JSON.stringify(
           port != null &&
             // Default to the HTTP port in the browser, only override


### PR DESCRIPTION
# ↪️ Pull Request

As well known the server listen host should not be equal to the client connect to, but `@parcel/runtime-browser-hmr` is doing so.

We usually use `0.0.0.0` as the host to make sure the service is listening to all of the network interfaces, but '0.0.0.0' must not be the client connect to.

## 💻 Examples
Start the parcel with `parcel  --host 0.0.0.0 --port 8081 ./demo/index.html` in remote dev machine, then start the web browser to connect will got following error message:

<img width="957" alt="Screen Shot 2021-11-24 at 11 01 14 PM" src="https://user-images.githubusercontent.com/32739/143262145-0cbaad16-3151-469d-8179-0dbba2bc8981.png">

Applied the patch, the `HMR_HOST` set to `null`, and the WebSocket connect correctly.

<img width="752" alt="screenshot" src="https://user-images.githubusercontent.com/32739/143263646-2a717380-3b2f-4031-8e10-983604f68f92.png">

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
