### PR TITLE
Only error for empty HTML dependency attributes

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -2718,7 +2718,7 @@ describe('html', function () {
         name: 'BuildError',
         diagnostics: [
           {
-            message: 'src should not be empty string',
+            message: "'src' should not be empty string",
             origin: '@parcel/transformer-html',
             codeFrames: [
               {
@@ -2744,7 +2744,7 @@ describe('html', function () {
           },
 
           {
-            message: 'src should not be empty string',
+            message: "'src' should not be empty string",
             origin: '@parcel/transformer-html',
             codeFrames: [
               {
@@ -2770,7 +2770,7 @@ describe('html', function () {
           },
 
           {
-            message: 'href should not be empty string',
+            message: "'href' should not be empty string",
             origin: '@parcel/transformer-html',
             codeFrames: [
               {

--- a/packages/core/integration-tests/test/integration/html-empty-reference/index.html
+++ b/packages/core/integration-tests/test/integration/html-empty-reference/index.html
@@ -1,3 +1,4 @@
 <img src="" />
 <script src=""></script>
 <link href="" />
+<input value="" checked data-x />

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -254,17 +254,17 @@ export default function collectDependencies(
         continue;
       }
 
-      // Check for empty string
-      if (attrs[attr].length === 0) {
-        errors.push({
-          message: `${attr} should not be empty string`,
-          filePath: asset.filePath,
-          loc: node.location,
-        });
-      }
-
       let elements = ATTRS[attr];
       if (elements && elements.includes(node.tag)) {
+        // Check for empty string
+        if (attrs[attr].length === 0) {
+          errors.push({
+            message: `'${attr}' should not be empty string`,
+            filePath: asset.filePath,
+            loc: node.location,
+          });
+        }
+
         let depHandler = getAttrDepHandler(attr);
         let depOptionsHandler = OPTIONS[node.tag];
         let depOptions =

--- a/packages/transformers/svg/src/dependencies.js
+++ b/packages/transformers/svg/src/dependencies.js
@@ -107,17 +107,17 @@ export default function collectDependencies(asset: MutableAsset, ast: AST) {
         continue;
       }
 
-      // Check for empty string
-      if (attrs[attr].length === 0) {
-        errors.push({
-          message: `${attr} should not be empty string`,
-          filePath: asset.filePath,
-          loc: node.location,
-        });
-      }
-
       const elements = ATTRS[attr];
       if (elements && elements.includes(node.tag)) {
+        // Check for empty string
+        if (attrs[attr].length === 0) {
+          errors.push({
+            message: `'${attr}' should not be empty string`,
+            filePath: asset.filePath,
+            loc: node.location,
+          });
+        }
+
         let options = OPTIONS[tag]?.[attr];
         if (node.tag === 'script') {
           options = {


### PR DESCRIPTION
- Only throw the "should not be empty string" error for attributes used in dependencies. Previously, all of these three attributes were "invalid":
```html
<input value="" checked data-x />
```
- Also, I've added quotes around the attributes name in the error message:
<img width="525" alt="Bildschirmfoto 2021-11-29 um 21 24 29" src="https://user-images.githubusercontent.com/4586894/143937681-5997b95b-78b7-4e05-9273-502baebd6e45.png">


Reported by @folknor in https://github.com/parcel-bundler/parcel/pull/7318#issuecomment-981971184