### PR TITLE
Allow $schema field in parcelrc config

### DIFF
--- a/packages/core/core/src/ParcelConfig.schema.js
+++ b/packages/core/core/src/ParcelConfig.schema.js
@@ -93,6 +93,9 @@ const mapStringSchema = (pluginType: string, key: string): SchemaEntity => {
 export default {
   type: 'object',
   properties: {
+    $schema: {
+      type: 'string',
+    },
     extends: {
       oneOf: [
         {


### PR DESCRIPTION
# ↪️ Pull Request

Related to https://github.com/parcel-bundler/parcel/pull/7975

## 💻 Examples

## 🚨 Test instructions

Build using `.parcelrc` with code completion:
```json
{
  "$schema": "https://raw.githubusercontent.com/lukaw3d/parcel-bundler-json-schemas/6b524b3/config_schema.json",
  "extends": "@parcel/config-default"
}
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
