### PR TITLE
Bump swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.49"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "libdeflate-sys"
@@ -1345,9 +1345,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -1746,9 +1746,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.17.19"
+version = "0.17.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00edee63ed3957d0842ac91f04010b04a5c240c752924fa53e6ebe72888b523a"
+checksum = "daac2e6fea713c68d37b29ea5fd6342213ca2915a868f38a3fd4aa6750a9b9f8"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7136acc7570e40253bbc91b55d7bc7e7eac6fda323994e972e8fcc74ae180b02"
+checksum = "72961898fbe56591997e667a1ec6a268383582810351c279a15ec710b6177d33"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1790,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ae900c3be1f9ed683585b766cb47981ecf1c7ecdd040eb10e15ced4b9160e7"
+checksum = "99ca430d8ea2c8791d1341c4035431c90b87330e39479b4a6dabb4fded124e30"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1840,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.99.0"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22675d02854553f2ebd5289aeefd73dc6374fe2ab0a36d08560b571949eb2d4"
+checksum = "890d967031e3e7330cd7892f27d826b7b4f37c7caa19db85c78a0862e1fe3974"
 dependencies = [
  "either",
  "enum_kind",
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.116.1"
+version = "0.117.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d1cc2c05edab411661c09093b20499324c1e2798b3a816579e1c4ddc8cab796"
+checksum = "77a37c95c8e7e47a1fd6bf09ff2744fe55570235e8aba2c9373200213ec2ce25"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1885,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.141.0"
+version = "0.142.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359c9c4f418842e61f366bdf3dd9b10fb5a13c471e950f154a39e0e1e48c2428"
+checksum = "f20e5e2d8ab843fa0454e049f73f6d99c444a8c0e2320f77028361ab75e2d18e"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee03e47c0e67bcb054772e0d9e0c53162cd136382aa4e8acb19397dc7b20a2c"
+checksum = "404c6ea7ca61ceb2ce1f4ed448d1436a38c31b8c572850f04541c0229c966bbf"
 dependencies = [
  "better_scoped_tls",
  "once_cell",
@@ -1925,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a9f6155ce9ee0e49f24096dfc09f8785fc27ae56855596edb8b90e21e688b5"
+checksum = "503f2f6bd0f9e6363a93406753bf64675163423774256a267c85a5d9b5b44b08"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.88.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559f132f286efa7e5dd911676b41f7689278e06eb00a23ff4603d51bb2f1fa47"
+checksum = "1d234c84cee8aeeda2ec60087f65acd420e2475bb334a64bbf988b538c21b31d"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1978,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.101.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01da317c4666470fdd9f195a11a8fb90ef8442d16fa06b4542fd399a751593cf"
+checksum = "6c340a0228a9a49240d97a4a4e99a0a61e6613b29b427cc09a60f6ad4dcbf728"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2002,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.111.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e073b79641f526fb81348cc78672a156df8046a1111a107ae1c6f311d56828f"
+checksum = "af43d7d92e0bb8ba60d64ce8a7edcab7738f7e858b8e42814fca5c133ba17c19"
 dependencies = [
  "ahash",
  "dashmap 5.2.0",
@@ -2024,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.96.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f774f86e13c0ab7932087309eda60fc318710afa10c1148e5c286c4666a8097"
+checksum = "93d08411e517736b0167f3c9784fe9b98cc09308ae12e6072abd2bb2c2236da2"
 dependencies = [
  "either",
  "serde",
@@ -2043,9 +2043,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d2bfd9111a6dd56a3a1ba3645b94d7edbbbe72a9c51751a1e684b63760bd62"
+checksum = "43cda44270dfcc95d61582981baddaf53d96c5233ea7384e81cd6e462816c58e"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.106.0"
+version = "0.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3de090e285f3bb6c7930503a587d7df5b61ccfed5bc8984532b73d7edb1081"
+checksum = "a09397169ed7ce0751a82cb71655f3a4a1fb00d8863aabd5cca9b46eff3dd5f2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2084,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.78.0"
+version = "0.79.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5a45ecbffa3812a92f2c75026cb01ae7411e88f5c33589ebeb4780022c43f6"
+checksum = "44ee8d60b9977f58214af7102dc30855a6754e742afe6d6e26e5bf13883c7b91"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.60.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465295d6ed9fe4722a38a96d67e470b9be0417fa6ddf96d1cbaaec9c1be83eae"
+checksum = "b5ea00a52ba2b971955c62275696d5c59f3cf0cd06db74a66dec378ec9843c78"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2113,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.142.0"
+version = "0.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81b45ed484fa78195aae0986411f17251ed8987252f70d4a2d12e5eb3ff862d"
+checksum = "ebda93aa6422956c184a9eb5fdb0f0f0ff433169fa15e55ef445e5ad0b5e0abe"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2140,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ed2e930f5a1a4071fe62c90fd3a296f6030e5d94bfe13993244423caf59a78"
+checksum = "033f8b6e2fc4991a8e422a20b4f52741affcac2267c29357c931508a1a500797"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.65"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2270,9 +2270,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -2326,9 +2326,9 @@ checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-id"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4285d92be83dfbc8950a2601178b89ed36f979ebf51bfcf7b272b17001184e6c"
+checksum = "69fe8d9274f490a36442acb4edfd0c4e473fdfc6a8b5cd32f28a0235761aedbe"
 
 [[package]]
 name = "unicode-normalization"
@@ -2404,9 +2404,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.72"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -2416,9 +2416,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.72"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2431,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.72"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2441,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.72"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2454,9 +2454,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.72"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wild"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.142.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.17.19", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.143.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.17.21", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.11"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -169,11 +169,7 @@ impl<'a> DependencyCollector<'a> {
     });
 
     create_url_constructor(
-      ast::Expr::Lit(ast::Lit::Str(ast::Str {
-        span,
-        value: placeholder.into(),
-        raw: None,
-      })),
+      ast::Expr::Lit(ast::Lit::Str(placeholder.into())),
       self.config.is_esm_output,
     )
   }
@@ -1023,11 +1019,7 @@ fn create_url_constructor(url: ast::Expr, use_import_meta: bool) -> ast::Expr {
     // CJS output: "file:" + __filename
     Expr::Bin(BinExpr {
       span: DUMMY_SP,
-      left: Box::new(Expr::Lit(Lit::Str(Str {
-        value: "file:".into(),
-        span: DUMMY_SP,
-        raw: None,
-      }))),
+      left: Box::new(Expr::Lit(Lit::Str("file:".into()))),
       op: BinaryOp::Add,
       right: Box::new(Expr::Ident(Ident::new("__filename".into(), DUMMY_SP))),
     })
@@ -1227,11 +1219,7 @@ impl<'a> DependencyCollector<'a> {
       String::from("unknown.js")
     };
 
-    Expr::Lit(Lit::Str(Str {
-      value: format!("file:///{}", filename).into(),
-      span: DUMMY_SP,
-      raw: None,
-    }))
+    Expr::Lit(Lit::Str(format!("file:///{}", filename).into()))
   }
 
   fn get_import_meta(&mut self) -> ast::Expr {

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -166,11 +166,7 @@ impl<'a> InlineFS<'a> {
           _ => return None,
         };
 
-        let contents = Expr::Lit(Lit::Str(Str {
-          value: contents.into(),
-          span: DUMMY_SP,
-          raw: None,
-        }));
+        let contents = Expr::Lit(Lit::Str(contents.into()));
 
         // Add a file dependency so the cache is invalidated when this file changes.
         self.deps.push(DependencyDescriptor {
@@ -201,11 +197,7 @@ impl<'a> InlineFS<'a> {
                 spread: None,
               },
               ExprOrSpread {
-                expr: Box::new(Expr::Lit(Lit::Str(Str {
-                  value: "base64".into(),
-                  span: DUMMY_SP,
-                  raw: None,
-                }))),
+                expr: Box::new(Expr::Lit(Lit::Str("base64".into()))),
                 spread: None,
               },
             ],
@@ -231,8 +223,8 @@ impl<'a> Fold for Evaluator<'a> {
 
     match &node {
       Expr::Ident(ident) => match ident.sym.to_string().as_str() {
-        "__dirname" => Expr::Lit(Lit::Str(Str {
-          value: self
+        "__dirname" => Expr::Lit(Lit::Str(
+          self
             .inline
             .filename
             .parent()
@@ -240,14 +232,8 @@ impl<'a> Fold for Evaluator<'a> {
             .to_str()
             .unwrap()
             .into(),
-          span: DUMMY_SP,
-          raw: None,
-        })),
-        "__filename" => Expr::Lit(Lit::Str(Str {
-          value: self.inline.filename.to_str().unwrap().into(),
-          span: DUMMY_SP,
-          raw: None,
-        })),
+        )),
+        "__filename" => Expr::Lit(Lit::Str(self.inline.filename.to_str().unwrap().into())),
         _ => node,
       },
       Expr::Bin(bin) => match bin.op {
@@ -262,11 +248,7 @@ impl<'a> Fold for Evaluator<'a> {
             _ => return node,
           };
 
-          Expr::Lit(Lit::Str(Str {
-            value: format!("{}{}", left, right).into(),
-            span: DUMMY_SP,
-            raw: None,
-          }))
+          Expr::Lit(Lit::Str(format!("{}{}", left, right).into()))
         }
         _ => node,
       },
@@ -300,11 +282,7 @@ impl<'a> Fold for Evaluator<'a> {
                 }
               }
 
-              return Expr::Lit(Lit::Str(Str {
-                value: path.to_str().unwrap().into(),
-                span: DUMMY_SP,
-                raw: None,
-              }));
+              return Expr::Lit(Lit::Str(path.to_str().unwrap().into()));
             }
             _ => return node,
           }

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -122,11 +122,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
             create_decl_stmt(
               id.sym.clone(),
               self.global_mark,
-              ast::Expr::Lit(ast::Lit::Str(ast::Str {
-                span: DUMMY_SP,
-                value: swc_atoms::JsWord::from(filename),
-                raw: None,
-              })),
+              ast::Expr::Lit(ast::Lit::Str(swc_atoms::JsWord::from(filename).into())),
             ),
           );
 
@@ -148,11 +144,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
             create_decl_stmt(
               id.sym.clone(),
               self.global_mark,
-              ast::Expr::Lit(ast::Lit::Str(ast::Str {
-                span: DUMMY_SP,
-                value: swc_atoms::JsWord::from(dirname),
-                raw: None,
-              })),
+              ast::Expr::Lit(ast::Lit::Str(swc_atoms::JsWord::from(dirname).into())),
             ),
           );
 
