### PR TITLE
Bump swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.5",
  "once_cell",
  "serde",
  "version_check",
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 
 [[package]]
 name = "arrayvec"
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -114,6 +114,15 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "better_scoped_tls"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73e8ecdec39e98aa3b19e8cd0b8ed8f77ccb86a6b0b2dc7cd86d105438a2123"
+dependencies = [
+ "scoped-tls",
+]
 
 [[package]]
 name = "bit-vec"
@@ -138,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31071741816efb54c473a6480724b2d31ed44eb460382d37f60cf4655fbe80a6"
+checksum = "67bf6eb040d26861376afa30a5b172f066bfda9cef992af7a55ac5395ef91437"
 dependencies = [
  "ahash",
  "anyhow",
@@ -186,9 +195,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 dependencies = [
  "jobserver",
 ]
@@ -303,9 +312,9 @@ checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -333,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -346,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -465,7 +474,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall 0.2.11",
  "winapi",
 ]
 
@@ -526,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -607,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
+checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
 dependencies = [
  "unindent",
 ]
@@ -721,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libdeflate-sys"
@@ -745,18 +754,18 @@ dependencies = [
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9636c194f9db483f4d0adf2f99a65011a99f904bd222bbd67fb4df4f37863c30"
+checksum = "7705fc40f6ed493f73584abbb324e74f96b358ff60dfe5659a0f8fc12c590a69"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -793,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5f78c1d9892fb5677a8b2f543f967ab891ac0f71feecd961435b74f877283a"
+checksum = "b0dfa131390c2f6bdb3242f65ff271fcdaca5ff7b6c08f28398be7f2280e3926"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -873,9 +882,9 @@ checksum = "67cf20e0081fea04e044aa4adf74cfea8ddc0324eec2894b1c700f4cafc72a56"
 
 [[package]]
 name = "nasm-rs"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f031925084b045b8ff1d7f9d035283a969c63c5849769e0b81ef0fe639370e72"
+checksum = "ce095842aee9aa3ecbda7a5d2a4df680375fd128a8596b6b56f8e497e231f483"
 dependencies = [
  "rayon",
 ]
@@ -988,15 +997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
 ]
 
@@ -1166,7 +1166,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.8.0",
  "rand",
 ]
 
@@ -1177,7 +1177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.8.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1189,6 +1189,15 @@ name = "phf_shared"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
@@ -1235,6 +1244,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "preset_env_base"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e072088b8b97a4ed729b40444fbb5cc6a7c1bc9b9c455a601d4de7f981a4987"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "browserslist-rs",
+ "dashmap",
+ "from_variant",
+ "once_cell",
+ "semver 1.0.6",
+ "serde",
+ "st-map",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1342,9 +1368,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -1368,9 +1394,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rgb"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a374af9a0e5fdcdd98c1c7b64f05004f9ea2555b6c75f211daa81268a3c50f1"
+checksum = "e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6"
 dependencies = [
  "bytemuck",
 ]
@@ -1396,7 +1422,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver 1.0.6",
 ]
 
 [[package]]
@@ -1404,15 +1430,6 @@ name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "scoped-tls"
@@ -1437,9 +1454,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 dependencies = [
  "serde",
 ]
@@ -1452,9 +1469,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -1482,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1493,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -1517,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1eead9e94aa5a2e02de9e7839f96a007f686ae7a1d57c7797774810d24908a"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "smallvec"
@@ -1554,12 +1571,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "static-map-macro"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,14 +1603,14 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923f0f39b6267d37d23ce71ae7235602134b250ace715dd2c90421998ddac0c6"
+checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
 ]
@@ -1611,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.8.0",
  "proc-macro2",
  "quote",
 ]
@@ -1653,23 +1664,23 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.17.0"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015b0c14152981b1590d05c6073ac602008e5fc414b7cc4b2bbae60220d27ff2"
+checksum = "ffd694004c48af55237f1e471ccefdb76f88da8d8ac4726612ea11c525d02425"
 dependencies = [
  "ahash",
  "ast_node",
  "atty",
+ "better_scoped_tls",
  "cfg-if 0.1.10",
  "debug_unreachable",
  "either",
  "from_variant",
  "num-bigint",
  "once_cell",
- "owning_ref",
  "rustc-hash",
- "scoped-tls",
  "serde",
+ "siphasher",
  "sourcemap",
  "string_cache",
  "swc_eq_ignore_macros",
@@ -1682,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.65.3"
+version = "0.68.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1aefdc512c8dfefa1de793c0e62a192bd74a7fa7e5affe3f08885751c127ee"
+checksum = "d465460177dcdf076f7c32b75cc0adede3c70506b4c7a859440001310e78e71f"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1697,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.89.0"
+version = "0.93.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667e9174226b2228b5ddc850f59db0b2689652efa0b5d5d3c072d1caba256cb7"
+checksum = "9c076c6b62b0504952c38c224b5cfc4c65ddf574210dba18e96babb2c0ca30e7"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1710,7 +1721,6 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
- "swc_ecma_parser",
  "tracing",
 ]
 
