### PR TITLE
Fix: more loosened React lib version check

### DIFF
--- a/packages/core/integration-tests/test/integration/jsx-preact-with-url/index.js
+++ b/packages/core/integration-tests/test/integration/jsx-preact-with-url/index.js
@@ -1,0 +1,1 @@
+module.exports = <div />;

--- a/packages/core/integration-tests/test/integration/jsx-preact-with-url/package.json
+++ b/packages/core/integration-tests/test/integration/jsx-preact-with-url/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "preact": "https://pkg.csb.dev/preactjs/preact/commit/96082866/preact"
+  }
+}

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -130,6 +130,15 @@ describe('transpilation', function () {
     assert(file.includes('h("div"'));
   });
 
+  it('should support compiling JSX in JS files with Preact url dependency', async function () {
+    await bundle(
+      path.join(__dirname, '/integration/jsx-preact-with-url/index.js'),
+    );
+
+    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
+    assert(file.includes('h("div"'));
+  });
+
   it('should support compiling JSX in TS files with Preact dependency', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/jsx-preact-ts/index.tsx'),

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -209,9 +209,13 @@ export default (new Transformer({
           pkg?.dependencies?.[effectiveReactLib] ||
           pkg?.devDependencies?.[effectiveReactLib] ||
           pkg?.peerDependencies?.[effectiveReactLib];
-        let minReactLibVersion = semver.valid(reactLibVersion)
-          ? semver.minVersion(reactLibVersion)?.toString()
+        reactLibVersion = reactLibVersion
+          ? semver.validRange(reactLibVersion)
           : null;
+        let minReactLibVersion =
+          reactLibVersion !== null && reactLibVersion !== '*'
+            ? semver.minVersion(reactLibVersion)?.toString()
+            : null;
 
         automaticJSXRuntime =
           automaticVersion &&

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -209,10 +209,9 @@ export default (new Transformer({
           pkg?.dependencies?.[effectiveReactLib] ||
           pkg?.devDependencies?.[effectiveReactLib] ||
           pkg?.peerDependencies?.[effectiveReactLib];
-        let minReactLibVersion =
-          reactLibVersion != null && reactLibVersion !== '*'
-            ? semver.minVersion(reactLibVersion)?.toString()
-            : null;
+        let minReactLibVersion = semver.valid(reactLibVersion)
+          ? semver.minVersion(reactLibVersion)?.toString()
+          : null;
 
         automaticJSXRuntime =
           automaticVersion &&


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes: #7335 

Hi team :wave:

Currently, `JSTransformer`'s detection of React lib version in package.json is crashed when react lib is specified with URL (such as `https://pkg.csb.dev/preactjs/preact/commit/96082866/preact` ). I fixed this.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
**package.json**
```json

{
  "private": true,
  "dependencies": {
    "preact": "https://pkg.csb.dev/preactjs/preact/commit/96082866/preact"
  }
}


```

## 🚨 Test instructions

I added a test case to whether or not check parcel correctly work with react dependency specified with URL.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