@@ -169,11 +161,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
                   obj: Box::new(Ident(Ident::new(js_word!("arguments"), DUMMY_SP))),
                   prop: MemberProp::Computed(ComputedPropName {
                     span: DUMMY_SP,
-                    expr: Box::new(Lit(ast::Lit::Num(ast::Number {
-                      value: 3.0,
-                      span: DUMMY_SP,
-                      raw: None,
-                    }))),
+                    expr: Box::new(Lit(ast::Lit::Num(3.into()))),
                   }),
                   span: DUMMY_SP,
                 }),

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -172,6 +172,7 @@ impl<'a> Fold for GlobalReplacer<'a> {
                     expr: Box::new(Lit(ast::Lit::Num(ast::Number {
                       value: 3.0,
                       span: DUMMY_SP,
+                      raw: None,
                     }))),
                   }),
                   span: DUMMY_SP,

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -142,11 +142,7 @@ impl<'a> Fold for Hoist<'a> {
                   specifiers: vec![],
                   asserts: None,
                   span: DUMMY_SP,
-                  src: Str {
-                    value: format!("{}:{}", self.module_id, import.src.value).into(),
-                    span: DUMMY_SP,
-                    raw: None,
-                  },
+                  src: format!("{}:{}", self.module_id, import.src.value).into(),
                   type_only: false,
                 })));
 
