### PR TITLE
Upgrade to version 2 of detect-libc

### DIFF
--- a/packages/optimizers/image/native.js
+++ b/packages/optimizers/image/native.js
@@ -1,7 +1,7 @@
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const {MUSL, family} = require('detect-libc');
-  if (family === MUSL) {
+  const {MUSL, familySync} = require('detect-libc');
+  if (familySync() === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {
     parts.push('gnueabihf');

--- a/packages/optimizers/image/package.json
+++ b/packages/optimizers/image/package.json
@@ -36,7 +36,7 @@
     "@parcel/plugin": "2.6.0",
     "@parcel/utils": "2.6.0",
     "@parcel/workers": "2.6.0",
-    "detect-libc": "^1.0.3"
+    "detect-libc": "^2.0.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.6.2",

--- a/packages/optimizers/image/src/ImageOptimizer.js
+++ b/packages/optimizers/image/src/ImageOptimizer.js
@@ -48,8 +48,8 @@ async function loadOnMainThreadIfNeeded() {
     process.platform === 'linux' &&
     WorkerFarm.isWorker()
   ) {
-    let {family, version} = require('detect-libc');
-    if (family === 'glibc' && parseFloat(version) <= 2.17) {
+    let {GLIBC, family, version} = require('detect-libc');
+    if ((await family()) === GLIBC && parseFloat(await version()) <= 2.17) {
       let api = WorkerFarm.getWorkerApi();
       await api.callMaster({
         location: __dirname + '/loadNative.js',

--- a/packages/transformers/js/native.js
+++ b/packages/transformers/js/native.js
@@ -1,7 +1,7 @@
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const {MUSL, family} = require('detect-libc');
-  if (family === MUSL) {
+  const {MUSL, familySync} = require('detect-libc');
+  if (familySync() === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {
     parts.push('gnueabihf');

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -37,7 +37,7 @@
     "@parcel/workers": "2.6.0",
     "@swc/helpers": "^0.3.15",
     "browserslist": "^4.6.6",
-    "detect-libc": "^1.0.3",
+    "detect-libc": "^2.0.1",
     "nullthrows": "^1.1.1",
     "regenerator-runtime": "^0.13.7",
     "semver": "^5.7.1"

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -880,8 +880,8 @@ async function loadOnMainThreadIfNeeded() {
     process.platform === 'linux' &&
     WorkerFarm.isWorker()
   ) {
-    let {family, version} = require('detect-libc');
-    if (family === 'glibc' && parseFloat(version) <= 2.17) {
+    let {GLIBC, family, version} = require('detect-libc');
+    if ((await family()) === GLIBC && parseFloat(await version()) <= 2.17) {
       let api = WorkerFarm.getWorkerApi();
       await api.callMaster({
         location: __dirname + '/loadNative.js',

--- a/packages/utils/fs-search/index.js
+++ b/packages/utils/fs-search/index.js
@@ -1,7 +1,7 @@
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const {MUSL, family} = require('detect-libc');
-  if (family === MUSL) {
+  const {MUSL, familySync} = require('detect-libc');
+  if (familySync() === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {
     parts.push('gnueabihf');

--- a/packages/utils/fs-search/package.json
+++ b/packages/utils/fs-search/package.json
@@ -28,7 +28,7 @@
     "build-release": "napi build --platform --release"
   },
   "dependencies": {
-    "detect-libc": "^1.0.3"
+    "detect-libc": "^2.0.1"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.6.2"

--- a/packages/utils/hash/index.js
+++ b/packages/utils/hash/index.js
@@ -1,7 +1,7 @@
 let parts = [process.platform, process.arch];
 if (process.platform === 'linux') {
-  const {MUSL, family} = require('detect-libc');
-  if (family === MUSL) {
+  const {MUSL, familySync} = require('detect-libc');
+  if (familySync() === MUSL) {
     parts.push('musl');
   } else if (process.arch === 'arm') {
     parts.push('gnueabihf');

--- a/packages/utils/hash/package.json
+++ b/packages/utils/hash/package.json
@@ -32,7 +32,7 @@
     "build-release": "napi build --platform --release"
   },
   "dependencies": {
-    "detect-libc": "^1.0.3",
+    "detect-libc": "^2.0.1",
     "xxhash-wasm": "^0.4.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4779,6 +4779,11 @@ detect-libc@^1.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+detect-libc@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
+
 detective@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/detective/-/detective-5.2.0.tgz#feb2a77e85b904ecdea459ad897cc90a99bd2a7b"


### PR DESCRIPTION
# ↪️ Pull Request

Hi, the latest `detect-libc` has been modernised to use the non-blocking Node.js Report API where available (Node.js >= 12), falling back to a more efficient single child process only when needed.

It's a major version bump for `detect-libc` as it drops support for versions of Node.js < 8 but `parcel` already requires >= 12 so this change is OK to include in a patch release.

https://www.npmjs.com/package/detect-libc

## 💻 Examples

Should anyone be interested in the background to this, please see lovell/detect-libc#14

## 🚨 Test instructions

Hopefully existing unit tests in this repo cover its use.

`detect-libc` has an extensive integration test suite, e.g. https://github.com/lovell/detect-libc/actions/runs/1717414863

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
