### PR TITLE
Don't discard invalidations when transformer throws an error

### DIFF
--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -26,9 +26,11 @@ import {Readable} from 'stream';
 import nullthrows from 'nullthrows';
 import logger, {PluginLogger} from '@parcel/logger';
 import ThrowableDiagnostic, {
+  anyToDiagnostic,
   errorToDiagnostic,
   escapeMarkdown,
   md,
+  type Diagnostic,
 } from '@parcel/diagnostic';
 import {SOURCEMAP_EXTENSIONS} from '@parcel/utils';
 import {hashString} from '@parcel/hash';
@@ -84,7 +86,7 @@ export type TransformationOpts = {|
 
 export type TransformationResult = {|
   assets?: Array<AssetValue>,
-  error?: Error,
+  error?: Array<Diagnostic>,
   configRequests: Array<ConfigRequest>,
   invalidations: Array<RequestInvalidation>,
   invalidateOnFileCreate: Array<InternalFileCreateInvalidation>,
@@ -197,7 +199,8 @@ export default class Transformation {
       $$raw: true,
       assets,
       configRequests,
-      error,
+      // When throwing an error, this (de)serialization is done automatically by the WorkerFarm
+      error: error ? anyToDiagnostic(error) : undefined,
       invalidateOnFileCreate: this.invalidateOnFileCreate,
       invalidations: [...this.invalidations.values()],
       devDepRequests,

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -128,6 +128,7 @@ async function run({input, api, farm, invalidateReason, options}: RunInput) {
   let {
     assets,
     configRequests,
+    error,
     invalidations,
     invalidateOnFileCreate,
     devDepRequests,
@@ -138,8 +139,10 @@ async function run({input, api, farm, invalidateReason, options}: RunInput) {
   }): TransformationResult);
 
   let time = Date.now() - start;
-  for (let asset of assets) {
-    asset.stats.time = time;
+  if (assets) {
+    for (let asset of assets) {
+      asset.stats.time = time;
+    }
   }
 
   for (let invalidation of invalidateOnFileCreate) {
@@ -171,5 +174,9 @@ async function run({input, api, farm, invalidateReason, options}: RunInput) {
     await runConfigRequest(api, configRequest);
   }
 
-  return assets;
+  if (error != null) {
+    throw error;
+  } else {
+    return nullthrows(assets);
+  }
 }

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -13,6 +13,7 @@ import type {ConfigAndCachePath} from './ParcelConfigRequest';
 import type {TransformationResult} from '../Transformation';
 
 import nullthrows from 'nullthrows';
+import ThrowableDiagnostic from '@parcel/diagnostic';
 import {hashString} from '@parcel/hash';
 import createParcelConfigRequest from './ParcelConfigRequest';
 import {runDevDepRequest} from './DevDepRequest';
@@ -175,7 +176,7 @@ async function run({input, api, farm, invalidateReason, options}: RunInput) {
   }
 
   if (error != null) {
-    throw error;
+    throw new ThrowableDiagnostic({diagnostic: error});
   } else {
     return nullthrows(assets);
   }

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -5836,6 +5836,49 @@ describe('cache', function () {
     }
   });
 
+  it('properly watches included files after a transformer error', async function () {
+    this.timeout(15000);
+    let subscription;
+    let fixture = path.join(__dirname, '/integration/included-file');
+    try {
+      let b = bundler(path.join(fixture, 'index.txt'), {
+        inputFS: overlayFS,
+        shouldDisableCache: false,
+      });
+      await overlayFS.mkdirp(fixture);
+      await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'a');
+      subscription = await b.watch();
+      let event = await getNextBuild(b);
+      invariant(event.type === 'buildSuccess');
+      let output1 = await overlayFS.readFile(
+        event.bundleGraph.getBundles()[0].filePath,
+        'utf8',
+      );
+      assert.strictEqual(output1, 'a');
+
+      // Change included file
+      await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'ERROR');
+      event = await getNextBuild(b);
+      invariant(event.type === 'buildFailure');
+      assert.strictEqual(event.diagnostics[0].message, 'Custom error');
+
+      // Change included file back
+      await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'b');
+      event = await getNextBuild(b);
+      invariant(event.type === 'buildSuccess');
+      let output3 = await overlayFS.readFile(
+        event.bundleGraph.getBundles()[0].filePath,
+        'utf8',
+      );
+      assert.strictEqual(output3, 'b');
+    } finally {
+      if (subscription) {
+        await subscription.unsubscribe();
+        subscription = null;
+      }
+    }
+  });
+
   it('should support moving the project root', async function () {
     // This test relies on the real filesystem because the memory fs doesn't support renames.
     // But renameSync is broken on windows in CI with EPERM errors. Just skip this test for now.

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -5862,7 +5862,7 @@ describe('cache', function () {
       invariant(event.type === 'buildFailure');
       assert.strictEqual(event.diagnostics[0].message, 'Custom error');
 
-      // Change included file back
+      // Clear transformer error
       await overlayFS.writeFile(path.join(fixture, 'included.txt'), 'b');
       event = await getNextBuild(b);
       invariant(event.type === 'buildSuccess');

--- a/packages/core/integration-tests/test/integration/included-file/node_modules/parcel-transformer-included/index.js
+++ b/packages/core/integration-tests/test/integration/included-file/node_modules/parcel-transformer-included/index.js
@@ -6,6 +6,9 @@ module.exports = new Transformer({
     let file = path.join(path.dirname(asset.filePath), "included.txt");
     asset.invalidateOnFileChange(file);
     let content = await options.inputFS.readFile(file, "utf8");
+    if (content === "ERROR") {
+      throw new Error("Custom error");
+    }
     asset.setCode(content);
     return [asset];
   }


### PR DESCRIPTION
No invalidation gets added to the graph if `runTransform` throws an error. So instead catch it and return the error along with invalidations that were added along the way

Closes https://github.com/parcel-bundler/parcel/issues/6124