### PR TITLE
Fix web extension scope hoisting

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -353,13 +353,20 @@ export default (new Transformer({
     // browsers, and because it avoids delegating extra config to the user
     asset.setEnvironment({
       context: 'browser',
-      engines: asset.env.engines,
-      shouldOptimize: asset.env.shouldOptimize,
-      sourceMap: {
+      engines: {
+        browsers: asset.env.engines.browsers,
+      },
+      sourceMap: asset.env.sourceMap && {
         ...asset.env.sourceMap,
         inline: true,
         inlineSources: true,
       },
+      includeNodeModules: asset.env.includeNodeModules,
+      outputFormat: asset.env.outputFormat,
+      sourceType: asset.env.sourceType,
+      isLibrary: asset.env.isLibrary,
+      shouldOptimize: asset.env.shouldOptimize,
+      shouldScopeHoist: asset.env.shouldScopeHoist,
     });
     const code = await asset.getCode();
     const parsed = parse(code);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes #7982 

In the web extension transformer, `asset.setEnvironment` did not include the `shouldScopeHoist` option, which meant scope hoisting was configured strangely in asset children. I'm not sure how exactly this became an issue, but the final result was that some shared JS bundles linked within HTML children had scope hoisting enabled without dependents' knowledge, causing certain imports to fail.

I guess this is why `setEnvironment` is discouraged. Nonetheless I still think it's way less cumbersome to do it this way.
