### PR TITLE
fix: don't convert specifier when already absolute path

### DIFF
--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -179,7 +179,7 @@ export class ResolverRunner {
     }
 
     // Entrypoints, convert ProjectPath in module specifier to absolute path
-    if (dep.resolveFrom == null) {
+    if (dep.resolveFrom == null && !path.isAbsolute(specifier)) {
       specifier = path.join(this.options.projectRoot, specifier);
     }
     let diagnostics: Array<Diagnostic> = [];


### PR DESCRIPTION
fixes #7493 

# ↪️ Pull Request

Allows to pass a relative path starting with `../` to parcel cli commands

## 💻 Examples

(in the correct project context) `parcel watch ../library` failed before and is working now

## 🚨 Test instructions

The issue doesn't happen when in the context of a yarn workspace (which is the case of the monorepo), so I couldn't provide tests.
However, [this repository](https://github.com/e-krebs/parcel-relative-path) allows to reproduce the issue.
