### PR TITLE
Add transformer for svelte (#7503).

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -42,6 +42,7 @@
     "*.{png,jpg,jpeg,webp}": ["@parcel/transformer-image"],
     "*.svg": ["@parcel/transformer-svg"],
     "*.{xml,rss,atom}": ["@parcel/transformer-xml"],
+    "*.svelte": ["@parcel/transformer-svelte"],
     "url:*": ["...", "@parcel/transformer-raw"]
   },
   "namers": ["@parcel/namer-default"],

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -66,6 +66,7 @@
     "@parcel/transformer-sass": "^2.0.1",
     "@parcel/transformer-stylus": "^2.0.1",
     "@parcel/transformer-sugarss": "^2.0.1",
+    "@parcel/transformer-svelte": "^2.0.1",
     "@parcel/transformer-toml": "^2.0.1",
     "@parcel/transformer-typescript-types": "^2.0.1",
     "@parcel/transformer-vue": "^2.0.1",

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -12,7 +12,6 @@
     "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json"
   },
   "devDependencies": {
-    "autoprefixer": "^10.4.0",
     "@babel/core": "^7.12.0",
     "@babel/plugin-syntax-class-properties": "^7.12.1",
     "@babel/plugin-syntax-export-default-from": "^7.2.0",
@@ -22,6 +21,7 @@
     "@babel/preset-typescript": "^7.14.5",
     "@jetbrains/kotlinc-js-api": "^1.2.12",
     "@mdx-js/react": "^1.5.3",
+    "autoprefixer": "^10.4.0",
     "chalk": "^4.1.0",
     "codecov": "^3.0.0",
     "command-exists": "^1.2.6",
@@ -53,6 +53,7 @@
     "react-dom": "^16.11.0",
     "rimraf": "^2.6.1",
     "sugarss": "^3.0.3",
+    "svelte-preprocess": "^4.10.1",
     "tailwindcss": "^3.0.2",
     "tempy": "^0.3.0",
     "ws": "^7.0.0"

--- a/packages/core/integration-tests/test/integration/svelte-nopreprocess/.svelterc
+++ b/packages/core/integration-tests/test/integration/svelte-nopreprocess/.svelterc
@@ -1,0 +1,1 @@
+{preprocess: null}

--- a/packages/core/integration-tests/test/integration/svelte-nopreprocess/App.svelte
+++ b/packages/core/integration-tests/test/integration/svelte-nopreprocess/App.svelte
@@ -1,0 +1,12 @@
+<script>
+  export let name;
+</script>
+
+<h1>{name}</h1>
+
+<style>
+  h1 {
+    background-color: black;
+    color: white;
+  }
+</style>

--- a/packages/core/integration-tests/test/integration/svelte-ts/App.svelte
+++ b/packages/core/integration-tests/test/integration/svelte-ts/App.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  export let name: string;
+</script>
+
+<div class="name">
+  <h1 class="name-text">{name}</h1>
+</div>
+
+<style lang="scss">
+  .name {
+    background-color: black;
+    &-text {
+      color: white;
+    }
+  }
+</style>

--- a/packages/core/integration-tests/test/integration/svelte/App.svelte
+++ b/packages/core/integration-tests/test/integration/svelte/App.svelte
@@ -1,0 +1,12 @@
+<script>
+  export let name;
+</script>
+
+<h1>{name}</h1>
+
+<style>
+  h1 {
+    background-color: black;
+    color: white;
+  }
+</style>

--- a/packages/core/integration-tests/test/svelte.js
+++ b/packages/core/integration-tests/test/svelte.js
@@ -1,0 +1,23 @@
+import {bundle, assertBundles, run} from '@parcel/test-utils';
+import path from 'path';
+
+describe('svelte', function () {
+  it('should support bundling Svelte', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/svelte/App.svelte'),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'css',
+        assets: ['App.svelte'],
+      },
+      {
+        type: 'js',
+        assets: ['App.svelte', 'esmodule-helpers.js', 'index.mjs'],
+      },
+    ]);
+
+    await run(b);
+  });
+});

--- a/packages/core/integration-tests/test/svelte.js
+++ b/packages/core/integration-tests/test/svelte.js
@@ -1,10 +1,61 @@
 import {bundle, assertBundles, run} from '@parcel/test-utils';
+import Logger from '@parcel/logger';
 import path from 'path';
