### PR TITLE
Sync peerdep versions on release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=* --no-git-tag-version --no-push",
     "tag:prerelease": "lerna version --exact --force-publish=* --no-git-tag-version --no-push && yarn adjust-versions --exact",
     "tag:release": "lerna version --force-publish=* --no-git-tag-version --no-push && yarn adjust-versions",
-    "adjust-versions": "node scripts/update-config-dependencies.js && node scripts/update-engines.js",
+    "adjust-versions": "node scripts/update-config-dependencies.js && node scripts/update-engines-peerdeps.js",
     "release": "lerna publish -y from-package --pre-dist-tag=next --no-git-tag-version --no-push",
     "prepare": "husky install"
   },

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -75,6 +75,6 @@
     "@parcel/transformer-yaml": "^2.0.1"
   },
   "peerDependencies": {
-    "@parcel/core": "^2.0.0"
+    "@parcel/core": "^2.0.1"
   }
 }

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -29,7 +29,7 @@
     "lmdb": "^2.0.2"
   },
   "peerDependencies": {
-    "@parcel/core": "^2.0.0"
+    "@parcel/core": "^2.0.1"
   },
   "devDependencies": {
     "idb": "^5.0.8"

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -39,7 +39,7 @@
     "utility-types": "^3.10.0"
   },
   "peerDependencies": {
-    "@parcel/core": "^2.0.0"
+    "@parcel/core": "^2.0.1"
   },
   "browser": {
     "./src/NodeFS.js": "./src/NodeFS.browser.js"

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -38,7 +38,7 @@
     "split2": "^3.1.1"
   },
   "peerDependencies": {
-    "@parcel/core": "^2.0.0"
+    "@parcel/core": "^2.0.1"
   },
   "browser": {
     "./src/Npm.js": false,

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -29,7 +29,7 @@
     "nullthrows": "^1.1.1"
   },
   "peerDependencies": {
-    "@parcel/core": "^2.0.0"
+    "@parcel/core": "^2.0.1"
   },
   "browser": {
     "./src/cpuCount.js": false,

--- a/scripts/update-engines-peerdeps.js
+++ b/scripts/update-engines-peerdeps.js
@@ -26,4 +26,8 @@ for (let [, {location}] of packageVersions) {
     pkg.engines.parcel = coreRange;
     fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
   }
+  if (pkg.peerDependencies?.['@parcel/core'] != null) {
+    pkg.peerDependencies['@parcel/core'] = coreRange;
+    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  }
 }


### PR DESCRIPTION
Update the peer dependency on core just like we update the engines field. This is especially important to make nightlies work correctly with npm. I think we also want this for actual releases?

Closes https://github.com/parcel-bundler/parcel/issues/7246

@jvanderen1 this should fix the situation with npm