### PR TITLE
Fix some internal peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/core": "^7.12.0",
     "@khanacademy/flow-to-ts": "^0.5.2",
     "@napi-rs/cli": "1.0.4",
+    "@parcel/babel-register": "2.4.1",
     "@types/node": "^15.12.4",
     "cross-env": "^7.0.0",
     "eslint": "^7.20.0",

--- a/packages/configs/webextension/package.json
+++ b/packages/configs/webextension/package.json
@@ -20,5 +20,8 @@
     "@parcel/runtime-webextension": "2.4.1",
     "@parcel/transformer-raw": "2.4.1",
     "@parcel/transformer-webextension": "2.4.1"
+  },
+  "peerDependencies": {
+    "@parcel/core": "^2.4.1"
   }
 }

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -37,6 +37,7 @@
     "v8-compile-cache": "^2.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1"
   }
 }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -42,7 +42,6 @@
     "chalk": "^4.1.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-flow-strip-types": "^7.2.0",
     "@iarna/toml": "^2.2.0",
     "ansi-html-community": "0.0.8",
     "clone": "^2.1.1",

--- a/packages/dev/babel-register/package.json
+++ b/packages/dev/babel-register/package.json
@@ -12,5 +12,8 @@
     "@babel/register": "^7.4.4",
     "@parcel/babel-preset": "2.4.1",
     "resolve": "^1.12.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
   }
 }

--- a/packages/dev/eslint-config-browser/package.json
+++ b/packages/dev/eslint-config-browser/package.json
@@ -4,5 +4,9 @@
   "version": "2.4.1",
   "dependencies": {
     "@parcel/eslint-config": "2.4.1"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0",
+    "eslint": ">= 7.0.0"
   }
 }

--- a/packages/dev/eslint-config/package.json
+++ b/packages/dev/eslint-config/package.json
@@ -11,5 +11,9 @@
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-monorepo": "^0.3.2",
     "eslint-plugin-react": "^7.22.0"
+  },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0",
+    "eslint": ">= 7.0.0"
   }
 }

--- a/packages/dev/eslint-plugin/package.json
+++ b/packages/dev/eslint-plugin/package.json
@@ -8,6 +8,7 @@
     "read-pkg-up": "^5.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/eslint-parser": "^7.12.1",
     "eslint": "^7.20.0"
   }

--- a/packages/dev/esm-fuzzer/package.json
+++ b/packages/dev/esm-fuzzer/package.json
@@ -6,6 +6,7 @@
     "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules -r @parcel/babel-register index.js"
   },
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/generator": "^7.9.0",
     "@babel/template": "^7.8.6",
     "@babel/types": "^7.9.0",

--- a/packages/examples/eslint-example/package.json
+++ b/packages/examples/eslint-example/package.json
@@ -17,6 +17,7 @@
     }
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "@parcel/core": "2.4.1",
     "@parcel/validator-eslint": "2.4.1",

--- a/packages/examples/eslint-example/package.json
+++ b/packages/examples/eslint-example/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@parcel/babel-register": "2.4.1",
     "@parcel/core": "2.4.1",
-    "@parcel/validator-eslint": "2.4.1"
+    "@parcel/validator-eslint": "2.4.1",
+    "parcel": "2.4.1"
   }
 }

--- a/packages/examples/html/package.json
+++ b/packages/examples/html/package.json
@@ -12,6 +12,7 @@
     "not firefox < 67"
   ],
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "parcel": "2.4.1"
   },

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "@parcel/babel-register": "2.4.1",
     "@parcel/config-default": "2.4.1",
+    "@parcel/core": "2.4.1",
     "@parcel/optimizer-esbuild": "2.4.1",
     "@parcel/reporter-sourcemap-visualiser": "2.4.1",
     "parcel": "2.4.1"

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -8,6 +8,7 @@
     "build": "rm -rf dist && parcel build src/index.html --no-cache"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "@parcel/config-default": "2.4.1",
     "@parcel/core": "2.4.1",

--- a/packages/examples/react-refresh/package.json
+++ b/packages/examples/react-refresh/package.json
@@ -7,6 +7,7 @@
     "start": "parcel src/index.html"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "@parcel/core": "2.4.1"
   },

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -8,6 +8,7 @@
     "clean-demo": "rm -rf .parcel-cache dist && yarn demo"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "@parcel/core": "2.4.1"
   },

--- a/packages/examples/three/package.json
+++ b/packages/examples/three/package.json
@@ -28,6 +28,8 @@
   },
   "devDependencies": {
     "@parcel/config-default": "2.4.1",
+    "@parcel/core": "2.4.1",
+    "@parcel/optimizer-esbuild": "2.4.1",
     "parcel": "2.4.1"
   }
 }

--- a/packages/examples/ts-example/package.json
+++ b/packages/examples/ts-example/package.json
@@ -7,6 +7,7 @@
     "demo": "parcel build src/index.ts --no-cache"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "@parcel/core": "2.4.1"
   },

--- a/packages/examples/ts-typecheck-example/package.json
+++ b/packages/examples/ts-typecheck-example/package.json
@@ -17,6 +17,7 @@
     }
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1",
     "@parcel/core": "2.4.1",
     "@parcel/validator-typescript": "2.4.1"

--- a/packages/utils/create-react-app/package.json
+++ b/packages/utils/create-react-app/package.json
@@ -31,6 +31,7 @@
     "v8-compile-cache": "^2.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@parcel/babel-register": "2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.12.0", "@babel/core@^7.12.2", "@babel/core@^7.15.5":
+"@babel/core@^7.0.0", "@babel/core@^7.12.0", "@babel/core@^7.12.2", "@babel/core@^7.15.5":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.7.tgz#db990f931f6d40cb9b87a0dc7d2adc749f1dcbcf"
   integrity sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==
@@ -639,7 +639,7 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.12.13"
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/plugin-transform-flow-strip-types@^7.13.0", "@babel/plugin-transform-flow-strip-types@^7.2.0":
+"@babel/plugin-transform-flow-strip-types@^7.13.0":
   version "7.13.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.13.0.tgz#58177a48c209971e8234e99906cb6bd1122addd3"
   integrity sha512-EXAGFMJgSX8gxWD7PZtW/P6M+z74jpx3wm/+9pn+c2dOawPpBkUX7BrfyPvo6ZpXbgRIEuwgwDb/MGlKvu2pOg==


### PR DESCRIPTION
Apart from the added `@parcel/core` peerdependency to the webextension config (the default config has it as well), these are all changes to non-published dependencies or `devDependencies` (mostly missing `eslint` or `@babel/core` dependencies).