### PR TITLE
Workaround to undo `__filename` rewriting in parcel/package-manager

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,10 +29,7 @@ const paths = {
     '!**/dev-prelude.js',
     ...IGNORED_PACKAGES,
   ],
-  packageOther: [
-    'packages/*/*/src/**/dev-prelude.js',
-    'packages/*/dev-server/src/templates/**',
-  ],
+  packageOther: ['packages/*/*/src/**/dev-prelude.js'],
   packageJson: [
     'packages/core/parcel/package.json',
     'packages/utils/create-react-app/package.json',

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -246,8 +246,14 @@ export function installPackage(
 ): Promise<mixed> {
   if (WorkerFarm.isWorker()) {
     let workerApi = WorkerFarm.getWorkerApi();
+    // TODO this should really be `__filename` but without the rewriting.
+    let bundlePath =
+      process.env.PARCEL_BUILD_ENV === 'production' &&
+      !process.env.PARCEL_SELF_BUILD
+        ? path.join(__dirname, '..', 'lib/index.js')
+        : __filename;
     return workerApi.callMaster({
-      location: __filename,
+      location: bundlePath,
       args: [fs, packageManager, modules, filePath, projectRoot, options],
       method: '_addToInstallQueue',
     });


### PR DESCRIPTION
To unbreak the nightlies. This was already quite sketchy

Related to https://github.com/parcel-bundler/parcel/pull/7727