### PR TITLE
Fix autoinstalling node builtins

### DIFF
--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -313,7 +313,7 @@ export default class NodeResolver {
             'https://parceljs.org/features/node-emulation/#polyfilling-%26-excluding-builtin-node-modules',
         });
 
-        await packageManager.resolve(packageName, this.projectRoot + '/index', {
+        await packageManager.resolve(builtin, this.projectRoot + '/index', {
           saveDev: true,
           shouldAutoInstall: true,
         });


### PR DESCRIPTION
Fixes #7697

We need to pass the original builtin specifier (e.g. `process/browser.js` or `buffer/`) to resolve rather than just the package name (e.g. `process` or `buffer`) because the package name will resolve in node to a builtin rather than the browser version.