### PR TITLE
Bump lmdb and swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
 
 [[package]]
 name = "libdeflate-sys"
@@ -756,9 +756,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46af3cd13ef452354c8704da88bfc4bfa38724ddb38963a5113099749710788"
+checksum = "d9584cc599cffd833a65527fb655bb65180f6ec8f26fba3081d2d989faa03bef"
 
 [[package]]
 name = "napi-derive"
@@ -839,9 +839,9 @@ checksum = "67cf20e0081fea04e044aa4adf74cfea8ddc0324eec2894b1c700f4cafc72a56"
 
 [[package]]
 name = "nasm-rs"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbff86bd2ee8cb407e8608e2c3504412a967c06286ef7e5cf7c1b9db756f0a9"
+checksum = "a06380d23b58dcdaf892fa36c3950cad3110e7d76851275d5f85c22eb9cdd614"
 dependencies = [
  "rayon",
 ]
@@ -1196,9 +1196,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
@@ -1316,9 +1316,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "retain_mut"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
+checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
 
 [[package]]
 name = "rgb"
@@ -1605,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.14.7"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "188984898a61b3d0d7aa7c2451ae23d6bda16cb1a94d19dd8d1b7d906c5754bc"
+checksum = "560998b621793a613c98ec8cdbd729e46332dd3fbf7619b57e9d98c15e142e2e"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1633,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.58.1"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8678255e15265b4cf564c44035b9901c5bef22c19c2c3f4babccfb8de5ccfbe"
+checksum = "a31826c0275a1062d1e16d5b428c5059d176274c4e6c1c499525ddd2c65fcacc"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.80.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c00f3932d286865ae2784cd4da1926d7668032b156360831103fc2a24c5ff18"
+checksum = "08ed18a9bf4bca94b2029ed267373b01f4e207f5f617ab403b3bca96a44f5547"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.24.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda70aee2118769474918d260e947fe08bfd56a5fc3d17c1a5aebeeb8d0c226e"
+checksum = "b0c9672f7cf71bf2a98fc0c66eed90d43db9252c82e52096c7159ea5521f3478"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1698,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.78.11"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe082abd0148a66e6b5c9c97c36a770bac1912bf500c3bc982ac7101c17218d"
+checksum = "97570156b3eec2e91b43f3adf9526caaf5cdf656c65a7722715b3537c2952261"
 dependencies = [
  "either",
  "enum_kind",
@@ -1719,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.67.5"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509d20f1fd97da6c0feca04b198d9a66c492ac8ae384118e30ceb128318d5984"
+checksum = "cc3cec2c243a4bcd9ff686b96fe59d342e632c5986cfc2a5cf548908903e574a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1745,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.95.2"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c954d14b46f24ea894f37cacad4bdf1a9f37a316aaefe62e3a5033689e71de"
+checksum = "15931263dab79ddee709e981b5222d84a684cfaa66d2913394bee6d5b4635cca"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.44.3"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e0f787be734204a739fb774d0c00b15dcf0f8a3040f993ac18f6b8e47cc50e"
+checksum = "0bfa5fa18d0f7b7f2cf3522049e22ca8c5a77072a30f597c38de1c5f10a69501"
 dependencies = [
  "once_cell",
  "phf",
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.30.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d4aa36016acc3da3f42036f5c6fdab84b0e6200a49b84280dd852bbae256a3"
+checksum = "7305d99e9851ae762e8bca1f7d43a0a1dd6c55b78220b10425b06a5f54c4498f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1800,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.52.19"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8857bd04b2b6fba11168c1a4c66b48c1d9e7867a7bf1c649fe7131d2c2cfb2"
+checksum = "2fbfdcbc9c834c61f84106f0258d875c29622a6df50a080577499b64ea92e707"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1820,6 +1820,7 @@ dependencies = [
  "swc_ecma_transforms_macros",
  "swc_ecma_utils",
  "swc_ecma_visit",
+ "tracing",
 ]
 
 [[package]]
@@ -1837,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.58.3"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866abb059c40d454d8010de499d9f8e12994a7213779596d1c9a9a611dac9dfa"
+checksum = "721c7aa29ce8a905a1aef0c29546a158fb1859b733329ead7c5b40d86a9e25cb"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1859,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.65.1"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd8f861cef30f9b3bd262828249cd32df4bbe5000d250fe63de2888d79ff08f"
+checksum = "7d528d813fd0af0c8727b0143b0c60759ff6a1cefb7223ee955da85c90edaaa6"
 dependencies = [
  "ahash",
  "dashmap",
@@ -1882,9 +1883,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.58.1"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954e89a6b90b36719530624b9607fe62f783e04b7f368d526ac0038e9d646faa"
+checksum = "1185431bc8fb9d5460f662effbe4eaa10f1038f4e7fc7cfb2edfef4a7cc1104e"
 dependencies = [
  "either",
  "serde",
@@ -1902,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.60.1"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380dc7c6617b4866f295baf4c41a0e64f5c265a734ac457008723fca18235765"
+checksum = "c0f9a87fba33abfae51b6442c521af5bc607fe81aca98efb131102eff2b3df38"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -1927,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.61.2"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92de92acef99e2e3cbd38eb0d864d46dbae66d45eb04cb64792d2aec5e8cf622"
+checksum = "104774e78a1c8e3f1a82c82e34f8664ba2975eaa4c61b4355499b4f270aac06f"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -1944,36 +1945,38 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.52.4"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a574cee3c938142eb2ba55ddc8de9416c03400f8c7e90a7ac9c1b1b8bae1d211"
+checksum = "f0adfd7c7ebc9133e5d98dbe307c8ef41d43ae9ba9e5f3f690880b057ab0adc3"
 dependencies = [
  "once_cell",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_visit",
+ "tracing",
  "unicode-xid",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.44.1"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635ac1f529c75c948a3a55d1bc2cef1861004811b733560cf3f62d0183dbdbb8"
+checksum = "f0b3826abd1e68214fe9743437236608a0a22d27912e84a85a53f1e977e10468"
 dependencies = [
  "num-bigint",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_visit",
+ "tracing",
 ]
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.88.3"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd485710cd6f3e1b7ff55f3249f613cee3e527bb169529b73fc62717b1e91f9f"
+checksum = "703291bc32dd81c1d73761e02442bdefed5844490f853f9979b8b8cb21e7392b"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2009,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8511a4788ab29daf00bee23e425aac92c9be4eec74c98fec4a45d0e710be695"
+checksum = "e5c639379dd2a8a0221fa1e12fafbdd594ba53a0cace6560054da52409dfcc1a"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -2019,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b2825fee79f10d0166e8e650e79c7a862fb991db275743083f07555d7641f0"
+checksum = "e505bbf8e11898fa05a65aa5e773c827ec743fc15aa3c064c9e06164ed0b6630"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@parcel/logger": "^2.0.1",
     "@parcel/utils": "^2.0.1",
-    "lmdb": "^2.0.1"
+    "lmdb": "^2.0.2"
   },
   "peerDependencies": {
     "@parcel/core": "^2.0.0"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.88.3", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils"] }
-swc_ecma_preset_env = "0.67.5"
-swc_common = { version = "0.14.7", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.95.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils"] }
+swc_ecma_preset_env = "0.73.0"
+swc_common = { version = "0.15.0", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.9"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/src/decl_collector.rs
+++ b/packages/transformers/js/core/src/decl_collector.rs
@@ -1,9 +1,9 @@
 use std::collections::HashSet;
 
 use swc_atoms::JsWord;
-use swc_common::{SyntaxContext, DUMMY_SP};
+use swc_common::SyntaxContext;
 use swc_ecmascript::ast;
-use swc_ecmascript::visit::{Node, Visit, VisitWith};
+use swc_ecmascript::visit::{Visit, VisitWith};
 
 /// This pass collects all declarations in a module into a single HashSet of tuples
 /// containing identifier names and their associated syntax context (scope).
@@ -13,7 +13,7 @@ pub fn collect_decls(module: &ast::Module) -> HashSet<(JsWord, SyntaxContext)> {
     decls: HashSet::new(),
     in_var: false,
   };
-  module.visit_with(&ast::Invalid { span: DUMMY_SP } as _, &mut c);
+  module.visit_with(&mut c);
   c.decls
 }
 
@@ -23,7 +23,7 @@ struct DeclCollector {
 }
 
 impl Visit for DeclCollector {
-  fn visit_decl(&mut self, node: &ast::Decl, _parent: &dyn Node) {
+  fn visit_decl(&mut self, node: &ast::Decl) {
     use ast::Decl::*;
 
     match node {
@@ -43,22 +43,22 @@ impl Visit for DeclCollector {
     node.visit_children_with(self);
   }
 
-  fn visit_var_declarator(&mut self, node: &ast::VarDeclarator, _parent: &dyn Node) {
+  fn visit_var_declarator(&mut self, node: &ast::VarDeclarator) {
     self.in_var = true;
-    node.name.visit_with(node, self);
+    node.name.visit_with(self);
     self.in_var = false;
     if let Some(init) = &node.init {
-      init.visit_with(node, self);
+      init.visit_with(self);
     }
   }
 
-  fn visit_binding_ident(&mut self, node: &ast::BindingIdent, _parent: &dyn Node) {
+  fn visit_binding_ident(&mut self, node: &ast::BindingIdent) {
     if self.in_var {
       self.decls.insert((node.id.sym.clone(), node.id.span.ctxt));
     }
   }
 
-  fn visit_assign_pat_prop(&mut self, node: &ast::AssignPatProp, _parent: &dyn Node) {
+  fn visit_assign_pat_prop(&mut self, node: &ast::AssignPatProp) {
     if self.in_var {
       self
         .decls
@@ -66,29 +66,29 @@ impl Visit for DeclCollector {
     }
   }
 
-  fn visit_function(&mut self, node: &ast::Function, _parent: &dyn Node) {
+  fn visit_function(&mut self, node: &ast::Function) {
     self.in_var = true;
     for param in &node.params {
-      param.visit_with(node, self);
+      param.visit_with(self);
     }
     self.in_var = false;
 
-    node.body.visit_with(node, self);
+    node.body.visit_with(self);
   }
 
-  fn visit_arrow_expr(&mut self, node: &ast::ArrowExpr, _parent: &dyn Node) {
+  fn visit_arrow_expr(&mut self, node: &ast::ArrowExpr) {
     self.in_var = true;
     for param in &node.params {
-      param.visit_with(node, self);
+      param.visit_with(self);
     }
     self.in_var = false;
 
-    node.body.visit_with(node, self);
+    node.body.visit_with(self);
   }
 
-  fn visit_import_specifier(&mut self, node: &ast::ImportSpecifier, _parent: &dyn Node) {
+  fn visit_import_specifier(&mut self, node: &ast::ImportSpecifier) {
     use ast::ImportSpecifier::*;
-    swc_ecmascript::visit::visit_import_specifier(self, node, _parent);
+    swc_ecmascript::visit::visit_import_specifier(self, node);
 
     match node {
       Default(default) => {

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -49,7 +49,7 @@ struct InlineFS<'a> {
 
 impl<'a> Fold for InlineFS<'a> {
   fn fold_module(&mut self, node: Module) -> Module {
-    node.visit_with(&Invalid { span: DUMMY_SP } as _, &mut self.collect);
+    node.visit_with(&mut self.collect);
     node.fold_children_with(self)
   }
 

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -5,7 +5,7 @@ use std::hash::Hasher;
 use swc_atoms::JsWord;
 use swc_common::{sync::Lrc, Mark, Span, SyntaxContext, DUMMY_SP};
 use swc_ecmascript::ast::*;
-use swc_ecmascript::visit::{Fold, FoldWith, Node, Visit, VisitWith};
+use swc_ecmascript::visit::{Fold, FoldWith, Visit, VisitWith};
 
 use crate::id;
 use crate::utils::{
@@ -1099,7 +1099,7 @@ impl<'a> Hoist<'a> {
 
 macro_rules! collect_visit_fn {
   ($name:ident, $type:ident) => {
-    fn $name(&mut self, node: &$type, _parent: &dyn Node) {
+    fn $name(&mut self, node: &$type) {
       let in_module_this = self.in_module_this;
       let in_function = self.in_function;
       self.in_module_this = false;
@@ -1279,7 +1279,7 @@ impl From<Collect> for CollectResult {
 }
 
 impl Visit for Collect {
-  fn visit_module(&mut self, node: &Module, _parent: &dyn Node) {
+  fn visit_module(&mut self, node: &Module) {
     self.in_module_this = true;
     self.in_top_level = true;
     self.in_function = false;
@@ -1307,14 +1307,14 @@ impl Visit for Collect {
   collect_visit_fn!(visit_getter_prop, GetterProp);
   collect_visit_fn!(visit_setter_prop, SetterProp);
 
-  fn visit_arrow_expr(&mut self, node: &ArrowExpr, _parent: &dyn Node) {
+  fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
     let in_function = self.in_function;
     self.in_function = true;
     node.visit_children_with(self);
     self.in_function = in_function;
   }
 
-  fn visit_module_item(&mut self, node: &ModuleItem, _parent: &dyn Node) {
+  fn visit_module_item(&mut self, node: &ModuleItem) {
     match node {
       ModuleItem::ModuleDecl(_decl) => {
         self.is_esm = true;
@@ -1345,7 +1345,7 @@ impl Visit for Collect {
     self.in_top_level = true;
   }
 
-  fn visit_import_decl(&mut self, node: &ImportDecl, _parent: &dyn Node) {
+  fn visit_import_decl(&mut self, node: &ImportDecl) {
     for specifier in &node.specifiers {
       match specifier {
         ImportSpecifier::Named(named) => {
@@ -1389,7 +1389,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_named_export(&mut self, node: &NamedExport, _parent: &dyn Node) {
+  fn visit_named_export(&mut self, node: &NamedExport) {
     for specifier in &node.specifiers {
       let source = node.src.as_ref().map(|s| s.value.clone());
       match specifier {
@@ -1441,7 +1441,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_export_decl(&mut self, node: &ExportDecl, _parent: &dyn Node) {
+  fn visit_export_decl(&mut self, node: &ExportDecl) {
     match &node.decl {
       Decl::Class(class) => {
         self.exports.insert(
@@ -1474,10 +1474,10 @@ impl Visit for Collect {
       Decl::Var(var) => {
         for decl in &var.decls {
           self.in_export_decl = true;
-          decl.name.visit_with(decl, self);
+          decl.name.visit_with(self);
           self.in_export_decl = false;
 
-          decl.init.visit_with(decl, self);
+          decl.init.visit_with(self);
         }
       }
       _ => {}
@@ -1486,7 +1486,7 @@ impl Visit for Collect {
     node.visit_children_with(self);
   }
 
-  fn visit_export_default_decl(&mut self, node: &ExportDefaultDecl, _parent: &dyn Node) {
+  fn visit_export_default_decl(&mut self, node: &ExportDefaultDecl) {
     match &node.decl {
       DefaultDecl::Class(class) => {
         if let Some(ident) = &class.ident {
@@ -1528,14 +1528,14 @@ impl Visit for Collect {
     node.visit_children_with(self);
   }
 
-  fn visit_export_all(&mut self, node: &ExportAll, _parent: &dyn Node) {
+  fn visit_export_all(&mut self, node: &ExportAll) {
     self.exports_all.insert(
       node.src.value.clone(),
       SourceLocation::from(&self.source_map, node.span),
     );
   }
 
-  fn visit_return_stmt(&mut self, node: &ReturnStmt, _parent: &dyn Node) {
+  fn visit_return_stmt(&mut self, node: &ReturnStmt) {
     if !self.in_function {
       self.should_wrap = true;
       self.add_bailout(node.span, BailoutReason::TopLevelReturn);
@@ -1544,7 +1544,7 @@ impl Visit for Collect {
     node.visit_children_with(self)
   }
 
-  fn visit_binding_ident(&mut self, node: &BindingIdent, _parent: &dyn Node) {
+  fn visit_binding_ident(&mut self, node: &BindingIdent) {
     if self.in_export_decl {
       self.exports.insert(
         node.id.sym.clone(),
@@ -1569,7 +1569,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_assign_pat_prop(&mut self, node: &AssignPatProp, _parent: &dyn Node) {
+  fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
     if self.in_export_decl {
       self.exports.insert(
         node.key.sym.clone(),
@@ -1594,7 +1594,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_member_expr(&mut self, node: &MemberExpr, _parent: &dyn Node) {
+  fn visit_member_expr(&mut self, node: &MemberExpr) {
     // if module.exports, ensure only assignment or static member expression
     // if exports, ensure only static member expression
     // if require, could be static access (handle in fold)
@@ -1675,7 +1675,7 @@ impl Visit for Collect {
     node.visit_children_with(self);
   }
 
-  fn visit_unary_expr(&mut self, node: &UnaryExpr, _parent: &dyn Node) {
+  fn visit_unary_expr(&mut self, node: &UnaryExpr) {
     if node.op == UnaryOp::TypeOf {
       match &*node.arg {
         Expr::Ident(ident)
@@ -1690,7 +1690,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_expr(&mut self, node: &Expr, _parent: &dyn Node) {
+  fn visit_expr(&mut self, node: &Expr) {
     // If we reached this visitor, this is a non-top-level require that isn't in a variable
     // declaration. We need to wrap the referenced module to preserve side effect ordering.
     if let Some(source) = self.match_require(node) {
@@ -1744,7 +1744,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_this_expr(&mut self, node: &ThisExpr, _parent: &dyn Node) {
+  fn visit_this_expr(&mut self, node: &ThisExpr) {
     if self.in_module_this {
       self.has_cjs_exports = true;
       self.static_cjs_exports = false;
@@ -1752,16 +1752,16 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_assign_expr(&mut self, node: &AssignExpr, _parent: &dyn Node) {
+  fn visit_assign_expr(&mut self, node: &AssignExpr) {
     // if rhs is a require, record static accesses
     // if lhs is `exports`, mark as CJS exports re-assigned
     // if lhs is `module.exports`
     // if lhs is `module.exports.XXX` or `exports.XXX`, record static export
 
     self.in_assign = true;
-    node.left.visit_with(node, self);
+    node.left.visit_with(self);
     self.in_assign = false;
-    node.right.visit_with(node, self);
+    node.right.visit_with(self);
 
     if let PatOrExpr::Pat(pat) = &node.left {
       if has_binding_identifier(pat, &"exports".into(), &self.decls) {
@@ -1789,7 +1789,7 @@ impl Visit for Collect {
     }
   }
 
-  fn visit_var_declarator(&mut self, node: &VarDeclarator, _parent: &dyn Node) {
+  fn visit_var_declarator(&mut self, node: &VarDeclarator) {
     // if init is a require call, record static accesses
     if let Some(init) = &node.init {
       if let Some(source) = self.match_require(init) {
@@ -1858,7 +1858,7 @@ impl Visit for Collect {
     self.in_top_level = in_top_level;
   }
 
-  fn visit_call_expr(&mut self, node: &CallExpr, _parent: &dyn Node) {
+  fn visit_call_expr(&mut self, node: &CallExpr) {
     if let ExprOrSuper::Expr(expr) = &node.callee {
       match &**expr {
         Expr::Ident(ident) => {
@@ -1894,7 +1894,7 @@ impl Visit for Collect {
                     self.add_bailout(node.span, BailoutReason::NonStaticDynamicImport);
                   }
 
-                  expr.visit_with(node, self);
+                  expr.visit_with(self);
                   return;
                 }
               }
@@ -2125,10 +2125,10 @@ mod tests {
   use crate::collect_decls;
   use std::iter::FromIterator;
   use swc_common::comments::SingleThreadedComments;
-  use swc_common::{sync::Lrc, FileName, Globals, Mark, SourceMap, DUMMY_SP};
+  use swc_common::{sync::Lrc, FileName, Globals, Mark, SourceMap};
   use swc_ecmascript::codegen::text_writer::JsWriter;
   use swc_ecmascript::parser::lexer::Lexer;
-  use swc_ecmascript::parser::{EsConfig, Parser, StringInput, Syntax};
+  use swc_ecmascript::parser::{Parser, StringInput};
   use swc_ecmascript::transforms::resolver_with_mark;
   extern crate indoc;
   use self::indoc::indoc;
@@ -2139,10 +2139,7 @@ mod tests {
 
     let comments = SingleThreadedComments::default();
     let lexer = Lexer::new(
-      Syntax::Es(EsConfig {
-        dynamic_import: true,
-        ..Default::default()
-      }),
+      Default::default(),
       Default::default(),
       StringInput::from(&*source_file),
       Some(&comments),
@@ -2164,7 +2161,7 @@ mod tests {
               global_mark,
               false,
             );
-            module.visit_with(&Invalid { span: DUMMY_SP } as _, &mut collect);
+            module.visit_with(&mut collect);
 
             let (module, res) = {
               let mut hoist = Hoist::new("abc", &collect);

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -29,10 +29,9 @@ use path_slash::PathExt;
 use serde::{Deserialize, Serialize};
 use swc_common::comments::SingleThreadedComments;
 use swc_common::errors::{DiagnosticBuilder, Emitter, Handler};
-use swc_common::DUMMY_SP;
 use swc_common::{chain, sync::Lrc, FileName, Globals, Mark, SourceMap};
 use swc_ecma_preset_env::{preset_env, Mode::Entry, Targets, Version, Versions};
-use swc_ecmascript::ast::{Invalid, Module};
+use swc_ecmascript::ast::Module;
 use swc_ecmascript::codegen::text_writer::JsWriter;
 use swc_ecmascript::parser::lexer::Lexer;
 use swc_ecmascript::parser::{EsConfig, PResult, Parser, StringInput, Syntax, TsConfig};
@@ -281,7 +280,10 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                   ),
                   config.is_type_script && config.is_jsx
                 ),
-                Optional::new(typescript::strip(), config.is_type_script && !config.is_jsx),
+                Optional::new(
+                  typescript::strip(global_mark),
+                  config.is_type_script && !config.is_jsx
+                ),
                 resolver_with_mark(global_mark),
                 Optional::new(
                   react::react(
@@ -403,7 +405,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
               global_mark,
               config.trace_bailouts,
             );
-            module.visit_with(&Invalid { span: DUMMY_SP } as _, &mut collect);
+            module.visit_with(&mut collect);
             if let Some(bailouts) = &collect.bailouts {
               diagnostics.extend(bailouts.iter().map(|bailout| bailout.to_diagnostic()));
             }
@@ -480,17 +482,13 @@ fn parse(
   let syntax = if config.is_type_script {
     Syntax::Typescript(TsConfig {
       tsx: config.is_jsx,
-      dynamic_import: true,
       decorators: config.decorators,
       ..Default::default()
     })
   } else {
     Syntax::Es(EsConfig {
       jsx: config.is_jsx,
-      dynamic_import: true,
       export_default_from: true,
-      export_namespace_from: true,
-      import_meta: true,
       decorators: config.decorators,
       ..Default::default()
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8300,10 +8300,10 @@ listr2@^2.1.0:
     rxjs "^6.5.5"
     through "^2.3.8"
 
-lmdb@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.0.1.tgz#db6096a61ee1ab3cc72e6dd925d062eef9efe79d"
-  integrity sha512-U1XEpQw04HiqxLok5g/aEyfObwo2v79QWvwYrl32fCrzvk3VPN/BpWPN4Hmfna7YJ3IoyFskc/StQaB1uRdWlw==
+lmdb@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.0.2.tgz#bdd78a686a4423cf2aaea38fb2acebbd1aca9f02"
+  integrity sha512-B0f4UePBHHsqVRrYJgNnlzDuhjjaCvyqugV3ZY7YO+9kLcoK/Fqm5yi4icTVIr+ijeVleN69puyx/2KSKVvtQw==
   dependencies:
     msgpackr "^1.5.0"
     nan "^2.14.2"


### PR DESCRIPTION
Bump lmdb range to ensure that https://github.com/DoctorEvidence/lmdb-js/issues/102 is fixed

swc:
- Closes https://github.com/parcel-bundler/parcel/issues/7284
- Closes https://github.com/parcel-bundler/parcel/issues/7270
- visit doesn't pass/need the parent node anymore
- dynamic_import, import.meta and export_namespace_from are now enabled by default