### PR TITLE
Fix require statements with plain template literals

### DIFF
--- a/packages/core/integration-tests/test/integration/commonjs-template-literal-interpolation/index.js
+++ b/packages/core/integration-tests/test/integration/commonjs-template-literal-interpolation/index.js
@@ -1,0 +1,7 @@
+const fn = 'add';
+
+module.exports = function (a, b) {
+  const add = require(`lodash/${fn}`);
+
+  return add(a, b);
+};

--- a/packages/core/integration-tests/test/integration/commonjs-template-literal-interpolation/package.json
+++ b/packages/core/integration-tests/test/integration/commonjs-template-literal-interpolation/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "commonjs-require",
+  "private": true,
+  "main": "dist/index.js",
+  "targets": {
+    "main": {
+      "context": "node"
+    }
+  },
+  "dependencies": {
+    "lodash": "*"
+  }
+}

--- a/packages/core/integration-tests/test/integration/commonjs-template-literal-plain/index.js
+++ b/packages/core/integration-tests/test/integration/commonjs-template-literal-plain/index.js
@@ -1,0 +1,5 @@
+const _ = require(`lodash`);
+
+module.exports = function (a, b) {
+  return _.add(a, b);
+};

--- a/packages/core/integration-tests/test/integration/commonjs-template-literal-plain/package.json
+++ b/packages/core/integration-tests/test/integration/commonjs-template-literal-plain/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "commonjs-require",
+  "private": true,
+  "main": "dist/index.js",
+  "targets": {
+    "main": {
+      "context": "node"
+    }
+  },
+  "dependencies": {
+    "lodash": "*"
+  }
+}

--- a/packages/core/integration-tests/test/integration/formats/commonjs/exports.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs/exports.js
@@ -1,4 +1,4 @@
-var b = require('./b');
+var b = require(`./b`);
 
 exports.bar = b.foo + 3;
 exports.foo = b.foo;

--- a/packages/core/integration-tests/test/integration/formats/commonjs/exports.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs/exports.js
@@ -1,4 +1,4 @@
-var b = require(`./b`);
+var b = require('./b');
 
 exports.bar = b.foo + 3;
 exports.foo = b.foo;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4422,6 +4422,45 @@ describe('javascript', function () {
     assert.equal(await run(b), 2);
   });
 
+  it('should detect requires in commonjs with plain template literals', async function () {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/commonjs-template-literal-plain/index.js',
+      ),
+    );
+    let dist = await outputFS.readFile(
+      b.getBundles().find(b => b.type === 'js').filePath,
+      'utf8',
+    );
+    assert(dist.includes('$cPUKg$lodash = require("lodash");'));
+
+    let add = await run(b);
+    assert.equal(add(2, 3), 5);
+  });
+
+  it(`should detect requires in commonjs with plain template literals`, async function () {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/commonjs-template-literal-interpolation/index.js',
+      ),
+    );
+    let dist = await outputFS.readFile(
+      b.getBundles().find(b => b.type === 'js').filePath,
+      'utf8',
+    );
+
+    assert(
+      dist.includes(
+        'const add = require(`lodash/${$8cad8166811e0063$var$fn}`);',
+      ),
+    );
+
+    let add = await run(b);
+    assert.equal(add(2, 3), 5);
+  });
+
   it('only updates bundle names of changed bundles for browsers', async () => {
     let fixtureDir = path.join(__dirname, '/integration/name-invalidation');
     let _bundle = () =>

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -109,6 +109,12 @@ pub fn match_require(
               if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
                 return Some(str_.value.clone());
               }
+
+              if let ast::Expr::Tpl(_tpl) = &*arg.expr {
+                if _tpl.quasis.len() == 1 && _tpl.exprs.is_empty() {
+                  return Some(_tpl.quasis[0].raw.clone().value);
+                }
+              }
             }
           }
 
@@ -119,6 +125,12 @@ pub fn match_require(
             if let Some(arg) = call.args.get(0) {
               if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
                 return Some(str_.value.clone());
+              }
+
+              if let ast::Expr::Tpl(_tpl) = &*arg.expr {
+                if _tpl.quasis.len() == 1 && _tpl.exprs.is_empty() {
+                  return Some(_tpl.quasis[0].raw.clone().value);
+                }
               }
             }
           }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Converts plain template literals into a string so dependency collector does find the dependency.

Fixes #7368
Fixes #5492

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
```
export const startLogger = () => {
  require("./test");
  if (process.env.GATSBY_LOGGER.includes(`json`)) {
    // TODO move to dynamic imports
    require(`./logger/test.js`).initializeJSONLogger();
  } else if (process.env.GATSBY_LOGGER.includes(`yurnalist`)) {
    // TODO move to dynamic imports
    require(`./logger/test.js`).initializeYurnalistLogger();
  } else {
    // TODO move to dynamic imports
    require(`./logger/test.js`).initializeINKLogger();
  }
}
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
