### PR TITLE
Bump lmdb to support non-ASCII project paths

### DIFF
--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -27,7 +27,7 @@
     "@parcel/fs": "2.3.2",
     "@parcel/logger": "2.3.2",
     "@parcel/utils": "2.3.2",
-    "lmdb": "2.2.3"
+    "lmdb": "2.2.4"
   },
   "peerDependencies": {
     "@parcel/core": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8254,10 +8254,10 @@ listr2@^2.1.0:
     rxjs "^6.5.5"
     through "^2.3.8"
 
-lmdb@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.2.3.tgz#713ffa515c31e042808abf364b4aa0feaeaf6360"
-  integrity sha512-+OiHQpw22mBBxocb/9vcVNETqf0k5vgHA2r+KX7eCf8j5tSV50ZIv388iY1mnnrERIUhs2sjKQbZhPg7z4HyPQ==
+lmdb@2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.2.4.tgz#6494d5a1d1db152e0be759edcfa06893e4cbdb53"
+  integrity sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==
   dependencies:
     msgpackr "^1.5.4"
     nan "^2.14.2"


### PR DESCRIPTION
To pull in https://github.com/DoctorEvidence/lmdb-js/issues/144

Closes https://github.com/parcel-bundler/parcel/issues/7621