@@ -281,11 +277,7 @@ impl<'a> Fold for Hoist<'a> {
                   specifiers: vec![],
                   asserts: None,
                   span: DUMMY_SP,
-                  src: Str {
-                    value: format!("{}:{}", self.module_id, export.src.value).into(),
-                    span: DUMMY_SP,
-                    raw: None,
-                  },
+                  src: format!("{}:{}", self.module_id, export.src.value).into(),
                   type_only: false,
                 })));
               self.re_exports.push(ImportedSymbol {
@@ -943,11 +935,7 @@ impl<'a> Hoist<'a> {
         specifiers: vec![],
         asserts: None,
         span: DUMMY_SP,
-        src: Str {
-          value: format!("{}:{}", self.module_id, source).into(),
-          span: DUMMY_SP,
-          raw: None,
-        },
+        src: format!("{}:{}", self.module_id, source).into(),
         type_only: false,
       })));
   }

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -162,11 +162,7 @@ impl ESMFold {
       js_word!("export"),
       vec![
         Expr::Ident(Ident::new("exports".into(), DUMMY_SP)),
-        Expr::Lit(Lit::Str(Str {
-          value: exported,
-          span: DUMMY_SP,
-          raw: None,
-        })),
+        Expr::Lit(Lit::Str(exported.into())),
         if matches!(self.versions, Some(versions) if Feature::ArrowFunctions.should_enable(versions, true, false)) {
           Expr::Fn(FnExpr {
             ident: None,

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -59,11 +59,7 @@ pub fn create_require(specifier: swc_atoms::JsWord) -> ast::CallExpr {
       DUMMY_SP,
     )))),
     args: vec![ast::ExprOrSpread {
-      expr: Box::new(ast::Expr::Lit(ast::Lit::Str(ast::Str {
-        span: DUMMY_SP,
-        value: normalized_specifier,
-        raw: None,
-      }))),
+      expr: Box::new(ast::Expr::Lit(ast::Lit::Str(normalized_specifier.into()))),
       spread: None,
     }],
     span: DUMMY_SP,


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7916

Also simplifies several expressions where `.into()` is enough to turn a string into a `ast::Lit::Str`.