### PR TITLE
Add React error overlay and HMR source maps

### DIFF
--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -10,6 +10,7 @@ import {
   overlayFS,
   sleep,
   run,
+  request,
 } from '@parcel/test-utils';
 import WebSocket from 'ws';
 import json5 from 'json5';
@@ -110,6 +111,7 @@ describe('hmr', function () {
     return {
       outputs: JSON.parse(JSON.stringify(outputs)),
       reloaded,
+      bundleGraph,
     };
   }
 
@@ -157,10 +159,12 @@ describe('hmr', function () {
       assert.equal(message.type, 'update');
 
       // Figure out why output doesn't change...
-      let localAsset = message.assets.find(
-        asset => asset.output === 'exports.a = 5;\nexports.b = 5;\n',
+      let localAsset = message.assets.find(asset =>
+        asset.output.includes('exports.a = 5;\nexports.b = 5;\n'),
       );
       assert(!!localAsset);
+      assert(localAsset.output.includes('//# sourceMappingURL'));
+      assert(localAsset.output.includes('//# sourceURL'));
     });
 
     it('should emit an HMR update for all new dependencies along with the changed file', async function () {
@@ -330,6 +334,31 @@ describe('hmr', function () {
       let message = await nextWSMessage(nullthrows(ws));
 
       assert.equal(message.type, 'update');
+    });
+
+    it('should respond to requests for assets by id', async function () {
+      let port = await getPort();
+      let b = bundler(path.join(__dirname, '/input/index.js'), {
+        serveOptions: {port},
+        hmrOptions: {port},
+        inputFS: overlayFS,
+        config,
+      });
+
+      subscription = await b.watch();
+      let event = await getNextBuild(b);
+
+      let bundleGraph = nullthrows(event.bundleGraph);
+      let asset = nullthrows(bundleGraph.getBundles()[0].getMainEntry());
+      let contents = await request('/__parcel_hmr/' + asset.id, port);
+      let publicId = nullthrows(bundleGraph).getAssetPublicId(asset);
+      assert(
+        contents.startsWith(
+          `parcelHotUpdate['${publicId}'] = function (require, module, exports) {`,
+        ),
+      );
+      assert(contents.includes('//# sourceMappingURL'));
+      assert(contents.includes('//# sourceURL'));
     });
   });
 
@@ -546,6 +575,29 @@ module.hot.dispose((data) => {
       assert(/test\.[0-9a-f]+\.txt/, url.pathname);
       assert(!isNaN(url.search.slice(1)));
       assert.notEqual(url.search, search);
+    });
+
+    it('should have correct source locations in errors', async function () {
+      let {outputs, bundleGraph} = await testHMRClient(
+        'hmr-accept-self',
+        outputs => {
+          return {
+            'local.js': 'output(new Error().stack);',
+          };
+        },
+      );
+
+      let asset = bundleGraph
+        .getBundles()[0]
+        .traverseAssets((asset, _, actions) => {
+          if (asset.filePath.endsWith('local.js')) {
+            actions.stop();
+            return asset;
+          }
+        });
+
+      let stack = outputs.pop();
+      assert(stack.includes('/__parcel_hmr/' + nullthrows(asset).id));
     });
 
     /*

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -580,7 +580,7 @@ module.hot.dispose((data) => {
     it('should have correct source locations in errors', async function () {
       let {outputs, bundleGraph} = await testHMRClient(
         'hmr-accept-self',
-        outputs => {
+        () => {
           return {
             'local.js': 'output(new Error().stack);',
           };

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -10,6 +10,7 @@ import {
   outputFS,
   overlayFS,
   ncp,
+  request as get,
 } from '@parcel/test-utils';
 import http from 'http';
 import https from 'https';
@@ -21,32 +22,6 @@ const config = path.join(
   __dirname,
   './integration/custom-configs/.parcelrc-dev-server',
 );
-
-function get(file, port, client = http) {
-  return new Promise((resolve, reject) => {
-    // $FlowFixMe
-    client.get(
-      {
-        hostname: 'localhost',
-        port: port,
-        path: file,
-        rejectUnauthorized: false,
-      },
-      res => {
-        res.setEncoding('utf8');
-        let data = '';
-        res.on('data', c => (data += c));
-        res.on('end', () => {
-          if (res.statusCode !== 200) {
-            return reject({statusCode: res.statusCode, data});
-          }
-
-          resolve(data);
-        });
-      },
-    );
-  });
-}
 
 describe('server', function () {
   let subscription;

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -12,7 +12,6 @@ import {
   ncp,
   request as get,
 } from '@parcel/test-utils';
-import http from 'http';
 import https from 'https';
 import getPort from 'get-port';
 import type {BuildEvent} from '@parcel/types';

--- a/packages/core/utils/src/prettyDiagnostic.js
+++ b/packages/core/utils/src/prettyDiagnostic.js
@@ -10,10 +10,18 @@ import nullthrows from 'nullthrows';
 // $FlowFixMe
 import terminalLink from 'terminal-link';
 
+export type FormattedCodeFrame = {|
+  location: string,
+  code: string,
+|};
+
 export type AnsiDiagnosticResult = {|
   message: string,
   stack: string,
+  /** A formatted string containing all code frames, including their file locations. */
   codeframe: string,
+  /** A list of code frames with highlighted code and file locations separately. */
+  frames: Array<FormattedCodeFrame>,
   hints: Array<string>,
   documentation: string,
 |};
@@ -39,6 +47,7 @@ export default async function prettyDiagnostic(
       (skipFormatting ? message : mdAnsi(message)),
     stack: '',
     codeframe: '',
+    frames: [],
     hints: [],
     documentation: '',
   };
@@ -69,16 +78,20 @@ export default async function prettyDiagnostic(
         });
       }
 
