### PR TITLE
Correctly remove orphaned non-tree subgraphs

### DIFF
--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -139,6 +139,10 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   removeNode(nodeId: NodeId) {
     this._assertHasNodeId(nodeId);
 
+    for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
+      this.removeEdge(nodeId, to, type);
+    }
+
     for (let {type, from} of this.adjacencyList.getInboundEdgesByType(nodeId)) {
       this.removeEdge(
         from,
@@ -148,10 +152,6 @@ export default class Graph<TNode, TEdgeType: number = 1> {
         // and is already being removed.
         false,
       );
-    }
-
-    for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
-      this.removeEdge(nodeId, to, type);
     }
 
     let wasRemoved = this.nodes.delete(nodeId);

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -137,7 +137,9 @@ export default class Graph<TNode, TEdgeType: number = 1> {
 
   // Removes node and any edges coming from or to that node
   removeNode(nodeId: NodeId) {
-    this._assertHasNodeId(nodeId);
+    if (!this.hasNode(nodeId)) {
+      return;
+    }
 
     for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
       this.removeEdge(nodeId, to, type);
@@ -159,7 +161,9 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   }
 
   removeEdges(nodeId: NodeId, type: TEdgeType | NullEdgeType = 1) {
-    this._assertHasNodeId(nodeId);
+    if (!this.hasNode(nodeId)) {
+      return;
+    }
 
     for (let to of this.getNodeIdsConnectedFrom(nodeId, type)) {
       this.removeEdge(nodeId, to, type);
@@ -174,9 +178,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     removeOrphans: boolean = true,
   ) {
     if (!this.adjacencyList.hasEdge(from, to, type)) {
-      throw new Error(
-        `Edge from ${fromNodeId(from)} to ${fromNodeId(to)} not found!`,
-      );
+      return;
     }
 
     this.adjacencyList.removeEdge(from, to, type);
@@ -186,7 +188,9 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   }
 
   isOrphanedNode(nodeId: NodeId): boolean {
-    this._assertHasNodeId(nodeId);
+    if (!this.hasNode(nodeId)) {
+      return false;
+    }
 
     if (this.rootNodeId == null) {
       // If the graph does not have a root, and there are inbound edges,

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -141,10 +141,6 @@ export default class Graph<TNode, TEdgeType: number = 1> {
       return;
     }
 
-    for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
-      this.removeEdge(nodeId, to, type);
-    }
-
     for (let {type, from} of this.adjacencyList.getInboundEdgesByType(nodeId)) {
       this.removeEdge(
         from,
@@ -154,6 +150,10 @@ export default class Graph<TNode, TEdgeType: number = 1> {
         // and is already being removed.
         false,
       );
+    }
+
+    for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
+      this.removeEdge(nodeId, to, type);
     }
 
     let wasRemoved = this.nodes.delete(nodeId);

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -318,7 +318,7 @@ describe('Graph', () => {
     assert.deepEqual(visited, [nodeA, nodeB, nodeD]);
   });
 
-  it('foo', () => {
+  it('correctly removes non-tree subgraphs', () => {
     let graph = new Graph();
     let nodeRoot = graph.addNode('root');
     let node1 = graph.addNode('1');

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -317,4 +317,24 @@ describe('Graph', () => {
 
     assert.deepEqual(visited, [nodeA, nodeB, nodeD]);
   });
+
+  it('foo', () => {
+    let graph = new Graph();
+    let nodeRoot = graph.addNode('root');
+    let node1 = graph.addNode('1');
+    let node2 = graph.addNode('2');
+    let node3 = graph.addNode('3');
+
+    graph.addEdge(nodeRoot, node1);
+    graph.addEdge(node1, node2);
+    graph.addEdge(node1, node3);
+    graph.addEdge(node2, node3);
+
+    graph.setRootNodeId(nodeRoot);
+
+    graph.removeNode(node1);
+
+    assert.strictEqual(graph.nodes.size, 1);
+    assert.deepStrictEqual(Array.from(graph.getAllEdges()), []);
+  });
 });

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -20,13 +20,6 @@ describe('Graph', () => {
     assert.equal(graph.nodes.get(id), node);
   });
 
-  it("errors when removeNode is called with a node that doesn't belong", () => {
-    let graph = new Graph();
-    assert.throws(() => {
-      graph.removeNode(toNodeId(-1));
-    }, /Does not have node/);
-  });
-
   it('errors when traversing a graph with no root', () => {
     let graph = new Graph();
 


### PR DESCRIPTION
# ↪️ Pull Request

`removeNode(1)`  first removes 0-1, then 1-2 (because 2 is an orphan), then 2-3 (because 2 is an orphan after 0-1 was removed). The the right branch is visited and 2-3 is removed again which fails

![undefined](https://user-images.githubusercontent.com/4586894/162528863-b1c3d810-3f7d-4ebd-aad9-ce97bedac613.png)

I think it makes more sense to first remove the outgoing edges and then the incoming edges. This way, the subgraph is removed bottom up and a nodes becomes only orphaned once the last parent of that node is removed. So there will always be exactly one anchestor node that is responsible for removing it and no double deletion as before.

## 💻 Examples

The asset graph looked like this, changing some target option in package.json would remove the subgraph and run into a `Edge from x to y not found`  error.

<img src="https://user-images.githubusercontent.com/4586894/162528906-1376dab1-af23-4e11-a87e-d2e6ea64c32b.png"  />

