### PR TITLE
Adds missing peer dependencies

### DIFF
--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "sharp": "^0.29.1"
+  },
+  "peerDependencies": {
+    "@parcel/core": "^2.4.1"
   }
 }

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -45,6 +45,9 @@
   "devDependencies": {
     "@napi-rs/cli": "1.0.4"
   },
+  "peerDependencies": {
+    "@parcel/core": "^2.4.1"
+  },
   "scripts": {
     "build": "napi build --platform --cargo-cwd napi",
     "build-release": "napi build --platform --release --cargo-cwd napi",


### PR DESCRIPTION
# ↪️ Pull Request

`@parcel/transformer-js` and `@parcel/transformer-image` both depend on `@parcel/workers`, which has a peer dependency on `@parcel/core`. As a result, they both should list it as a peer dependency themselves.

Fixes https://github.com/yarnpkg/berry/runs/6081290793?check_suite_focus=true

## 💻 Examples

Cf crash in https://github.com/yarnpkg/berry/runs/6081290793?check_suite_focus=true

## 🚨 Test instructions

Tested locally with Yarn & `packageExtensions`

## ✔️ PR Todo

- n/a Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
