### PR TITLE
Update pnpm to allow installing dependencies in a monorepo

### DIFF
--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -84,7 +84,7 @@ export class Pnpm implements PackageInstaller {
   }: InstallerOptions): Promise<void> {
     let args = ['add', '--reporter', 'ndjson'];
     if (saveDev) {
-      args.push('-D');
+      args.push('-D', '-W');
     }
     args = args.concat(modules.map(npmSpecifierFromModuleRequest));
 


### PR DESCRIPTION
# ↪️ Pull Request
As with Yarn 2, PNPM needs the -W parameter to install packages in root in a monorepo.