### PR TITLE
Fix Vue pug rendering by specifying HTML5 by default

### DIFF
--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -211,7 +211,16 @@ async function processPipeline({
       }
       let content = template.content;
       if (template.lang && !['htm', 'html'].includes(template.lang)) {
+        let options = {};
         let preprocessor = consolidate[template.lang];
+        // Pug doctype fix (fixes #7756)
+        switch (template.lang) {
+          case 'pug':
+            options.doctype = 'html';
+            break;
+          default:
+            break;
+        }
         if (!preprocessor) {
           // TODO: codeframe
           throw new ThrowableDiagnostic({
@@ -221,7 +230,7 @@ async function processPipeline({
             },
           });
         }
-        content = await preprocessor.render(content, {});
+        content = await preprocessor.render(content, options);
       }
       let templateComp = compiler.compileTemplate({
         filename: asset.filePath,

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -232,8 +232,6 @@ async function processPipeline({
           case 'pug':
             options.doctype = 'html';
             break;
-          default:
-            break;
         }
         if (!preprocessor) {
           // TODO: codeframe


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

For the pug template engine for Vue, make HTML5 the default. This will fix #7756.
See discussion at #8050 for considerations about this change.

## 💻 Examples

```vue
<template lang="pug">

.wrapper

	p(v-if="false") foo
	p(v-else) bug

</template>
```
should now render properly without any workarounds.

## 🚨 Test instructions

I will add the above example as an integration test.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
