### PR TITLE
Include invalidation hash in asset content keys

### DIFF
--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -5789,6 +5789,53 @@ describe('cache', function () {
     }
   });
 
+  it('properly handles included files even after when changing back to a cached state', async function () {
+    this.timeout(15000);
+    let subscription;
+    let fixture = path.join(__dirname, '/integration/included-file');
+    try {
+      let b = bundler(path.join(fixture, 'index.txt'), {
+        inputFS: overlayFS,
+        shouldDisableCache: false,
+      });
+      await overlayFS.mkdirp(fixture);
+      await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'a');
+      subscription = await b.watch();
+      let event = await getNextBuild(b);
+      invariant(event.type === 'buildSuccess');
+      let output1 = await overlayFS.readFile(
+        event.bundleGraph.getBundles()[0].filePath,
+        'utf8',
+      );
+      assert.strictEqual(output1, 'a');
+
+      // Change included file
+      await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'b');
+      event = await getNextBuild(b);
+      invariant(event.type === 'buildSuccess');
+      let output2 = await overlayFS.readFile(
+        event.bundleGraph.getBundles()[0].filePath,
+        'utf8',
+      );
+      assert.strictEqual(output2, 'b');
+
+      // Change included file back
+      await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'a');
+      event = await getNextBuild(b);
+      invariant(event.type === 'buildSuccess');
+      let output3 = await overlayFS.readFile(
+        event.bundleGraph.getBundles()[0].filePath,
+        'utf8',
+      );
+      assert.strictEqual(output3, 'a');
+    } finally {
+      if (subscription) {
+        await subscription.unsubscribe();
+        subscription = null;
+      }
+    }
+  });
+
   it('should support moving the project root', async function () {
     // This test relies on the real filesystem because the memory fs doesn't support renames.
     // But renameSync is broken on windows in CI with EPERM errors. Just skip this test for now.


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7524

Previously, the invalidation hash was included in the cache key of  the asset itself (so for that `{filePath, committed, contentKey, mapKey, ...}` object), but not in `contentKey` (and the other keys). So when changing for example an included file, the new build would overwrite the cache entry for the previous build. This causes the problem described in the issue (when changing an included file, and then changing it back you don't get the original bundle output).

I think including the invalidation hash in for `contentKey` is what we want?