### PR TITLE
Don't run Gzip and Brotli compressors in development

### DIFF
--- a/packages/compressors/brotli/src/BrotliCompressor.js
+++ b/packages/compressors/brotli/src/BrotliCompressor.js
@@ -1,9 +1,13 @@
-// @flow
+// @flow strict-local
 import {Compressor} from '@parcel/plugin';
 import zlib from 'zlib';
 
 export default (new Compressor({
-  compress({stream}) {
+  compress({options, stream}) {
+    if (options.mode !== 'production') {
+      return null;
+    }
+
     return {
       stream: stream.pipe(zlib.createBrotliCompress()),
       type: 'br',

--- a/packages/compressors/gzip/src/GzipCompressor.js
+++ b/packages/compressors/gzip/src/GzipCompressor.js
@@ -1,9 +1,13 @@
-// @flow
+// @flow strict-local
 import {Compressor} from '@parcel/plugin';
 import zlib from 'zlib';
 
 export default (new Compressor({
-  compress({stream}) {
+  compress({options, stream}) {
+    if (options.mode !== 'production') {
+      return null;
+    }
+
     return {
       stream: stream.pipe(zlib.createGzip()),
       type: 'gz',

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -105,7 +105,7 @@ async function assertFile(
     throw new ThrowableDiagnostic({
       diagnostic: {
         origin: '@parcel/core',
-        message: `${path.relative(process.cwd(), source)} does not exist.`,
+        message: md`${path.relative(process.cwd(), source)} does not exist.`,
         codeFrames: [
           {
             filePath: pkgFilePath,
@@ -118,7 +118,7 @@ async function assertFile(
           },
         ],
         hints: alternatives.map(r => {
-          return `Did you mean '__${r}__'?`;
+          return md`Did you mean '__${r}__'?`;
         }),
       },
     });
@@ -129,7 +129,7 @@ async function assertFile(
     throw new ThrowableDiagnostic({
       diagnostic: {
         origin: '@parcel/core',
-        message: `${path.relative(process.cwd(), source)} is not a file.`,
+        message: md`${path.relative(process.cwd(), source)} is not a file.`,
         codeFrames: [
           {
             filePath: pkgFilePath,
@@ -309,7 +309,7 @@ export class EntryResolver {
 
     throw new ThrowableDiagnostic({
       diagnostic: {
-        message: `Unknown entry: ${entry}`,
+        message: md`Unknown entry: ${entry}`,
       },
     });
   }

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -248,19 +248,21 @@ async function runCompressor(
       logger: new PluginLogger({origin: compressor.name}),
     });
 
-    await new Promise((resolve, reject) =>
-      pipeline(
-        res.stream,
-        outputFS.createWriteStream(
-          filePath + (res.type != null ? '.' + res.type : ''),
-          writeOptions,
+    if (res != null) {
+      await new Promise((resolve, reject) =>
+        pipeline(
+          res.stream,
+          outputFS.createWriteStream(
+            filePath + (res.type != null ? '.' + res.type : ''),
+            writeOptions,
+          ),
+          err => {
+            if (err) reject(err);
+            else resolve();
+          },
         ),
-        err => {
-          if (err) reject(err);
-          else resolve();
-        },
-      ),
-    );
+      );
+    }
   } catch (err) {
     throw new ThrowableDiagnostic({
       diagnostic: errorToDiagnostic(err, {

--- a/packages/core/core/test/EntryRequest.test.js
+++ b/packages/core/core/test/EntryRequest.test.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 import assert from 'assert';
 import path from 'path';
+import {md} from '@parcel/diagnostic';
 import {inputFS as fs} from '@parcel/test-utils';
 import {EntryResolver} from '../src/requests/EntryRequest';
 import {DEFAULT_OPTIONS as _DEFAULT_OPTIONS} from './test-utils';
@@ -45,7 +46,7 @@ describe('EntryResolver', function () {
         diagnostics: [
           {
             origin: '@parcel/core',
-            message: `${path.join(
+            message: md`${path.join(
               path.relative(fs.cwd(), INVALID_SOURCE_MISSING_FIXTURE_PATH),
               'missing.js',
             )} does not exist.`,
@@ -85,7 +86,7 @@ describe('EntryResolver', function () {
         diagnostics: [
           {
             origin: '@parcel/core',
-            message: `${path.join(
+            message: md`${path.join(
               path.relative(fs.cwd(), INVALID_SOURCE_NOT_FILE_FIXTURE_PATH),
               'src',
             )} is not a file.`,
@@ -125,7 +126,7 @@ describe('EntryResolver', function () {
         diagnostics: [
           {
             origin: '@parcel/core',
-            message: `${path.join(
+            message: md`${path.join(
               path.relative(
                 fs.cwd(),
                 INVALID_TARGET_SOURCE_MISSING_FIXTURE_PATH,
@@ -169,7 +170,7 @@ describe('EntryResolver', function () {
         diagnostics: [
           {
             origin: '@parcel/core',
-            message: `${path.join(
+            message: md`${path.join(
               path.relative(
                 fs.cwd(),
                 INVALID_TARGET_SOURCE_NOT_FILE_FIXTURE_PATH,

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -5454,6 +5454,7 @@ describe('cache', function () {
             }),
           );
         },
+        mode: 'production',
       });
 
       let files = await outputFS.readdir(distDir);

--- a/packages/core/integration-tests/test/compressors.js
+++ b/packages/core/integration-tests/test/compressors.js
@@ -4,8 +4,17 @@ import zlib from 'zlib';
 import {bundle, outputFS, distDir} from '@parcel/test-utils';
 
 describe('compressors', function () {
-  it('should compress output with gzip and brotli', async function () {
+  it('should not compress output with gzip and brotli in development', async function () {
     await bundle(path.join(__dirname, 'integration/compressors/index.js'));
+
+    let output = await outputFS.readdir(distDir);
+    assert.deepEqual(output.sort(), ['index.js', 'index.js.map']);
+  });
+
+  it('should compress output with gzip and brotli', async function () {
+    await bundle(path.join(__dirname, 'integration/compressors/index.js'), {
+      mode: 'production',
+    });
 
     let output = await outputFS.readdir(distDir);
     assert.deepEqual(output.sort(), [
@@ -28,6 +37,9 @@ describe('compressors', function () {
   it('should be able to disable raw output', async function () {
     await bundle(
       path.join(__dirname, 'integration/compressors-disable-default/index.js'),
+      {
+        mode: 'production',
+      },
     );
 
     let output = await outputFS.readdir(distDir);

--- a/packages/core/plugin/src/PluginAPI.d.ts
+++ b/packages/core/plugin/src/PluginAPI.d.ts
@@ -6,10 +6,11 @@ import type {
   Runtime as RuntimeOpts,
   Packager as PackagerOpts,
   Optimizer as OptimizerOpts,
+  Compressor as CompressorOpts,
   Reporter as ReporterOpts,
   Validator as ValidatorOpts,
 } from '@parcel/types';
-  
+
 export declare class Transformer<T> {
   constructor(opts: TransformerOpts<T>);
 }
@@ -40,6 +41,10 @@ export declare class Packager<T> {
 
 export declare class Optimizer<T> {
   constructor(opts: OptimizerOpts<T>);
+}
+
+export declare class Compressor {
+  constructor(opts: CompressorOpts);
 }
 
 export declare class Reporter {

--- a/packages/core/plugin/src/PluginAPI.js
+++ b/packages/core/plugin/src/PluginAPI.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict-local
 
 import type {
   Transformer as TransformerOpts,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1614,7 +1614,7 @@ export type Compressor = {|
     stream: Readable,
     options: PluginOptions,
     logger: PluginLogger,
-  |}): Async<{|
+  |}): Async<?{|
     stream: Readable,
     type?: string,
   |}>,


### PR DESCRIPTION
Allow returning null or undefined from compressors to skip that plugin based on some condition at runtime, and use that to only run the gzip and brotli compressors in production. This is technically a breaking change but I can't image you would want the old behaviour

Other small fixes:
- add compressor to TS types, closes https://github.com/parcel-bundler/parcel/issues/7507
- add a few more `md` escapes for error messages, closes https://github.com/parcel-bundler/parcel/issues/7509