-      result.codeframe +=
+      let location =
         typeof filePath !== 'string'
           ? ''
-          : chalk.gray.underline(
-              `${filePath}:${highlights[0].start.line}:${highlights[0].start.column}\n`,
-            );
+          : `${filePath}:${highlights[0].start.line}:${highlights[0].start.column}`;
+      result.codeframe += location ? chalk.gray.underline(location) + '\n' : '';
       result.codeframe += formattedCodeFrame;
       if (codeFrame !== codeFrames[codeFrames.length - 1]) {
         result.codeframe += '\n\n';
       }
+
+      result.frames.push({
+        location,
+        code: formattedCodeFrame,
+      });
     }
   }
 

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -38,6 +38,7 @@
     "connect": "^3.7.0",
     "ejs": "^3.1.6",
     "http-proxy-middleware": "^2.0.1",
+    "launch-editor": "^2.3.0",
     "mime-types": "2.1.18",
     "nullthrows": "^1.1.1",
     "serve-handler": "^6.0.0",

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -38,6 +38,7 @@
     "connect": "^3.7.0",
     "ejs": "^3.1.6",
     "http-proxy-middleware": "^2.0.1",
+    "mime-types": "2.1.18",
     "nullthrows": "^1.1.1",
     "serve-handler": "^6.0.0",
     "ws": "^7.0.0"

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -35,7 +35,7 @@ export type HMRMessage =
       type: 'error',
       diagnostics: {|
         ansi: Array<AnsiDiagnosticResult>,
-        html: Array<AnsiDiagnosticResult>,
+        html: Array<$Rest<AnsiDiagnosticResult, {|codeframe: string|}>>,
       |},
     |};
 
