### PR TITLE
Bundle validator for preventing duplicate assets

### DIFF
--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -64,7 +64,7 @@ export default class ParcelConfig {
   namers: PureParcelConfigPipeline;
   runtimes: PureParcelConfigPipeline;
   packagers: GlobMap<ParcelPluginNode>;
-  validators: GlobMap<ExtendableParcelConfigPipeline>;
+  validators: $ReadOnlyArray<ParcelPluginNode>;
   optimizers: GlobMap<ExtendableParcelConfigPipeline>;
   compressors: GlobMap<ExtendableParcelConfigPipeline>;
   reporters: PureParcelConfigPipeline;
@@ -83,7 +83,7 @@ export default class ParcelConfig {
     this.optimizers = config.optimizers || {};
     this.compressors = config.compressors || {};
     this.reporters = config.reporters || [];
-    this.validators = config.validators || {};
+    this.validators = config.validators || [];
     this.pluginCache = new Map();
     this.regexCache = new Map();
   }
@@ -169,23 +169,17 @@ export default class ParcelConfig {
     return this.loadPlugins<Resolver>(this.resolvers);
   }
 
-  _getValidatorNodes(filePath: ProjectPath): $ReadOnlyArray<ParcelPluginNode> {
-    let validators: PureParcelConfigPipeline =
-      this.matchGlobMapPipelines(filePath, this.validators) || [];
-
-    return validators;
+  _getValidatorNodes(): $ReadOnlyArray<ParcelPluginNode> {
+    return this.validators;
   }
 
-  getValidatorNames(filePath: ProjectPath): Array<string> {
-    let validators: PureParcelConfigPipeline =
-      this._getValidatorNodes(filePath);
+  getValidatorNames(): Array<string> {
+    let validators: PureParcelConfigPipeline = this._getValidatorNodes();
     return validators.map(v => v.packageName);
   }
 
-  getValidators(
-    filePath: ProjectPath,
-  ): Promise<Array<LoadedPlugin<Validator>>> {
-    let validators = this._getValidatorNodes(filePath);
+  getValidators(): Promise<Array<LoadedPlugin<Validator>>> {
+    let validators = this._getValidatorNodes();
     return this.loadPlugins<Validator>(validators);
   }
 

--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -117,7 +117,7 @@ export default {
       'transformer',
       'transformers',
     ): SchemaEntity),
-    validators: (mapPipelineSchema('validator', 'validators'): SchemaEntity),
+    validators: (pipelineSchema('validator', 'validators'): SchemaEntity),
     namers: (pipelineSchema('namer', 'namers'): SchemaEntity),
     packagers: (mapStringSchema('packager', 'packagers'): SchemaEntity),
     optimizers: (mapPipelineSchema('optimizer', 'optimizers'): SchemaEntity),

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -142,9 +142,7 @@ export default class Validation {
 
         let asset = await this.loadAsset(request);
 
-        let validators = await this.parcelConfig.getValidators(
-          request.filePath,
-        );
+        let validators = await this.parcelConfig.getValidators();
 
         for (let validator of validators) {
           this.allValidators[validator.name] = validator.plugin;

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -2,12 +2,11 @@
 
 import type {WorkerApi} from '@parcel/workers';
 import type {AssetGroup, ParcelOptions, ReportFn} from './types';
-import type {Validator, ValidateResult, PackagedBundle} from '@parcel/types';
-import type {Diagnostic} from '@parcel/diagnostic';
+import type {ValidateResult, PackagedBundle} from '@parcel/types';
 
 import path from 'path';
 import {resolveConfig} from '@parcel/utils';
-import logger, {PluginLogger} from '@parcel/logger';
+import {PluginLogger} from '@parcel/logger';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 import ParcelConfig from './ParcelConfig';
 import UncommittedAsset from './UncommittedAsset';
@@ -21,7 +20,6 @@ import {
   fromProjectPathRelative,
 } from './projectPath';
 import BundleGraph from './public/BundleGraph';
-import invariant from 'assert';
 
 export type ValidationMap = {|
   validate: Map<ProjectPath, ValidateResult>,
@@ -156,7 +154,7 @@ export default class Validation {
                 ),
             });
             result.validateAll = validateAllResults;
-            validatorResults.push(...validateAllResults);
+            validatorResults.push(...validateAllResults); //could this ever be an array ?
           } catch (e) {
             throw new ThrowableDiagnostic({
               diagnostic: errorToDiagnostic(e, {

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -172,8 +172,9 @@ export default class Validation {
             options: pluginOptions,
             logger: validatorLogger,
           });
-          validatorResults.push(...validateBundlesResult);
-          result.validateBundles = validateBundlesResult;
+
+          validatorResults.push(validateBundlesResult);
+          result.validateBundles = [validateBundlesResult];
         }
 
         // }
@@ -218,8 +219,11 @@ export default class Validation {
 export function combineValidateResults(
   validateResults: Array<ValidateResult>,
 ): ValidateResult {
-  return validateResults.reduce((previous, current) => ({
-    warnings: previous.warnings.concat(current.warnings),
-    errors: previous.errors.concat(current.errors),
-  }));
+  return validateResults.reduce(
+    (previous, current) => ({
+      warnings: previous.warnings.concat(current.warnings),
+      errors: previous.errors.concat(current.errors),
+    }),
+    {warnings: [], errors: []},
+  );
 }

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -98,11 +98,11 @@ export default class Validation {
               if (plugin.validateBundles) {
                 invariant(this.bundleGraph);
                 validatorResults.push(
-                  ...(await plugin.validateBundles({
+                  await plugin.validateBundles({
                     bundleGraph: this.bundleGraph,
                     options: pluginOptions,
                     logger: validatorLogger,
-                  })),
+                  }),
                 );
               }
             }

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -400,11 +400,11 @@ export async function processConfig(
       '/reporters',
       configFile.filePath,
     ),
-    validators: await processMap(
+    validators: processPipeline(
+      options,
       configFile.validators,
       '/validators',
       configFile.filePath,
-      options,
     ),
   };
 }
@@ -602,7 +602,9 @@ export function mergeConfigs(
       ext.transformers,
       mergePipelines,
     ),
-    validators: mergeMaps(base.validators, ext.validators, mergePipelines),
+    validators: assertPurePipeline(
+      mergePipelines(base.validators, ext.validators),
+    ),
     bundler: ext.bundler || base.bundler,
     namers: assertPurePipeline(mergePipelines(base.namers, ext.namers)),
     runtimes: assertPurePipeline(mergePipelines(base.runtimes, ext.runtimes)),

--- a/packages/core/core/src/requests/ValidationRequest.js
+++ b/packages/core/core/src/requests/ValidationRequest.js
@@ -42,9 +42,7 @@ export default function createValidationRequest(
       );
 
       let config = new ParcelConfig(processedConfig, options);
-      let trackedRequestsDesc = assetRequests.filter(request => {
-        return config.getValidatorNames(request.filePath).length > 0;
-      });
+      let trackedRequestsDesc = assetRequests;
 
       // Schedule validations on workers for all plugins that implement the one-asset-at-a-time "validate" method.
       let promises = trackedRequestsDesc.map(async request =>

--- a/packages/core/core/src/requests/ValidationRequest.js
+++ b/packages/core/core/src/requests/ValidationRequest.js
@@ -1,9 +1,10 @@
 // @flow strict-local
-import type {Async} from '@parcel/types';
+import type {Async, PackagedBundle} from '@parcel/types';
 import type {SharedReference} from '@parcel/workers';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {AssetGroup} from '../types';
 import type {ConfigAndCachePath} from './ParcelConfigRequest';
+import type BundleGraph from '../public/BundleGraph';
 
 import nullthrows from 'nullthrows';
 import ParcelConfig from '../ParcelConfig';
@@ -26,6 +27,7 @@ type RunOpts = {|
 type ValidationRequestInput = {|
   assetRequests: Array<AssetGroup>,
   optionsRef: SharedReference,
+  bundleGraph: BundleGraph<PackagedBundle>,
 |};
 
 export default function createValidationRequest(
@@ -34,7 +36,12 @@ export default function createValidationRequest(
   return {
     id: 'validation',
     type: 'validation_request',
-    run: async ({input: {assetRequests, optionsRef}, api, options, farm}) => {
+    run: async ({
+      input: {assetRequests, optionsRef, bundleGraph},
+      api,
+      options,
+      farm,
+    }) => {
       let {config: processedConfig, cachePath} = nullthrows(
         await api.runRequest<null, ConfigAndCachePath>(
           createParcelConfigRequest(),
@@ -66,6 +73,7 @@ export default function createValidationRequest(
           config,
           report,
           dedicatedThread: true,
+          bundleGraph,
         }).run(),
       );
       await Promise.all(promises);

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -53,7 +53,7 @@ export type ProcessedParcelConfig = {|
   optimizers?: {[Glob]: ExtendableParcelConfigPipeline, ...},
   compressors?: {[Glob]: ExtendableParcelConfigPipeline, ...},
   reporters?: PureParcelConfigPipeline,
-  validators?: {[Glob]: ExtendableParcelConfigPipeline, ...},
+  validators?: PureParcelConfigPipeline,
   filePath: ProjectPath,
   resolveFrom?: ProjectPath,
 |};

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
 import type {
+  AssetGroup,
   Bundle,
   ParcelOptions,
   ProcessedParcelConfig,
@@ -9,6 +10,7 @@ import type {
 import type {SharedReference, WorkerApi} from '@parcel/workers';
 import {loadConfig as configCache} from '@parcel/utils';
 import type {DevDepSpecifier} from './requests/DevDepRequest';
+import type {ValidateResult} from '@parcel/types';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -43,6 +45,7 @@ type WorkerValidationOpts = {|
   ...$Diff<ValidationOpts, {|workerApi: mixed, options: ParcelOptions|}>,
   optionsRef: SharedReference,
   configCachePath: string,
+  assetGroup: AssetGroup,
 |};
 
 // TODO: this should eventually be replaced by an in memory cache layer
@@ -95,8 +98,8 @@ export async function runTransform(
 export async function runValidate(
   workerApi: WorkerApi,
   opts: WorkerValidationOpts,
-): Promise<void> {
-  let {optionsRef, configCachePath, ...rest} = opts;
+): Promise<?ValidateResult> {
+  let {optionsRef, configCachePath, assetGroup, ...rest} = opts;
   let options = loadOptions(optionsRef, workerApi);
   let config = await loadConfig(configCachePath, options);
 
@@ -106,7 +109,7 @@ export async function runValidate(
     options,
     config,
     ...rest,
-  }).run();
+  }).runValidateAsset(assetGroup);
 }
 
 export async function runPackage(

--- a/packages/core/integration-tests/test/eslint-validation.js
+++ b/packages/core/integration-tests/test/eslint-validation.js
@@ -114,4 +114,21 @@ describe('eslint-validator', function () {
     }
     assert(didThrow);
   });
+
+  it('should not validate patterns ignored by eslintrc', async function () {
+    let didThrow = true;
+    let entry = path.join(
+      __dirname,
+      '/integration/eslint-ignore-patterns/index.js',
+    );
+    try {
+      await bundle(entry, {
+        defaultConfig: config,
+      });
+    } catch (e) {
+      didThrow = false;
+    }
+
+    assert(didThrow);
+  });
 });

--- a/packages/core/integration-tests/test/eslint-validation.js
+++ b/packages/core/integration-tests/test/eslint-validation.js
@@ -81,4 +81,37 @@ describe('eslint-validator', function () {
 
     assert(didThrow);
   });
+
+  it.only('should throw validation error with eslint errors on subsequent build', async function () {
+    let didThrow = false;
+    let entry = path.join(__dirname, '/integration/eslint-error/index.js');
+    try {
+      await bundle(entry, {
+        defaultConfig: config,
+        shouldDisableCache: false,
+      });
+    } catch (e) {
+      assert.equal(e.name, 'BuildError');
+      assert(Array.isArray(e.diagnostics));
+      assert(e.diagnostics[0].codeFrames);
+      assert.equal(e.diagnostics[0].origin, '@parcel/validator-eslint');
+      didThrow = true;
+    }
+
+    assert(didThrow);
+    didThrow = false;
+    try {
+      await bundle(entry, {
+        defaultConfig: config,
+        shouldDisableCache: false,
+      });
+    } catch (e) {
+      assert.equal(e.name, 'BuildError');
+      assert(Array.isArray(e.diagnostics));
+      assert(e.diagnostics[0].codeFrames);
+      assert.equal(e.diagnostics[0].origin, '@parcel/validator-eslint');
+      didThrow = true;
+    }
+    assert(didThrow);
+  });
 });

--- a/packages/core/integration-tests/test/eslint-validation.js
+++ b/packages/core/integration-tests/test/eslint-validation.js
@@ -82,7 +82,7 @@ describe('eslint-validator', function () {
     assert(didThrow);
   });
 
-  it.only('should throw validation error with eslint errors on subsequent build', async function () {
+  it('should throw validation error with eslint errors on subsequent build', async function () {
     let didThrow = false;
     let entry = path.join(__dirname, '/integration/eslint-error/index.js');
     try {

--- a/packages/core/integration-tests/test/integration/custom-configs/.parcelrc-eslint
+++ b/packages/core/integration-tests/test/integration/custom-configs/.parcelrc-eslint
@@ -1,7 +1,7 @@
 {
   "extends": "@parcel/config-default",
-  "validators": {
-    "*.{js,jsx,ts,tsx}": ["@parcel/validator-eslint"]
-  },
+  "validators": [
+    "@parcel/validator-eslint"
+  ],
   "reporters": []
 }

--- a/packages/core/integration-tests/test/integration/custom-configs/.parcelrc-typescript-validation
+++ b/packages/core/integration-tests/test/integration/custom-configs/.parcelrc-typescript-validation
@@ -1,6 +1,4 @@
 {
   "extends": "@parcel/config-default",
-  "validators": {
-    "*.{ts,tsx}": ["@parcel/validator-typescript"]
-  }
+  "validators": ["@parcel/validator-typescript"]
 }

--- a/packages/core/integration-tests/test/integration/eslint-ignore-patterns/.eslintrc.json
+++ b/packages/core/integration-tests/test/integration/eslint-ignore-patterns/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
+  "rules": {
+    "no-console": "error",
+    "no-unused-vars": "warn"
+  },
+  "ignorePatterns": "*.js"
+}

--- a/packages/core/integration-tests/test/integration/eslint-ignore-patterns/index.js
+++ b/packages/core/integration-tests/test/integration/eslint-ignore-patterns/index.js
@@ -1,0 +1,7 @@
+module.exports = function hello() {
+  console.log('Say hello world...');
+
+  let hey = '';
+
+  return 'hello';
+};

--- a/packages/core/integration-tests/test/integration/no-duplicate-assets-validation/.parcelrc
+++ b/packages/core/integration-tests/test/integration/no-duplicate-assets-validation/.parcelrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@parcel/config-default",
+  "validators": ["@parcel/validator-no-duplicate-assets"]
+}

--- a/packages/core/integration-tests/test/integration/no-duplicate-assets-validation/entry1.js
+++ b/packages/core/integration-tests/test/integration/no-duplicate-assets-validation/entry1.js
@@ -1,0 +1,1 @@
+import './nodup.js';

--- a/packages/core/integration-tests/test/integration/no-duplicate-assets-validation/entry2.js
+++ b/packages/core/integration-tests/test/integration/no-duplicate-assets-validation/entry2.js
@@ -1,0 +1,1 @@
+import './nodup.js';

--- a/packages/core/integration-tests/test/no-duplicate-assets-validation.js
+++ b/packages/core/integration-tests/test/no-duplicate-assets-validation.js
@@ -23,7 +23,7 @@ describe('nodup-validator', function () {
   });
 
   //TODO: move to cache test?
-  it.only('should throw validation error on subsequent builds for duplicate specified assets', async function () {
+  it('should throw validation error on subsequent builds for duplicate specified assets', async function () {
     let didThrow = false;
     let entry = ['entry1.js', 'entry2.js'].map(entry =>
       path.join(

--- a/packages/core/integration-tests/test/no-duplicate-assets-validation.js
+++ b/packages/core/integration-tests/test/no-duplicate-assets-validation.js
@@ -4,7 +4,7 @@ import path from 'path';
 import {bundle} from '@parcel/test-utils';
 
 describe('nodup-validator', function () {
-  it.only('should throw validation error with eslint errors', async function () {
+  it('should throw validation error for duplicate specified asset', async function () {
     let didThrow = false;
     let entry = ['entry1.js', 'entry2.js'].map(entry =>
       path.join(
@@ -16,8 +16,36 @@ describe('nodup-validator', function () {
     try {
       await bundle(entry);
     } catch (e) {
-      console.log(e.diagnostics[0]);
       assert.equal(e.name, 'BuildError');
+      didThrow = true;
+    }
+    assert(didThrow);
+  });
+
+  //TODO: move to cache test?
+  it.only('should throw validation error on subsequent builds for duplicate specified assets', async function () {
+    let didThrow = false;
+    let entry = ['entry1.js', 'entry2.js'].map(entry =>
+      path.join(
+        __dirname,
+        '/integration/no-duplicate-assets-validation/',
+        entry,
+      ),
+    );
+    try {
+      await bundle(entry, {
+        shouldDisableCache: false,
+      });
+    } catch (e) {
+      assert.equal(e.name, 'BuildError');
+      didThrow = true;
+    }
+    assert(didThrow);
+    didThrow = false;
+    try {
+      await bundle(entry, {shouldDisableCache: false});
+    } catch (e2) {
+      assert.equal(e2.name, 'BuildError');
       didThrow = true;
     }
     assert(didThrow);

--- a/packages/core/integration-tests/test/no-duplicate-assets-validation.js
+++ b/packages/core/integration-tests/test/no-duplicate-assets-validation.js
@@ -1,0 +1,25 @@
+// @flow
+import assert from 'assert';
+import path from 'path';
+import {bundle} from '@parcel/test-utils';
+
+describe('nodup-validator', function () {
+  it.only('should throw validation error with eslint errors', async function () {
+    let didThrow = false;
+    let entry = ['entry1.js', 'entry2.js'].map(entry =>
+      path.join(
+        __dirname,
+        '/integration/no-duplicate-assets-validation/',
+        entry,
+      ),
+    );
+    try {
+      await bundle(entry);
+    } catch (e) {
+      console.log(e.diagnostics[0]);
+      assert.equal(e.name, 'BuildError');
+      didThrow = true;
+    }
+    assert(didThrow);
+  });
+});

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -987,7 +987,7 @@ export type DedicatedThreadValidator = {|
     bundleGraph: BundleGraph<PackagedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
-  |}) => Async<Array<?ValidateResult>>,
+  |}) => ValidateResult,
 |};
 
 /**

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -64,7 +64,7 @@ export type RawParcelConfig = {|
   optimizers?: {[Glob]: RawParcelConfigPipeline, ...},
   compressors?: {[Glob]: RawParcelConfigPipeline, ...},
   reporters?: RawParcelConfigPipeline,
-  validators?: {[Glob]: RawParcelConfigPipeline, ...},
+  validators?: RawParcelConfigPipeline,
 |};
 
 /** A .parcelrc where all package names are resolved */

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -977,9 +977,14 @@ export type ValidateResult = {|
  * @experimental
  */
 export type DedicatedThreadValidator = {|
-  validateAll: ({|
+  validateAll?: ({|
     assets: Asset[],
     resolveConfigWithPath: ResolveConfigWithPathFn,
+    options: PluginOptions,
+    logger: PluginLogger,
+  |}) => Async<Array<?ValidateResult>>,
+  validateBundles?: ({|
+    bundleGraph: BundleGraph<PackagedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
   |}) => Async<Array<?ValidateResult>>,

--- a/packages/validators/no-duplicate-assets/package.json
+++ b/packages/validators/no-duplicate-assets/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@parcel/validator-no-duplicate-assets",
+  "version": "2.3.2",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "lib/NoDuplicateAssetsValidator.js",
+  "source": "src/NoDuplicateAssetsValidator.js",
+  "engines": {
+    "node": ">= 12.0.0",
+    "parcel": "^2.3.2"
+  },
+  "dependencies": {
+    "@parcel/plugin": "2.3.2",
+    "@parcel/utils": "2.3.2"
+  }
+}

--- a/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
+++ b/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
@@ -1,11 +1,9 @@
 // @flow
 import {Validator} from '@parcel/plugin';
 import {type DiagnosticCodeFrame, escapeMarkdown} from '@parcel/diagnostic';
-import eslint from 'eslint';
 import invariant from 'assert';
 
-let cliEngine = null;
-
+// only do this in prod?
 export default (new Validator({
-  async validateBundle({bundle, bundleGraph}) {},
+  async validateBundles({bundleGraph}) {},
 }): Validator);

--- a/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
+++ b/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
@@ -2,8 +2,46 @@
 import {Validator} from '@parcel/plugin';
 import {type DiagnosticCodeFrame, escapeMarkdown} from '@parcel/diagnostic';
 import invariant from 'assert';
+import path from 'path';
+
+let assetNoDupPath = 'nodup.js';
 
 // only do this in prod?
 export default (new Validator({
-  async validateBundles({bundleGraph}) {},
+  validateBundles({bundleGraph, options}) {
+    //should be async ?
+    let validatorResult = {
+      warnings: [],
+      errors: [],
+    };
+    let duplicateAsset;
+    bundleGraph.traverse(node => {
+      if (node.type !== 'asset') {
+        return;
+      }
+      if (
+        node.value.filePath === path.join(options.projectRoot, assetNoDupPath)
+      ) {
+        duplicateAsset = node.value;
+      }
+    });
+    if (duplicateAsset) {
+      let bundlesWithAsset = bundleGraph.getBundlesWithAsset(duplicateAsset);
+      if (bundlesWithAsset.length > 0) {
+        validatorResult.errors.push({
+          origin: '@parcel/validator-no-duplicate-assets',
+          message: `Found duplicate asset **${assetNoDupPath}** in ${bundlesWithAsset
+            .map(b => b.filePath)
+            .join(', ')}`,
+        });
+      }
+    } else {
+      validatorResult.warnings.push({
+        origin: '@parcel/validator-no-duplicate-assets',
+        message: `Unable to find asset at filepath **${assetNoDupPath}**`,
+      });
+    }
+
+    return validatorResult;
+  },
 }): Validator);

--- a/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
+++ b/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
@@ -1,10 +1,8 @@
 // @flow
 import {Validator} from '@parcel/plugin';
-import {type DiagnosticCodeFrame, escapeMarkdown} from '@parcel/diagnostic';
-import invariant from 'assert';
 import path from 'path';
 
-let assetNoDupPath = 'nodup.js';
+let assetNoDupPath = 'noDup.js';
 
 // only do this in prod?
 export default (new Validator({
@@ -27,11 +25,14 @@ export default (new Validator({
     });
     if (duplicateAsset) {
       let bundlesWithAsset = bundleGraph.getBundlesWithAsset(duplicateAsset);
-      if (bundlesWithAsset.length > 0) {
+      if (bundlesWithAsset.length > 1) {
         validatorResult.errors.push({
           origin: '@parcel/validator-no-duplicate-assets',
-          message: `Found duplicate asset **${assetNoDupPath}** in ${bundlesWithAsset
-            .map(b => b.filePath)
+          message: `Found duplicate asset **${assetNoDupPath}** in bundle(s) ${bundlesWithAsset
+            .map(b => {
+              let splitArray = b.filePath.split('/');
+              return splitArray[splitArray.length - 1];
+            })
             .join(', ')}`,
         });
       }

--- a/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
+++ b/packages/validators/no-duplicate-assets/src/NoDuplicateAssetsValidator.js
@@ -1,0 +1,11 @@
+// @flow
+import {Validator} from '@parcel/plugin';
+import {type DiagnosticCodeFrame, escapeMarkdown} from '@parcel/diagnostic';
+import eslint from 'eslint';
+import invariant from 'assert';
+
+let cliEngine = null;
+
+export default (new Validator({
+  async validateBundle({bundle, bundleGraph}) {},
+}): Validator);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->
Co-Author @wbinnssmith 

### ↪️ Main Changes

Created a new validator, `NoDuplicateAssetsValidator`, which validates all bundles against some asset that should not be duplicated. Currently this is a hard coded value `noDup.js` for testing purposes.

Validators now return a`ValidationResult` which is then stored and reused on subsequent builds, thus, fixing the cache issue where diagnostics disappear after a build where nothing changed. I believe this is similar to [this issue](https://github.com/parcel-bundler/parcel/issues/7166). 

Whether or not validators are run is _no longer based solely_ on if there are changed assets.

### 🚨 Questions

- Should we move any cache-related validation tests to the cache tests? 


<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added tests for this change
- [ ] Determine what assets should we *actually* enforce no duplication for 
- [ ] Or add way to customize what assets shouldn't be duplicated
- [ ] Remove hard coded `NoDup.js` and update test and cleanup
