### PR TITLE
Apply segfault workaround to image optimizer as well

### DIFF
--- a/packages/optimizers/image/package.json
+++ b/packages/optimizers/image/package.json
@@ -35,6 +35,7 @@
     "@parcel/diagnostic": "^2.0.1",
     "@parcel/plugin": "^2.0.1",
     "@parcel/utils": "^2.0.1",
+    "@parcel/workers": "^2.0.1",
     "detect-libc": "^1.0.3"
   },
   "devDependencies": {

--- a/packages/optimizers/image/src/loadNative.js
+++ b/packages/optimizers/image/src/loadNative.js
@@ -1,0 +1,6 @@
+// This function is called from the main thread to prevent unloading the module
+// until the main thread exits. This avoids a segfault in older glibc versions.
+// See https://github.com/rust-lang/rust/issues/91979
+module.exports = () => {
+  require('../native');
+};


### PR DESCRIPTION
Another case of https://github.com/rust-lang/rust/issues/91979. Same fix as #7457.