### PR TITLE
fix: add undeclared dependencies

### DIFF
--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -24,6 +24,7 @@
     "check-ts": "tsc --noEmit index.d.ts"
   },
   "dependencies": {
+    "@parcel/fs": "^2.0.1",
     "@parcel/logger": "^2.0.1",
     "@parcel/utils": "^2.0.1",
     "lmdb": "^2.0.2"

--- a/packages/core/graph/package.json
+++ b/packages/core/graph/package.json
@@ -20,6 +20,7 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
+    "@parcel/utils": "^2.0.1",
     "nullthrows": "^1.1.1"
   }
 }


### PR DESCRIPTION
# ↪️ Pull Request

`@parcel/graph` depends on `@parcel/utils` and `@parcel/cache` depends on `@parcel/fs` but neither declare it so this PR updates them to declare their dependencies.