@@ -1729,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764c8e31524d35722aacdbee51e132424798365ddfd75deb81634f342c5fdce3"
+checksum = "be60d3b599557e0b49d06e9cad351ec196e2ab9e9a369a0780f000a47ab58404"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1747,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.87.1"
+version = "0.91.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f032c57793a287a8b374e92a2b606e5eb890539285e4723fe6acb9be1fadcec6"
+checksum = "ab23775f027fdff03db6c7c95e6070fea6eac25e21c5381b301ddea97ec39713"
 dependencies = [
  "either",
  "enum_kind",
@@ -1767,17 +1777,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.86.1"
+version = "0.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9526e01ade81f832d31b8d453593aa30a56e4538c49565fdd0b296ac1f04f2"
+checksum = "16954dd8ff0ad4ef4046a8aee5a31122413242d520efef38bea3c13f350e9a54"
 dependencies = [
  "ahash",
  "anyhow",
- "browserslist-rs",
  "dashmap",
  "indexmap",
  "once_cell",
- "semver 1.0.4",
+ "preset_env_base",
+ "semver 1.0.6",
  "serde",
  "serde_json",
  "st-map",
@@ -1788,19 +1798,17 @@ dependencies = [
  "swc_ecma_transforms",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "walkdir",
 ]
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.113.3"
+version = "0.124.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6abcf70753dafd6e04292c98a9c3d25198227df55586ead58aada57181f787"
+checksum = "514749f9cf31840fafb5124aa8442ad4f355fa7369cd1ec324df8632e5898684"
 dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
@@ -1815,13 +1823,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.57.1"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df852cb3c04bfde542f2fe4493ff0262a053a94a8da068fcb3ab2f6f40bffe8f"
+checksum = "49cfcab3966f8dc8c82604a50ccf54541dcc4101bff72ff70bbd6e73a37a1af7"
 dependencies = [
+ "better_scoped_tls",
  "once_cell",
  "phf",
- "scoped-tls",
  "serde",
  "smallvec",
  "swc_atoms",
@@ -1835,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.44.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b841535a8a97698a556c50fd5993a351e76b8bfd1e770ffc1b5425c1814b98"
+checksum = "d15131c3944964e290102ddc180251f01b1264e8873f5565fb3f3c097962f800"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1849,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.68.2"
+version = "0.75.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c335ec4c8cb999ca678330a61f4f18e6a9e45965124b8ae72c53bd047c9b816"
+checksum = "b5b8ead35220e5428d0f6e5497c345408c5222830183db31e7e2f869851c594d"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -1869,6 +1877,7 @@ dependencies = [
  "swc_ecma_transforms_macros",
  "swc_ecma_utils",
  "swc_ecma_visit",
+ "swc_trace_macro",
  "tracing",
 ]
 
@@ -1887,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.74.0"
+version = "0.84.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691383bb754c9d0e0ea2ebd6894543280b6aeeb60cbcd02250be3381f1618095"
+checksum = "b5f450d2aac7d2b6c75e283c9da385f05dac886dec990cb866c07752304527e2"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1909,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.83.0"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842d2cfb201a02be5b0bb1a1d048f4390ef95256088c87ef913b6a8de4d96991"
+checksum = "4103b2ba1f24dd7ff735d2fa33d86be5eefad4316d046e09509c11dba4f9bb5f"
 dependencies = [
  "ahash",
  "dashmap",
@@ -1931,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.74.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d729ed8b56df0376e60a370fc267445febada7da8237610ef8322ad59a642cf"
+checksum = "41bca77e95bdebfd9df234e707416bd57015808371010f5f1527314df86fc1e7"
 dependencies = [
  "either",
  "serde",
@@ -1941,7 +1950,6 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
@@ -1951,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.76.0"
+version = "0.86.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47983646bacdcb436194b40ff5c3254e80839bef1ab07c79b39977c2f8fa06a3"
+checksum = "165f0ca38eda6622b166e95d1b8643ad5358b4fa84f00c27377a0d12af08cbcc"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -1976,15 +1984,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.78.0"
+version = "0.89.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19732184e9832a5908ced92448bbb530f07a66b3ca90f8f27589868a42af5256"
+checksum = "5e5d6a8cd797383193a8138615a3f78de5da910fdd9b3f3543f02bcced603008"
 dependencies = [
  "serde",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
  "swc_ecma_utils",
@@ -1993,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.64.0"
+version = "0.69.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8105c87f59b54e49b95164efbdf346b710e0a77390e89869527ee20f68687b91"
+checksum = "3b289ad92ab2c2b5c55c7b2a8e3395b68b42a8145186549191786af5d44998d3"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2008,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.51.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95cf6f39cd1c3682885125955e881bec872e0c1743eb1a31735da69b894f065e"
+checksum = "768c7cb86162cb2538a188586909b5499740da73b2eb80b258210cf147652c84"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2022,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.110.6"
+version = "0.123.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308a6825900fff05a47e8dab932f611bf58fa131f1328763e2db8a8576ff9cf7"
+checksum = "643e8b16370a73258bfb162a1b1bf27888b4ed65d05c3962083fed7cae26bf6d"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2060,6 +2067,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_trace_macro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85341fb96c46bd873272553b8b1d4330f886fe5231969cc1564e1c659fee8334"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "swc_visit"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e505bbf8e11898fa05a65aa5e773c827ec743fc15aa3c064c9e06164ed0b6630"
+checksum = "c3b9b72892df873972549838bf84d6c56234c7502148a7e23b5a3da6e0fedfb8"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -2168,9 +2186,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2180,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2191,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
 ]
@@ -2245,9 +2263,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unindent"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
+checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
 
 [[package]]
 name = "unreachable"
@@ -2287,17 +2305,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "walkdir"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
-dependencies = [
- "same-file",
- "winapi",
- "winapi-util",
-]
 
 [[package]]
 name = "wasi"
@@ -2409,9 +2416,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575e15bedf6e57b5c2d763ffc6c3c760143466cbd09d762d539680ab5992ded"
+checksum = "886f21441c6731b9e06a9fdacbc5e29319c17a4069c2a511d80349874864702d"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.4",
  "once_cell",
  "serde",
  "version_check",
@@ -168,9 +168,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytemuck"
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -505,9 +505,9 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "generic-array"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
@@ -526,9 +526,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -727,18 +727,18 @@ checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libdeflate-sys"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce0b849741cecad96125e51124570c46741f50db12007224295b63e221f0034"
+checksum = "4cceaf6e335d658ec0602685bfe50d0f35248d6d8848b194058bfda37a9eb728"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32b70f071880dd130e410be35f8017892837913374a311e277219d3ead3ab18"
+checksum = "15f0c115fd181333eb7a82cf42e2ce2d9fac0ad06babd3ab79a9ec5bd66352fe"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -873,9 +873,9 @@ checksum = "67cf20e0081fea04e044aa4adf74cfea8ddc0324eec2894b1c700f4cafc72a56"
 
 [[package]]
 name = "nasm-rs"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06380d23b58dcdaf892fa36c3950cad3110e7d76851275d5f85c22eb9cdd614"
+checksum = "f031925084b045b8ff1d7f9d035283a969c63c5849769e0b81ef0fe639370e72"
 dependencies = [
  "rayon",
 ]
@@ -983,9 +983,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "ordered-float"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c9d06878b3a851e8026ef94bf7fef9ba93062cd412601da4d9cf369b1cc62d"
+checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
 dependencies = [
  "num-traits",
 ]
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pmutil"
@@ -1224,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "precomputed-hash"
@@ -1493,9 +1493,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1517,15 +1517,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "ba1eead9e94aa5a2e02de9e7839f96a007f686ae7a1d57c7797774810d24908a"
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "sourcemap"
@@ -1682,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.65.2"
+version = "0.65.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a82d26122365a721a7df46bd3e4240fbf19188d9ccf18c7faaa4d12dfc51488"
+checksum = "ff1aefdc512c8dfefa1de793c0e62a192bd74a7fa7e5affe3f08885751c127ee"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.84.0"
+version = "0.86.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b064eca226637af7fa7f734fc6dd0d01b50c90418d7fce2c64da26ff89d2e4f1"
+checksum = "5d9526e01ade81f832d31b8d453593aa30a56e4538c49565fdd0b296ac1f04f2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1793,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.111.3"
+version = "0.113.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd7878bd017ed942fdcd5a892fa4990c21b1fe49c4aca7be1ecba16403e7052"
+checksum = "cd6abcf70753dafd6e04292c98a9c3d25198227df55586ead58aada57181f787"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1815,9 +1815,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.56.2"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d62c460e81027cdda2325348c1e5c0233c59127ab3227a45aaeac80eac7c5df1"
+checksum = "df852cb3c04bfde542f2fe4493ff0262a053a94a8da068fcb3ab2f6f40bffe8f"
 dependencies = [
  "once_cell",
  "phf",
@@ -1835,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.43.1"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd6d1fbe53dfa365827eddadbafec687c7afecd294c54a62fedcd92c4e44293"
+checksum = "b1b841535a8a97698a556c50fd5993a351e76b8bfd1e770ffc1b5425c1814b98"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1849,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.67.3"
+version = "0.68.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2093adad355fe2e90ad1b64d85dee2c128469013f90ce64725dcae78ee8ab316"
+checksum = "8c335ec4c8cb999ca678330a61f4f18e6a9e45965124b8ae72c53bd047c9b816"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -1887,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddd82f8308d0ac207cb89c35b929db98add685cce708bf161402595fa00eae6"
+checksum = "691383bb754c9d0e0ea2ebd6894543280b6aeeb60cbcd02250be3381f1618095"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1909,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.81.1"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "653395bad3ace0b3dcc99d9edf45bd08bbd97f48f8aec519d5b8ac336779ee00"
+checksum = "842d2cfb201a02be5b0bb1a1d048f4390ef95256088c87ef913b6a8de4d96991"
 dependencies = [
  "ahash",
  "dashmap",
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.73.1"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da8cb3be65a35abfef0f4311d3f76dda381162a4920e526e3e7ac39d693df360"
+checksum = "3d729ed8b56df0376e60a370fc267445febada7da8237610ef8322ad59a642cf"
 dependencies = [
  "either",
  "serde",
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.75.2"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9e590632bfd9b958f7b68f408040a320a95920021a241f1a403e6670f004cb"
+checksum = "47983646bacdcb436194b40ff5c3254e80839bef1ab07c79b39977c2f8fa06a3"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -1976,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.77.2"
+version = "0.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fe8ca3b3ad557407449fcc653acde3026aa6078fa4307ae6b318a35514fd8f"
+checksum = "19732184e9832a5908ced92448bbb530f07a66b3ca90f8f27589868a42af5256"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -1993,10 +1993,11 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.63.0"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05826c1edd7d58ec97af8be523c9c15e24e6dc4c1762435bb12573d716dd7ba"
+checksum = "8105c87f59b54e49b95164efbdf346b710e0a77390e89869527ee20f68687b91"
 dependencies = [
+ "indexmap",
  "once_cell",
  "swc_atoms",
  "swc_common",
@@ -2021,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.108.4"
+version = "0.110.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5feaed38d2e24849c1b1bb725ea455855ebe4bff52332a491cabc07d107db322"
+checksum = "308a6825900fff05a47e8dab932f611bf58fa131f1328763e2db8a8576ff9cf7"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2277,9 +2278,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "browserslist-rs"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +373,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +470,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -718,24 +747,74 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical"
-version = "5.2.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f404a90a744e32e8be729034fc33b90cf2a56418fbf594d69aa3c0214ad414e5"
+checksum = "ccd3e434c16f0164124ade12dcdee324fcc3dafb1cad0c7f1d8c2451a1aa6886"
 dependencies = [
- "cfg-if 1.0.0",
  "lexical-core",
 ]
 
 [[package]]
 name = "lexical-core"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+checksum = "92912c4af2e7d9075be3e5e3122c4d7263855fa6cce34fbece4dd08e5884624d"
 dependencies = [
- "arrayvec 0.5.2",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f518eed87c3be6debe6d26b855c97358d8a11bf05acec137e5f53080f5ad2dd8"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc852ec67c6538bbb2b9911116a385b24510e879a69ab516e6a151b15a79168"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72a9d52c5c4e62fa2cdc2cb6c694a39ae1382d9c2a17a466f18e272a0930eb1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26f6202bff3d35ede41a6200227837468bb92e4ecdd437328b1055ed218fb855"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094060bd2a7c2ff3a16d5304a6ae82727cb3cc9d1c70f813cc73f744c319337e"
+dependencies = [
+ "lexical-util",
  "static_assertions",
 ]
 
@@ -928,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1080,7 +1159,7 @@ dependencies = [
  "pathdiff",
  "serde",
  "serde_bytes",
- "sha-1",
+ "sha-1 0.9.8",
  "swc_atoms",
  "swc_common",
  "swc_ecmascript",
@@ -1185,12 +1264,12 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phf"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
  "phf_macros",
- "phf_shared 0.8.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
 
@@ -1201,17 +1280,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared 0.8.0",
- "rand",
+ "rand 0.7.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
- "phf_generator",
- "phf_shared 0.8.0",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -1279,9 +1368,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaaf9314d89d97abb69a81dc8ae2ac4ee398184068e085c0e20ecb4fea034084"
+checksum = "e44b8d534a4ecea4519138ff80780a499691c4e948bc063651487e069966a703"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1326,10 +1415,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
  "rand_pcg",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1339,7 +1439,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1352,12 +1462,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.5",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1366,7 +1485,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1559,11 +1678,22 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1655,7 +1785,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.8.0",
  "phf_shared 0.8.0",
  "proc-macro2",
  "quote",
@@ -1713,15 +1843,15 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.17.14"
+version = "0.17.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e413d6e2d304b45adb55f85d9ba684e1020616156a7483e6a060a2e47db972"
+checksum = "af06472bfc423fb7b75c483eccfb9b6790db9de0fb2d6ff1ef8369a2551a3707"
 dependencies = [
  "ahash",
  "ast_node",
  "atty",
  "better_scoped_tls",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "debug_unreachable",
  "either",
  "from_variant",
@@ -1742,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b2e9a1a9e3f71557971dd096aa3fff7487f2c419d2f93c0d71445352a36dc8"
+checksum = "e35d736b61d3dceb5a4e18a86d69bfc352aa7136fd3c5a6c2f3353231cd9d839"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1757,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.94.1"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f352c9d36b0d5b92ccab7e774bbf243a1d3be721792798815b76f69e1e56e32"
+checksum = "8fa4a2b82e2bab5bea6472e23b14bd96c462ae9e1e29d9af2ea8ea6d58dcc406"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1806,9 +1936,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.92.7"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53e529ee2504ac513171e8c31c77c6c527d56a27259807d1950ed58b3901a28"
+checksum = "6bcc4ebfd0c5f7c9e5fd03b3dff680d61e997e51147e6f4738ee3274be5ad382"
 dependencies = [
  "either",
  "enum_kind",
@@ -1826,13 +1956,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.104.0"
+version = "0.106.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ed547302d317c6e629b80747f5a75d06d6887ba2e4434f2e81411f33e05f00"
+checksum = "4c76924d65625afb0536c433d59a6f63fee0388e0ab7f121bda9ec92a84b4678"
 dependencies = [
  "ahash",
  "anyhow",
- "dashmap 4.0.2",
+ "dashmap 5.1.0",
  "indexmap",
  "once_cell",
  "preset_env_base",
@@ -1851,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.130.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9333d80deef03e37cfbf0a396d1604fbec8a6d72ad6cb27138367c1d19fc94"
+checksum = "484ab8024a62c8f35a408898d0b8aa664e03a992c2f262cda6173274f48d955e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1871,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.66.1"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a3def66ae98c8e3cd6436e02e42a787fc2ee7956ee73e13a8b449c0560a328"
+checksum = "6786157670709b3c9e2a81aee7aef8042b582b4b599f233025b28ca5353a29d9"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
@@ -1891,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4314241d66c22a6015e87c563ab7e0ac2519712822dc81c91c56575fe1de613"
+checksum = "6dd06b4fa72cd85640fcab59c210c34c8e63f6ea5e547c856febcf18000c0bda"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1905,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.79.1"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d07603599624024734fe85961cd48a3eace1a72f316d3d0232187a594f29f5"
+checksum = "f622788e39755b4a0b9902e37314fbc59f163d5e9e24c121a95c8352fb00e1e0"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -1944,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.90.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60762763c4c5ec8f9f8a86408fd0cfa01802d5a274f8ecdb4327ba6292fff52a"
+checksum = "3b050435473be3392bdc665682cf3637c006ea5fe57f6f58cf3be08ae597fab9"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1968,12 +2098,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.100.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ce53a1efa05e9bbeb2f8a16a1e153801708d7bea692776442bf43576f1921b"
+checksum = "a0638979a3445e49125ab28a30dc734c272e66406db5583d9095f459543056ac"
 dependencies = [
  "ahash",
- "dashmap 4.0.2",
+ "dashmap 5.1.0",
  "indexmap",
  "once_cell",
  "serde_json",
@@ -1990,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.87.0"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb5290bb79e3112c2124167c3b4a6e1225afcd576fd769912ed691f5bf46029"
+checksum = "7bf987316b088789266b108b9ad87f8479402a76233565ef31807103766bc079"
 dependencies = [
  "either",
  "serde",
@@ -2009,18 +2139,18 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.92.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b618bfc4d3a99df1081bfe0b833d14572ab36dd2c245d1ab51c581b2d74b843"
+checksum = "dd2d009bb8be4149a1b3bb8ea2e4c59c5a26ed5b5ae797563026887480ed9141"
 dependencies = [
  "ahash",
  "base64 0.13.0",
- "dashmap 4.0.2",
+ "dashmap 5.1.0",
  "indexmap",
  "once_cell",
  "regex",
  "serde",
- "sha-1",
+ "sha-1 0.10.0",
  "string_enum",
  "swc_atoms",
  "swc_common",
@@ -2034,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.95.0"
+version = "0.96.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b126d9e2545e975d2ae09277c2f16bb682b0111f03e643e3b59e56831a7f6b4"
+checksum = "ed2e388f0b424de694aac45aaad513e7ccb03aeb87ed42781ce353e1346b3d86"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2050,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.71.0"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee41829a14f59d6f93a5f5721f08797b214caa4d037913b51ab61a9d31e10576"
+checksum = "43689c9f051b48c4ea9eb86b236b27277594a9c4311d3ee88d7007f5d65b1ff5"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2065,9 +2195,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b359c0ddd3f474dcc379d3c011670be3b855229bcb523e6571897c5beae42957"
+checksum = "9b70316301b54ead435ae2660824ba3049de1854710b73395e1b8e615dc0bca6"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2079,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.130.0"
+version = "0.132.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3469465d772bf49b29b735e2f1cd0f1124064b15fd8ccfa0ab4ab75fab997"
+checksum = "7fa1f0e2b8bcb94f30b276c633743e6d2cf06e5ceb0561fe1bb55d47d020921e"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,10 +67,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "ast_node"
-version = "0.7.4"
+name = "arrayvec"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96d5444b02f3080edac8a144f6baf29b2fb6ff589ad4311559731a7c7529381"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
+name = "ast_node"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b2dd56b7c509b3a0bb47a97a066cba459983470d3b8a3c20428737270f70bd"
 dependencies = [
  "darling",
  "pmutil",
@@ -619,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "is-macro"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a322dd16d960e322c3d92f541b4c1a4f0a2e81e1fdeee430d8cecc8b72e8015f"
+checksum = "94b2c46692aee0d1b3aad44e781ac0f0e7db42ef27adaa0a877b627040019813"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -706,7 +712,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "bitflags",
  "cfg-if 1.0.0",
  "ryu",
@@ -1361,12 +1367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "retain_mut"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11000e6ba5020e53e7cc26f73b91ae7d5496b4977851479edb66b694c0675c21"
-
-[[package]]
 name = "rgb"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,7 +1433,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
- "serde",
 ]
 
 [[package]]
@@ -1441,6 +1440,9 @@ name = "semver"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -1450,9 +1452,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
@@ -1480,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1547,7 +1549,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3caeb13a58f859600a7b75fffe66322e1fca0122ca02cfc7262344a7e30502d1"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "static-map-macro",
 ]
 
@@ -1651,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.15.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf33ac965b9ce43b653baa35a5de6ecfd96b9bbab9547a5fb4ce33c46a36fe75"
+checksum = "015b0c14152981b1590d05c6073ac602008e5fc414b7cc4b2bbae60220d27ff2"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1680,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.60.3"
+version = "0.65.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ab2356281c38cf629f3cdb165c4d34e17b2757b020dab914bae477ee0fb373"
+checksum = "3a82d26122365a721a7df46bd3e4240fbf19188d9ccf18c7faaa4d12dfc51488"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1695,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.84.1"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "383ac26d122a9f97a1773ffa6f44366e8ab08ccc14e5698111c698ca17acfa65"
+checksum = "667e9174226b2228b5ddc850f59db0b2689652efa0b5d5d3c072d1caba256cb7"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1727,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.25.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645b674e9f537053026670985486004a47c3c168a71de8de0c0d57c2f2cb61f8"
+checksum = "764c8e31524d35722aacdbee51e132424798365ddfd75deb81634f342c5fdce3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1739,16 +1741,15 @@ dependencies = [
  "path-clean",
  "serde",
  "serde_json",
- "swc_atoms",
  "swc_common",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.82.6"
+version = "0.87.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b0455e02c59d53891422593b2e0aaf06548873a1c319ddcf3e9a741d34ce41d"
+checksum = "f032c57793a287a8b374e92a2b606e5eb890539285e4723fe6acb9be1fadcec6"
 dependencies = [
  "either",
  "enum_kind",
@@ -1766,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.76.2"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4ce83d144d995a8362cea85fe7c6adaa728fbe4a8bad05d05f8d3d2b27e37b"
+checksum = "b064eca226637af7fa7f734fc6dd0d01b50c90418d7fce2c64da26ff89d2e4f1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1776,7 +1777,7 @@ dependencies = [
  "dashmap",
  "indexmap",
  "once_cell",
- "semver 0.9.0",
+ "semver 1.0.4",
  "serde",
  "serde_json",
  "st-map",
@@ -1792,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.103.8"
+version = "0.111.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e5d7bbc83aca7b172f18fe1ad713a58490f7420bd4831481e18a3d86e0199f"
+checksum = "8dd7878bd017ed942fdcd5a892fa4990c21b1fe49c4aca7be1ecba16403e7052"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1814,13 +1815,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.49.2"
+version = "0.56.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f401256219e566fc92f637182d20eb04de8cd1bb650dd72d3e0e81851a5367b"
+checksum = "d62c460e81027cdda2325348c1e5c0233c59127ab3227a45aaeac80eac7c5df1"
 dependencies = [
  "once_cell",
  "phf",
  "scoped-tls",
+ "serde",
  "smallvec",
  "swc_atoms",
  "swc_common",
@@ -1833,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.36.1"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd400da7c4b061a95c38f98d7a72f12c7cf7d49fee33e5bb5ca577e19a344b52"
+checksum = "5cd6d1fbe53dfa365827eddadbafec687c7afecd294c54a62fedcd92c4e44293"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1847,12 +1849,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.59.10"
+version = "0.67.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d76ac375527f495b5b095e7e32d43e47b57113abe72b75306dcd58b4d15fbde"
+checksum = "2093adad355fe2e90ad1b64d85dee2c128469013f90ce64725dcae78ee8ab316"
 dependencies = [
  "ahash",
- "arrayvec",
+ "arrayvec 0.7.2",
  "indexmap",
  "is-macro",
  "num-bigint",
@@ -1885,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.65.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701c941a6ba8d4e396a3e63031a9d4ee4807dc91b29c30069e88c0276a44a01e"
+checksum = "fddd82f8308d0ac207cb89c35b929db98add685cce708bf161402595fa00eae6"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1907,15 +1909,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.73.1"
+version = "0.81.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dddf3630b5c60aa4d05e3486099eec7195d96ec17895fa58753d383935b09c"
+checksum = "653395bad3ace0b3dcc99d9edf45bd08bbd97f48f8aec519d5b8ac336779ee00"
 dependencies = [
  "ahash",
  "dashmap",
  "indexmap",
  "once_cell",
- "retain_mut",
  "serde_json",
  "swc_atoms",
  "swc_common",
@@ -1930,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.65.2"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1493c6460a5009cff53e5adaac7e2090bde73be9dccb92b01fe132c190824b2"
+checksum = "da8cb3be65a35abfef0f4311d3f76dda381162a4920e526e3e7ac39d693df360"
 dependencies = [
  "either",
  "serde",
@@ -1950,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.67.1"
+version = "0.75.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a9c3ed9ff2c30faba6851d9287a2b21a9efdc0f4aba234980f8c57028bf2ea"
+checksum = "4d9e590632bfd9b958f7b68f408040a320a95920021a241f1a403e6670f004cb"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -1975,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.69.1"
+version = "0.77.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00d48c902c53d5118ecfa5eb8346d78a9d51f062da425bf03bfc101205b390f6"
+checksum = "29fe8ca3b3ad557407449fcc653acde3026aa6078fa4307ae6b318a35514fd8f"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -1992,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.56.2"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a3cb85935a25f5a78bdcf8252a0423eeb3aa3d027c16d2ae425454e0ab2a4c2"
+checksum = "a05826c1edd7d58ec97af8be523c9c15e24e6dc4c1762435bb12573d716dd7ba"
 dependencies = [
  "once_cell",
  "swc_atoms",
@@ -2002,14 +2003,13 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
- "unicode-xid",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c03856f785763e50019ebd70281e9490c5b019f93cfc1dda180d49e30fcb4c"
+checksum = "95cf6f39cd1c3682885125955e881bec872e0c1743eb1a31735da69b894f065e"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2021,9 +2021,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.99.9"
+version = "0.108.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f0c9a2b6acfa0fff19ba80a6bff86240417bd9b1a168af97c3591eea99555"
+checksum = "5feaed38d2e24849c1b1bb725ea455855ebe4bff52332a491cabc07d107db322"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "arrayvec"
@@ -74,9 +74,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ast_node"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2dd56b7c509b3a0bb47a97a066cba459983470d3b8a3c20428737270f70bd"
+checksum = "bc4c00309ed1c8104732df4a5fa9acc3b796b6f8531dfbd5ce0078c86f997244"
 dependencies = [
  "darling",
  "pmutil",
@@ -147,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bf6eb040d26861376afa30a5b172f066bfda9cef992af7a55ac5395ef91437"
+checksum = "a0f43be8e0fc9203f6ed7731d2a9a6bf5924cb78907e67e1fe9133617be402be"
 dependencies = [
  "ahash",
  "anyhow",
@@ -183,9 +183,9 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytemuck"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439989e6b8c38d1b6570a384ef1e49c8848128f5a97f3914baef02920842712f"
+checksum = "0e851ca7c24871e7336801608a4797d7376545b6928a10d32d75685687141ead"
 
 [[package]]
 name = "byteorder"
@@ -406,6 +406,17 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
@@ -980,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "opaque-debug"
@@ -1093,7 +1104,7 @@ version = "0.1.0"
 dependencies = [
  "js-sys",
  "parcel-js-swc-core",
- "parking_lot_core",
+ "parking_lot_core 0.8.0",
  "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
@@ -1107,7 +1118,17 @@ checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.0",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1123,6 +1144,19 @@ dependencies = [
  "redox_syscall 0.1.57",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.11",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1245,14 +1279,14 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "preset_env_base"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e072088b8b97a4ed729b40444fbb5cc6a7c1bc9b9c455a601d4de7f981a4987"
+checksum = "eaaf9314d89d97abb69a81dc8ae2ac4ee398184068e085c0e20ecb4fea034084"
 dependencies = [
  "ahash",
  "anyhow",
  "browserslist-rs",
- "dashmap",
+ "dashmap 4.0.2",
  "from_variant",
  "once_cell",
  "semver 1.0.6",
@@ -1377,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1534,9 +1568,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
@@ -1609,7 +1643,7 @@ checksum = "33994d0838dc2d152d17a62adf608a869b5e846b65b389af7f3dbc1de45c5b26"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "parking_lot",
+ "parking_lot 0.11.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -1663,10 +1697,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "swc_common"
-version = "0.17.9"
+name = "swc_cached"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd694004c48af55237f1e471ccefdb76f88da8d8ac4726612ea11c525d02425"
+checksum = "84fed4a980e12c737171a7b17c5e0a2f4272899266fa0632ea4e31264ebdfdb5"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "dashmap 5.1.0",
+ "once_cell",
+ "regex",
+ "serde",
+ "swc_atoms",
+]
+
+[[package]]
+name = "swc_common"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e413d6e2d304b45adb55f85d9ba684e1020616156a7483e6a060a2e47db972"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1693,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.68.3"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d465460177dcdf076f7c32b75cc0adede3c70506b4c7a859440001310e78e71f"
+checksum = "d4b2e9a1a9e3f71557971dd096aa3fff7487f2c419d2f93c0d71445352a36dc8"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1703,14 +1752,14 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "unicode-xid",
+ "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.93.5"
+version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c076c6b62b0504952c38c224b5cfc4c65ddf574210dba18e96babb2c0ca30e7"
+checksum = "8f352c9d36b0d5b92ccab7e774bbf243a1d3be721792798815b76f69e1e56e32"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1739,13 +1788,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be60d3b599557e0b49d06e9cad351ec196e2ab9e9a369a0780f000a47ab58404"
+checksum = "f9ab69df5d4de425833e02de111f14b5544b39ad9c9b82c97e4835fc55c8f1b6"
 dependencies = [
  "ahash",
  "anyhow",
- "dashmap",
+ "dashmap 4.0.2",
  "normpath",
  "once_cell",
  "path-clean",
@@ -1757,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.91.12"
+version = "0.92.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab23775f027fdff03db6c7c95e6070fea6eac25e21c5381b301ddea97ec39713"
+checksum = "d53e529ee2504ac513171e8c31c77c6c527d56a27259807d1950ed58b3901a28"
 dependencies = [
  "either",
  "enum_kind",
@@ -1772,18 +1821,18 @@ dependencies = [
  "swc_ecma_ast",
  "tracing",
  "typed-arena 2.0.1",
- "unicode-xid",
+ "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.98.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16954dd8ff0ad4ef4046a8aee5a31122413242d520efef38bea3c13f350e9a54"
+checksum = "65ed547302d317c6e629b80747f5a75d06d6887ba2e4434f2e81411f33e05f00"
 dependencies = [
  "ahash",
  "anyhow",
- "dashmap",
+ "dashmap 4.0.2",
  "indexmap",
  "once_cell",
  "preset_env_base",
@@ -1802,9 +1851,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.124.1"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514749f9cf31840fafb5124aa8442ad4f355fa7369cd1ec324df8632e5898684"
+checksum = "1a9333d80deef03e37cfbf0a396d1604fbec8a6d72ad6cb27138367c1d19fc94"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1818,14 +1867,13 @@ dependencies = [
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "unicode-xid",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.63.0"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49cfcab3966f8dc8c82604a50ccf54541dcc4101bff72ff70bbd6e73a37a1af7"
+checksum = "f8a3def66ae98c8e3cd6436e02e42a787fc2ee7956ee73e13a8b449c0560a328"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
@@ -1843,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.51.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15131c3944964e290102ddc180251f01b1264e8873f5565fb3f3c097962f800"
+checksum = "d4314241d66c22a6015e87c563ab7e0ac2519712822dc81c91c56575fe1de613"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1857,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.75.5"
+version = "0.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b8ead35220e5428d0f6e5497c345408c5222830183db31e7e2f869851c594d"
+checksum = "b2d07603599624024734fe85961cd48a3eace1a72f316d3d0232187a594f29f5"
 dependencies = [
  "ahash",
  "arrayvec 0.7.2",
@@ -1896,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.84.2"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f450d2aac7d2b6c75e283c9da385f05dac886dec990cb866c07752304527e2"
+checksum = "60762763c4c5ec8f9f8a86408fd0cfa01802d5a274f8ecdb4327ba6292fff52a"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1907,6 +1955,7 @@ dependencies = [
  "pathdiff",
  "serde",
  "swc_atoms",
+ "swc_cached",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_loader",
@@ -1914,16 +1963,17 @@ dependencies = [
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
+ "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.94.0"
+version = "0.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4103b2ba1f24dd7ff735d2fa33d86be5eefad4316d046e09509c11dba4f9bb5f"
+checksum = "98ce53a1efa05e9bbeb2f8a16a1e153801708d7bea692776442bf43576f1921b"
 dependencies = [
  "ahash",
- "dashmap",
+ "dashmap 4.0.2",
  "indexmap",
  "once_cell",
  "serde_json",
@@ -1940,9 +1990,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.82.0"
+version = "0.87.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bca77e95bdebfd9df234e707416bd57015808371010f5f1527314df86fc1e7"
+checksum = "3cb5290bb79e3112c2124167c3b4a6e1225afcd576fd769912ed691f5bf46029"
 dependencies = [
  "either",
  "serde",
@@ -1959,13 +2009,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.86.2"
+version = "0.92.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165f0ca38eda6622b166e95d1b8643ad5358b4fa84f00c27377a0d12af08cbcc"
+checksum = "6b618bfc4d3a99df1081bfe0b833d14572ab36dd2c245d1ab51c581b2d74b843"
 dependencies = [
  "ahash",
  "base64 0.13.0",
- "dashmap",
+ "dashmap 4.0.2",
  "indexmap",
  "once_cell",
  "regex",
@@ -1984,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.89.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5d6a8cd797383193a8138615a3f78de5da910fdd9b3f3543f02bcced603008"
+checksum = "6b126d9e2545e975d2ae09277c2f16bb682b0111f03e643e3b59e56831a7f6b4"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2000,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.69.0"
+version = "0.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b289ad92ab2c2b5c55c7b2a8e3395b68b42a8145186549191786af5d44998d3"
+checksum = "ee41829a14f59d6f93a5f5721f08797b214caa4d037913b51ab61a9d31e10576"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2015,9 +2065,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.54.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "768c7cb86162cb2538a188586909b5499740da73b2eb80b258210cf147652c84"
+checksum = "b359c0ddd3f474dcc379d3c011670be3b855229bcb523e6571897c5beae42957"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2029,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.123.0"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643e8b16370a73258bfb162a1b1bf27888b4ed65d05c3962083fed7cae26bf6d"
+checksum = "cde3469465d772bf49b29b735e2f1cd0f1124064b15fd8ccfa0ab4ab75fab997"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2068,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_trace_macro"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85341fb96c46bd873272553b8b1d4330f886fe5231969cc1564e1c659fee8334"
+checksum = "8d1a05fdb40442d687cb2eff4e5c374886a66ced1436ad87515de7d72b3ec10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2114,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -2186,9 +2236,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tracing"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2198,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2209,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
 ]
@@ -2239,6 +2289,12 @@ name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4285d92be83dfbc8950a2601178b89ed36f979ebf51bfcf7b272b17001184e6c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2413,6 +2469,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "xxhash-rust"

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -23,6 +23,7 @@ import {makeDeferredWithPromise, normalizePath} from '@parcel/utils';
 import vm from 'vm';
 import Logger from '@parcel/logger';
 import nullthrows from 'nullthrows';
+import {md} from '@parcel/diagnostic';
 
 describe('javascript', function () {
   beforeEach(async () => {
@@ -5308,7 +5309,7 @@ describe('javascript', function () {
         name: 'BuildError',
         diagnostics: [
           {
-            message: `Failed to resolve '@swc/helpers' from '${normalizePath(
+            message: md`Failed to resolve '@swc/helpers' from '${normalizePath(
               require.resolve('@parcel/transformer-js/src/JSTransformer.js'),
             )}'`,
             origin: '@parcel/core',

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.130.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.17.14", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.132.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.17.15", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.9"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.110.4", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.17.0", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.123.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.17.9", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.9"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.123.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.17.9", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.130.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.17.14", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.9"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.99.9", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.15.1", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.108.4", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.17.0", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.9"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.108.4", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_ecmascript = { version = "0.110.4", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
 swc_common = { version = "0.17.0", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.9"
 indoc = "1.0.3"

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -427,22 +427,18 @@ impl<'a> Fold for DependencyCollector<'a> {
             }
           }
           Member(member) => {
-            if match_member_expr(&member, vec!["module", "require"], self.decls) {
+            if match_member_expr(member, vec!["module", "require"], self.decls) {
               DependencyKind::Require
             } else if self.config.is_browser
               && match_member_expr(
-                &member,
+                member,
                 vec!["navigator", "serviceWorker", "register"],
                 self.decls,
               )
             {
               DependencyKind::ServiceWorker
             } else if self.config.is_browser
-              && match_member_expr(
-                &member,
-                vec!["CSS", "paintWorklet", "addModule"],
-                self.decls,
-              )
+              && match_member_expr(member, vec!["CSS", "paintWorklet", "addModule"], self.decls)
             {
               DependencyKind::Worklet
             } else {
@@ -450,7 +446,7 @@ impl<'a> Fold for DependencyCollector<'a> {
 
               // Match compiled dynamic imports (Parcel)
               // Promise.resolve(require('foo'))
-              if match_member_expr(&member, vec!["Promise", "resolve"], self.decls) {
+              if match_member_expr(member, vec!["Promise", "resolve"], self.decls) {
                 if let Some(expr) = node.args.get(0) {
                   if match_require(&*expr.expr, self.decls, Mark::fresh(Mark::root())).is_some() {
                     self.in_promise = true;
@@ -1164,7 +1160,7 @@ impl<'a> DependencyCollector<'a> {
           return false;
         }
 
-        let name = match_property_name(&member);
+        let name = match_property_name(member);
 
         if let Some((name, _)) = name {
           name == js_word!("url")

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 use swc_atoms::JsWord;
 use swc_common::{Mark, SourceMap, Span, SyntaxContext, DUMMY_SP};
-use swc_ecmascript::ast;
+use swc_ecmascript::ast::{self, Callee, MemberProp};
 use swc_ecmascript::utils::ident::IdentLike;
 use swc_ecmascript::visit::{Fold, FoldWith};
 
@@ -185,7 +185,7 @@ impl<'a> DependencyCollector<'a> {
     // For scripts, we replace with __parcel__require__, which is later replaced
     // by a real parcelRequire of the resolved asset in the packager.
     if self.config.source_type == SourceType::Script {
-      res.callee = ast::ExprOrSuper::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
+      res.callee = ast::Callee::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
         "__parcel__require__".into(),
         DUMMY_SP,
       ))));
@@ -326,166 +326,168 @@ impl<'a> Fold for DependencyCollector<'a> {
   }
 
   fn fold_call_expr(&mut self, node: ast::CallExpr) -> ast::CallExpr {
-    use ast::{Expr::*, ExprOrSuper::*, Ident};
+    use ast::{Expr::*, Ident};
 
-    let call_expr = match node.callee.clone() {
-      Super(_) => return node,
-      Expr(boxed) => boxed,
-    };
-
-    let kind = match &*call_expr {
-      Ident(ident) => {
-        // Bail if defined in scope
-        if self.decls.contains(&ident.to_id()) {
-          return node.fold_children_with(self);
-        }
-
-        match ident.sym.to_string().as_str() {
-          "import" => DependencyKind::DynamicImport,
-          "require" => {
-            if self.in_promise {
-              DependencyKind::DynamicImport
-            } else {
-              DependencyKind::Require
+    let kind = match &node.callee {
+      Callee::Import(_) => DependencyKind::DynamicImport,
+      Callee::Expr(expr) => {
+        match &**expr {
+          Ident(ident) => {
+            // Bail if defined in scope
+            if self.decls.contains(&ident.to_id()) {
+              return node.fold_children_with(self);
             }
-          }
-          "importScripts" => {
-            if self.config.is_worker {
-              let (msg, span) = if self.config.source_type == SourceType::Script {
-                // Ignore if argument is not a string literal.
-                let span = if let Some(ast::ExprOrSpread { expr, .. }) = node.args.get(0) {
-                  match &**expr {
-                    Lit(ast::Lit::Str(ast::Str { value, span, .. })) => {
-                      // Ignore absolute URLs.
-                      if value.starts_with("http:")
-                        || value.starts_with("https:")
-                        || value.starts_with("//")
-                      {
-                        return node.fold_children_with(self);
-                      }
-                      span
-                    }
-                    _ => {
-                      return node.fold_children_with(self);
-                    }
-                  }
+
+            match ident.sym.to_string().as_str() {
+              "require" => {
+                if self.in_promise {
+                  DependencyKind::DynamicImport
                 } else {
-                  return node.fold_children_with(self);
-                };
-
-                (
-                  "Argument to importScripts() must be a fully qualified URL.",
-                  *span,
-                )
-              } else {
-                (
-                  "importScripts() is not supported in module workers.",
-                  node.span,
-                )
-              };
-              self.diagnostics.push(Diagnostic {
-                message: msg.to_string(),
-                code_highlights: Some(vec![CodeHighlight {
-                  message: None,
-                  loc: SourceLocation::from(self.source_map, span),
-                }]),
-                hints: Some(vec![String::from(
-                  "Use a static `import`, or dynamic `import()` instead.",
-                )]),
-                show_environment: self.config.source_type == SourceType::Script,
-                severity: DiagnosticSeverity::Error,
-                documentation_url: Some(String::from(
-                  "https://parceljs.org/languages/javascript/#classic-script-workers",
-                )),
-              });
-            }
-
-            return node.fold_children_with(self);
-          }
-          "__parcel__require__" => {
-            let mut call = node.fold_children_with(self);
-            call.callee = ast::ExprOrSuper::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
-              "require".into(),
-              DUMMY_SP.apply_mark(self.ignore_mark),
-            ))));
-            return call;
-          }
-          "__parcel__import__" => {
-            let mut call = node.fold_children_with(self);
-            call.callee = ast::ExprOrSuper::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
-              "import".into(),
-              DUMMY_SP.apply_mark(self.ignore_mark),
-            ))));
-            return call;
-          }
-          "__parcel__importScripts__" => {
-            let mut call = node.fold_children_with(self);
-            call.callee = ast::ExprOrSuper::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
-              "importScripts".into(),
-              DUMMY_SP.apply_mark(self.ignore_mark),
-            ))));
-            return call;
-          }
-          _ => return node.fold_children_with(self),
-        }
-      }
-      Member(member) => {
-        if match_member_expr(member, vec!["module", "require"], self.decls) {
-          DependencyKind::Require
-        } else if self.config.is_browser
-          && match_member_expr(
-            member,
-            vec!["navigator", "serviceWorker", "register"],
-            self.decls,
-          )
-        {
-          DependencyKind::ServiceWorker
-        } else if self.config.is_browser
-          && match_member_expr(member, vec!["CSS", "paintWorklet", "addModule"], self.decls)
-        {
-          DependencyKind::Worklet
-        } else {
-          let was_in_promise = self.in_promise;
-
-          // Match compiled dynamic imports (Parcel)
-          // Promise.resolve(require('foo'))
-          if match_member_expr(member, vec!["Promise", "resolve"], self.decls) {
-            if let Some(expr) = node.args.get(0) {
-              if match_require(&*expr.expr, self.decls, Mark::fresh(Mark::root())).is_some() {
-                self.in_promise = true;
-                let node = node.fold_children_with(self);
-                self.in_promise = was_in_promise;
-                return node;
+                  DependencyKind::Require
+                }
               }
+              "importScripts" => {
+                if self.config.is_worker {
+                  let (msg, span) = if self.config.source_type == SourceType::Script {
+                    // Ignore if argument is not a string literal.
+                    let span = if let Some(ast::ExprOrSpread { expr, .. }) = node.args.get(0) {
+                      match &**expr {
+                        Lit(ast::Lit::Str(ast::Str { value, span, .. })) => {
+                          // Ignore absolute URLs.
+                          if value.starts_with("http:")
+                            || value.starts_with("https:")
+                            || value.starts_with("//")
+                          {
+                            return node.fold_children_with(self);
+                          }
+                          span
+                        }
+                        _ => {
+                          return node.fold_children_with(self);
+                        }
+                      }
+                    } else {
+                      return node.fold_children_with(self);
+                    };
+
+                    (
+                      "Argument to importScripts() must be a fully qualified URL.",
+                      *span,
+                    )
+                  } else {
+                    (
+                      "importScripts() is not supported in module workers.",
+                      node.span,
+                    )
+                  };
+                  self.diagnostics.push(Diagnostic {
+                    message: msg.to_string(),
+                    code_highlights: Some(vec![CodeHighlight {
+                      message: None,
+                      loc: SourceLocation::from(self.source_map, span),
+                    }]),
+                    hints: Some(vec![String::from(
+                      "Use a static `import`, or dynamic `import()` instead.",
+                    )]),
+                    show_environment: self.config.source_type == SourceType::Script,
+                    severity: DiagnosticSeverity::Error,
+                    documentation_url: Some(String::from(
+                      "https://parceljs.org/languages/javascript/#classic-script-workers",
+                    )),
+                  });
+                }
+
+                return node.fold_children_with(self);
+              }
+              "__parcel__require__" => {
+                let mut call = node.fold_children_with(self);
+                call.callee = ast::Callee::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
+                  "require".into(),
+                  DUMMY_SP.apply_mark(self.ignore_mark),
+                ))));
+                return call;
+              }
+              "__parcel__import__" => {
+                let mut call = node.fold_children_with(self);
+                call.callee = ast::Callee::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
+                  "import".into(),
+                  DUMMY_SP.apply_mark(self.ignore_mark),
+                ))));
+                return call;
+              }
+              "__parcel__importScripts__" => {
+                let mut call = node.fold_children_with(self);
+                call.callee = ast::Callee::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
+                  "importScripts".into(),
+                  DUMMY_SP.apply_mark(self.ignore_mark),
+                ))));
+                return call;
+              }
+              _ => return node.fold_children_with(self),
             }
           }
+          Member(member) => {
+            if match_member_expr(&member, vec!["module", "require"], self.decls) {
+              DependencyKind::Require
+            } else if self.config.is_browser
+              && match_member_expr(
+                &member,
+                vec!["navigator", "serviceWorker", "register"],
+                self.decls,
+              )
+            {
+              DependencyKind::ServiceWorker
+            } else if self.config.is_browser
+              && match_member_expr(
+                &member,
+                vec!["CSS", "paintWorklet", "addModule"],
+                self.decls,
+              )
+            {
+              DependencyKind::Worklet
+            } else {
+              let was_in_promise = self.in_promise;
 
-          // Match compiled dynamic imports (TypeScript)
-          // Promise.resolve().then(() => require('foo'))
-          // Promise.resolve().then(() => { return require('foo') })
-          // Promise.resolve().then(function () { return require('foo') })
-          if let Expr(ref expr) = member.obj {
-            if let Call(call) = &**expr {
-              if let Expr(e) = &call.callee {
-                if let Member(m) = &**e {
-                  if match_member_expr(m, vec!["Promise", "resolve"], self.decls) {
-                    if let Ident(id) = &*member.prop {
-                      if id.sym.to_string().as_str() == "then" {
-                        if let Some(arg) = node.args.get(0) {
-                          match &*arg.expr {
-                            Fn(_) | Arrow(_) => {
-                              self.in_promise = true;
-                              let node = swc_ecmascript::visit::fold_call_expr(self, node.clone());
-                              self.in_promise = was_in_promise;
+              // Match compiled dynamic imports (Parcel)
+              // Promise.resolve(require('foo'))
+              if match_member_expr(&member, vec!["Promise", "resolve"], self.decls) {
+                if let Some(expr) = node.args.get(0) {
+                  if match_require(&*expr.expr, self.decls, Mark::fresh(Mark::root())).is_some() {
+                    self.in_promise = true;
+                    let node = node.fold_children_with(self);
+                    self.in_promise = was_in_promise;
+                    return node;
+                  }
+                }
+              }
 
-                              // Transform Promise.resolve().then(() => __importStar(require('foo')))
-                              //   => Promise.resolve().then(() => require('foo')).then(res => __importStar(res))
-                              if let Some(require_node) = self.require_node.clone() {
-                                self.require_node = None;
-                                return build_promise_chain(node, require_node);
+              // Match compiled dynamic imports (TypeScript)
+              // Promise.resolve().then(() => require('foo'))
+              // Promise.resolve().then(() => { return require('foo') })
+              // Promise.resolve().then(function () { return require('foo') })
+              if let Call(call) = &*member.obj {
+                if let Callee::Expr(e) = &call.callee {
+                  if let Member(m) = &**e {
+                    if match_member_expr(m, vec!["Promise", "resolve"], self.decls) {
+                      if let MemberProp::Ident(id) = &member.prop {
+                        if id.sym.to_string().as_str() == "then" {
+                          if let Some(arg) = node.args.get(0) {
+                            match &*arg.expr {
+                              Fn(_) | Arrow(_) => {
+                                self.in_promise = true;
+                                let node =
+                                  swc_ecmascript::visit::fold_call_expr(self, node.clone());
+                                self.in_promise = was_in_promise;
+
+                                // Transform Promise.resolve().then(() => __importStar(require('foo')))
+                                //   => Promise.resolve().then(() => require('foo')).then(res => __importStar(res))
+                                if let Some(require_node) = self.require_node.clone() {
+                                  self.require_node = None;
+                                  return build_promise_chain(node, require_node);
+                                }
                               }
+                              _ => {}
                             }
-                            _ => {}
                           }
                         }
                       }
@@ -493,10 +495,11 @@ impl<'a> Fold for DependencyCollector<'a> {
                   }
                 }
               }
+
+              return node.fold_children_with(self);
             }
           }
-
-          return node.fold_children_with(self);
+          _ => return node.fold_children_with(self),
         }
       }
       _ => return node.fold_children_with(self),
@@ -637,7 +640,7 @@ impl<'a> Fold for DependencyCollector<'a> {
           SourceType::Module => "require",
           SourceType::Script => "__parcel__require__",
         };
-        call.callee = ast::ExprOrSuper::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
+        call.callee = ast::Callee::Expr(Box::new(ast::Expr::Ident(ast::Ident::new(
           name.into(),
           DUMMY_SP,
         ))));
@@ -824,10 +827,7 @@ impl<'a> Fold for DependencyCollector<'a> {
         // Free `require` -> undefined
         sym == &js_word!("require") && !self.decls.contains(&(sym.clone(), span.ctxt()))
       }
-      Expr::Member(MemberExpr {
-        obj: ExprOrSuper::Expr(expr),
-        ..
-      }) => {
+      Expr::Member(MemberExpr { obj: expr, .. }) => {
         // e.g. `require.extensions` -> undefined
         if let Expr::Ident(Ident { sym, span, .. }) = &**expr {
           sym == &js_word!("require") && !self.decls.contains(&(sym.clone(), span.ctxt()))
@@ -884,7 +884,7 @@ impl<'a> DependencyCollector<'a> {
         };
 
         if let Some(ast::Expr::Call(call)) = expr {
-          if let ast::ExprOrSuper::Expr(callee) = &call.callee {
+          if let ast::Callee::Expr(callee) = &call.callee {
             if let ast::Expr::Ident(id) = &**callee {
               if id.to_id() == resolve_id {
                 if let Some(arg) = call.args.get(0) {
@@ -969,10 +969,9 @@ fn build_promise_chain(node: ast::CallExpr, require_node: ast::CallExpr) -> ast:
       };
 
       return ast::CallExpr {
-        callee: ast::ExprOrSuper::Expr(Box::new(ast::Expr::Member(ast::MemberExpr {
+        callee: ast::Callee::Expr(Box::new(ast::Expr::Member(ast::MemberExpr {
           span: DUMMY_SP,
-          computed: false,
-          obj: ast::ExprOrSuper::Expr(Box::new(ast::Expr::Call(ast::CallExpr {
+          obj: (Box::new(ast::Expr::Call(ast::CallExpr {
             callee: node.callee,
             args: vec![ast::ExprOrSpread {
               expr: Box::new(ast::Expr::Fn(ast::FnExpr {
@@ -999,7 +998,7 @@ fn build_promise_chain(node: ast::CallExpr, require_node: ast::CallExpr) -> ast:
             span: DUMMY_SP,
             type_args: None,
           }))),
-          prop: Box::new(ast::Expr::Ident(ast::Ident::new("then".into(), DUMMY_SP))),
+          prop: MemberProp::Ident(ast::Ident::new("then".into(), DUMMY_SP)),
         }))),
         args: vec![ast::ExprOrSpread {
           expr: Box::new(f),
@@ -1020,12 +1019,11 @@ fn create_url_constructor(url: ast::Expr, use_import_meta: bool) -> ast::Expr {
   let expr = if use_import_meta {
     Expr::Member(MemberExpr {
       span: DUMMY_SP,
-      obj: ExprOrSuper::Expr(Box::new(Expr::MetaProp(MetaPropExpr {
-        meta: Ident::new(js_word!("import"), DUMMY_SP),
-        prop: Ident::new(js_word!("meta"), DUMMY_SP),
-      }))),
-      prop: Box::new(Expr::Ident(Ident::new(js_word!("url"), DUMMY_SP))),
-      computed: false,
+      obj: Box::new(Expr::MetaProp(MetaPropExpr {
+        kind: MetaPropKind::ImportMeta,
+        span: DUMMY_SP,
+      })),
+      prop: MemberProp::Ident(Ident::new(js_word!("url"), DUMMY_SP)),
     })
   } else {
     // CJS output: "file:" + __filename
@@ -1162,16 +1160,11 @@ impl<'a> DependencyCollector<'a> {
 
     match expr {
       Expr::Member(member) => {
-        match &member.obj {
-          ExprOrSuper::Expr(expr) if self.is_import_meta(&**expr) => {}
-          _ => return false,
+        if !self.is_import_meta(&member.obj) {
+          return false;
         }
 
-        let name = if !member.computed {
-          match_str_or_ident(&*member.prop)
-        } else {
-          match_str(&*member.prop)
-        };
+        let name = match_property_name(&member);
 
         if let Some((name, _)) = name {
           name == js_word!("url")
@@ -1203,15 +1196,8 @@ impl<'a> DependencyCollector<'a> {
 
     match &expr {
       ast::Expr::MetaProp(MetaPropExpr {
-        meta: Ident {
-          sym: js_word!("import"),
-          ..
-        },
-        prop: Ident {
-          sym: js_word!("meta"),
-          span,
-          ..
-        },
+        kind: MetaPropKind::ImportMeta,
+        span,
       }) => {
         if self.config.source_type == SourceType::Script {
           self.diagnostics.push(Diagnostic {
@@ -1279,25 +1265,17 @@ impl<'a> DependencyCollector<'a> {
         decls: vec![VarDeclarator {
           name: Pat::Ident(BindingIdent::from(ident.clone())),
           init: Some(Box::new(Expr::Call(CallExpr {
-            callee: ExprOrSuper::Expr(Box::new(Expr::Member(MemberExpr {
-              obj: ExprOrSuper::Expr(Box::new(Expr::Ident(Ident::new(
-                js_word!("Object"),
-                DUMMY_SP,
-              )))),
-              prop: Box::new(Expr::Ident(Ident::new("assign".into(), DUMMY_SP))),
-              computed: false,
+            callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+              obj: Box::new(Expr::Ident(Ident::new(js_word!("Object"), DUMMY_SP))),
+              prop: MemberProp::Ident(Ident::new("assign".into(), DUMMY_SP)),
               span: DUMMY_SP,
             }))),
             args: vec![
               ExprOrSpread {
                 expr: Box::new(Expr::Call(CallExpr {
-                  callee: ExprOrSuper::Expr(Box::new(Expr::Member(MemberExpr {
-                    obj: ExprOrSuper::Expr(Box::new(Expr::Ident(Ident::new(
-                      js_word!("Object"),
-                      DUMMY_SP,
-                    )))),
-                    prop: Box::new(Expr::Ident(Ident::new("create".into(), DUMMY_SP))),
-                    computed: false,
+                  callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+                    obj: (Box::new(Expr::Ident(Ident::new(js_word!("Object"), DUMMY_SP)))),
+                    prop: MemberProp::Ident(Ident::new("create".into(), DUMMY_SP)),
                     span: DUMMY_SP,
                   }))),
                   args: vec![ExprOrSpread {

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -53,24 +53,18 @@ impl<'a> Fold for EnvReplacer<'a> {
         return node.fold_children_with(self);
       }
 
-      if let MemberExpr {
-        obj: ExprOrSuper::Expr(ref expr),
-        ref prop,
-        computed,
-        ..
-      } = member
-      {
-        if let Expr::Member(member) = &**expr {
+      if let MemberExpr { obj, prop, .. } = &member {
+        if let Expr::Member(member) = &**obj {
           if match_member_expr(member, vec!["process", "env"], self.decls) {
-            if let Expr::Lit(Lit::Str(Str { value: ref sym, .. })) = &**prop {
-              if let Some(replacement) = self.replace(sym, true) {
-                return replacement;
-              }
-            } else if let Expr::Ident(Ident { ref sym, .. }) = &**prop {
-              if !computed {
+            if let MemberProp::Computed(ComputedPropName { expr, .. }) = prop {
+              if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**expr {
                 if let Some(replacement) = self.replace(sym, true) {
                   return replacement;
                 }
+              }
+            } else if let MemberProp::Ident(Ident { sym, .. }) = prop {
+              if let Some(replacement) = self.replace(sym, true) {
+                return replacement;
               }
             }
           }
@@ -128,11 +122,7 @@ impl<'a> Fold for EnvReplacer<'a> {
         PatOrExpr::Expr(expr) => Some(&**expr),
       };
 
-      if let Some(Expr::Member(MemberExpr {
-        obj: ExprOrSuper::Expr(ref obj),
-        ..
-      })) = expr
-      {
+      if let Some(Expr::Member(MemberExpr { obj, .. })) = &expr {
         if let Expr::Member(member) = &**obj {
           if match_member_expr(member, vec!["process", "env"], self.decls) {
             self.emit_mutating_error(assign.span);
@@ -148,7 +138,7 @@ impl<'a> Fold for EnvReplacer<'a> {
         Expr::Unary(UnaryExpr { op: UnaryOp::Delete, arg, span, .. }) |
         // e.g. process.env.UPDATE++
         Expr::Update(UpdateExpr { arg, span, .. }) => {
-          if let Expr::Member(MemberExpr { obj: ExprOrSuper::Expr(ref obj), .. }) = &**arg {
+          if let Expr::Member(MemberExpr { ref obj, .. }) = &**arg {
             if let Expr::Member(member) = &**obj {
               if match_member_expr(member, vec!["process", "env"], self.decls) {
                 self.emit_mutating_error(*span);

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -53,19 +53,17 @@ impl<'a> Fold for EnvReplacer<'a> {
         return node.fold_children_with(self);
       }
 
-      if let MemberExpr { obj, prop, .. } = &member {
-        if let Expr::Member(member) = &**obj {
-          if match_member_expr(member, vec!["process", "env"], self.decls) {
-            if let MemberProp::Computed(ComputedPropName { expr, .. }) = prop {
-              if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**expr {
-                if let Some(replacement) = self.replace(sym, true) {
-                  return replacement;
-                }
-              }
-            } else if let MemberProp::Ident(Ident { sym, .. }) = prop {
+      if let Expr::Member(member) = &*member.obj {
+        if match_member_expr(member, vec!["process", "env"], self.decls) {
+          if let MemberProp::Computed(ComputedPropName { expr, .. }) = &member.prop {
+            if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**expr {
               if let Some(replacement) = self.replace(sym, true) {
                 return replacement;
               }
+            }
+          } else if let MemberProp::Ident(Ident { sym, .. }) = &member.prop {
+            if let Some(replacement) = self.replace(sym, true) {
+              return replacement;
             }
           }
         }

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -53,16 +53,10 @@ impl<'a> Fold for EnvReplacer<'a> {
         return node.fold_children_with(self);
       }
 
-      if let Expr::Member(member) = &*member.obj {
-        if match_member_expr(member, vec!["process", "env"], self.decls) {
-          if let MemberProp::Computed(ComputedPropName { expr, .. }) = &member.prop {
-            if let Expr::Lit(Lit::Str(Str { value: sym, .. })) = &**expr {
-              if let Some(replacement) = self.replace(sym, true) {
-                return replacement;
-              }
-            }
-          } else if let MemberProp::Ident(Ident { sym, .. }) = &member.prop {
-            if let Some(replacement) = self.replace(sym, true) {
+      if let Expr::Member(obj) = &*member.obj {
+        if match_member_expr(obj, vec!["process", "env"], self.decls) {
+          if let Some((sym, _)) = match_property_name(member) {
+            if let Some(replacement) = self.replace(&sym, true) {
               return replacement;
             }
           }

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -406,46 +406,44 @@ impl<'a> Fold for Hoist<'a> {
                       }
 
                       if let Expr::Member(member) = &**init {
-                        if let ExprOrSuper::Expr(expr) = &member.obj {
-                          // Match var x = require('foo').bar;
-                          if let Some(source) =
-                            match_require(&*expr, &self.collect.decls, self.collect.ignore_mark)
-                          {
-                            if !self.collect.non_static_requires.contains(&source) {
-                              // If this is not the first declarator in the variable declaration, we need to
-                              // split the declaration into multiple to preserve side effect ordering.
-                              // var x = sideEffect(), y = require('foo').bar, z = 2;
-                              //   -> var x = sideEffect(); import 'foo'; var y = $id$import$foo$bar, z = 2;
-                              if !decls.is_empty() {
-                                let var = VarDecl {
-                                  span: var.span,
-                                  kind: var.kind,
-                                  declare: var.declare,
-                                  decls: std::mem::take(&mut decls),
-                                };
-                                self
-                                  .module_items
-                                  .push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))));
-                              }
-
+                        // Match var x = require('foo').bar;
+                        if let Some(source) =
+                          match_require(&*member.obj, &self.collect.decls, self.collect.ignore_mark)
+                        {
+                          if !self.collect.non_static_requires.contains(&source) {
+                            // If this is not the first declarator in the variable declaration, we need to
+                            // split the declaration into multiple to preserve side effect ordering.
+                            // var x = sideEffect(), y = require('foo').bar, z = 2;
+                            //   -> var x = sideEffect(); import 'foo'; var y = $id$import$foo$bar, z = 2;
+                            if !decls.is_empty() {
+                              let var = VarDecl {
+                                span: var.span,
+                                kind: var.kind,
+                                declare: var.declare,
+                                decls: std::mem::take(&mut decls),
+                              };
                               self
                                 .module_items
-                                .push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
-                                  specifiers: vec![],
-                                  asserts: None,
-                                  span: DUMMY_SP,
-                                  src: Str {
-                                    value: format!("{}:{}", self.module_id, source).into(),
-                                    span: DUMMY_SP,
-                                    kind: StrKind::Synthesized,
-                                    has_escape: false,
-                                  },
-                                  type_only: false,
-                                })));
-
-                              self.handle_non_const_require(v, &source);
-                              continue;
+                                .push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))));
                             }
+
+                            self
+                              .module_items
+                              .push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                                specifiers: vec![],
+                                asserts: None,
+                                span: DUMMY_SP,
+                                src: Str {
+                                  value: format!("{}:{}", self.module_id, source).into(),
+                                  span: DUMMY_SP,
+                                  kind: StrKind::Synthesized,
+                                  has_escape: false,
+                                },
+                                type_only: false,
+                              })));
+
+                            self.handle_non_const_require(v, &source);
+                            continue;
                           }
                         }
                       }
@@ -541,110 +539,101 @@ impl<'a> Fold for Hoist<'a> {
           }
         }
 
-        let key = match &*member.prop {
-          Expr::Ident(ident) => {
-            if !member.computed {
-              ident.sym.clone()
-            } else {
-              return Expr::Member(member.fold_children_with(self));
-            }
-          }
-          Expr::Lit(Lit::Str(str_)) => str_.value.clone(),
+        let key = match match_property_name(&member) {
+          Some(v) => v.0,
           _ => return Expr::Member(member.fold_children_with(self)),
         };
 
-        if let ExprOrSuper::Expr(ref expr) = member.obj {
-          match &**expr {
-            Expr::Ident(ident) => {
-              // import * as y from 'x'; OR const y = require('x'); OR const y = await import('x');
-              // y.foo -> $id$import$d141bba7fdc215a3$y
-              if let Some(Import {
-                source,
-                specifier,
-                kind,
-                ..
-              }) = self.collect.imports.get(&id!(ident))
+        match &*member.obj {
+          Expr::Ident(ident) => {
+            // import * as y from 'x'; OR const y = require('x'); OR const y = await import('x');
+            // y.foo -> $id$import$d141bba7fdc215a3$y
+            if let Some(Import {
+              source,
+              specifier,
+              kind,
+              ..
+            }) = self.collect.imports.get(&id!(ident))
+            {
+              // If there are any non-static accesses of the namespace, don't perform any replacement.
+              // This will be handled in the Ident visitor below, which replaces y -> $id$import$d141bba7fdc215a3.
+              if specifier == "*"
+                && !self.collect.non_static_access.contains_key(&id!(ident))
+                && !self.collect.non_const_bindings.contains_key(&id!(ident))
+                && !self.collect.non_static_requires.contains(source)
               {
-                // If there are any non-static accesses of the namespace, don't perform any replacement.
-                // This will be handled in the Ident visitor below, which replaces y -> $id$import$d141bba7fdc215a3.
-                if specifier == "*"
-                  && !self.collect.non_static_access.contains_key(&id!(ident))
-                  && !self.collect.non_const_bindings.contains_key(&id!(ident))
-                  && !self.collect.non_static_requires.contains(source)
-                {
-                  if *kind == ImportKind::DynamicImport {
-                    let name: JsWord = format!(
-                      "${}$importAsync${:x}${:x}",
-                      self.module_id,
-                      hash!(source),
-                      hash!(key)
-                    )
-                    .into();
-                    self.imported_symbols.push(ImportedSymbol {
-                      source: source.clone(),
-                      local: name,
-                      imported: key.clone(),
-                      loc: SourceLocation::from(&self.collect.source_map, member.span),
-                    });
-                  } else {
-                    return Expr::Ident(self.get_import_ident(
-                      member.span,
-                      source,
-                      &key,
-                      SourceLocation::from(&self.collect.source_map, member.span),
-                    ));
-                  }
+                if *kind == ImportKind::DynamicImport {
+                  let name: JsWord = format!(
+                    "${}$importAsync${:x}${:x}",
+                    self.module_id,
+                    hash!(source),
+                    hash!(key)
+                  )
+                  .into();
+                  self.imported_symbols.push(ImportedSymbol {
+                    source: source.clone(),
+                    local: name,
+                    imported: key.clone(),
+                    loc: SourceLocation::from(&self.collect.source_map, member.span),
+                  });
+                } else {
+                  return Expr::Ident(self.get_import_ident(
+                    member.span,
+                    source,
+                    &key,
+                    SourceLocation::from(&self.collect.source_map, member.span),
+                  ));
                 }
               }
+            }
 
-              // exports.foo -> $id$export$foo
-              let exports: JsWord = "exports".into();
-              if ident.sym == exports
-                && !self.collect.decls.contains(&id!(ident))
-                && self.collect.static_cjs_exports
-                && !self.collect.should_wrap
-              {
-                self.self_references.insert(key.clone());
-                return Expr::Ident(self.get_export_ident(member.span, &key));
-              }
+            // exports.foo -> $id$export$foo
+            let exports: JsWord = "exports".into();
+            if ident.sym == exports
+              && !self.collect.decls.contains(&id!(ident))
+              && self.collect.static_cjs_exports
+              && !self.collect.should_wrap
+            {
+              self.self_references.insert(key.clone());
+              return Expr::Ident(self.get_export_ident(member.span, &key));
             }
-            Expr::Call(_call) => {
-              // require('foo').bar -> $id$import$foo$bar
-              if let Some(source) =
-                match_require(expr, &self.collect.decls, self.collect.ignore_mark)
-              {
-                self.add_require(&source);
-                return Expr::Ident(self.get_import_ident(
-                  member.span,
-                  &source,
-                  &key,
-                  SourceLocation::from(&self.collect.source_map, member.span),
-                ));
-              }
-            }
-            Expr::Member(mem) => {
-              // module.exports.foo -> $id$export$foo
-              if self.collect.static_cjs_exports
-                && !self.collect.should_wrap
-                && match_member_expr(mem, vec!["module", "exports"], &self.collect.decls)
-              {
-                self.self_references.insert(key.clone());
-                return Expr::Ident(self.get_export_ident(member.span, &key));
-              }
-            }
-            Expr::This(_) => {
-              // this.foo -> $id$export$foo
-              if self.collect.static_cjs_exports
-                && !self.collect.should_wrap
-                && !self.in_function_scope
-                && !self.collect.is_esm
-              {
-                self.self_references.insert(key.clone());
-                return Expr::Ident(self.get_export_ident(member.span, &key));
-              }
-            }
-            _ => {}
           }
+          Expr::Call(_call) => {
+            // require('foo').bar -> $id$import$foo$bar
+            if let Some(source) =
+              match_require(&member.obj, &self.collect.decls, self.collect.ignore_mark)
+            {
+              self.add_require(&source);
+              return Expr::Ident(self.get_import_ident(
+                member.span,
+                &source,
+                &key,
+                SourceLocation::from(&self.collect.source_map, member.span),
+              ));
+            }
+          }
+          Expr::Member(mem) => {
+            // module.exports.foo -> $id$export$foo
+            if self.collect.static_cjs_exports
+              && !self.collect.should_wrap
+              && match_member_expr(&mem, vec!["module", "exports"], &self.collect.decls)
+            {
+              self.self_references.insert(key.clone());
+              return Expr::Ident(self.get_export_ident(member.span, &key));
+            }
+          }
+          Expr::This(_) => {
+            // this.foo -> $id$export$foo
+            if self.collect.static_cjs_exports
+              && !self.collect.should_wrap
+              && !self.in_function_scope
+              && !self.collect.is_esm
+            {
+              self.self_references.insert(key.clone());
+              return Expr::Ident(self.get_export_ident(member.span, &key));
+            }
+          }
+          _ => {}
         }
 
         // Don't visit member.prop so we avoid the ident visitor.
@@ -652,7 +641,6 @@ impl<'a> Fold for Hoist<'a> {
           span: member.span,
           obj: member.obj.fold_with(self),
           prop: member.prop,
-          computed: member.computed,
         });
       }
       Expr::Call(ref call) => {
@@ -870,17 +858,14 @@ impl<'a> Fold for Hoist<'a> {
         };
       }
 
-      let is_cjs_exports = match &member.obj {
-        ExprOrSuper::Expr(expr) => match &**expr {
-          Expr::Member(member) => {
-            match_member_expr(member, vec!["module", "exports"], &self.collect.decls)
-          }
-          Expr::Ident(ident) => {
-            let exports: JsWord = "exports".into();
-            ident.sym == exports && !self.collect.decls.contains(&id!(ident))
-          }
-          _ => false,
-        },
+      let is_cjs_exports = match &*member.obj {
+        Expr::Member(member) => {
+          match_member_expr(member, vec!["module", "exports"], &self.collect.decls)
+        }
+        Expr::Ident(ident) => {
+          let exports: JsWord = "exports".into();
+          ident.sym == exports && !self.collect.decls.contains(&id!(ident))
+        }
         _ => false,
       };
 
@@ -923,9 +908,8 @@ impl<'a> Fold for Hoist<'a> {
           } else {
             PatOrExpr::Pat(Box::new(Pat::Expr(Box::new(Expr::Member(MemberExpr {
               span: member.span,
-              obj: ExprOrSuper::Expr(Box::new(Expr::Ident(ident.id))),
+              obj: Box::new(Expr::Ident(ident.id)),
               prop: member.prop.clone().fold_with(self),
-              computed: member.computed,
             })))))
           },
           right: node.right.fold_with(self),
@@ -1679,45 +1663,43 @@ impl Visit for Collect {
       };
     }
 
-    if let ExprOrSuper::Expr(expr) = &node.obj {
-      match &**expr {
-        Expr::Member(member) => {
-          if match_member_expr(member, vec!["module", "exports"], &self.decls) {
-            handle_export!();
-          }
-          return;
+    match &*node.obj {
+      Expr::Member(member) => {
+        if match_member_expr(member, vec!["module", "exports"], &self.decls) {
+          handle_export!();
         }
-        Expr::Ident(ident) => {
-          let exports: JsWord = "exports".into();
-          if ident.sym == exports && !self.decls.contains(&id!(ident)) {
-            handle_export!();
-          }
-
-          if ident.sym == js_word!("module") && !self.decls.contains(&id!(ident)) {
-            self.has_cjs_exports = true;
-            self.static_cjs_exports = false;
-            self.should_wrap = true;
-            self.add_bailout(node.span, BailoutReason::FreeModule);
-          }
-
-          // `import` isn't really an identifier...
-          if match_property_name(node).is_none() && ident.sym != js_word!("import") {
-            self
-              .non_static_access
-              .entry(id!(ident))
-              .or_default()
-              .push(node.span);
-          }
-          return;
-        }
-        Expr::This(_this) => {
-          if self.in_module_this {
-            handle_export!();
-          }
-          return;
-        }
-        _ => {}
+        return;
       }
+      Expr::Ident(ident) => {
+        let exports: JsWord = "exports".into();
+        if ident.sym == exports && !self.decls.contains(&id!(ident)) {
+          handle_export!();
+        }
+
+        if ident.sym == js_word!("module") && !self.decls.contains(&id!(ident)) {
+          self.has_cjs_exports = true;
+          self.static_cjs_exports = false;
+          self.should_wrap = true;
+          self.add_bailout(node.span, BailoutReason::FreeModule);
+        }
+
+        // `import` isn't really an identifier...
+        if match_property_name(node).is_none() && ident.sym != js_word!("import") {
+          self
+            .non_static_access
+            .entry(id!(ident))
+            .or_default()
+            .push(node.span);
+        }
+        return;
+      }
+      Expr::This(_this) => {
+        if self.in_module_this {
+          handle_export!();
+        }
+        return;
+      }
+      _ => {}
     }
 
     node.visit_children_with(self);
@@ -1847,43 +1829,32 @@ impl Visit for Collect {
 
       match &**init {
         Expr::Member(member) => {
-          if let ExprOrSuper::Expr(expr) = &member.obj {
-            if let Some(source) = self.match_require(&*expr) {
-              // Convert member expression on require to a destructuring assignment.
-              // const yx = require('y').x; -> const {x: yx} = require('x');
-              let key = match &*member.prop {
-                Expr::Ident(ident) => {
-                  if !member.computed {
-                    PropName::Ident(ident.clone())
-                  } else {
-                    PropName::Computed(ComputedPropName {
-                      span: DUMMY_SP,
-                      expr: Box::new(*expr.clone()),
-                    })
-                  }
-                }
-                Expr::Lit(Lit::Str(str_)) => PropName::Str(str_.clone()),
-                _ => PropName::Computed(ComputedPropName {
-                  span: DUMMY_SP,
-                  expr: Box::new(*expr.clone()),
-                }),
-              };
+          if let Some(source) = self.match_require(&*member.obj) {
+            // Convert member expression on require to a destructuring assignment.
+            // const yx = require('y').x; -> const {x: yx} = require('x');
+            let key = match &member.prop {
+              MemberProp::Computed(expr) => PropName::Computed(ComputedPropName {
+                span: DUMMY_SP,
+                expr: Box::new(*member.obj.clone()),
+              }),
+              MemberProp::Ident(ident) => PropName::Ident(ident.clone()),
+              _ => unreachable!(),
+            };
 
-              self.add_pat_imports(
-                &Pat::Object(ObjectPat {
-                  optional: false,
-                  span: DUMMY_SP,
-                  type_ann: None,
-                  props: vec![ObjectPatProp::KeyValue(KeyValuePatProp {
-                    key,
-                    value: Box::new(node.name.clone()),
-                  })],
-                }),
-                &source,
-                ImportKind::Require,
-              );
-              return;
-            }
+            self.add_pat_imports(
+              &Pat::Object(ObjectPat {
+                optional: false,
+                span: DUMMY_SP,
+                type_ann: None,
+                props: vec![ObjectPatProp::KeyValue(KeyValuePatProp {
+                  key,
+                  value: Box::new(node.name.clone()),
+                })],
+              }),
+              &source,
+              ImportKind::Require,
+            );
+            return;
           }
         }
         Expr::Await(await_exp) => {
@@ -1907,7 +1878,7 @@ impl Visit for Collect {
   }
 
   fn visit_call_expr(&mut self, node: &CallExpr) {
-    if let ExprOrSuper::Expr(expr) = &node.callee {
+    if let Callee::Expr(expr) = &node.callee {
       match &**expr {
         Expr::Ident(ident) => {
           if ident.sym == js_word!("eval") && !self.decls.contains(&id!(ident)) {
@@ -1917,34 +1888,26 @@ impl Visit for Collect {
         }
         Expr::Member(member) => {
           // import('foo').then(foo => ...);
-          if let ExprOrSuper::Expr(obj) = &member.obj {
-            if let Some(source) = match_import(&*obj, self.ignore_mark) {
-              let then: JsWord = "then".into();
-              let is_then = match &*member.prop {
-                Expr::Ident(ident) => !member.computed && ident.sym == then,
-                Expr::Lit(Lit::Str(str)) => str.value == then,
-                _ => false,
-              };
+          if let Some(source) = match_import(&*member.obj, self.ignore_mark) {
+            let then: JsWord = "then".into();
+            if match_property_name(member).map_or(false, |f| f.0 == then) {
+              if let Some(ExprOrSpread { expr, .. }) = node.args.get(0) {
+                let param = match &**expr {
+                  Expr::Fn(func) => func.function.params.get(0).map(|param| &param.pat),
+                  Expr::Arrow(arrow) => arrow.params.get(0),
+                  _ => None,
+                };
 
-              if is_then {
-                if let Some(ExprOrSpread { expr, .. }) = node.args.get(0) {
-                  let param = match &**expr {
-                    Expr::Fn(func) => func.function.params.get(0).map(|param| &param.pat),
-                    Expr::Arrow(arrow) => arrow.params.get(0),
-                    _ => None,
-                  };
-
-                  if let Some(param) = param {
-                    self.add_pat_imports(param, &source, ImportKind::DynamicImport);
-                  } else {
-                    self.non_static_requires.insert(source.clone());
-                    self.wrapped_requires.insert(source);
-                    self.add_bailout(node.span, BailoutReason::NonStaticDynamicImport);
-                  }
-
-                  expr.visit_with(self);
-                  return;
+                if let Some(param) = param {
+                  self.add_pat_imports(param, &source, ImportKind::DynamicImport);
+                } else {
+                  self.non_static_requires.insert(source.clone());
+                  self.wrapped_requires.insert(source);
+                  self.add_bailout(node.span, BailoutReason::NonStaticDynamicImport);
                 }
+
+                expr.visit_with(self);
+                return;
               }
             }
           }

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -379,7 +379,12 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                 ),
                 // Transpile new syntax to older syntax if needed
                 Optional::new(
-                  preset_env(global_mark, Some(&comments), preset_env_config),
+                  preset_env(
+                    global_mark,
+                    Some(&comments),
+                    preset_env_config,
+                    Default::default()
+                  ),
                   config.targets.is_some()
                 ),
                 // Inject SWC helpers if needed.

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -1,5 +1,5 @@
 use crate::id;
-use crate::utils::IdentId;
+use crate::utils::{match_export_name, match_export_name_ident, IdentId};
 use inflector::Inflector;
 use std::collections::{HashMap, HashSet};
 use swc_atoms::JsWord;
@@ -270,7 +270,7 @@ impl Fold for ESMFold {
             match specifier {
               ImportSpecifier::Named(named) => {
                 let imported = match &named.imported {
-                  Some(imported) => imported.sym.clone(),
+                  Some(imported) => match_export_name(imported).0.clone(),
                   None => named.local.sym.clone(),
                 };
                 self.imports.insert(
@@ -329,13 +329,16 @@ impl Fold for ESMFold {
                         None => named.orig.clone(),
                       };
 
-                      if named.orig.sym == js_word!("default") {
+                      if match_export_name(&named.orig).0 == js_word!("default") {
                         self.create_interop_default(src.value.clone());
                       }
 
-                      let specifier =
-                        self.create_import_access(&src.value, &named.orig.sym, DUMMY_SP);
-                      self.create_export(exported.sym, specifier, export.span);
+                      let specifier = self.create_import_access(
+                        &src.value,
+                        &match_export_name(&named.orig).0,
+                        DUMMY_SP,
+                      );
+                      self.create_export(match_export_name(&exported).0, specifier, export.span);
                     }
                     ExportSpecifier::Default(default) => {
                       self.create_interop_default(src.value.clone());
@@ -346,7 +349,7 @@ impl Fold for ESMFold {
                     ExportSpecifier::Namespace(namespace) => {
                       let local = self.get_require_name(&src.value, DUMMY_SP);
                       self.create_export(
-                        namespace.name.sym.clone(),
+                        match_export_name(&namespace.name).0,
                         Expr::Ident(local),
                         export.span,
                       )
@@ -360,17 +363,21 @@ impl Fold for ESMFold {
                       Some(exported) => exported.clone(),
                       None => named.orig.clone(),
                     };
+                    let orig = match_export_name_ident(&named.orig);
 
                     // Handle import {foo} from 'bar'; export {foo};
-                    let value = if let Some((source, imported)) =
-                      self.imports.get(&id!(named.orig)).cloned()
-                    {
-                      self.create_import_access(&source, &imported, named.orig.span)
-                    } else {
-                      Expr::Ident(named.orig.clone())
-                    };
+                    let value =
+                      if let Some((source, imported)) = self.imports.get(&id!(orig)).cloned() {
+                        self.create_import_access(
+                          &source,
+                          &imported,
+                          match_export_name(&named.orig).1,
+                        )
+                      } else {
+                        Expr::Ident(orig.clone())
+                      };
 
-                    self.create_export(exported.sym, value, export.span);
+                    self.create_export(match_export_name(&exported).0, value, export.span);
                   }
                 }
               }

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -17,7 +17,7 @@ pub fn match_member_expr(
   let mut idents = idents;
   while idents.len() > 1 {
     let expected = idents.pop().unwrap();
-    let prop = match member.prop {
+    let prop = match &member.prop {
       MemberProp::Computed(comp) => {
         if let Expr::Lit(Lit::Str(Str { value: ref sym, .. })) = *comp.expr {
           sym
@@ -101,21 +101,26 @@ pub fn match_str(node: &ast::Expr) -> Option<(JsWord, Span)> {
   }
 }
 
-pub fn match_str_or_ident(node: &ast::Expr) -> Option<(JsWord, Span)> {
-  use ast::*;
-
-  if let Expr::Ident(id) = node {
-    return Some((id.sym.clone(), id.span));
-  }
-
-  match_str(node)
-}
-
 pub fn match_property_name(node: &ast::MemberExpr) -> Option<(JsWord, Span)> {
   match &node.prop {
     ast::MemberProp::Computed(s) => match_str(&*s.expr),
     ast::MemberProp::Ident(id) => Some((id.sym.clone(), id.span)),
     ast::MemberProp::PrivateName(_) => None,
+  }
+}
+
+pub fn match_export_name(name: &ast::ModuleExportName) -> (JsWord, Span) {
+  match name {
+    ast::ModuleExportName::Ident(id) => (id.sym.clone(), id.span),
+    ast::ModuleExportName::Str(s) => (s.value.clone(), s.span),
+  }
+}
+
+/// Properties like `ExportNamedSpecifier::orig` have to be an Ident if `src` is `None`
+pub fn match_export_name_ident(name: &ast::ModuleExportName) -> &ast::Ident {
+  match name {
+    ast::ModuleExportName::Ident(id) => id,
+    ast::ModuleExportName::Str(_) => unreachable!(),
   }
 }
 

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -35,7 +35,7 @@
     "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.3.2",
     "@parcel/workers": "2.3.2",
-    "@swc/helpers": "^0.2.11",
+    "@swc/helpers": "^0.3.6",
     "browserslist": "^4.6.6",
     "detect-libc": "^1.0.3",
     "nullthrows": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,10 +2412,10 @@
     "@swc/core-win32-ia32-msvc" "^1.2.106"
     "@swc/core-win32-x64-msvc" "^1.2.106"
 
-"@swc/helpers@^0.2.11":
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.2.11.tgz#34c842dcd8182810b4ab72d0d1fc34b553909e2e"
-  integrity sha512-0FFPZrCwRDLsbJDKzs1Oo+TAqfAyxnZWZoTF6rUrfWQCYpwuKFj7tAEt/wa830fqCPE5Uk6qIo9KMkPe7Qgukg==
+"@swc/helpers@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.3.6.tgz#b41e77dbf14e9cb138988484563ad9680ae5dc3d"
+  integrity sha512-xVl7Sddrl9/eMjEMqkH9lT8fLOGCuWHH9VmR2IBKQ8xTcjA6UQw4O3/4oS3xnyZHLtL9vC3P+C0kLneHpiqeEg==
 
 "@tootallnate/once@2":
   version "2.0.0"


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7551

1. There is no `ExprOrSuper` anymore, there's a `Callee` enum instead now
2. `import()` and `import.meta.*` now have specialized `Callee::Import` and `Expr::MemberProp` variants, no more `id == "import"`
3. `MemberExpr` now contains an expression and a `MemberProp` enum which differentiates between computed, identifier and private class property.
4. Import and export declarations now support both strings and literals as identifiers because this has been standardized: `import { "foo bar" as foo} from "xyz";`

Notably, I needed to bump the swc helpers dependency because new helpers were added in the meantime. If you upgrade Parcel without doing this, code using private class properties might break