### PR TITLE
Enable parsing static initialization blocks

### DIFF
--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -508,6 +508,7 @@ fn parse(
     Syntax::Es(EsConfig {
       jsx: config.is_jsx,
       export_default_from: true,
+      static_blocks: true,
       decorators: config.decorators,
       ..Default::default()
     })


### PR DESCRIPTION
I guess this is a "shippedProposal" by now
https://caniuse.com/mdn-javascript_classes_static_initialization_blocks

Closes https://github.com/parcel-bundler/parcel/issues/7838