### PR TITLE
fix: getNodeIdsConnected should remove duplicate values

### DIFF
--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -439,20 +439,24 @@ export default class AdjacencyList<TEdgeType: number = 1> {
       (Array.isArray(type)
         ? type.includes(this.#nodes.typeOf(node))
         : type === this.#nodes.typeOf(node));
-
-    let nodes = new Set<NodeId>();
+    let nodes = [];
+    let seen = new Set<NodeId>();
     let node = this.#nodes.head(from);
     while (node !== null) {
       if (matches(node)) {
         let edge = this.#nodes.firstOut(node);
         while (edge !== null) {
-          nodes.add(this.#edges.to(edge));
+          let to = this.#edges.to(edge);
+          if (!seen.has(to)) {
+            nodes.push(to);
+            seen.add(to);
+          }
           edge = this.#edges.nextOut(edge);
         }
       }
       node = this.#nodes.next(node);
     }
-    return [...nodes];
+    return nodes;
   }
 
   /**
@@ -472,19 +476,24 @@ export default class AdjacencyList<TEdgeType: number = 1> {
         ? type.includes(this.#nodes.typeOf(node))
         : type === this.#nodes.typeOf(node));
 
-    let nodes = new Set<NodeId>();
+    let nodes = [];
+    let seen = new Set<NodeId>();
     let node = this.#nodes.head(to);
     while (node !== null) {
       if (matches(node)) {
         let edge = this.#nodes.firstIn(node);
         while (edge !== null) {
-          nodes.add(this.#edges.from(edge));
+          let from = this.#edges.from(edge);
+          if (!seen.has(from)) {
+            nodes.push(from);
+            seen.add(from);
+          }
           edge = this.#edges.nextIn(edge);
         }
       }
       node = this.#nodes.next(node);
     }
-    return [...nodes];
+    return nodes;
   }
 
   inspect(): any {

--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -440,19 +440,19 @@ export default class AdjacencyList<TEdgeType: number = 1> {
         ? type.includes(this.#nodes.typeOf(node))
         : type === this.#nodes.typeOf(node));
 
-    let nodes = [];
+    let nodes = new Set<NodeId>();
     let node = this.#nodes.head(from);
     while (node !== null) {
       if (matches(node)) {
         let edge = this.#nodes.firstOut(node);
         while (edge !== null) {
-          nodes.push(this.#edges.to(edge));
+          nodes.add(this.#edges.to(edge));
           edge = this.#edges.nextOut(edge);
         }
       }
       node = this.#nodes.next(node);
     }
-    return nodes;
+    return [...nodes];
   }
 
   /**
@@ -472,19 +472,19 @@ export default class AdjacencyList<TEdgeType: number = 1> {
         ? type.includes(this.#nodes.typeOf(node))
         : type === this.#nodes.typeOf(node));
 
-    let nodes = [];
+    let nodes = new Set<NodeId>();
     let node = this.#nodes.head(to);
     while (node !== null) {
       if (matches(node)) {
         let edge = this.#nodes.firstIn(node);
         while (edge !== null) {
-          nodes.push(this.#edges.from(edge));
+          nodes.add(this.#edges.from(edge));
           edge = this.#edges.nextIn(edge);
         }
       }
       node = this.#nodes.next(node);
     }
-    return nodes;
+    return [...nodes];
   }
 
   inspect(): any {

--- a/packages/core/graph/test/AdjacencyList.test.js
+++ b/packages/core/graph/test/AdjacencyList.test.js
@@ -57,6 +57,18 @@ describe('AdjacencyList', () => {
     assert.deepEqual(graph.getNodeIdsConnectedTo(node1), [0, 2, 4, 5, 6]);
   });
 
+  it('getNodeIdsConnectedTo and getNodeIdsConnectedFrom should remove duplicate values', () => {
+    let graph = new AdjacencyList();
+    let a = graph.addNode();
+    let b = graph.addNode();
+    let c = graph.addNode();
+    graph.addEdge(a, b);
+    graph.addEdge(a, c);
+    graph.addEdge(a, b, 2);
+    assert.deepEqual(graph.getNodeIdsConnectedFrom(a, -1), [b, c]);
+    assert.deepEqual(graph.getNodeIdsConnectedTo(b, -1), [a]);
+  });
+
   it('removeEdge should remove an edge of a specific type from the graph', () => {
     let graph = new AdjacencyList();
     let a = graph.addNode();


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
getNodeIdsConnectedFrom and getNodeIdsConnectedTo use Array save nodeId, and we should remove duplicate values
```
  let graph = new Graph();
  let a = graph.addNode(1);
  let b = graph.addNode(2);
  let c = graph.addNode(3);
  graph.addEdge(a, b);
  graph.addEdge(a, c);
  graph.addEdge(a, b, 2);
  // [ 1, 2, 1 ]
  console.log(graph.getNodeIdsConnectedFrom(a, -1))
  // [ 0, 0 ]
  console.log(graph.getNodeIdsConnectedTo(b, -1))
```


<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
 

## 🚨 Test instructions
By using set to  remove duplicate values
```
  let graph = new AdjacencyList();
  let a = graph.addNode();
  let b = graph.addNode();
  let c = graph.addNode();
  graph.addEdge(a, b);
  graph.addEdge(a, c);
  graph.addEdge(a, b, 2);
  assert.deepEqual(graph.getNodeIdsConnectedFrom(a, -1), [b, c]);
  assert.deepEqual(graph.getNodeIdsConnectedTo(b, -1), [a]);
```
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
