### PR TITLE
Fix: not import `@swc/helpers` in script tag without `type="module"`

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1408,6 +1408,28 @@ describe('html', function () {
     assert(errored);
   });
 
+  it('should not import swc/helpers without type="module"', async function () {
+    await bundle(
+      path.join(
+        __dirname,
+        '/integration/html-js-not-import-swc-helpers-without-module/index.html',
+      ),
+      {
+        defaultTargetOptions: {
+          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#browser_compatibility
+          browsers: ['Chrome 48'],
+        },
+      },
+    );
+
+    let html = await outputFS.readFile(
+      path.join(distDir, 'index.html'),
+      'utf8',
+    );
+    assert(!html.includes('swc/helpers'));
+    assert(html.includes('slicedToArray'));
+  });
+
   it('should allow imports and requires in inline <script> tags', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/html-inline-js-require/index.html'),

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1416,8 +1416,10 @@ describe('html', function () {
       ),
       {
         defaultTargetOptions: {
-          // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#browser_compatibility
-          browsers: ['Chrome 48'],
+          engines: {
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#browser_compatibility
+            browsers: ['Chrome 48'],
+          },
         },
       },
     );

--- a/packages/core/integration-tests/test/integration/html-js-not-import-swc-helpers-without-module/index.html
+++ b/packages/core/integration-tests/test/integration/html-js-not-import-swc-helpers-without-module/index.html
@@ -1,0 +1,8 @@
+<html>
+    <script>
+        function arr() {
+            return [1, 2, 3];
+        }
+        const [a, b, c] = arr();
+    </script>
+</html>

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -223,9 +223,15 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
       let should_inline_fs = config.inline_fs
         && config.source_type != SourceType::Script
         && code.contains("readFileSync");
+      let should_import_swc_helpers = match config.source_type {
+        SourceType::Module => true,
+        SourceType::Script => false,
+      };
       swc_common::GLOBALS.set(&Globals::new(), || {
         helpers::HELPERS.set(
-          &helpers::Helpers::new(/* external helpers from @swc/helpers */ true),
+          &helpers::Helpers::new(
+            /* external helpers from @swc/helpers */ should_import_swc_helpers,
+          ),
           || {
             let mut react_options = react::Options::default();
             if config.is_jsx {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Fixes: #7597 

Hi team! 👋  

I investigated about #7597 bug. I found that this issue is caused by the behavior of `swc` replacing new(?) JavaScript syntax with the module imported from `@swc/helpers` while `swc` parses the source code. This inserted import declaration causes this error.

I fixed this by changing the behavior of importing polyfill into inserting itself.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

```html
<html>
<script>
  function hoge() {
    return [1,2,3]
}

const [one, two] = hoge();
</script>
</html>
```

This script will be transpiled. see https://play.swc.rs/?version=1.2.133&code=H4sIAAAAAAAAA0srzUsuyczPU8jIT0%2FV0FSo5lIAgqLUktKiPIVoQx0jHeNYrlouruT8vOIShej8vFQdhZLy%2FFgFW6gOawBY3PGGQgAAAA%3D%3D&config=H4sIAAAAAAAAA01POw7CMAy9i2c2JIaegIVDWKlbBeUn20GtqtwdJ1TA9uz3sw94ioPpgIIsxB3JnhQ3mED3QuLYF4ULqNhqwSDUbEBeSU1CcjUu5Cx0shegTYkThjuFQiwwKVdbR5%2F8svcCl2NhEvk6IqY10F88Y5Ilc%2BxqJnQ6QE3qo8kAq%2BaI6p11z%2FSikEukpJ%2Bm1iwh5rn2xGM8MQ69QfsdcRZ7eZzC4XwDSiW6fQ0BAAA%3D 

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

I've written a test to make sure it doesn't give an error and doesn't import swc helper in a bundled HTML with targeting Chrome 48, which doesn't support Array Destructuring.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
