### PR TITLE
Fix loading index.html in dev server when packager/optimizer changes bundle type

### DIFF
--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -315,7 +315,9 @@ export class PackagedBundle extends NamedBundle implements IPackagedBundle {
   }
 
   get type(): string {
-    return nullthrows(this.#bundleInfo).type;
+    // The bundle type may be overridden in the packager.
+    // However, inline bundles will not have a bundleInfo here since they are not written to the filesystem.
+    return this.#bundleInfo ? this.#bundleInfo.type : this.#bundle.type;
   }
 
   get stats(): Stats {

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -314,6 +314,10 @@ export class PackagedBundle extends NamedBundle implements IPackagedBundle {
     );
   }
 
+  get type(): string {
+    return nullthrows(this.#bundleInfo).type;
+  }
+
   get stats(): Stats {
     return nullthrows(this.#bundleInfo).stats;
   }

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -181,6 +181,7 @@ async function run({input, options, api}: RunInput) {
 
   let res = {
     filePath,
+    type: info.type,
     stats: {
       size,
       time: info.time ?? 0,

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -71,6 +71,7 @@ async function run({input, api, farm, options}: RunInput) {
       let name = nullthrows(bundle.name).replace(bundle.hashReference, hash);
       res.set(bundle.id, {
         filePath: joinProjectPath(bundle.target.distDir, name),
+        type: bundle.type, // FIXME: this is wrong if the packager changes the type...
         stats: {
           time: 0,
           size: 0,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -500,6 +500,7 @@ export type BundleGroupNode = {|
 
 export type PackagedBundleInfo = {|
   filePath: ProjectPath,
+  type: string,
   stats: Stats,
 |};
 

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -161,16 +161,16 @@ export default class Server {
   sendIndex(req: Request, res: Response) {
     if (this.bundleGraph) {
       // If the main asset is an HTML file, serve it
-      let htmlBundleFilePaths = [];
-      this.bundleGraph.traverseBundles(bundle => {
-        if (bundle.type === 'html' && bundle.bundleBehavior !== 'inline') {
-          htmlBundleFilePaths.push(bundle.filePath);
-        }
-      });
-
-      htmlBundleFilePaths = htmlBundleFilePaths.map(p => {
-        return `/${relativePath(this.options.distDir, p, false)}`;
-      });
+      let htmlBundleFilePaths = this.bundleGraph
+        .getBundles()
+        .filter(bundle => bundle.type === 'html')
+        .map(bundle => {
+          return `/${relativePath(
+            this.options.distDir,
+            bundle.filePath,
+            false,
+          )}`;
+        });
 
       let indexFilePath = null;
       if (htmlBundleFilePaths.length === 1) {


### PR DESCRIPTION
Packagers and optimizers can return a type, which overrides the bundle type. However, this was not correctly exposed by `PackagedBundle` which still returned the old type. That prevented the dev server from finding index.html for example.