### PR TITLE
web-ext | Add #schema key for json schema autocompletion

### DIFF
--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -76,6 +76,7 @@ const warBase = {
 };
 
 const commonProps = {
+  "$schema": string,
   name: string,
   version: {
     type: 'string',


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

closes #7970

By allowing a `#schema` key in the manifest file, a developer can enjoy intelligence/autocompletion working with it.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

The schema file location for chrome extension manifest is as follow:

```json
  "$schema": "https://json.schemastore.org/chrome-manifest",
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

With nightly build:
- Setup a v3 manifest.json file
- Add the schema url like above, and test out the intellisense on vscode or any editor supporting json schema

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
