### PR TITLE
Clean up async bundles after they are internalized 

### DIFF
--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -289,10 +289,6 @@ function createIdealGraph(
   let entries: Map<Asset, Dependency> = new Map();
   let sharedToSourceBundleIds: Map<NodeId, Array<NodeId>> = new Map();
 
-  // Attempt to replace reachable roots by building it earlier.
-  // this models bundleRoots and the assets that require it synchronously
-  let syncRootsAvailable: ContentGraph<Asset> = new ContentGraph();
-
   assetGraph.traverse((node, context, actions) => {
     if (node.type !== 'asset') {
       return node;
@@ -337,41 +333,6 @@ function createIdealGraph(
       dependencyPriorityEdges[dependency.priority],
     );
     bundleGroupBundleIds.push(nodeId);
-    syncRootsAvailable.addNodeByContentKeyIfNeeded(asset.id, asset);
-    assetGraph.traverse((node, _, actions) => {
-      if (node.value === asset) {
-        return;
-      }
-
-      if (node.type === 'dependency') {
-        let dependency = node.value;
-
-        let assets = assetGraph.getDependencyAssets(dependency);
-        if (assets.length === 0) {
-          return;
-        }
-
-        invariant(assets.length === 1);
-        let resolved = assets[0];
-        let isAsync = dependency.priority !== 'sync';
-        if (
-          isAsync ||
-          resolved.bundleBehavior === 'isolated' ||
-          resolved.bundleBehavior === 'inline' ||
-          asset.type !== resolved.type
-        ) {
-          actions.skipChildren();
-        }
-
-        return;
-      }
-      //asset node type
-      let nodeId = syncRootsAvailable.addNodeByContentKeyIfNeeded(
-        node.value.id,
-        node.value,
-      );
-      syncRootsAvailable.addEdge(rootNodeId, nodeId);
-    }, asset);
   }
 
   let assets = [];
@@ -380,18 +341,11 @@ function createIdealGraph(
     Array<[Bundle, Asset]>,
   > = new DefaultMap(() => []);
 
-  let currentRoot;
   // Step 2: Traverse the asset graph and create bundles for asset type changes and async dependencies,
   // only adding the entry asset of each bundle, not the subgraph.
   assetGraph.traverse({
     enter(node, context, actions) {
       if (node.type === 'asset') {
-        if (bundleRoots.has(node.value)) {
-          currentRoot = syncRootsAvailable.addNodeByContentKeyIfNeeded(
-            node.value.id,
-            node.value,
-          );
-        }
         assets.push(node.value);
 
         let bundleIdTuple = bundleRoots.get(node.value);
@@ -430,36 +384,6 @@ function createIdealGraph(
                 bundleGraph.getNode(stack[0][1]),
               );
               invariant(firstBundleGroup !== 'root');
-              let entry = [...firstBundleGroup.assets][0];
-              let entrynodeId = syncRootsAvailable.getNodeIdByContentKey(
-                entry.id,
-              );
-              if (entrynodeId !== null) {
-                let hasThisAssetBySync = false;
-                syncRootsAvailable
-                  .getNodeIdsConnectedFrom(entrynodeId)
-                  .forEach(nodeId => {
-                    let child = syncRootsAvailable.getNode(nodeId);
-                    if (child?.id === childAsset.id) {
-                      hasThisAssetBySync = true;
-                    }
-                  });
-                if (hasThisAssetBySync) {
-                  //for this dependency mark it internally resolvable for that bundle
-                  let parentBundleId = bundles.has(parentAsset.id)
-                    ? bundles.get(parentAsset.id)
-                    : null;
-                  let parentBundle;
-                  if (parentBundleId !== null) {
-                    parentBundle = nullthrows(
-                      bundleGraph.getNode(parentBundleId),
-                    );
-                    invariant(parentBundle !== 'root');
-                    parentBundle.internalizedAssetIds.push(childAsset.id);
-                  }
-                  continue;
-                }
-              }
               bundle = createBundle({
                 asset: childAsset,
                 target: firstBundleGroup.target,
@@ -474,10 +398,6 @@ function createIdealGraph(
               bundleId = bundleGraph.addNode(bundle);
               bundles.set(childAsset.id, bundleId);
               bundleRoots.set(childAsset, [bundleId, bundleId]);
-              syncRootsAvailable.addNodeByContentKeyIfNeeded(
-                childAsset.id,
-                childAsset,
-              );
               bundleGroupBundleIds.push(bundleId);
               bundleGraph.addEdge(bundleGraphRootNodeId, bundleId);
             } else {
@@ -579,10 +499,6 @@ function createIdealGraph(
 
             bundles.set(childAsset.id, bundleId);
             bundleRoots.set(childAsset, [bundleId, bundleGroupNodeId]);
-            syncRootsAvailable.addNodeByContentKeyIfNeeded(
-              childAsset.id,
-              childAsset,
-            );
             bundleGraph.addEdge(bundleGraphRootNodeId, bundleId);
 
             if (bundleId != bundleGroupNodeId) {
@@ -611,13 +527,6 @@ function createIdealGraph(
 
             assetReference.get(childAsset).push([dependency, bundle]);
             continue;
-          }
-          if (dependency.priority === 'sync') {
-            let nodeId = syncRootsAvailable.addNodeByContentKeyIfNeeded(
-              childAsset.id,
-              childAsset,
-            );
-            syncRootsAvailable.addEdge(currentRoot, nodeId);
           }
         }
       }
@@ -878,10 +787,12 @@ function createIdealGraph(
     }
   }
 
-  function getBundleFromBundleRoot(a: Asset): Bundle {
-    let b = nullthrows(bundleGraph.getNode(nullthrows(bundles.get(a.id))));
-    invariant(b !== 'root');
-    return b;
+  function getBundleFromBundleRoot(bundleRoot: BundleRoot): Bundle {
+    let bundle = bundleGraph.getNode(
+      nullthrows(bundleRoots.get(bundleRoot))[0],
+    );
+    invariant(bundle !== 'root' && bundle != null);
+    return bundle;
   }
 
   return {

--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -594,26 +594,22 @@ function createIdealGraph(
           }
         }
 
-        let assets = assetGraph.getDependencyAssets(dependency);
-        if (assets.length === 0) {
-          return;
-        }
-
-        invariant(assets.length === 1);
-        let resolved = assets[0];
-        let isAsync = dependency.priority !== 'sync';
-        if (
-          isAsync ||
-          resolved.bundleBehavior === 'isolated' ||
-          resolved.bundleBehavior === 'inline' ||
-          root.type !== resolved.type
-        ) {
+        if (dependency.priority !== 'sync') {
           actions.skipChildren();
         }
 
         return;
       }
       //asset node type
+      let asset = node.value;
+      if (
+        asset.bundleBehavior === 'isolated' ||
+        asset.bundleBehavior === 'inline' ||
+        root.type !== asset.type
+      ) {
+        actions.skipChildren();
+        return;
+      }
       let nodeId = reachableRoots.addNodeByContentKeyIfNeeded(
         node.value.id,
         node.value,

--- a/packages/core/integration-tests/test/integration/async-dep-internal-external/async.js
+++ b/packages/core/integration-tests/test/integration/async-dep-internal-external/async.js
@@ -1,0 +1,1 @@
+export default 30;

--- a/packages/core/integration-tests/test/integration/async-dep-internal-external/child.js
+++ b/packages/core/integration-tests/test/integration/async-dep-internal-external/child.js
@@ -1,0 +1,1 @@
+export default import('./async').then(mod => mod.default);

--- a/packages/core/integration-tests/test/integration/async-dep-internal-external/entry1.js
+++ b/packages/core/integration-tests/test/integration/async-dep-internal-external/entry1.js
@@ -1,0 +1,4 @@
+import a from './async';
+import c from './child';
+
+output = [a,c];

--- a/packages/core/integration-tests/test/integration/async-dep-internal-external/entry2.js
+++ b/packages/core/integration-tests/test/integration/async-dep-internal-external/entry2.js
@@ -1,0 +1,2 @@
+import c from './child';
+

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4578,6 +4578,45 @@ describe('javascript', function () {
     assert.deepEqual(await (await run(b)).default, [42, 42, 42]);
   });
 
+  it('async dependency can be resolved internally and externally from two different bundles', async () => {
+    let b = await bundle(
+      ['entry1.js', 'entry2.js'].map(entry =>
+        path.join(
+          __dirname,
+          '/integration/async-dep-internal-external/',
+          entry,
+        ),
+      ),
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+        },
+      },
+    );
+
+    assertBundles(b, [
+      {
+        assets: ['async.js'],
+      },
+      {
+        name: 'entry1.js',
+        assets: ['child.js', 'entry1.js', 'async.js'],
+      },
+      {
+        name: 'entry2.js',
+        assets: [
+          'bundle-manifest.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'child.js',
+          'entry2.js',
+          'js-loader.js',
+        ],
+      },
+    ]);
+  });
+
   it('can static import and dynamic import in the same bundle ancestry without creating a new bundle', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/sync-async/same-ancestry.js'),


### PR DESCRIPTION
# ↪️ Pull Request

Added cleanup code to internalization on entries, which checks if the asset to be internalized is associated with its own async bundle, and if yes, checks if it can be removed by pruning edges
  
## 💻 Examples

This fix reduces the failing tests from 15 -> 8 🎉 

HTML test suite has 13 failing (this did not impact those)

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Determine if any test cases regressed
- [x] flow, lint