### PR TITLE
Fix createImportSpecifier with typescript 4.5+

### DIFF
--- a/packages/transformers/typescript-types/src/shake.js
+++ b/packages/transformers/typescript-types/src/shake.js
@@ -4,7 +4,7 @@ import type {TSModuleGraph} from './TSModuleGraph';
 
 import ts from 'typescript';
 import nullthrows from 'nullthrows';
-import {getExportedName, isDeclaration} from './utils';
+import {getExportedName, isDeclaration, createImportSpecifier} from './utils';
 
 export function shake(
   moduleGraph: TSModuleGraph,
@@ -238,7 +238,8 @@ function generateImports(moduleGraph: TSModuleGraph) {
         );
       } else {
         namedSpecifiers.push(
-          ts.createImportSpecifier(
+          createImportSpecifier(
+            ts,
             name === imported ? undefined : ts.createIdentifier(imported),
             ts.createIdentifier(name),
           ),

--- a/packages/transformers/typescript-types/src/utils.js
+++ b/packages/transformers/typescript-types/src/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
+import type {Identifier, ImportSpecifier} from 'typescript';
 
 export function getExportedName(ts: TypeScriptModule, node: any): ?string {
   if (!node.modifiers) {
@@ -25,4 +26,23 @@ export function isDeclaration(ts: TypeScriptModule, node: any): boolean {
     ts.isEnumDeclaration(node) ||
     ts.isTypeAliasDeclaration(node)
   );
+}
+
+export function createImportSpecifier(
+  ts: TypeScriptModule,
+  propertyName: Identifier | void,
+  name: Identifier,
+  isTypeOnly: boolean = false,
+): ImportSpecifier {
+  const [majorVersion, minorVersion] = ts.versionMajorMinor
+    .split('.')
+    .map(num => parseInt(num, 10));
+  // The signature of createImportSpecifier had a breaking change in Typescript 4.5.
+  // see: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names
+  if (majorVersion > 4 || (majorVersion === 4 && minorVersion >= 5)) {
+    // $FlowFixMe
+    return ts.createImportSpecifier(isTypeOnly, propertyName, name);
+  } else {
+    return ts.createImportSpecifier(propertyName, name);
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13024,9 +13024,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@>=3.0.0:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
 
 uglify-js@^3.1.4:
   version "3.7.6"


### PR DESCRIPTION
# ↪️ Pull Request

This fixes #7325 and possibly also #7400. The issue, as @benpigchu pointed out [here](https://github.com/parcel-bundler/parcel/issues/7325#issuecomment-988697578), was that Typescript 4.5 added support for [type modifiers on specific import names](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#type-modifiers-on-import-names). For example, it is now valid to write:
```ts
import { someFunc, type BaseType } from "./some-module.js";
```
Unfortunately, the way that the compiler API was changed to support this is not backward compatible :-(

Here's what the pre-4.5 API looked like:
```ts
createImportSpecifier(propertyName: Identifier | undefined, name: Identifier): ImportSpecifier;
```
And here's the new API ([see PR](https://github.com/microsoft/TypeScript/pull/45998)):
```ts
createImportSpecifier(isTypeOnly: boolean, propertyName: Identifier | undefined, name: Identifier): ImportSpecifier;
```
Since there's no way that I know of to check a function's arity at runtime, I had to resort to a version check.

There were several other backward-incompatible changes in that PR (to `updateImportSpecifier`, `createExportSpecifier` and `updateExportSpecifier`), and I verified that we don't use these APIs in parcel.

## 💻 Examples

Without this change, when you have typescript 4.5+, `@parcel/transformer-typescript-types` will generate output like:
```ts
import { something as } from "./foo"
```
instead of
```ts
import { something } from "./foo
```
This change ensures that we do the right thing.

## 🚨 Test instructions

Several of the existing unit tests will break if you upgrade to typescript 4.5+ and don't apply this change, so it didn't seem necessary to add new ones.

I manually verified that with this change, and typescript 4.2.4 (the old version in the repo), all the unit tests still pass. You can test it yourself by modifying `yarn.lock` to revert back to `4.2.4`, running `yarn install`, then `yarn test:integration`.

## ✔️ PR Todo

- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
