### PR TITLE
Add support for Vue 3 <script setup>

### DIFF
--- a/packages/core/integration-tests/test/integration/vue-script-setup/App.vue
+++ b/packages/core/integration-tests/test/integration/vue-script-setup/App.vue
@@ -1,0 +1,9 @@
+<script setup>
+import { ref } from 'vue';
+
+const name = ref("parcel");
+</script>
+
+<template>
+<p>Hello {{ name }}</p>
+</template>

--- a/packages/core/integration-tests/test/vue.js
+++ b/packages/core/integration-tests/test/vue.js
@@ -105,4 +105,13 @@ describe('vue', function () {
     assert(contents.includes('h2:hover'));
     assert(contents.includes('.box p'));
   });
+
+  it('should load <script setup> component files', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/vue-script-setup/App.vue'),
+    );
+    let output = (await run(b)).default;
+    assert.equal(typeof output.render, 'function');
+    assert.equal(typeof output.setup, 'function');
+  });
 });

--- a/packages/core/integration-tests/test/vue.js
+++ b/packages/core/integration-tests/test/vue.js
@@ -105,7 +105,6 @@ describe('vue', function () {
     assert(contents.includes('h2:hover'));
     assert(contents.includes('.box p'));
   });
-
   it('should load <script setup> component files', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/vue-script-setup/App.vue'),

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -31,6 +31,7 @@
     "@parcel/reporter-cli": "2.5.0",
     "@parcel/reporter-dev-server": "2.5.0",
     "@parcel/utils": "2.5.0",
+    "@parcel/babel-register": "2.5.0",
     "chalk": "^4.1.0",
     "commander": "^7.0.0",
     "get-port": "^4.2.0",

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -31,7 +31,6 @@
     "@parcel/reporter-cli": "2.5.0",
     "@parcel/reporter-dev-server": "2.5.0",
     "@parcel/utils": "2.5.0",
-    "@parcel/babel-register": "2.5.0",
     "chalk": "^4.1.0",
     "commander": "^7.0.0",
     "get-port": "^4.2.0",

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -246,6 +246,7 @@ async function processPipeline({
         compilerOptions: {
           bindingMetadata: script ? script.bindings : undefined,
         },
+        isProd: options.mode === 'production',
         id,
       });
       if (templateComp.errors.length) {

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -64,6 +64,9 @@ export default (new Transformer({
     }
 
     const descriptor = parsed.descriptor;
+    let id = hashObject({
+      filePath: asset.filePath,
+    }).slice(-6);
 
     return {
       type: 'vue',
@@ -73,7 +76,7 @@ export default (new Transformer({
         script:
           !!descriptor.script || !!descriptor.scriptSetup
             ? compiler.compileScript(descriptor, {
-                id: asset.id,
+                id,
                 isProd: options.mode === 'production',
               })
             : null,

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -46,7 +46,7 @@ export default (new Transformer({
     };
   },
   canReuseAST({ast}) {
-    return ast.type === 'vue' && semver.satisfies(ast.version, '^3.0.0');
+    return ast.type === 'vue' && semver.satisfies(ast.version, '^3.2.0');
   },
   async parse({asset, options}) {
     // TODO: This parses the vue component multiple times. Fix?
@@ -65,11 +65,11 @@ export default (new Transformer({
 
     return {
       type: 'vue',
-      version: '3.0.0',
+      version: '3.2.0',
       program: {
         ...parsed.descriptor,
         script: compiler.compileScript(parsed.descriptor, {
-          id,
+          id: asset.id,
           isProd: options.mode === 'production',
         }),
       },

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -74,7 +74,7 @@ export default (new Transformer({
       program: {
         ...descriptor,
         script:
-          !!descriptor.script || !!descriptor.scriptSetup
+          descriptor.script != null || descriptor.scriptSetup != null
             ? compiler.compileScript(descriptor, {
                 id,
                 isProd: options.mode === 'production',

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -366,7 +366,8 @@ ${
             modules: style.module,
             preprocessLang: style.lang || 'css',
             scoped: style.scoped,
-            map: style.src ? undefined : style.map,
+            inMap: style.src ? undefined : style.map,
+            isProd: options.mode === 'production',
             id,
           });
           if (styleComp.errors.length) {

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -46,7 +46,7 @@ export default (new Transformer({
     };
   },
   canReuseAST({ast}) {
-    return ast.type === 'vue' && semver.satisfies(ast.version, '^3.2.0');
+    return ast.type === 'vue' && semver.satisfies(ast.version, '^3.0.0');
   },
   async parse({asset, options}) {
     // TODO: This parses the vue component multiple times. Fix?
@@ -65,11 +65,11 @@ export default (new Transformer({
 
     return {
       type: 'vue',
-      version: '3.2.0',
+      version: '3.0.0',
       program: {
         ...parsed.descriptor,
         script: compiler.compileScript(parsed.descriptor, {
-          id: asset.id,
+          id,
           isProd: options.mode === 'production',
         }),
       },

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -235,6 +235,9 @@ async function processPipeline({
         inMap: template.src ? undefined : template.map,
         scoped: styles.some(style => style.scoped),
         isFunctional,
+        compilerOptions: {
+          bindingMetadata: script ? script.bindings : undefined,
+        },
         id,
       });
       if (templateComp.errors.length) {

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -48,7 +48,7 @@ export default (new Transformer({
   canReuseAST({ast}) {
     return ast.type === 'vue' && semver.satisfies(ast.version, '^3.0.0');
   },
-  async parse({asset}) {
+  async parse({asset, options}) {
     // TODO: This parses the vue component multiple times. Fix?
     let code = await asset.getCode();
     let parsed = compiler.parse(code, {
@@ -66,7 +66,13 @@ export default (new Transformer({
     return {
       type: 'vue',
       version: '3.0.0',
-      program: parsed.descriptor,
+      program: {
+        ...parsed.descriptor,
+        script: compiler.compileScript(parsed.descriptor, {
+          id,
+          isProd: options.mode === 'production',
+        }),
+      },
     };
   },
   async transform({asset, options, resolve, config}) {

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -68,7 +68,7 @@ export default (new Transformer({
     let id = hashObject({
       filePath: asset.filePath,
       source: options.mode === 'production' ? code : null,
-    }).substring(0, 6);
+    }).slice(-6);
 
     return {
       type: 'vue',

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -69,7 +69,7 @@ export default (new Transformer({
       program: {
         ...parsed.descriptor,
         script: compiler.compileScript(parsed.descriptor, {
-          id,
+          id: asset.id,
           isProd: options.mode === 'production',
         }),
       },

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -245,11 +245,11 @@ async function processPipeline({
         scoped: styles.some(style => style.scoped),
         isFunctional,
         compilerOptions: {
+          ...config.compilerOptions,
           bindingMetadata: script ? script.bindings : undefined,
         },
         isProd: options.mode === 'production',
         id,
-        compilerOptions: config.compilerOptions,
       });
       if (templateComp.errors.length) {
         throw new ThrowableDiagnostic({

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -63,15 +63,20 @@ export default (new Transformer({
       });
     }
 
+    const descriptor = parsed.descriptor;
+
     return {
       type: 'vue',
       version: '3.0.0',
       program: {
-        ...parsed.descriptor,
-        script: compiler.compileScript(parsed.descriptor, {
-          id: asset.id,
-          isProd: options.mode === 'production',
-        }),
+        ...descriptor,
+        script:
+          !!descriptor.script || !!descriptor.scriptSetup
+            ? compiler.compileScript(descriptor, {
+                id: asset.id,
+                isProd: options.mode === 'production',
+              })
+            : null,
       },
     };
   },

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -67,7 +67,8 @@ export default (new Transformer({
     const descriptor = parsed.descriptor;
     let id = hashObject({
       filePath: asset.filePath,
-    }).slice(-6);
+      source: options.mode === 'production' ? code : null,
+    }).substring(0, 6);
 
     return {
       type: 'vue',
@@ -81,19 +82,17 @@ export default (new Transformer({
                 isProd: options.mode === 'production',
               })
             : null,
+        id,
       },
     };
   },
   async transform({asset, options, resolve, config}) {
-    let id = hashObject({
-      filePath: asset.filePath,
-    }).slice(-6);
+    let {template, script, styles, customBlocks, id} = nullthrows(
+      await asset.getAST(),
+    ).program;
     let scopeId = 'data-v-' + id;
     let hmrId = id + '-hmr';
     let basePath = basename(asset.filePath);
-    let {template, script, styles, customBlocks} = nullthrows(
-      await asset.getAST(),
-    ).program;
     if (asset.pipeline != null) {
       return processPipeline({
         asset,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR is meant to close #6949, and add support for Vue 3's `<script setup>` tags.

## 💻 Examples

A component defined like:
```vue
<template lang="pug">
div Hello {{ name }}
</template>

<script setup lang="ts">
import { ref } from 'vue';

const name = ref("Vue");
</script>
```
should compile and say "Hello Vue", rather than "Hello ".

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

TBH I would want help with adding test cases. Basically, I'd want people to go ham on Vue 3 `<script setup>` SFCs and see if anything breaks (or even combine `<script>` and `<script setup>` as is allowed by Vue).

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Added more comprehensive test suite
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
