### PR TITLE
Fix web extension schema

### DIFF
--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -445,6 +445,7 @@ export const MV3Schema = ({
       },
     },
   },
+  required: ['manifest_version', 'name', 'version'],
   additionalProperties: false,
 }: SchemaEntity);
 
@@ -480,6 +481,7 @@ export const MV2Schema = ({
     content_security_policy: string,
     web_accessible_resources: arrStr,
   },
+  required: ['manifest_version', 'name', 'version'],
   additionalProperties: false,
 }: SchemaEntity);
 
@@ -491,4 +493,5 @@ export const VersionSchema = ({
       enum: [2, 3],
     },
   },
+  required: ['manifest_version'],
 }: SchemaEntity);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Minor fix for the web extension schema that makes it throw when the required fields aren't present.

## 💻 Examples

`manifest.json`:

```json
{
  "gobble": "degook",
  "this": "should throw an error"
}
```

The above used to pass successfully through the transformer and now errors.