@@ -90,7 +90,10 @@ export default class HMRServer {
           return {
             message: ansiHtml(d.message),
             stack: ansiHtml(d.stack),
-            codeframe: ansiHtml(d.codeframe),
+            frames: d.frames.map(f => ({
+              location: f.location,
+              code: ansiHtml(f.code),
+            })),
             hints: d.hints.map(hint => ansiHtml(hint)),
             documentation: diagnostics[i].documentationURL ?? '',
           };

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -1,6 +1,13 @@
 // @flow
 
-import type {BuildSuccessEvent, Dependency, PluginOptions} from '@parcel/types';
+import type {
+  BuildSuccessEvent,
+  Dependency,
+  PluginOptions,
+  BundleGraph,
+  PackagedBundle,
+  Asset,
+} from '@parcel/types';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {AnsiDiagnosticResult} from '@parcel/utils';
 import type {ServerError, HMRServerOptions} from './types.js.flow';
@@ -8,9 +15,11 @@ import type {ServerError, HMRServerOptions} from './types.js.flow';
 import WebSocket from 'ws';
 import invariant from 'assert';
 import {ansiHtml, prettyDiagnostic, PromiseQueue} from '@parcel/utils';
+import {HMR_ENDPOINT} from './Server';
 
 export type HMRAsset = {|
   id: string,
+  url: string,
   type: string,
   output: string,
   envHash: string,
@@ -141,9 +150,13 @@ export default class HMRServer {
 
         return {
           id: event.bundleGraph.getAssetPublicId(asset),
+          url: getSourceURL(event.bundleGraph, asset),
           type: asset.type,
           // No need to send the contents of non-JS assets to the client.
-          output: asset.type === 'js' ? await asset.getCode() : '',
+          output:
+            asset.type === 'js'
+              ? await getHotAssetContents(event.bundleGraph, asset)
+              : '',
           envHash: asset.env.id,
           depsByBundle,
         };
@@ -184,4 +197,35 @@ function getSpecifier(dep: Dependency): string {
   }
 
   return dep.specifier;
+}
+
+export async function getHotAssetContents(
+  bundleGraph: BundleGraph<PackagedBundle>,
+  asset: Asset,
+): Promise<string> {
+  let output = await asset.getCode();
+  if (asset.type === 'js') {
+    let publicId = bundleGraph.getAssetPublicId(asset);
+    output = `parcelHotUpdate['${publicId}'] = function (require, module, exports) {${output}}`;
+  }
+
+  let sourcemap = await asset.getMap();
+  if (sourcemap) {
+    let sourcemapStringified = await sourcemap.stringify({
+      format: 'inline',
+      sourceRoot: '/__parcel_source_root/',
+      // $FlowFixMe
+      fs: asset.fs,
+    });
+
+    invariant(typeof sourcemapStringified === 'string');
+    output += `\n//# sourceMappingURL=${sourcemapStringified}`;
+    output += `\n//# sourceURL=${getSourceURL(bundleGraph, asset)}\n`;
+  }
+
+  return output;
+}
+
+function getSourceURL(bundleGraph, asset) {
+  return HMR_ENDPOINT + asset.id;
 }

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -381,6 +381,7 @@ export default class Server {
       return res.end(
         ejs.render(TEMPLATE_500, {
           errors: this.errors,
+          hmrOptions: this.options.hmrOptions,
         }),
       );
     }

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -10,7 +10,7 @@ import type {
 } from '@parcel/types';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {FileSystem} from '@parcel/fs';
-import type {HTTPServer} from '@parcel/utils';
+import type {HTTPServer, FormattedCodeFrame} from '@parcel/utils';
 
 import invariant from 'assert';
 import path from 'path';
@@ -28,10 +28,11 @@ import ejs from 'ejs';
 import connect from 'connect';
 import serveHandler from 'serve-handler';
 import {createProxyMiddleware} from 'http-proxy-middleware';
-import {URL} from 'url';
+import {URL, URLSearchParams} from 'url';
 import {getHotAssetContents} from './HMRServer';
 import nullthrows from 'nullthrows';
 import mime from 'mime-types';
+import launchEditor from 'launch-editor';
 
 function setHeaders(res: Response) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -47,6 +48,7 @@ function setHeaders(res: Response) {
 
 const SOURCES_ENDPOINT = '/__parcel_source_root';
 export const HMR_ENDPOINT = '/__parcel_hmr/';
+const EDITOR_ENDPOINT = '/__parcel_launch_editor';
 const TEMPLATE_404 = fs.readFileSync(
   path.join(__dirname, 'templates/404.html'),
   'utf8',
@@ -67,7 +69,8 @@ export default class Server {
   requestBundle: ?(bundle: PackagedBundle) => Promise<BuildSuccessEvent>;
   errors: Array<{|
     message: string,
-    stack: string,
+    stack: ?string,
+    frames: Array<FormattedCodeFrame>,
     hints: Array<string>,
     documentation: string,
   |}> | null;
@@ -117,9 +120,11 @@ export default class Server {
 
         return {
           message: ansiHtml(ansiDiagnostic.message),
-          stack: ansiDiagnostic.codeframe
-            ? ansiHtml(ansiDiagnostic.codeframe)
-            : ansiHtml(ansiDiagnostic.stack),
+          stack: ansiDiagnostic.stack ? ansiHtml(ansiDiagnostic.stack) : null,
+          frames: ansiDiagnostic.frames.map(f => ({
+            location: f.location,
+            code: ansiHtml(f.code),
+          })),
           hints: ansiDiagnostic.hints.map(hint => ansiHtml(hint)),
           documentation: d.documentationURL ?? '',
         };
@@ -128,13 +133,25 @@ export default class Server {
   }
 
   respond(req: Request, res: Response): mixed {
-    let {pathname} = url.parse(req.originalUrl || req.url);
+    let {pathname, search} = url.parse(req.originalUrl || req.url);
 
     if (pathname == null) {
       pathname = '/';
     }
 
-    if (this.errors) {
+    if (pathname.startsWith(EDITOR_ENDPOINT) && search) {
+      let query = new URLSearchParams(search);
+      let file = query.get('file');
+      if (file) {
+        // File location might start with /__parcel_source_root if it came from a source map.
+        if (file.startsWith(SOURCES_ENDPOINT)) {
+          file = file.slice(SOURCES_ENDPOINT.length + 1);
+        }
+        launchEditor(file);
+      }
+      setHeaders(res);
+      res.end();
+    } else if (this.errors) {
       return this.send500(req, res);
     } else if (pathname.startsWith(HMR_ENDPOINT)) {
       let id = pathname.slice(HMR_ENDPOINT.length);

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -34,6 +34,7 @@ export default (new Reporter({
             inputFS: options.inputFS,
             outputFS: options.outputFS,
             logger,
+            hmrOptions,
           };
 
           server = new Server(serverOptions);

--- a/packages/reporters/dev-server/src/templates/500.html
+++ b/packages/reporters/dev-server/src/templates/500.html
@@ -72,7 +72,9 @@
     <h1 class="title-heading">🚨 Parcel encountered errors</h1>
     <% errors.forEach(function(error){ %>
     <h2 class="error-message"><%- error.message %></h2>
-    <div class="error-stack-trace"><%- error.stack %></div>
+
+    <div class="error-stack-trace"><% if (error.frames?.length) { %><% error.frames.forEach(function(frame){ %><a href="/__parcel_launch_editor?file=<%- encodeURIComponent(frame.location) %>" style="text-decoration: underline; color: #888" onclick="fetch(this.href); return false"><%- frame.location %></a>
+<%- frame.code %><% }); %><% } else { %><%- error.stack %><% } %></div>
     <ul class="error-hints-container">
       <% error.hints.forEach(function(hint){ %>
       <li class="error-hint"><%- hint %></li>

--- a/packages/reporters/dev-server/src/templates/500.html
+++ b/packages/reporters/dev-server/src/templates/500.html
@@ -84,5 +84,31 @@
     <div class="documentation">📝 <a href="<%- error.documentation %>" target="_blank">Learn more</a></div>
     <% } %>
     <% }); %>
+    <% if (hmrOptions) { %>
+    <script>
+      // Reload the page when an HMR update occurs.
+      var protocol =
+        (location.protocol == 'https:' &&
+          !/localhost|127.0.0.1|0.0.0.0/.test(hostname))
+          ? 'wss'
+          : 'ws';
+      var hostname = <%- JSON.stringify(hmrOptions.host || null) %> || location.protocol.indexOf('http') === 0 ? location.hostname : 'localhost';
+      var port = <%- JSON.stringify(hmrOptions.port || null) %> || location.port;
+      var ws = new WebSocket(protocol + '://' + hostname + (port ? ':' + port : '') + '/');
+
+      var receivedInitialMessage = false;
+      ws.onmessage = (e) => {
+        let data = JSON.parse(e.data);
+
+        // The HMR server sends the pending error immediately on connect. Ignore this.
+        if (data.type == 'error' && !receivedInitialMessage) {
+          receivedInitialMessage = true;
+          return;
+        }
+
+        location.reload();
+      };
+    </script>
+    <% } %>
   </body>
 </html>

--- a/packages/reporters/dev-server/src/types.js.flow
+++ b/packages/reporters/dev-server/src/types.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import type {ServerOptions, PluginLogger} from '@parcel/types';
+import type {ServerOptions, PluginLogger, HMROptions} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import type {HTTPServer} from '@parcel/utils';
 import {
@@ -27,6 +27,7 @@ export type DevServerOptions = {|
   inputFS: FileSystem,
   outputFS: FileSystem,
   logger: PluginLogger,
+  hmrOptions: ?HMROptions,
 |};
 
 // TODO: Figure out if there is a node.js type that could be imported with a complete ServerError

--- a/packages/runtimes/hmr/src/loaders/.babelrc
+++ b/packages/runtimes/hmr/src/loaders/.babelrc
@@ -1,9 +1,0 @@
-{
-  "presets": [
-    ["@babel/preset-env", {
-      "targets": {
-        "ie": 11
-      }
-    }]
-  ]
-}

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -1,5 +1,5 @@
 // @flow
-/* global HMR_HOST, HMR_PORT, HMR_ENV_HASH, HMR_SECURE, chrome, browser */
+/* global HMR_HOST, HMR_PORT, HMR_ENV_HASH, HMR_SECURE, chrome, browser, importScripts */
 
 /*::
 import type {

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -214,7 +214,17 @@ function createErrorOverlay(diagnostics) {
     '<div style="background: black; opacity: 0.85; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; font-family: Menlo, Consolas, monospace; z-index: 9999;">';
 
   for (let diagnostic of diagnostics) {
-    let stack = diagnostic.codeframe ? diagnostic.codeframe : diagnostic.stack;
+    let stack = diagnostic.frames.length
+      ? diagnostic.frames.reduce((p, frame) => {
+          return `${p}
+<a href="/__parcel_launch_editor?file=${encodeURIComponent(
+            frame.location,
+          )}" style="text-decoration: underline; color: #888" onclick="fetch(this.href); return false">${
+            frame.location
+          }</a>
+${frame.code}`;
+        }, '')
+      : diagnostic.stack;
 
     errorHTML += `
       <div>

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -92,8 +92,18 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
   var ws = new WebSocket(
     protocol + '://' + hostname + (port ? ':' + port : '') + '/',
   );
+
+  // Safari doesn't support sourceURL in error stacks.
+  // eval may also be disabled via CSP, so do a quick check.
+  var supportsSourceURL = false;
+  try {
+    (0, eval)('throw new Error("test"); //# sourceURL=test.js');
+  } catch (err) {
+    supportsSourceURL = err.stack.includes('test.js');
+  }
+
   // $FlowFixMe
-  ws.onmessage = function (event /*: {data: string, ...} */) {
+  ws.onmessage = async function (event /*: {data: string, ...} */) {
     checkedAssets = ({} /*: {|[string]: boolean|} */);
     acceptedAssets = ({} /*: {|[string]: boolean|} */);
     assetsToAccept = [];
@@ -120,9 +130,15 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
       if (handled) {
         console.clear();
 
-        assets.forEach(function (asset) {
-          hmrApply(module.bundle.root, asset);
-        });
+        // Dispatch custom event so other runtimes (e.g React Refresh) are aware.
+        if (
+          typeof window !== 'undefined' &&
+          typeof CustomEvent !== 'undefined'
+        ) {
+          window.dispatchEvent(new CustomEvent('parcelhmraccept'));
+        }
+
+        await hmrApplyUpdates(assets);
 
         for (var i = 0; i < assetsToAccept.length; i++) {
           var id = assetsToAccept[i][1];
@@ -299,6 +315,59 @@ function reloadCSS() {
   }, 50);
 }
 
+async function hmrApplyUpdates(assets) {
+  global.parcelHotUpdate = Object.create(null);
+
+  let scriptsToRemove;
+  try {
+    // If sourceURL comments aren't supported in eval, we need to load
+    // the update from the dev server over HTTP so that stack traces
+    // are correct in errors/logs. This is much slower than eval, so
+    // we only do it if needed (currently just Safari).
+    // https://bugs.webkit.org/show_bug.cgi?id=137297
+    // This path is also taken if a CSP disallows eval.
+    if (!supportsSourceURL) {
+      let promises = assets.map(asset => {
+        if (asset.type === 'js') {
+          if (typeof document !== 'undefined') {
+            let script = document.createElement('script');
+            script.src = asset.url;
+            return new Promise((resolve, reject) => {
+              script.onload = () => resolve(script);
+              script.onerror = reject;
+              document.head?.appendChild(script);
+            });
+          } else if (typeof importScripts === 'function') {
+            return new Promise((resolve, reject) => {
+              try {
+                importScripts(asset.url);
+              } catch (err) {
+                reject(err);
+              }
+            });
+          }
+        }
+      });
+
+      scriptsToRemove = await Promise.all(promises);
+    }
+
+    assets.forEach(function (asset) {
+      hmrApply(module.bundle.root, asset);
+    });
+  } finally {
+    delete global.parcelHotUpdate;
+
+    if (scriptsToRemove) {
+      scriptsToRemove.forEach(script => {
+        if (script) {
+          document.head?.removeChild(script);
+        }
+      });
+    }
+  }
+}
+
 function hmrApply(bundle /*: ParcelRequire */, asset /*:  HMRAsset */) {
   var modules = bundle.modules;
   if (!modules) {
@@ -325,7 +394,13 @@ function hmrApply(bundle /*: ParcelRequire */, asset /*:  HMRAsset */) {
         }
       }
 
-      var fn = new Function('require', 'module', 'exports', asset.output);
+      if (supportsSourceURL) {
+        // Global eval. We would use `new Function` here but browser
+        // support for source maps is better with eval.
+        (0, eval)(asset.output);
+      }
+
+      let fn = global.parcelHotUpdate[asset.id];
       modules[asset.id] = [fn, deps];
     } else if (bundle.parent) {
       hmrApply(bundle.parent, asset);

--- a/packages/runtimes/react-refresh/package.json
+++ b/packages/runtimes/react-refresh/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@parcel/plugin": "2.5.0",
     "@parcel/utils": "2.5.0",
-    "react-refresh": "^0.9.0"
+    "react-refresh": "^0.9.0",
+    "react-error-overlay": "6.0.9"
   }
 }

--- a/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
+++ b/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
@@ -16,7 +16,7 @@ window.$RefreshSig$ = function() {
 };
 
 ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
-  let file = \`\${errorLocation.fileName}:\${errorLocation.lineNumber ||}:\${errorLocation.colNumber || 1}\`;
+  let file = \`\${errorLocation.fileName}:\${errorLocation.lineNumber || 1}:\${errorLocation.colNumber || 1}\`;
   fetch(\`/__parcel_launch_editor?file=\${encodeURIComponent(file)}\`);
 });
 

--- a/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
+++ b/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
@@ -15,6 +15,11 @@ window.$RefreshSig$ = function() {
   };
 };
 
+ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
+  let file = \`\${errorLocation.fileName}:\${errorLocation.lineNumber ||}:\${errorLocation.colNumber || 1}\`;
+  fetch(\`/__parcel_launch_editor?file=\${encodeURIComponent(file)}\`);
+});
+
 ErrorOverlay.startReportingRuntimeErrors({
   onError: function () {},
 });

--- a/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
+++ b/packages/runtimes/react-refresh/src/ReactRefreshRuntime.js
@@ -5,6 +5,7 @@ import {loadConfig} from '@parcel/utils';
 
 const CODE = `
 var Refresh = require('react-refresh/runtime');
+var ErrorOverlay = require('react-error-overlay');
 
 Refresh.injectIntoGlobalHook(window);
 window.$RefreshReg$ = function() {};
@@ -12,7 +13,16 @@ window.$RefreshSig$ = function() {
   return function(type) {
     return type;
   };
-};`;
+};
+
+ErrorOverlay.startReportingRuntimeErrors({
+  onError: function () {},
+});
+
+window.addEventListener('parcelhmraccept', () => {
+  ErrorOverlay.dismissRuntimeErrors();
+});
+`;
 
 export default (new Runtime({
   async apply({bundle, options}) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7986,6 +7986,14 @@ last-run@^1.1.0:
     default-resolution "^2.0.0"
     es6-weak-map "^2.0.1"
 
+launch-editor@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.3.0.tgz#23b2081403b7eeaae2918bda510f3535ccab0ee4"
+  integrity sha512-3QrsCXejlWYHjBPFXTyGNhPj4rrQdB+5+r5r3wArpLH201aR+nWUgw/zKKkTmilCfY/sv6u8qo98pNvtg8LUTA==
+  dependencies:
+    picocolors "^1.0.0"
+    shell-quote "^1.6.1"
+
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -10720,6 +10728,11 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-overlay@6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
+  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
+
 react-fast-compare@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
@@ -11519,6 +11532,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+shell-quote@^1.6.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
+  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
 side-channel@^1.0.3, side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Closes #7604. Closes #643. Closes #5316.

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/19409/166131688-ddc05e6f-7491-4be7-9ea7-1524b9c26a8d.png">

This adds an overlay that appears when there is a runtime error in a React app, using the [react-error-overlay](https://github.com/facebook/create-react-app/tree/a422bf227cf5294a34d68696664e9568a152fd8f/packages/react-error-overlay) package from Create React App. It is implemented as part of `@parcel/runtime-react-refresh` since it is React-specific, and that seemed like the easiest place to put it. It will appear when a runtime error occurs, and is automatically dismissed when an HMR update comes in.

This required support for source maps in HMR, which has been a longstanding issue due to our use of `new Function`, which has poor support for source maps. Now, we use `eval` instead, which has better support in Chrome and Firefox. However, Safari still doesn't support `sourceMappingURL` or `sourceURL` in `eval` error stack traces, so we detect this case and fall back to loading the asset from a new dev server endpoint that serves asset contents by id.

As a side benefit, HMR should now fall back to loading URLs for changed assets via HTTP if `eval` is not allowed, e.g. with a strict CSP. This may help web extension v3 support, though I have not tested this. (cc. @101arrowz)

The error overlay also supports clicking the code frame to open it directly in your editor, which I also added to the standard parcel build error overlay and the error 500 page. This is implemented through a second new dev server endpoint which auto-detects which editor you're using, and opens it to the line and column of the error message.

Finally, the error 500 page has been improved to automatically reload when an HMR update comes in so you don't need to manually do that.