### PR TITLE
feat(core): add AMD output format support

### DIFF
--- a/packages/core/core/src/TargetDescriptor.schema.js
+++ b/packages/core/core/src/TargetDescriptor.schema.js
@@ -61,7 +61,7 @@ export const PACKAGE_DESCRIPTOR_SCHEMA: SchemaObject = {
     },
     outputFormat: {
       type: 'string',
-      enum: ['global', 'esmodule', 'commonjs'],
+      enum: ['global', 'esmodule', 'commonjs', 'amd'],
     },
     distDir: {
       type: 'string',

--- a/packages/core/integration-tests/test/integration/formats/amd/cjs-require.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/cjs-require.js
@@ -1,0 +1,5 @@
+const rd = require('react-dom')
+const {upperCase} = require('lodash')
+
+export const UPPER_CASE = upperCase('foo')
+export const REACT_DOM = rd

--- a/packages/core/integration-tests/test/integration/formats/amd/conflicting-names.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/conflicting-names.js
@@ -1,0 +1,7 @@
+const {upperCase} = require('lodash')
+
+// name of this function is equal to package name - 'lodash'
+function lodash(s) {
+  return 'print-' + s
+}
+export const foo = lodash(upperCase('foo'))

--- a/packages/core/integration-tests/test/integration/formats/amd/exports.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/exports.js
@@ -1,0 +1,3 @@
+export const LuckySeven = 777
+
+export default 'foo'

--- a/packages/core/integration-tests/test/integration/formats/amd/import-external-module.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/import-external-module.js
@@ -1,0 +1,3 @@
+import 'react';
+
+export const foo = 123

--- a/packages/core/integration-tests/test/integration/formats/amd/import-star.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/import-star.js
@@ -1,0 +1,3 @@
+import * as lodashAll from 'lodash';
+
+export const UPPER_CASE = lodashAll.upperCase('hello world ')

--- a/packages/core/integration-tests/test/integration/formats/amd/imports-from-external-deps.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/imports-from-external-deps.js
@@ -1,0 +1,5 @@
+import {upperCase, kebabCase} from 'lodash';
+const s = 'hello world';
+
+export const UPPER_CASE = upperCase(s);
+export const KEBAB_CASE = kebabCase(s);

--- a/packages/core/integration-tests/test/integration/formats/amd/package.json
+++ b/packages/core/integration-tests/test/integration/formats/amd/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "amd",
+  "private": true,
+  "main": "dist/index.js",
+  "dependencies": {
+    "lodash": "^4.17.11",
+    "react": "^16.11.0",
+    "react-dom": "^16.11.0"
+  }
+}

--- a/packages/core/integration-tests/test/integration/formats/amd/with-dynamic-import.js
+++ b/packages/core/integration-tests/test/integration/formats/amd/with-dynamic-import.js
@@ -1,0 +1,5 @@
+export function getLazyLoadedExports() {
+  return import('./exports.js').then(module => {
+    return module
+  })
+}

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -18,6 +18,7 @@
     "@parcel/fs": "2.5.0",
     "@parcel/package-manager": "2.5.0",
     "@parcel/utils": "2.5.0",
+    "amdefine": "^1.0.1",
     "chalk": "^4.1.0",
     "ncp": "^2.0.0",
     "nullthrows": "^1.1.1",

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -116,7 +116,7 @@ export type EnvironmentContext =
   | 'electron-renderer';
 
 /** The JS module format for the bundle output */
