### PR TITLE
Fix: join srcset in source with ", "

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -834,6 +834,12 @@ describe('html', function () {
         assets: ['300x300.png'],
       },
     ]);
+
+    const html = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+
+    const source = html.match(/<source srcset=".*>/)[0];
+
+    assert(source.split(', ').length === 3);
   });
 
   it('should detect imagesrcset attribute', async function () {

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -96,6 +96,12 @@ function collectSrcSetDependencies(asset, srcset, opts) {
     newSources.push(pair.join(' '));
   }
 
+  /**
+   * https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
+   *
+   * If an image candidate string in srcset contains a width descriptor or a pixel density descriptor or ASCII whitespace, the following image candidate string must begin with whitespace.
+   * So we need to join each image candidate string with ", ".
+   */
   return newSources.join(', ');
 }
 

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -96,7 +96,7 @@ function collectSrcSetDependencies(asset, srcset, opts) {
     newSources.push(pair.join(' '));
   }
 
-  return newSources.join(',');
+  return newSources.join(', ');
 }
 
 function getAttrDepHandler(attr) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes: #7884 

I found this is parcel’s issue. htmlnano depends on [srcset](https://github.com/sindresorhus/srcset), npm module to parse srcset attribute and after https://github.com/sindresorhus/srcset/pull/11 PR was merged `srcset` **module** cannot parse srcset **attribute** without whitespace after “,” because `hoge.png,bar.png` is a valid URL.

However, parsel joins multiple image URLs in srcset **attribute** with “,” so this issue happens. parcel should join multiple image URLs in srcset **attribute** with “, “(with space), so I fixed so.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

```html
<source srcset="hoge.png?as=webp&width=400, hoge.png?as=webp&width=800 2x">
```

into transformed into above by HTMLTransformer

```html
<source srcset="hoge.HASH.png,hoge.HASH.png 2x">
```

but `srcset` module cannot parse this srcset **attribute** as a two image URLs.

## 🚨 Test instructions

I fixed html srcset integration testcase to check output HTML's srcset is valid.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
