### PR TITLE
Webextension fixes

### DIFF
--- a/packages/packagers/webextension/src/WebExtensionPackager.js
+++ b/packages/packagers/webextension/src/WebExtensionPackager.js
@@ -42,22 +42,26 @@ export default (new Packager({
         ),
       ];
 
-      war.push({
-        matches: contentScript.matches,
-        extension_ids: [],
-        resources: jsBundles
-          .flatMap(b => {
-            const children = [];
-            const siblings = bundleGraph.getReferencedBundles(b);
-            bundleGraph.traverseBundles(child => {
-              if (b !== child && !siblings.includes(child)) {
-                children.push(child);
-              }
-            }, b);
-            return children;
-          })
-          .map(relPath),
-      });
+      const resources = jsBundles
+        .flatMap(b => {
+          const children = [];
+          const siblings = bundleGraph.getReferencedBundles(b);
+          bundleGraph.traverseBundles(child => {
+            if (b !== child && !siblings.includes(child)) {
+              children.push(child);
+            }
+          }, b);
+          return children;
+        })
+        .map(relPath);
+
+      if (resources.length > 0) {
+        // In the future, maybe use "matches" as well
+        war.push({
+          extension_ids: [],
+          resources,
+        });
+      }
     }
     manifest.web_accessible_resources = (
       manifest.web_accessible_resources || []

--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -99,6 +99,7 @@ async function collectDependencies(
           assets[j] = asset.addURLDependency(assets[j], {
             // This causes the packager to re-run when these assets update
             priority: 'parallel',
+            bundleBehavior: 'isolated',
             loc: {
               filePath,
               ...getJSONSourceLocation(
@@ -190,6 +191,8 @@ async function collectDependencies(
           await glob(path.join(assetDir, files[j]), fs, {})
         ).map(fp =>
           asset.addURLDependency(path.relative(assetDir, fp), {
+            priority: 'parallel',
+            bundleBehavior: 'isolated',
             needsStableName: true,
             loc: {
               filePath,
@@ -224,6 +227,8 @@ async function collectDependencies(
     const obj = parent[lastLoc];
     if (typeof obj == 'string')
       parent[lastLoc] = asset.addURLDependency(obj, {
+        priority: 'parallel',
+        bundleBehavior: 'isolated',
         loc: {
           filePath,
           ...getJSONSourceLocation(ptrs[location], 'value'),
@@ -233,6 +238,8 @@ async function collectDependencies(
     else {
       for (const k of Object.keys(obj)) {
         obj[k] = asset.addURLDependency(obj[k], {
+          priority: 'parallel',
+          bundleBehavior: 'isolated',
           loc: {
             filePath,
             ...getJSONSourceLocation(ptrs[location + '/' + k], 'value'),
@@ -247,6 +254,8 @@ async function collectDependencies(
       program.background.page = asset.addURLDependency(
         program.background.page,
         {
+          priority: 'parallel',
+          bundleBehavior: 'isolated',
           loc: {
             filePath,
             ...getJSONSourceLocation(ptrs['/background/page'], 'value'),
@@ -285,6 +294,8 @@ async function collectDependencies(
       program.background.service_worker = asset.addURLDependency(
         program.background.service_worker,
         {
+          priority: 'parallel',
+          bundleBehavior: 'isolated',
           loc: {
             filePath,
             ...getJSONSourceLocation(

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -91,7 +91,7 @@ const commonProps = {
     additionalProperties: {
       type: 'object',
       properties: {},
-    }
+    },
   },
   chrome_settings_overrides: {
     type: 'object',

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -85,6 +85,14 @@ const commonProps = {
   description: string,
   icons,
   author: string,
+  browser_specific_settings: {
+    type: 'object',
+    properties: {},
+    additionalProperties: {
+      type: 'object',
+      properties: {},
+    }
+  },
   chrome_settings_overrides: {
     type: 'object',
     properties: {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Don't use shared dependencies for manifest children, allow `browser_specific_settings`, and fix `web_accessible_resources` generation for the web extension config.

Fixes #7952
Fixes #7953 (mostly)
Fixes https://github.com/parcel-bundler/parcel/pull/7050#issuecomment-1099085684 (we should support this key since it's sometimes mandatory in Firefox)
