### PR TITLE
Workaround segfault with old glibc versions

### DIFF
--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -34,6 +34,7 @@
     "@parcel/plugin": "^2.0.1",
     "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "^2.0.1",
+    "@parcel/workers": "^2.0.1",
     "@swc/helpers": "^0.2.11",
     "browserslist": "^4.6.6",
     "detect-libc": "^1.0.3",

--- a/packages/transformers/js/src/loadNative.js
+++ b/packages/transformers/js/src/loadNative.js
@@ -1,0 +1,6 @@
+// This function is called from the main thread to prevent unloading the module
+// until the main thread exits. This avoids a segfault in older glibc versions.
+// See https://github.com/rust-lang/rust/issues/91979
+module.exports = () => {
+  require('../native');
+};


### PR DESCRIPTION
Fixes #7408. #5961

This is a workaround for https://github.com/rust-lang/rust/issues/91979. This manifests as a segmentation fault that occurs on CentOS 7 systems when Parcel exits (after a successful build). It occurs due to the thread local variables used by SWC.

We can workaround this by preventing the library from being unloaded until process exit rather than when worker threads exit. This is done by also loading SWC on the main thread in addition to workers. For performance reasons, this is only done on linux when the glibc version is <= 2.17. In glibc 2.18+, this crash does not occur because unloading dynamic libraries is already deferred until process exit if there are TLS destructors registered.