-export type OutputFormat = 'esmodule' | 'commonjs' | 'global';
+export type OutputFormat = 'esmodule' | 'commonjs' | 'amd' | 'global';
 
 /**
  * The format of <code>pkg#targets.*</code>

--- a/packages/packagers/js/src/AMDOutputFormat.js
+++ b/packages/packagers/js/src/AMDOutputFormat.js
@@ -1,0 +1,94 @@
+// @flow
+import type {
+  ScopeHoistingPackager,
+  OutputFormat,
+} from './ScopeHoistingPackager';
+
+export class AMDOutputFormat implements OutputFormat {
+  packager: ScopeHoistingPackager;
+
+  constructor(packager: ScopeHoistingPackager) {
+    this.packager = packager;
+  }
+
+  getMainEntryAssetId(): ?string {
+    const mainEntryAsset = this.packager.bundle.getMainEntry();
+
+    // Sometimes there is no main asset, e.g. in the case of shared bundles.
+    // In that case we don't need AMD wrapper as parcelRequire will be used for
+    // loading shared bundle.
+    if (!mainEntryAsset) {
+      return;
+    }
+
+    const assetId = mainEntryAsset.id;
+    // We don't need AMD wrapper for assets wrapped in parcelRequire.
+    // For example, dynamically loaded chunk does not need to be an AMD.
+    if (this.packager.wrappedAssets.has(assetId)) {
+      return;
+    }
+    return assetId;
+  }
+
+  buildBundlePrelude(): [string, number] {
+    const assetId = this.getMainEntryAssetId();
+    if (!assetId) {
+      return ['', 0];
+    }
+
+    const envSupportsArrowFunctions = this.packager.bundle.env.supports(
+      'arrow-functions',
+      true,
+    );
+    let prelude = '';
+    let preludeLines = 0;
+
+    let depArgs = [`$${assetId}$exports`];
+    for (const [, specifiers] of this.packager.externals) {
+      let arg = specifiers.get('*');
+      if (!arg) {
+        arg = `$${assetId}$arg${depArgs.length}`;
+      }
+
+      if (envSupportsArrowFunctions) {
+        let destructuredItems = [];
+        for (const [originalName, mangledName] of specifiers) {
+          if (originalName !== '*') {
+            destructuredItems.push(`${originalName}: ${mangledName}`);
+          }
+        }
+        if (destructuredItems.length > 0) {
+          prelude += `const {${destructuredItems.join(', ')}} = ${arg};\n`;
+          preludeLines++;
+        }
+      } else {
+        for (const [originalName, mangledName] of specifiers) {
+          if (originalName !== '*') {
+            prelude += `var ${mangledName} = ${arg}['${originalName}'];\n`;
+            preludeLines++;
+          }
+        }
+      }
+
+      depArgs.push(arg);
+    }
+    depArgs = depArgs.join(', ');
+
+    let deps = JSON.stringify(['exports', ...this.packager.externals.keys()]);
+    prelude =
+      (envSupportsArrowFunctions
+        ? `define(${deps}, (${depArgs}) => {\n`
+        : `define(${deps}, function (${depArgs}) {\n`) + prelude;
+    preludeLines++;
+
+    return [prelude, preludeLines];
+  }
+
+  buildBundlePostlude(): [string, number] {
+    const assetId = this.getMainEntryAssetId();
+    if (!assetId) {
+      return ['', 0];
+    }
+    return ['});', 0];
+  }
+}

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -21,6 +21,7 @@ import ThrowableDiagnostic from '@parcel/diagnostic';
 import globals from 'globals';
 import path from 'path';
 
+import {AMDOutputFormat} from './AMDOutputFormat';
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
 import {GlobalOutputFormat} from './GlobalOutputFormat';
@@ -58,6 +59,7 @@ const GLOBALS_BY_CONTEXT = {
 const OUTPUT_FORMATS = {
   esmodule: ESMOutputFormat,
   commonjs: CJSOutputFormat,
+  amd: AMDOutputFormat,
   global: GlobalOutputFormat,
 };
 
@@ -953,7 +955,7 @@ ${code}
       // the `module.exports` object provided by CJS.
       if (
         !shouldWrap &&
-        (this.bundle.env.outputFormat !== 'commonjs' ||
+        (!['commonjs', 'amd'].includes(this.bundle.env.outputFormat) ||
           asset !== this.bundle.getMainEntry())
       ) {
         prepend += `var $${assetId}$exports = {};\n`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,7 +2758,7 @@ alphanum-sort@^1.0.2:
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
-amdefine@>=0.0.4:
+amdefine@>=0.0.4, amdefine@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This PR adds a new `outputFormat` - `amd`, which. will create bundle in [AMD format](https://requirejs.org/docs/whyamd.html#amd).

This is related to https://github.com/parcel-bundler/parcel/issues/7312, and most probably code in this MR will be slightly refactored later to reuse as much as it is possible for UMD support.  

But in any case this is a separate feature, and deserves a separate MR.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

Essentially, I want this to work:
```
{
  "source": "src/index.js",
  "main": "dist/index.js",
  "targets": {
    "main": {
      "context": "browser",
      "outputFormat": "amd",
      "includeNodeModules": {
        "lodash": false,
        "react": false,
        "react-dom": false
      }
    }
  }
}
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