+import assert from 'assert';
 
 describe('svelte', function () {
   it('should support bundling Svelte', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/svelte/App.svelte'),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'css',
+        assets: ['App.svelte'],
+      },
+      {
+        type: 'js',
+        assets: ['App.svelte', 'esmodule-helpers.js', 'index.mjs'],
+      },
+    ]);
+
+    await run(b);
+  });
+
+  it('should support preprocessing out of the box', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/svelte-ts/App.svelte'),
+    );
+
+    assertBundles(b, [
+      {
+        type: 'css',
+        assets: ['App.svelte'],
+      },
+      {
+        type: 'js',
+        assets: ['App.svelte', 'esmodule-helpers.js', 'index.mjs'],
+      },
+    ]);
+
+    await run(b);
+  });
+
+  it('should permit disabling preprocessor', async () => {
+    const messages = [];
+    let loggerDisposable = Logger.onLog(message => {
+      messages.push(...message.diagnostics.map(diag => diag.message));
+    });
+    let b = await bundle(
+      path.join(__dirname, '/integration/svelte-nopreprocess/App.svelte'),
+      {logLevel: 'verbose'},
+    );
+    loggerDisposable.dispose();
+
+    assert(
+      !messages.includes('Preprocessing svelte file.'),
+      'preprocessing was run',
     );
 
     assertBundles(b, [

--- a/packages/transformers/svelte/package.json
+++ b/packages/transformers/svelte/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@parcel/transformer-svelte",
+  "version": "2.0.1",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "lib/SvelteTransformer.js",
+  "source": "src/SvelteTransformer.js",
+  "engines": {
+    "node": ">= 12.0.0",
+    "parcel": "^2.0.1"
+  },
+  "dependencies": {
+    "@parcel/diagnostic": "^2.0.1",
+    "@parcel/plugin": "^2.0.1",
+    "@parcel/source-map": "^2.0.0",
+    "@parcel/utils": "^2.0.1",
+    "svelte": "^3.44.3"
+  }
+}

--- a/packages/transformers/svelte/package.json
+++ b/packages/transformers/svelte/package.json
@@ -24,6 +24,7 @@
     "@parcel/plugin": "^2.0.1",
     "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "^2.0.1",
-    "svelte": "^3.44.3"
+    "svelte": "^3.44.3",
+    "svelte-hmr": "^0.14.9"
   }
 }

--- a/packages/transformers/svelte/src/SvelteTransformer.js
+++ b/packages/transformers/svelte/src/SvelteTransformer.js
@@ -43,6 +43,9 @@ export default (new Transformer({
     let source = await asset.getCode();
     const filename = relativeUrl(options.projectRoot, asset.filePath);
 
+    // If the preprocessor config is never defined in the svelte config, attempt
+    // to import `svelte-preprocess`. If that is importable, use that to
+    // preprocess the file. Otherwise, do not run any preprocessors.
     if (preprocessConf === undefined) {
       let preprocessor = null;
       logger.verbose({
@@ -50,7 +53,7 @@ export default (new Transformer({
           'No preprocess specified; attempting to use `svelte-preprocess`.',
       });
       try {
-        preprocessor = await import('svelte-preprocess');
+        preprocessor = require('svelte-preprocess');
       } catch (e) {
         logger.verbose({
           message:
@@ -58,10 +61,11 @@ export default (new Transformer({
         });
       }
       if (preprocessor) {
-        preprocessConf = preprocessor.default();
+        preprocessConf = preprocessor();
       }
     }
 
+    // Only preprocess if there is a config for it.
     if (preprocessConf) {
       logger.verbose({message: 'Preprocessing svelte file.'});
       const processed = await catchDiag(

--- a/packages/transformers/svelte/src/SvelteTransformer.js
+++ b/packages/transformers/svelte/src/SvelteTransformer.js
@@ -1,0 +1,147 @@
+import {Transformer} from '@parcel/plugin';
+import SourceMap from '@parcel/source-map';
+import {relativeUrl} from '@parcel/utils';
+import {compile, preprocess} from 'svelte/compiler';
+import ThrowableDiagnostic from '@parcel/diagnostic';
+
+export default new Transformer({
+  async loadConfig({config, options, logger}) {
+    const svelteConfig = await config.getConfig([
+      '.svelterc',
+      'svelte.config.js',
+    ]);
+    if (!svelteConfig) return {};
+    if (svelteConfig.filePath.endsWith('.js')) {
+      // TODO: Is there a better way of handling this warning? Probably just
+      // mention it in the documentation and silently invalidate.
+      logger.warn({
+        message:
+          'WARNING: Using a JavaScript Svelte config file means losing ' +
+          'out on caching features of Parcel. Use a .svelterc(.json) ' +
+          'file whenever possible.',
+      });
+      config.invalidateOnStartup();
+    }
+    return {
+      ...svelteConfig.contents,
+      compilerOptions: {
+        // TODO: Call this out in the documentation.
+        css: false,
+        ...svelteConfig.contents.compilerOptions,
+        dev: options.mode !== 'production',
+      },
+    };
+  },
+
+  async transform({asset, config, options, logger}) {
+    let source = await asset.getCode();
+    const filename = relativeUrl(options.projectRoot, asset.filePath);
+
+    if (!config.preprocess) {
+      let preprocessor = null;
+      try {
+        // This seems sufficiently batteries included. Only apply
+        // svelte-preprocess if it is importable. Otherwise, assume the lack of
+        // a preprocess entry is intentional.
+        // TODO: Is it possible to utilize parcel's pipelines in lieu of
+        // svelte-preprocess?
+        // TODO: Call this out in the documenation.
+        logger.verbose({message: 'Attempting to use svelte-preprocess.'});
+        preprocessor = await import('svelte-preprocess');
+      } catch (e) {
+        logger.warn({message: JSON.stringify(e)});
+        logger.verbose({
+          message:
+            'svelte-preprocess is not available; not using any preprocessor.',
+        });
+      }
+      if (preprocessor) {
+        config.preprocess = {preprocess: preprocessor()};
+      }
+    }
+
+    if (config.preprocess) {
+      logger.verbose({message: 'Preprocessing svelte file.'});
+      const processed = await catchDiag(
+        async () =>
+          await preprocess(source, config.preprocess, {
+            filename,
+          }),
+        source,
+      );
+      source = processed.code;
+    }
+
+    logger.verbose({message: 'Compiling svelte file.'});
+    const compiled = await catchDiag(
+      async () =>
+        await compile(source, {
+          ...config.compilerOptions,
+          filename,
+        }),
+      source,
+    );
+
+    // Create the new assets from the compilation result.
+    const assets = [
+      {
+        type: 'js',
+        content: compiled.js.code,
+        uniqueKey: `${asset.id}-js`,
+        map: extractSourceMaps(asset, compiled.js.map),
+      },
+    ];
+    if (compiled.css && compiled.css.code) {
+      assets.push({
+        type: 'css',
+        content: compiled.css.code,
+        uniqueKey: `${asset.id}-css`,
+        map: extractSourceMaps(asset, compiled.css.map),
+      });
+    }
+
+    // Forward any warnings from the svelte compiler to the parcel diagnostics.
+    if (compiled.warnings.length > 0) {
+      for (const warning of compiled.warnings) {
+        logger.warn(convertDiag(warning));
+      }
+    }
+
+    return assets;
+  },
+});
+
+function extractSourceMaps(asset, sourceMap) {
+  if (!sourceMap) return;
+  sourceMap.sources = [asset.filePath];
+  const map = new SourceMap();
+  map.addVLQMap(sourceMap);
+  return map;
+}
+
+async function catchDiag(fn, code) {
+  try {
+    return await fn();
+  } catch (e) {
+    throw new ThrowableDiagnostic({
+      diagnostic: convertDiag(e, code),
+    });
+  }
+}
+
+function convertDiag(svelteDiag, code) {
+  const codeFrame = {
+    filePath: svelteDiag.filename,
+    code,
+    codeHighlights: [
+      {
+        start: svelteDiag.start,
+        end: svelteDiag.end,
+      },
+    ],
+  };
+  return {
+    message: svelteDiag.message,
+    codeFrames: [codeFrame],
+  };
+}

--- a/packages/transformers/svelte/src/SvelteTransformer.js
+++ b/packages/transformers/svelte/src/SvelteTransformer.js
@@ -1,3 +1,4 @@
+// @flow
 import {Transformer} from '@parcel/plugin';
 import SourceMap from '@parcel/source-map';
 import {relativeUrl} from '@parcel/utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2439,10 +2439,22 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
+"@types/pug@^2.0.4":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.6.tgz#f830323c88172e66826d0bde413498b61054b5a6"
+  integrity sha512-SnHmG9wN1UVmagJOnyo/qkk0Z7gejYxOYYmaAwr5u2yFYfsupN3sg10kyzN8Hep/2zbHxCnsumxOoRIRMBwKCg==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/sass@^1.16.0":
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.43.1.tgz#86bb0168e9e881d7dade6eba16c9ed6d25dc2f68"
+  integrity sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==
+  dependencies:
+    "@types/node" "*"
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
   version "2.0.3"
@@ -3427,6 +3439,11 @@ btoa-lite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
   integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
+
+buffer-crc32@^0.2.5:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
 buffer-equal@^1.0.0:
   version "1.0.0"
@@ -4913,6 +4930,11 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
+detect-indent@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
+  integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
+
 detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -5314,6 +5336,11 @@ es6-object-assign@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
+es6-promise@^3.1.2:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+  integrity sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=
 
 es6-promise@^4.0.3:
   version "4.2.8"
@@ -6792,6 +6819,11 @@ graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
+graceful-fs@^4.1.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 graphql-import-macro@^1.0.0:
   version "1.0.0"
@@ -11715,7 +11747,7 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -11782,6 +11814,16 @@ safe-regex@^1.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sander@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/sander/-/sander-0.5.1.tgz#741e245e231f07cafb6fdf0f133adfa216a502ad"
+  integrity sha1-dB4kXiMfB8r7b98PEzrfohalAq0=
+  dependencies:
+    es6-promise "^3.1.2"
+    graceful-fs "^4.1.3"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.2"
 
 sass@^1.38.0:
   version "1.38.0"
@@ -12103,6 +12145,16 @@ socks@~2.3.2:
     ip "1.1.5"
     smart-buffer "^4.1.0"
 
+sorcery@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/sorcery/-/sorcery-0.10.0.tgz#8ae90ad7d7cb05fc59f1ab0c637845d5c15a52b7"
+  integrity sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=
+  dependencies:
+    buffer-crc32 "^0.2.5"
+    minimist "^1.2.0"
+    sander "^0.5.0"
+    sourcemap-codec "^1.3.0"
+
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
@@ -12169,7 +12221,7 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.3.0, sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -12629,6 +12681,23 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+svelte-preprocess@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.1.tgz#5f435e8aaa82976165bc8f5fa690e2e5ba084760"
+  integrity sha512-NSNloaylf+o9UeyUR2KvpdxrAyMdHl3U7rMnoP06/sG0iwJvlUM4TpMno13RaNqovh4AAoGsx1jeYcIyuGUXMw==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    magic-string "^0.25.7"
+    sorcery "^0.10.0"
+    strip-indent "^3.0.0"
+
+svelte@^3.44.3:
+  version "3.44.3"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.44.3.tgz#795b1ced6ed3da44969099e5061b850c93c95e9a"
+  integrity sha512-aGgrNCip5PQFNfq9e9tmm7EYxWLVHoFsEsmKrtOeRD8dmoGDdyTQ+21xd7qgFd8MNdKGSYvg7F9dr+Tc0yDymg==
 
 sver-compat@^1.5.0:
   version "1.5.0"
@@ -13190,6 +13259,11 @@ typescript@>=3.0.0:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
+
+typescript@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 uglify-js@^3.1.4:
   version "3.7.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12682,6 +12682,11 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+svelte-hmr@^0.14.9:
+  version "0.14.9"
+  resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.14.9.tgz#35f277efc789e1a6230185717347cddb2f8e9833"
+  integrity sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==
+
 svelte-preprocess@^4.10.1:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.10.1.tgz#5f435e8aaa82976165bc8f5fa690e2e5ba084760"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13260,11 +13260,6 @@ typescript@>=3.0.0:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
   integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
 
-typescript@^4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
-
 uglify-js@^3.1.4:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.6.tgz#0783daa867d4bc962a37cc92f67f6e3238c47485"


### PR DESCRIPTION
This is the implementation of the plugin discussed in #7503. There are still some loose ends I would like some help on, but it is tested for the non-preprocessor scenario.

Closes #7503

# ↪️ Pull Request

Adds a transformer plugin for [svelte](https://svelte.dev) files. It optionally preprocesses the files using svelte's builtin mechanism for typescript, scss, etc. It then compiles the svelte file into a js and css asset. Preprocessing only occurs if `svelte.config.js` specifies a `preprocess` key whose value is truthy or if the `svelte-preprocess` package is importable.


## 🚨 Test instructions

An integration test has been added for the simple case of a svelte file. I'm a little at a loss for how to automate testing the typescript scenario since it would require additional packages (i.e.: `svelte-preprocess`) which I don't know how to add to the integration test.

Ideally, a repository like this [example](https://github.com/gcoakes/example-parcel-svelte-ts) would compile perfectly fine. It includes `svelte-preprocess` in its package.json, so it should convert the typescript script block from within svelte to a javascript asset.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
