### PR TITLE
Fix wrong `does not export` error because of missing symbols

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed2/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed2/a.js
@@ -1,0 +1,3 @@
+import { x } from './b.js';
+
+output = x;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed2/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed2/b.js
@@ -1,0 +1,4 @@
+export { x as y } from './c.js'
+
+export const x = 'foobar';
+

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed2/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-renamed2/c.js
@@ -1,0 +1,1 @@
+export const x = 'xyz';

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1039,6 +1039,18 @@ describe('scope hoisting', function () {
       assert.deepEqual(output, 'foobar');
     });
 
+    it('supports requiring a re-exported and renamed ES6 import (reversed order)', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-renamed2/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.deepEqual(output, 'foobar');
+    });
+
     it('supports requiring a re-exported and renamed ES6 namespace import', async function () {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
Regression from https://github.com/parcel-bundler/parcel/pull/7222 @thebriando 

We have this `exports_locals` map that maps local bindings to their (potential) exported name. So `const x = 2; export {x as y}` would be `{ x -> y }`. Previously, this map was also populated by `export ... from "something";` which are of course not actually local bindings.

We actually had an integration test for this, but apparently in this case the order of `export { x as y } from` and `export x` mattered.