### PR TITLE
Add diagnostic for failed autoinstall of node polyfill

### DIFF
--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -290,6 +290,7 @@ export default class NodeResolver {
 
     // Auto install node builtin polyfills if not already available
     if (resolved === undefined && builtin != null) {
+      let packageName = builtin.split('/')[0];
       let packageManager = this.packageManager;
       if (packageManager) {
         this.logger?.warn({
@@ -312,7 +313,7 @@ export default class NodeResolver {
             'https://parceljs.org/features/node-emulation/#polyfilling-%26-excluding-builtin-node-modules',
         });
 
-        await packageManager.resolve(builtin, this.projectRoot + '/index', {
+        await packageManager.resolve(packageName, this.projectRoot + '/index', {
           saveDev: true,
           shouldAutoInstall: true,
         });
@@ -323,6 +324,31 @@ export default class NodeResolver {
         } catch (err) {
           // ignore
         }
+      } else {
+        throw new ThrowableDiagnostic({
+          diagnostic: {
+            message: md`Node builtin polyfill "${packageName}" is not installed, but auto install is disabled.`,
+            codeFrames: [
+              {
+                filePath: ctx.loc?.filePath ?? sourceFile,
+                codeHighlights: ctx.loc
+                  ? [
+                      {
+                        message: 'used here',
+                        start: ctx.loc.start,
+                        end: ctx.loc.end,
+                      },
+                    ]
+                  : [],
+              },
+            ],
+            documentationURL:
+              'https://parceljs.org/features/node-emulation/#polyfilling-%26-excluding-builtin-node-modules',
+            hints: [
+              md`Install the "${packageName}" package with your package manager, and run Parcel again.`,
+            ],
+          },
+        });
       }
     }
 


### PR DESCRIPTION
This could happen e.g. in renovate/dependabot upgrades because auto install is disabled in CI and users might be confused. So adding a more specific diagnostic.

<img width="892" alt="image" src="https://user-images.githubusercontent.com/19409/153299110-39d26dec-c49d-4d43-ac74-8aa974d8db80.png">
