### PR TITLE
Fix `web_accessible_resources` and HMR

### DIFF
--- a/packages/packagers/webextension/src/WebExtensionPackager.js
+++ b/packages/packagers/webextension/src/WebExtensionPackager.js
@@ -42,22 +42,26 @@ export default (new Packager({
         ),
       ];
 
-      war.push({
-        matches: contentScript.matches,
-        extension_ids: [],
-        resources: jsBundles
-          .flatMap(b => {
-            const children = [];
-            const siblings = bundleGraph.getReferencedBundles(b);
-            bundleGraph.traverseBundles(child => {
-              if (b !== child && !siblings.includes(child)) {
-                children.push(child);
-              }
-            }, b);
-            return children;
-          })
-          .map(relPath),
-      });
+      const resources = jsBundles
+        .flatMap(b => {
+          const children = [];
+          const siblings = bundleGraph.getReferencedBundles(b);
+          bundleGraph.traverseBundles(child => {
+            if (b !== child && !siblings.includes(child)) {
+              children.push(child);
+            }
+          }, b);
+          return children;
+        })
+        .map(relPath);
+
+      if (resources.length > 0) {
+        // In the future, maybe use "matches" as well
+        war.push({
+          extension_ids: [],
+          resources,
+        });
+      }
     }
     manifest.web_accessible_resources = (
       manifest.web_accessible_resources || []

--- a/packages/runtimes/webextension/src/WebExtensionRuntime.js
+++ b/packages/runtimes/webextension/src/WebExtensionRuntime.js
@@ -4,7 +4,6 @@ import {Runtime} from '@parcel/plugin';
 import nullthrows from 'nullthrows';
 import fs from 'fs';
 import path from 'path';
-import {relativeBundlePath} from '@parcel/utils';
 
 const AUTORELOAD_BG = fs.readFileSync(
   path.join(__dirname, 'autoreload-bg.js'),
@@ -12,7 +11,7 @@ const AUTORELOAD_BG = fs.readFileSync(
 );
 
 export default (new Runtime({
-  async apply({bundle, bundleGraph, options}) {
+  apply({bundle, bundleGraph, options}) {
     if (!bundle.env.isBrowser() || bundle.env.isWorklet()) {
       return;
     }

--- a/packages/runtimes/webextension/src/WebExtensionRuntime.js
+++ b/packages/runtimes/webextension/src/WebExtensionRuntime.js
@@ -4,6 +4,7 @@ import {Runtime} from '@parcel/plugin';
 import nullthrows from 'nullthrows';
 import fs from 'fs';
 import path from 'path';
+import {relativeBundlePath} from '@parcel/utils';
 
 const AUTORELOAD_BG = fs.readFileSync(
   path.join(__dirname, 'autoreload-bg.js'),
@@ -11,40 +12,51 @@ const AUTORELOAD_BG = fs.readFileSync(
 );
 
 export default (new Runtime({
-  apply({bundle, bundleGraph, options}) {
-    if (
-      bundle.type != 'js' ||
-      !options.hmrOptions ||
-      !bundle.env.isBrowser() ||
-      bundle.env.isWorklet()
-    ) {
+  async apply({bundle, bundleGraph, options}) {
+    if (!bundle.env.isBrowser() || bundle.env.isWorklet()) {
       return;
     }
-    const manifest = bundleGraph
-      .getBundles()
-      .find(b => b.getMainEntry()?.meta.webextEntry === true);
-    const entry = manifest?.getMainEntry();
-    const insertDep = entry?.meta.webextBGInsert;
-    if (insertDep == null) return;
-    const insertBundle = bundleGraph.getReferencedBundle(
-      nullthrows(entry?.getDependencies().find(dep => dep.id === insertDep)),
-      nullthrows(manifest),
-    );
-    let firstInsertableBundle;
-    bundleGraph.traverseBundles((b, _, actions) => {
-      if (b.type == 'js') {
-        firstInsertableBundle = b;
-        actions.stop();
-      }
-    }, insertBundle);
+    if (bundle.name == 'manifest.json') {
+      const asset = bundle.getMainEntry();
+      if (asset?.meta.webextEntry !== true) return;
 
-    // Add autoreload
-    if (bundle === firstInsertableBundle) {
+      // Hack to bust packager cache when any descendants update
+      const descendants = [];
+      bundleGraph.traverseBundles(b => {
+        descendants.push(b.id);
+      }, bundle);
       return {
         filePath: __filename,
-        code: AUTORELOAD_BG,
+        code: JSON.stringify(descendants),
         isEntry: true,
       };
+    } else if (options.hmrOptions && bundle.type == 'js') {
+      const manifest = bundleGraph
+        .getBundles()
+        .find(b => b.getMainEntry()?.meta.webextEntry === true);
+      const entry = manifest?.getMainEntry();
+      const insertDep = entry?.meta.webextBGInsert;
+      if (insertDep == null) return;
+      const insertBundle = bundleGraph.getReferencedBundle(
+        nullthrows(entry?.getDependencies().find(dep => dep.id === insertDep)),
+        nullthrows(manifest),
+      );
+      let firstInsertableBundle;
+      bundleGraph.traverseBundles((b, _, actions) => {
+        if (b.type == 'js') {
+          firstInsertableBundle = b;
+          actions.stop();
+        }
+      }, insertBundle);
+
+      // Add autoreload
+      if (bundle === firstInsertableBundle) {
+        return {
+          filePath: __filename,
+          code: AUTORELOAD_BG,
+          isEntry: true,
+        };
+      }
     }
   },
 }): Runtime);

--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -99,6 +99,7 @@ async function collectDependencies(
           assets[j] = asset.addURLDependency(assets[j], {
             // This causes the packager to re-run when these assets update
             priority: 'parallel',
+            bundleBehavior: 'isolated',
             loc: {
               filePath,
               ...getJSONSourceLocation(
@@ -190,6 +191,8 @@ async function collectDependencies(
           await glob(path.join(assetDir, files[j]), fs, {})
         ).map(fp =>
           asset.addURLDependency(path.relative(assetDir, fp), {
+            priority: 'parallel',
+            bundleBehavior: 'isolated',
             needsStableName: true,
             loc: {
               filePath,
@@ -224,6 +227,8 @@ async function collectDependencies(
     const obj = parent[lastLoc];
     if (typeof obj == 'string')
       parent[lastLoc] = asset.addURLDependency(obj, {
+        priority: 'parallel',
+        bundleBehavior: 'isolated',
         loc: {
           filePath,
           ...getJSONSourceLocation(ptrs[location], 'value'),
@@ -233,6 +238,8 @@ async function collectDependencies(
     else {
       for (const k of Object.keys(obj)) {
         obj[k] = asset.addURLDependency(obj[k], {
+          priority: 'parallel',
+          bundleBehavior: 'isolated',
           loc: {
             filePath,
             ...getJSONSourceLocation(ptrs[location + '/' + k], 'value'),
@@ -247,6 +254,8 @@ async function collectDependencies(
       program.background.page = asset.addURLDependency(
         program.background.page,
         {
+          priority: 'parallel',
+          bundleBehavior: 'isolated',
           loc: {
             filePath,
             ...getJSONSourceLocation(ptrs['/background/page'], 'value'),
@@ -285,6 +294,8 @@ async function collectDependencies(
       program.background.service_worker = asset.addURLDependency(
         program.background.service_worker,
         {
+          priority: 'parallel',
+          bundleBehavior: 'isolated',
           loc: {
             filePath,
             ...getJSONSourceLocation(

--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -97,8 +97,6 @@ async function collectDependencies(
         const assets = sc[k] || [];
         for (let j = 0; j < assets.length; ++j) {
           assets[j] = asset.addURLDependency(assets[j], {
-            // This causes the packager to re-run when these assets update
-            priority: 'parallel',
             bundleBehavior: 'isolated',
             loc: {
               filePath,
@@ -186,12 +184,12 @@ async function collectDependencies(
       // TODO: this doesn't support Parcel resolution
       const currentEntry = program.web_accessible_resources[i];
       const files = isMV2 ? [currentEntry] : currentEntry.resources;
+      let currentFiles = [];
       for (let j = 0; j < files.length; ++j) {
         const globFiles = (
           await glob(path.join(assetDir, files[j]), fs, {})
         ).map(fp =>
           asset.addURLDependency(path.relative(assetDir, fp), {
-            priority: 'parallel',
             bundleBehavior: 'isolated',
             needsStableName: true,
             loc: {
@@ -206,12 +204,13 @@ async function collectDependencies(
             },
           }),
         );
-        if (isMV2) {
-          war = war.concat(globFiles);
-        } else {
-          currentEntry.resources = globFiles;
-          war.push(currentEntry);
-        }
+        currentFiles = currentFiles.concat(globFiles);
+      }
+      if (isMV2) {
+        war = war.concat(currentFiles);
+      } else {
+        currentEntry.resources = currentFiles;
+        war.push(currentEntry);
       }
     }
     program.web_accessible_resources = war;
@@ -227,7 +226,6 @@ async function collectDependencies(
     const obj = parent[lastLoc];
     if (typeof obj == 'string')
       parent[lastLoc] = asset.addURLDependency(obj, {
-        priority: 'parallel',
         bundleBehavior: 'isolated',
         loc: {
           filePath,
@@ -238,7 +236,6 @@ async function collectDependencies(
     else {
       for (const k of Object.keys(obj)) {
         obj[k] = asset.addURLDependency(obj[k], {
-          priority: 'parallel',
           bundleBehavior: 'isolated',
           loc: {
             filePath,
@@ -254,7 +251,6 @@ async function collectDependencies(
       program.background.page = asset.addURLDependency(
         program.background.page,
         {
-          priority: 'parallel',
           bundleBehavior: 'isolated',
           loc: {
             filePath,
@@ -294,7 +290,6 @@ async function collectDependencies(
       program.background.service_worker = asset.addURLDependency(
         program.background.service_worker,
         {
-          priority: 'parallel',
           bundleBehavior: 'isolated',
           loc: {
             filePath,

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -91,7 +91,7 @@ const commonProps = {
     additionalProperties: {
       type: 'object',
       properties: {},
-    }
+    },
   },
   chrome_settings_overrides: {
     type: 'object',

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -85,6 +85,14 @@ const commonProps = {
   description: string,
   icons,
   author: string,
+  browser_specific_settings: {
+    type: 'object',
+    properties: {},
+    additionalProperties: {
+      type: 'object',
+      properties: {},
+    }
+  },
   chrome_settings_overrides: {
     type: 'object',
     properties: {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Actually fixes #7953

This actually, really fixes `web_accessible_resources` generation for web extensions and HMR by using a runtime as a cache invalidator for the packager based on the state of the bundle graph. This is probably bad practice compared to just doing the generation from the runtime, but since JSON assets are automatically transformed to JS it's not possible to actually consume the result of the transformer in the packager without eval.
