### PR TITLE
Improve emoji support detection

### DIFF
--- a/packages/reporters/cli/src/emoji.js
+++ b/packages/reporters/cli/src/emoji.js
@@ -1,7 +1,23 @@
 // @flow strict-local
 
-const supportsEmoji =
-  process.platform !== 'win32' || process.env.TERM === 'xterm-256color';
+// From https://github.com/sindresorhus/is-unicode-supported/blob/8f123916d5c25a87c4f966dcc248b7ca5df2b4ca/index.js
+// This package is ESM-only so it has to be vendored
+function isUnicodeSupported() {
+  if (process.platform !== 'win32') {
+    return process.env.TERM !== 'linux'; // Linux console (kernel)
+  }
+
+  return (
+    Boolean(process.env.CI) ||
+    Boolean(process.env.WT_SESSION) || // Windows Terminal
+    process.env.ConEmuTask === '{cmd::Cmder}' || // ConEmu and cmder
+    process.env.TERM_PROGRAM === 'vscode' ||
+    process.env.TERM === 'xterm-256color' ||
+    process.env.TERM === 'alacritty'
+  );
+}
+
+const supportsEmoji = isUnicodeSupported();
 
 // Fallback symbols for Windows from https://en.wikipedia.org/wiki/Code_page_437
 export const progress: string = supportsEmoji ? '⏳' : '∞';

--- a/packages/utils/create-react-app/src/emoji.js
+++ b/packages/utils/create-react-app/src/emoji.js
@@ -1,7 +1,23 @@
 // @flow strict-local
 
-const supportsEmoji =
-  process.platform !== 'win32' || process.env.TERM === 'xterm-256color';
+// From https://github.com/sindresorhus/is-unicode-supported/blob/8f123916d5c25a87c4f966dcc248b7ca5df2b4ca/index.js
+// This package is ESM-only so it has to be vendored
+function isUnicodeSupported() {
+  if (process.platform !== 'win32') {
+    return process.env.TERM !== 'linux'; // Linux console (kernel)
+  }
+
+  return (
+    Boolean(process.env.CI) ||
+    Boolean(process.env.WT_SESSION) || // Windows Terminal
+    process.env.ConEmuTask === '{cmd::Cmder}' || // ConEmu and cmder
+    process.env.TERM_PROGRAM === 'vscode' ||
+    process.env.TERM === 'xterm-256color' ||
+    process.env.TERM === 'alacritty'
+  );
+}
+
+const supportsEmoji = isUnicodeSupported();
 
 // Fallback symbols for Windows from https://en.wikipedia.org/wiki/Code_page_437
 export const progress: string = supportsEmoji ? '⏳' : '∞';


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Resolve #7767

Unfortunately [`is-unicode-supported`](https://github.com/sindresorhus/is-unicode-supported) has to be vendored since it's ESM-only.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Assuming you are not on Windows (ironically, but this is easier to test):

```sh
# 1. Inspect $TERM
$ echo $TERM
xterm-256color
# 2. Create a dummy
$ touch index.html
# 3. Build the dummy, you should be able to see an emoji
$ yarn parcel build index.html
✨ Built in 511ms
# 4. Pretend to be Linux console and build the dummy again, should be able to see the fallback symbols:
$ TERM=linux yarn parcel build index.html
√ Built in 511ms
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
