### PR TITLE
Use level 9 Zlib compression

### DIFF
--- a/packages/compressors/gzip/src/GzipCompressor.js
+++ b/packages/compressors/gzip/src/GzipCompressor.js
@@ -9,7 +9,7 @@ export default (new Compressor({
     }
 
     return {
-      stream: stream.pipe(zlib.createGzip({ level: 9 })),
+      stream: stream.pipe(zlib.createGzip({level: 9})),
       type: 'gz',
     };
   },

--- a/packages/compressors/gzip/src/GzipCompressor.js
+++ b/packages/compressors/gzip/src/GzipCompressor.js
@@ -9,7 +9,7 @@ export default (new Compressor({
     }
 
     return {
-      stream: stream.pipe(zlib.createGzip()),
+      stream: stream.pipe(zlib.createGzip({ level: 9 })),
       type: 'gz',
     };
   },


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Use max-level compression for Gzip by default. As far as I know `BROTLI_DEFAULT_QUALITY == BROTLI_MAX_QUALITY`, so max-level compression is already done in the Brotli compressor by default.

Closes #7087

Not really much to test here. This is a minor improvement in compression quality for ~50% slower performance in my experience, but most web assets are so tiny that this performance hit really doesn't matter for build times, while the bytes saved could be nice for production.
