### PR TITLE
ExperimentalBundler: merge bundleBehavior for isolated dependencies

### DIFF
--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -406,6 +406,15 @@ function createIdealGraph(
             } else {
               bundle = nullthrows(bundleGraph.getNode(bundleId));
               invariant(bundle !== 'root');
+
+              if (
+                // If this dependency requests isolated, but the bundle is not,
+                // make the bundle isolated for all uses.
+                dependency.bundleBehavior === 'isolated' &&
+                bundle.bundleBehavior == null
+              ) {
+                bundle.bundleBehavior = dependency.bundleBehavior;
+              }
             }
 
             dependencyBundleGraph.addEdge(

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5707,27 +5707,47 @@ describe('javascript', function () {
         ),
       );
 
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: [
-            'dynamic-url.js',
-            'esmodule-helpers.js',
-            'bundle-url.js',
-            'cacheLoader.js',
-            'js-loader.js',
-          ],
-        },
-        {
-          type: 'js',
-          assets: ['other.js'],
-        },
-        {
-          type: 'js',
-          assets: ['other.js', 'esmodule-helpers.js'],
-        },
-      ]);
-
+      // Change in behavior: ExperimentalBundler now produces a single bundle
+      // of the lowest common denominator of bundleBehavior
+      if (process.env.PARCEL_TEST_EXPERIMENTAL_BUNDLER) {
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: [
+              'dynamic-url.js',
+              'esmodule-helpers.js',
+              'bundle-url.js',
+              'cacheLoader.js',
+              'js-loader.js',
+            ],
+          },
+          {
+            type: 'js',
+            assets: ['other.js', 'esmodule-helpers.js'],
+          },
+        ]);
+      } else {
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: [
+              'dynamic-url.js',
+              'esmodule-helpers.js',
+              'bundle-url.js',
+              'cacheLoader.js',
+              'js-loader.js',
+            ],
+          },
+          {
+            type: 'js',
+            assets: ['other.js'],
+          },
+          {
+            type: 'js',
+            assets: ['other.js', 'esmodule-helpers.js'],
+          },
+        ]);
+      }
       let res = await run(b);
       assert.equal(typeof res.lazy, 'object');
       assert.equal(typeof (await res.lazy), 'function');
@@ -5752,20 +5772,35 @@ describe('javascript', function () {
         },
       );
 
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['dynamic-url.js'],
-        },
-        {
-          type: 'js',
-          assets: ['other.js'],
-        },
-        {
-          type: 'js',
-          assets: ['other.js'],
-        },
-      ]);
+      if (process.env.PARCEL_TEST_EXPERIMENTAL_BUNDLER) {
+        // Change in behavior: ExperimentalBundler now produces a single bundle
+        // of the lowest common denominator of bundleBehavior
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: ['dynamic-url.js'],
+          },
+          {
+            type: 'js',
+            assets: ['other.js'],
+          },
+        ]);
+      } else {
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: ['dynamic-url.js'],
+          },
+          {
+            type: 'js',
+            assets: ['other.js'],
+          },
+          {
+            type: 'js',
+            assets: ['other.js'],
+          },
+        ]);
+      }
 
       let res = await run(b);
       assert.equal(typeof res.lazy, 'object');


### PR DESCRIPTION
This:

* ~Adds a nullable property `mainEntryAsset` to bundle objects in the ExperimentalBundler for ease of reference~
* Combines bundles down to the "lowest common denominator" by overriding bundleBehavior ~and needsStableName~ based on other incoming dependencies. This is a breaking change from the current bundler, trading potential asset deduplication for bundle deduplication.

One case we'll need to handle before landing:
~* [ ] Marking a bundle as existing both as an inline bundle and a non-inline bundle. Currently we never write inline bundles to disk. In this case we'll need to.~ Let's defer this, as it seems like different asset bundleBehavior creates different assets, and as far as I can tell, it's not possible to have a non-inline asset and an inline dependency.

Test Plan: Adjusted existing test(s) to use the reduced bundle count
