### PR TITLE
Add "key" and "update_url" to webextension manifest schema

### DIFF
--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -94,6 +94,8 @@ const commonProps = {
       properties: {},
     },
   },
+  key: string,
+  update_url: string,
   chrome_settings_overrides: {
     type: 'object',
     properties: {


### PR DESCRIPTION
# ↪️ Pull Request

This pull request fixes #8042 by adding "key" and "update_url" to the webextension manifest schema.

## 🚨 Test instructions

Make sure Parcel is able to successfully build a webextension with the following manifest.json:
```json
{
   "manifest_version": 3,
   "name": "Test extension",
   "version": "1.0.0",
   "update_url": "https://clients2.google.com/service/update2/crx",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnF7RGLAxIon0/XeNZ4MLdP3DMkoORzEAKVg0sb89JpA/W2osTHr91Wqwdc9lW0mFcSpCYS9Y3e7cUMFo/M2ETASIuZncMiUzX2/0rrWtGQ3UuEj3KSe5PdaVZfisyJw/FebvHwirEWrhqcgzVUj9fL9YjE0G45d1zMKcc1umKvLqPyTznNuKBZ9GJREdGLRJCBmUgCkI8iwtwC+QZTUppmaD50/ksnEUXv+QkgGN07/KoNA5oAgo49Jf1XBoMv4QXtVZQlBYZl84zAsI82hb63a6Gu29U/4qMWDdI7+3Ne5TRvo6Zi3EI4M2NQNplJhik105qrz+eTLJJxvf4slrWwIDAQAB"
}
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
