### PR TITLE
Drop Node 12 in tests and add Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: Unit tests (${{matrix.os}}, Node ${{matrix.node}})
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14, 16]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
@@ -64,7 +64,7 @@ jobs:
     name: Integration tests (${{matrix.os}}, Node ${{matrix.node}})
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14, 16]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -988,7 +988,8 @@ export async function runESM(
         identifier: `${normalizeSeparators(
           path.relative(baseDir, filename),
         )}?id=${id}`,
-        importModuleDynamically: entry,
+        importModuleDynamically: (specifier, referrer) =>
+          entry(specifier, referrer),
         context,
         initializeImportMeta(meta) {
           meta.url = `http://localhost/${path.basename(filename)}`;


### PR DESCRIPTION
Node 12 is EOL at the end of April.

We should add Node 16 to CI, but also the the number of jobs should stay the same to not make flakeyness even worse. So either
- keep Node 12 and remove 14
- remove Node 12 but still transpile our code for Node 12  ("deprecate" it)
- remove Node 12, and bump engines to Node 14 (this would be a breaking change though).

<br>

- [x] The `vm` module used in the integration tests requires a change for Node 16. The only item regarding vm in the changelog is https://github.com/nodejs/node/pull/40249