### PR TITLE
Pin lmdb@2.2.3

### DIFF
--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -27,7 +27,7 @@
     "@parcel/fs": "2.3.2",
     "@parcel/logger": "2.3.2",
     "@parcel/utils": "2.3.2",
-    "lmdb": "^2.0.2"
+    "lmdb": "2.2.3"
   },
   "peerDependencies": {
     "@parcel/core": "^2.3.2"

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -45,7 +45,7 @@
     "dotenv-expand": "^5.1.0",
     "json-source-map": "^0.6.1",
     "json5": "^2.2.0",
-    "msgpackr": "^1.5.1",
+    "msgpackr": "^1.5.4",
     "nullthrows": "^1.1.1",
     "semver": "^5.7.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8262,16 +8262,16 @@ listr2@^2.1.0:
     rxjs "^6.5.5"
     through "^2.3.8"
 
-lmdb@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.0.2.tgz#bdd78a686a4423cf2aaea38fb2acebbd1aca9f02"
-  integrity sha512-B0f4UePBHHsqVRrYJgNnlzDuhjjaCvyqugV3ZY7YO+9kLcoK/Fqm5yi4icTVIr+ijeVleN69puyx/2KSKVvtQw==
+lmdb@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.2.3.tgz#713ffa515c31e042808abf364b4aa0feaeaf6360"
+  integrity sha512-+OiHQpw22mBBxocb/9vcVNETqf0k5vgHA2r+KX7eCf8j5tSV50ZIv388iY1mnnrERIUhs2sjKQbZhPg7z4HyPQ==
   dependencies:
-    msgpackr "^1.5.0"
+    msgpackr "^1.5.4"
     nan "^2.14.2"
     node-gyp-build "^4.2.3"
-    ordered-binary "^1.1.0"
-    weak-lru-cache "^1.1.0"
+    ordered-binary "^1.2.4"
+    weak-lru-cache "^1.2.2"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -8986,10 +8986,10 @@ msgpackr-extract@^1.0.14:
     nan "^2.14.2"
     node-gyp-build "^4.2.3"
 
-msgpackr@^1.5.0, msgpackr@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.5.1.tgz#2a8e39d25458406034b8cb50dc7d6a7abd3dfff2"
-  integrity sha512-I1CXFG8BYYSeIhtDlHpUVMsdDiyvP9JAh1d9QoBnkPx3ETPeH/1lR14hweM9GETs09wCWlaOyhtXxIc9boxAAA==
+msgpackr@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.5.4.tgz#2b6ea6cb7d79c0ad98fc76c68163c48eda50cf0d"
+  integrity sha512-Z7w5Jg+2Q9z9gJxeM68d7tSuWZZGnFIRhZnyqcZCa/1dKkhOCNvR1TUV3zzJ3+vj78vlwKRzUgVDlW4jiSOeDA==
   optionalDependencies:
     msgpackr-extract "^1.0.14"
 
@@ -9579,10 +9579,10 @@ ora@^5.2.0:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-ordered-binary@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.1.3.tgz#11dbc0a4cb7f8248183b9845e031b443be82571e"
-  integrity sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ==
+ordered-binary@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.2.4.tgz#51d3a03af078a0bdba6c7bc8f4fedd1f5d45d83e"
+  integrity sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg==
 
 ordered-read-streams@^1.0.0:
   version "1.0.1"
@@ -13587,10 +13587,10 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-weak-lru-cache@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.1.3.tgz#8a691884501b611d2b5aeac1ee5a011b2a97d9a8"
-  integrity sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ==
+weak-lru-cache@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
+  integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
 
 web-namespaces@^1.0.0:
   version "1.1.3"


### PR DESCRIPTION
Also bump msgpackr@^1.5.4 to avoid the duplicate dependency.

Short synopsis (See [this comment](https://github.com/parcel-bundler/parcel/issues/7702#issuecomment-1047806811) for a more authoritative story):

- At lmdb@2.2.0, an optimization for committing transactions was enabled by default. It performs asynchronous flushes of transacted data to disk, and then notifies when the flush has completed.
- In Parcel's default multithreaded mode, a race condition occurs when threads would commit lmdb transactions and then terminate, thinking the transaction complete, while the flush to disk was still pending. When the flush completed, the attempt to notify the thread would segfault.
- At lmdb@2.2.2, this optimization was again disabled by default

This PR pins the version of lmdb to avoid the possibility of installing a version that might trigger the race.

We will be trading the ability for lmdb to ship fixes for Parcel users without a new Parcel release, but many projects will have a lockfile that effectively prevents upgrading lmdb without a bump from Parcel, anyway.

Related: 
- https://github.com/parcel-bundler/parcel/issues/7402
- https://github.com/parcel-bundler/parcel/issues/7645
- https://github.com/parcel-bundler/parcel/issues/7720
- https://github.com/parcel-bundler/parcel/issues/7702