### PR TITLE
Correctly pad numbers in parcel-hash browser polyfill

### DIFF
--- a/packages/utils/hash/browser.js
+++ b/packages/utils/hash/browser.js
@@ -8,7 +8,7 @@ module.exports.init = (xxhash().then(xxh => {
 
 const encoder = new TextEncoder();
 function hashString(s /*: string */) /*: string */ {
-  return h64(s);
+  return h64(s).padStart(16, '0');
 }
 module.exports.hashString = hashString;
 function hashBuffer(b /*: Uint8Array */) /*: string */ {
@@ -49,7 +49,7 @@ function concatUint8Arrays(arrays) {
 function toHex(arr) {
   let dataView = new DataView(arr.buffer);
   return (
-    dataView.getUint32(0, true).toString(16) +
-    dataView.getUint32(4, true).toString(16)
+    dataView.getUint32(0, true).toString(16).padStart(8, '0') +
+    dataView.getUint32(4, true).toString(16).padStart(8, '0')
   );
 }


### PR DESCRIPTION
To behave like

https://github.com/parcel-bundler/parcel/blob/20afa0c02da6296e0551ca643cba5f70f0d74572/packages/utils/hash/src/lib.rs#L15