### PR TITLE
Refactor string matching into util

### DIFF
--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -217,10 +217,10 @@ impl<'a> DependencyCollector<'a> {
 
 fn rewrite_require_specifier(node: ast::CallExpr) -> ast::CallExpr {
   if let Some(arg) = node.args.get(0) {
-    if let ast::Expr::Lit(ast::Lit::Str(str_)) = &*arg.expr {
-      if str_.value.starts_with("node:") {
+    if let Some((value, _)) = match_str(&*arg.expr) {
+      if value.starts_with("node:") {
         // create_require will take care of replacing the node: prefix...
-        return create_require(str_.value.clone());
+        return create_require(value);
       }
     }
   }
@@ -539,19 +539,6 @@ impl<'a> Fold for DependencyCollector<'a> {
     }
 
     let node = if let Some(arg) = node.args.get(0) {
-      let mut arg = arg.clone();
-
-      // convert require(`./name`) to require("./name")
-      if let ast::Expr::Tpl(_tpl) = &*arg.expr {
-        if _tpl.quasis.len() == 1 && _tpl.exprs.is_empty() {
-          let tpl_str = &_tpl.quasis[0].raw;
-          arg.expr = Box::new(ast::Expr::Lit(ast::Lit::Str(ast::Str {
-            value: tpl_str.clone().value,
-            ..tpl_str.clone()
-          })));
-        }
-      }
-
       if kind == DependencyKind::ServiceWorker || kind == DependencyKind::Worklet {
         let (source_type, opts) = if kind == DependencyKind::ServiceWorker {
           match_worker_type(node.args.get(1))
@@ -572,7 +559,7 @@ impl<'a> Fold for DependencyCollector<'a> {
           } else {
             (
               "Registering worklets with a string literal is not supported.",
-              "http://localhost:8080/languages/javascript/#worklets",
+              "https://parceljs.org/languages/javascript/#worklets",
             )
           };
           self.diagnostics.push(Diagnostic {
@@ -607,7 +594,7 @@ impl<'a> Fold for DependencyCollector<'a> {
         return node;
       }
 
-      if let Lit(ast::Lit::Str(str_)) = &*arg.expr {
+      if let Some((specifier, span)) = match_str(&*arg.expr) {
         // require() calls aren't allowed in scripts, flag as an error.
         if kind == DependencyKind::Require && self.config.source_type == SourceType::Script {
           self.add_script_error(node.span);
@@ -615,8 +602,8 @@ impl<'a> Fold for DependencyCollector<'a> {
         }
 
         let placeholder = self.add_dependency(
-          str_.value.clone(),
-          str_.span,
+          specifier,
+          span,
           kind.clone(),
           attributes,
           kind == DependencyKind::Require && self.in_try,
@@ -627,7 +614,7 @@ impl<'a> Fold for DependencyCollector<'a> {
           let mut node = node.clone();
           node.args[0].expr = Box::new(ast::Expr::Lit(ast::Lit::Str(ast::Str {
             value: placeholder,
-            span: str_.span,
+            span,
             has_escape: false,
             kind: ast::StrKind::Synthesized,
           })));
@@ -1142,18 +1129,15 @@ impl<'a> DependencyCollector<'a> {
       }
 
       if let Some(args) = &new.args {
-        let specifier = if let Some(arg) = args.get(0) {
-          match &*arg.expr {
-            Expr::Lit(Lit::Str(s)) => s,
-            _ => return None,
-          }
+        let (specifier, span) = if let Some(arg) = args.get(0) {
+          match_str(&*arg.expr)?
         } else {
           return None;
         };
 
         if let Some(arg) = args.get(1) {
           if self.is_import_meta_url(&*arg.expr) {
-            return Some((specifier.value.clone(), specifier.span));
+            return Some((specifier, span));
           }
         }
       }
@@ -1183,10 +1167,16 @@ impl<'a> DependencyCollector<'a> {
           _ => return false,
         }
 
-        match &*member.prop {
-          Expr::Ident(id) => id.sym == js_word!("url") && !member.computed,
-          Expr::Lit(Lit::Str(str)) => str.value == js_word!("url"),
-          _ => false,
+        let name = if !member.computed {
+          match_str_or_ident(&*member.prop)
+        } else {
+          match_str(&*member.prop)
+        };
+
+        if let Some((name, _)) = name {
+          name == js_word!("url")
+        } else {
+          false
         }
       }
       Expr::Bin(BinExpr {
@@ -1196,9 +1186,10 @@ impl<'a> DependencyCollector<'a> {
         ..
       }) => {
         // Match "file:" + __filename
-        match (&**left, &**right) {
-          (Expr::Lit(Lit::Str(Str { value: left, .. })), Expr::Ident(Ident { sym: right, .. })) => {
-            left == "file:" && right == "__filename"
+        let left = match_str(&*left);
+        match (left, &**right) {
+          (Some((left, _)), Expr::Ident(Ident { sym: right, .. })) => {
+            &left == "file:" && right == "__filename"
           }
           _ => false,
         }
@@ -1374,12 +1365,13 @@ fn match_worker_type(expr: Option<&ast::ExprOrSpread>) -> (SourceType, Option<as
             _ => return true,
           };
 
-          let v = match &*kv.value {
-            Expr::Lit(Lit::Str(Str { value, .. })) => value,
-            _ => return true,
+          let v = if let Some((v, _)) = match_str(&*kv.value) {
+            v
+          } else {
+            return true;
           };
 
-          source_type = Some(match *v {
+          source_type = Some(match v {
             js_word!("module") => SourceType::Module,
             _ => SourceType::Script,
           });

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -90,6 +90,30 @@ fn is_marked(span: Span, mark: Mark) -> bool {
   }
 }
 
+pub fn match_str(node: &ast::Expr) -> Option<(JsWord, Span)> {
+  use ast::*;
+
+  match node {
+    // "string" or 'string'
+    Expr::Lit(Lit::Str(s)) => Some((s.value.clone(), s.span)),
+    // `string`
+    Expr::Tpl(tpl) if tpl.quasis.len() == 1 && tpl.exprs.is_empty() => {
+      Some((tpl.quasis[0].raw.value.clone(), tpl.span))
+    }
+    _ => None,
+  }
+}
+
+pub fn match_str_or_ident(node: &ast::Expr) -> Option<(JsWord, Span)> {
+  use ast::*;
+
+  if let Expr::Ident(id) = node {
+    return Some((id.sym.clone(), id.span));
+  }
+
+  match_str(node)
+}
+
 pub fn match_require(
   node: &ast::Expr,
   decls: &HashSet<(JsWord, SyntaxContext)>,
@@ -106,15 +130,7 @@ pub fn match_require(
             && !is_marked(ident.span, ignore_mark)
           {
             if let Some(arg) = call.args.get(0) {
-              if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
-                return Some(str_.value.clone());
-              }
-
-              if let ast::Expr::Tpl(_tpl) = &*arg.expr {
-                if _tpl.quasis.len() == 1 && _tpl.exprs.is_empty() {
-                  return Some(_tpl.quasis[0].raw.clone().value);
-                }
-              }
+              return match_str(&*arg.expr).map(|(name, _)| name);
             }
           }
 
@@ -123,15 +139,7 @@ pub fn match_require(
         Expr::Member(member) => {
           if match_member_expr(member, vec!["module", "require"], decls) {
             if let Some(arg) = call.args.get(0) {
-              if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
-                return Some(str_.value.clone());
-              }
-
-              if let ast::Expr::Tpl(_tpl) = &*arg.expr {
-                if _tpl.quasis.len() == 1 && _tpl.exprs.is_empty() {
-                  return Some(_tpl.quasis[0].raw.clone().value);
-                }
-              }
+              return match_str(&*arg.expr).map(|(name, _)| name);
             }
           }
 
@@ -154,9 +162,7 @@ pub fn match_import(node: &ast::Expr, ignore_mark: Mark) -> Option<JsWord> {
         Expr::Ident(ident) => {
           if ident.sym == js_word!("import") && !is_marked(ident.span, ignore_mark) {
             if let Some(arg) = call.args.get(0) {
-              if let Expr::Lit(Lit::Str(str_)) = &*arg.expr {
-                return Some(str_.value.clone());
-              }
+              return match_str(&*arg.expr).map(|(name, _)| name);
             }
           }
 


### PR DESCRIPTION
Adds two utils to centralize static string matching logic:

* `match_str` matches both string literals and static template literals
* `match_str_or_ident` matches a string, static template literal, or an identifier