### PR TITLE
Add $schema support in web extension manifest

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -43,6 +43,7 @@ async function collectDependencies(
   const filePath = asset.filePath;
   const assetDir = path.dirname(filePath);
   const isMV2 = program.manifest_version == 2;
+  delete program.$schema;
   if (program.default_locale) {
     const locales = path.join(assetDir, '_locales');
     let err = !(await fs.exists(locales))

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -76,6 +76,7 @@ const warBase = {
 };
 
 const commonProps = {
+  "$schema": string,
   name: string,
   version: {
     type: 'string',

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -76,7 +76,7 @@ const warBase = {
 };
 
 const commonProps = {
-  "$schema": string,
+  $schema: string,
   name: string,
   version: {
     type: 'string',
@@ -497,6 +497,7 @@ export const MV2Schema = ({
 export const VersionSchema = ({
   type: 'object',
   properties: {
+    $schema: string,
     manifest_version: {
       type: 'number',
       enum: [2, 3],


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Adds support for `$schema`, which is automatically filtered out in the final result, within web extension manifests.

Supersedes #7969, fixes #7970
