### PR TITLE
getSymbolResolution: fallback to asset's symbol with non-static dependencies

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1398,13 +1398,14 @@ export default class BundleGraph {
     }
 
     let found = false;
+    let nonStaticDependency = false;
     let skipped = false;
     let deps = this.getDependencies(asset).reverse();
     let potentialResults = [];
     for (let dep of deps) {
       let depSymbols = dep.symbols;
       if (!depSymbols) {
-        found = true;
+        nonStaticDependency = true;
         continue;
       }
       // If this is a re-export, find the original module.
@@ -1523,15 +1524,31 @@ export default class BundleGraph {
       // ..., but if it does exist, it has to be behind this one reexport.
       return potentialResults[0];
     } else {
-      // ... and there is no single reexport, but `bailout` tells us if it might still be exported.
+      let result = identifier;
+      if (skipped) {
+        // ... and it was excluded (by symbol propagation) or deferred.
+        result = false;
+      } else {
+        // ... and there is no single reexport, but it might still be exported:
+        if (found) {
+          // Fallback to namespace access, because of a bundle boundary.
+          result = null;
+        } else if (result === undefined) {
+          // If not exported explicitly by the asset (= would have to be in * or a reexport-all) ...
+          if (nonStaticDependency || asset.symbols?.has('*')) {
+            // ... and if there are non-statically analyzable dependencies or it's a CJS asset,
+            // fallback to namespace access.
+            result = null;
+          }
+          // (It shouldn't be possible for the symbol to be in a reexport-all and to end up here).
+          // Otherwise return undefined to report that the symbol wasn't found.
+        }
+      }
+
       return {
         asset,
         exportSymbol: symbol,
-        symbol: skipped
-          ? false
-          : found
-          ? null
-          : identifier ?? (asset.symbols?.has('*') ? null : undefined),
+        symbol: result,
         loc: asset.symbols?.get(symbol)?.loc,
       };
     }

--- a/packages/core/integration-tests/test/integration/formats/esm-filename-import/index.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-filename-import/index.js
@@ -1,0 +1,3 @@
+import path from "path";
+
+export const foo = __filename;

--- a/packages/core/integration-tests/test/integration/formats/esm-filename-import/package.json
+++ b/packages/core/integration-tests/test/integration/formats/esm-filename-import/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "esm-filename-import",
+  "private": true,
+  "main": "dist/index.js",
+  "engines": {
+    "node": ">=10"
+  }
+}

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1206,6 +1206,17 @@ describe('output formats', function () {
       assert.deepEqual({...ns}, {default: {default: 'default'}});
     });
 
+    it('should support rewriting filename and importing path', async function () {
+      let input = path.join(
+        __dirname,
+        '/integration/formats/esm-filename-import/index.js',
+      );
+      let b = await bundle(input);
+
+      let ns = await run(b);
+      assert.deepEqual(ns.foo, input);
+    });
+
     it('should rename shadowed imported specifiers to something unique', async function () {
       let b = await bundle(
         path.join(__dirname, '/integration/formats/esm-import-shadow/a.mjs'),


### PR DESCRIPTION
Previously, `getSymbolResultion` would return null in a situation like this (can be caused by importing `buffer`and also using the global or using `__filename` while also importing `path` manually).

Now, it will fallback to the symbol that the asset declares (`asset.symbols.get("foo")`), which will work fine if the asset doesn't reexport said symbol. If if that symbol was reexported (and has the value `$id1$export$id2`) then there will definitely have been a dependency with symbols and the corresponding mapping.

This doesn't trigger the  `Asset was skipped or not found.` assertion in the general case because many instances of `getSymbolResolution` returning null to fallback are handled gracefully (by falling back...). But when building a library, the symbols of the entry *have* to be determined.

This whole duplicate dependency and missing symbols problem isn't ideal, but this could also occur with two unrelated dependencies. I couldn't think of a reproduction outside of the buffer/path globals.

![AssetGraph_Main](https://user-images.githubusercontent.com/4586894/163046675-1b9e5a80-fc8d-48ff-a7e1-dc281920b13a.png)
