### PR TITLE
Disable react refresh for library targets

### DIFF
--- a/packages/core/integration-tests/test/integration/react-refresh-library-target/Component.jsx
+++ b/packages/core/integration-tests/test/integration/react-refresh-library-target/Component.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Component = () => {
+  return <div>test</div>;
+}
+
+export default Component

--- a/packages/core/integration-tests/test/integration/react-refresh-library-target/index.js
+++ b/packages/core/integration-tests/test/integration/react-refresh-library-target/index.js
@@ -1,0 +1,3 @@
+import Component from './Component'
+
+export {Component}

--- a/packages/core/integration-tests/test/integration/react-refresh-library-target/package.json
+++ b/packages/core/integration-tests/test/integration/react-refresh-library-target/package.json
@@ -1,0 +1,9 @@
+{
+  "source": "index.js",
+  "main": "dist/main.js",
+  "dependencies": {
+    "@parcel/transformer-react-refresh-wrap": "*",
+    "react": "*",
+    "react-dom": "*"
+  }
+}

--- a/packages/core/integration-tests/test/react-refresh.js
+++ b/packages/core/integration-tests/test/react-refresh.js
@@ -9,9 +9,10 @@ import {
   overlayFS as fs,
   sleep,
   run,
+  getNextBuildSuccess,
 } from '@parcel/test-utils';
 import getPort from 'get-port';
-import type {BuildEvent} from '@parcel/types';
+import type {BuildEvent, Asset} from '@parcel/types';
 // flowlint-next-line untyped-import:off
 import JSDOM from 'jsdom';
 import nullthrows from 'nullthrows';
@@ -203,8 +204,47 @@ if (MessageChannel) {
           },
         },
       );
-
       await run(b, {}, {require: false});
+    });
+
+    it('does not apply to library targets', async () => {
+      let port = await getPort();
+      let parcel = await bundler(
+        path.join(
+          __dirname,
+          '/integration/react-refresh-library-target/index.js',
+        ),
+        {
+          hmrOptions: {
+            port,
+          },
+        },
+      );
+      let result = await getNextBuildSuccess(parcel);
+      let bundle = nullthrows(
+        result.bundleGraph.getBundles().find(b => b.type === 'js'),
+      );
+
+      // Make sure react-refresh transforms were not applied.
+      let assets: Asset[] = [];
+      bundle.traverse(node => {
+        if (node.type === 'asset') {
+          assets.push(node.value);
+        } else if (node.type === 'dependency') {
+          assert(
+            !node.value.specifier.startsWith('react-refresh/runtime') &&
+              !node.value.specifier.startsWith(
+                '@parcel/transformer-react-refresh-wrap',
+              ),
+          );
+        }
+      });
+      for (let asset of assets) {
+        let code = await asset.getCode();
+        assert(
+          !code.includes('$RefreshReg$') && !code.includes('$RefreshSig$'),
+        );
+      }
     });
   });
 }

--- a/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
+++ b/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
@@ -20,6 +20,7 @@ export default (new Runtime({
       bundle.type !== 'js' ||
       !options.hmrOptions ||
       !bundle.env.isBrowser() ||
+      bundle.env.isLibrary ||
       bundle.env.isWorker() ||
       bundle.env.isWorklet() ||
       options.mode !== 'development' ||

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -404,6 +404,7 @@ export default (new Transformer({
       is_development: options.mode === 'development',
       react_refresh:
         asset.env.isBrowser() &&
+        !asset.env.isLibrary &&
         !asset.env.isWorker() &&
         !asset.env.isWorklet() &&
         Boolean(config?.reactRefresh),

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -8,6 +8,7 @@ function shouldExclude(asset, options) {
     !asset.isSource ||
     !options.hmrOptions ||
     !asset.env.isBrowser() ||
+    asset.env.isLibrary ||
     asset.env.isWorker() ||
     asset.env.isWorklet() ||
     options.mode !== 'development' ||


### PR DESCRIPTION
For library targets:
  - Skips applying refresh transforms in `JSTransformer`
  - Skips applying `ReactRefreshRuntime`
  - Skips applying transforms in `ReactRefreshWrapTransformer`
  - Adds test asserting that runtime and transforms are not applied

Fixes #7359, #7496, #7652, #7900
See also: #6892

## Background

This was a tough one to track down because it often 'failed' silently,
and when it did produce a symptom at build time, it looked like a scope hoisting bug:
```
AssertionError [ERR_ASSERTION]: Asset was skipped or not found.
            at ScopeHoistingPackager.getSymbolResolution (...)
            ...
```
The error would only occur when:
- The build target was a library
- The build was in a development env (watch mode)
- A component that was being wrapped for fast refresh happened to be re-exported
  in a way that required deep symbol resolution in the packaging step.

For a while, the working theory was that there was an issue in symbol resolution because the last condition would result in the build failure. But the underlying problem was actually the combination of the first two conditions.

The issue can be summarized as:
- a library target requires scope hoisting to produce valid modules
- react-refresh functionality is incompatible with scope hoisting
- the react-refresh transforms (and runtime) did not exclude library targets

## Testing

One integration test was added: `yarn test:integration --grep "refresh.*library"`
Additionally, reproductions involving library targets from all of the linked issues were resolved with this fix.



