### PR TITLE
GitHub Actions: disable fail-fast for integration_tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       matrix:
         node: [12, 14]
         os: [ubuntu-latest, macos-latest, windows-latest]
+      # These tend to be quite flakey, so one failed instance shouldn't stop
+      # others from potentially succeeding
+      fail-fast: false
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Previously, one failure from a flakey build would cancel all other in-progress integration tests. This stops that from happening, but only for integration tests.