### PR TITLE
Feature: replace environmental variable with in binary expression

### DIFF
--- a/packages/core/integration-tests/test/integration/env-binary-in-expression/index.js
+++ b/packages/core/integration-tests/test/integration/env-binary-in-expression/index.js
@@ -1,0 +1,7 @@
+const existVar = 'ABC' in process.env ? 'correct' : 'incorrect';
+const notExistVar = 'DEF' in process.env ? 'incorrect' : 'correct';
+
+module.exports = {
+  existVar,
+  notExistVar,
+};

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3081,7 +3081,7 @@ describe('javascript', function () {
     });
   });
 
-  it('should inline environment variables in the left branch of in binary expression', async function () {
+  it('should inline environment variables with in binary expression whose right branch is process.env and left branch is string literal', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/env-binary-in-expression/index.js'),
       {

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3081,6 +3081,29 @@ describe('javascript', function () {
     });
   });
 
+  it('should inline environment variables in the left branch of in binary expression', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/env-binary-in-expression/index.js'),
+      {
+        env: {ABC: 'any'},
+        defaultTargetOptions: {
+          engines: {
+            browsers: '>= 0.25%',
+          },
+        },
+      },
+    );
+
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(!contents.includes('process.env'));
+
+    let output = await run(b);
+    assert.deepEqual(output, {
+      existVar: 'correct',
+      notExistVar: 'correct',
+    });
+  });
+
   it('should insert environment variables from a file', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/env-file/index.js'),

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -43,30 +43,24 @@ impl<'a> Fold for EnvReplacer<'a> {
 
     if let Expr::Bin(ref binary) = node {
       if let Expr::Member(ref member) = &*binary.right {
-        if let Expr::Lit(ref lit) = &*binary.left {
-          if let Lit::Str(ref left) = lit {
-            let obj = &member.obj;
-            match &**obj {
-              Expr::Ident(ref ident) => {
-                if &ident.sym == "process" {
-                  if let MemberProp::Ident(ref prop) = member.prop {
-                    if &prop.sym == "env" {
-                      if self.env.contains_key(&left.value) {
-                        return Expr::Lit(Lit::Bool(Bool {
-                          value: true,
-                          span: DUMMY_SP,
-                        }));
-                      } else {
-                        return Expr::Lit(Lit::Bool(Bool {
-                          value: false,
-                          span: DUMMY_SP,
-                        }));
-                      }
-                    }
+        if let Expr::Lit(Lit::Str(ref left)) = &*binary.left {
+          if let Expr::Ident(ref ident) = &*member.obj {
+            if &ident.sym == "process" {
+              if let MemberProp::Ident(ref prop) = member.prop {
+                if &prop.sym == "env" {
+                  if self.env.contains_key(&left.value) {
+                    return Expr::Lit(Lit::Bool(Bool {
+                      value: true,
+                      span: DUMMY_SP,
+                    }));
+                  } else {
+                    return Expr::Lit(Lit::Bool(Bool {
+                      value: false,
+                      span: DUMMY_SP,
+                    }));
                   }
                 }
               }
-              _ => {}
             }
           }
         }

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -41,6 +41,38 @@ impl<'a> Fold for EnvReplacer<'a> {
       }
     }
 
+    if let Expr::Bin(ref binary) = node {
+      if let Expr::Member(ref member) = &*binary.right {
+        if let Expr::Lit(ref lit) = &*binary.left {
+          if let Lit::Str(ref left) = lit {
+            let obj = &member.obj;
+            match &**obj {
+              Expr::Ident(ref ident) => {
+                if &ident.sym == "process" {
+                  if let MemberProp::Ident(ref prop) = member.prop {
+                    if &prop.sym == "env" {
+                      if self.env.contains_key(&left.value) {
+                        return Expr::Lit(Lit::Bool(Bool {
+                          value: true,
+                          span: DUMMY_SP,
+                        }));
+                      } else {
+                        return Expr::Lit(Lit::Bool(Bool {
+                          value: false,
+                          span: DUMMY_SP,
+                        }));
+                      }
+                    }
+                  }
+                }
+              }
+              _ => {}
+            }
+          }
+        }
+      }
+    }
+
     if let Expr::Member(ref member) = node {
       if self.is_browser && match_member_expr(member, vec!["process", "browser"], self.decls) {
         return Expr::Lit(Lit::Bool(Bool {

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -43,16 +43,18 @@ impl<'a> Fold for EnvReplacer<'a> {
     }
 
     if let Expr::Bin(ref binary) = node {
-      if let Expr::Member(ref member) = &*binary.right {
-        if let Expr::Lit(Lit::Str(ref left)) = &*binary.left {
-          if let Expr::Ident(ref ident) = &*member.obj {
-            if !self.decls.contains(&id!(ident)) && &ident.sym == "process" {
-              if let MemberProp::Ident(ref prop) = member.prop {
-                if &prop.sym == "env" {
-                  return Expr::Lit(Lit::Bool(Bool {
-                    value: self.env.contains_key(&left.value),
-                    span: DUMMY_SP,
-                  }));
+      if let BinaryOp::In = binary.op {
+        if let Expr::Member(ref member) = &*binary.right {
+          if let Expr::Lit(Lit::Str(ref left)) = &*binary.left {
+            if let Expr::Ident(ref ident) = &*member.obj {
+              if !self.decls.contains(&id!(ident)) && &ident.sym == "process" {
+                if let MemberProp::Ident(ref prop) = member.prop {
+                  if &prop.sym == "env" {
+                    return Expr::Lit(Lit::Bool(Bool {
+                      value: self.env.contains_key(&left.value),
+                      span: DUMMY_SP,
+                    }));
+                  }
                 }
               }
             }

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -6,6 +6,7 @@ use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecmascript::ast;
 use swc_ecmascript::visit::{Fold, FoldWith};
 
+use crate::id;
 use crate::utils::*;
 use ast::*;
 
@@ -45,7 +46,7 @@ impl<'a> Fold for EnvReplacer<'a> {
       if let Expr::Member(ref member) = &*binary.right {
         if let Expr::Lit(Lit::Str(ref left)) = &*binary.left {
           if let Expr::Ident(ref ident) = &*member.obj {
-            if &ident.sym == "process" {
+            if !self.decls.contains(&id!(ident)) && &ident.sym == "process" {
               if let MemberProp::Ident(ref prop) = member.prop {
                 if &prop.sym == "env" {
                   if self.env.contains_key(&left.value) {

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -49,17 +49,10 @@ impl<'a> Fold for EnvReplacer<'a> {
             if !self.decls.contains(&id!(ident)) && &ident.sym == "process" {
               if let MemberProp::Ident(ref prop) = member.prop {
                 if &prop.sym == "env" {
-                  if self.env.contains_key(&left.value) {
-                    return Expr::Lit(Lit::Bool(Bool {
-                      value: true,
-                      span: DUMMY_SP,
-                    }));
-                  } else {
-                    return Expr::Lit(Lit::Bool(Bool {
-                      value: false,
-                      span: DUMMY_SP,
-                    }));
-                  }
+                  return Expr::Lit(Lit::Bool(Bool {
+                    value: self.env.contains_key(&left.value),
+                    span: DUMMY_SP,
+                  }));
                 }
               }
             }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request


<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Fixes: #7904 

I implemented the feature to replace `in` binary expression ,whose right branch is `process.env` and left branch is string literal value, with boolean literal value.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

```javascript
"SOME_VAR" in process.env
```

into

```javascript
true // or false
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

prepare the test case to cover this.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
