### PR TITLE
Support named module wildcard re-export when generating typescript types

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/exporting/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting/expected.d.ts
@@ -13,5 +13,8 @@ export var a: number, b: number;
 export function toUpperCase(foo: string): string;
 declare const _default: "test";
 export default _default;
+export declare module Module1 {
+    export const hello = "world";
+}
 
 //# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/exporting/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting/index.ts
@@ -1,3 +1,8 @@
 export {createMessage} from './message';
 export * from './other';
 export {test as toUpperCase, default} from './test';
+export * as Module1 from './module1';
+
+// TODO: Make this work
+// import * as Module2 from './module2';
+// export { Module2 };

--- a/packages/core/integration-tests/test/integration/ts-types/exporting/module1.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting/module1.ts
@@ -1,0 +1,4 @@
+export const hello = "world";
+
+// TODO: Make this work
+// export * as Nested from "./nested-module";

--- a/packages/core/integration-tests/test/integration/ts-types/exporting/module2.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting/module2.ts
@@ -1,0 +1,4 @@
+export const hello = 2;
+
+// import * as Nested from "./nested-module";
+// export { Nested };

--- a/packages/core/integration-tests/test/integration/ts-types/exporting/nested-module.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/exporting/nested-module.ts
@@ -1,0 +1,1 @@
+export const nested = true;

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -117,7 +117,7 @@ describe('typescript types', function () {
     assertBundles(b, [
       {
         type: 'js',
-        assets: ['index.ts', 'message.ts', 'other.ts', 'test.ts'],
+        assets: ['index.ts', 'message.ts', 'module1.ts', 'other.ts', 'test.ts'],
       },
       {
         type: 'ts',

--- a/packages/transformers/typescript-types/src/TSModuleGraph.js
+++ b/packages/transformers/typescript-types/src/TSModuleGraph.js
@@ -88,6 +88,15 @@ export class TSModuleGraph {
         return null;
       }
 
+      if (e.imported === '*') {
+        // Named, wildcard re-export, e.g. export * as Something from "./something-else"
+        return {
+          module: m,
+          imported: '*',
+          name: exportName,
+        };
+      }
+
       let exp = this.resolveExport(m, e.imported);
       if (!exp) {
         return null;

--- a/packages/transformers/typescript-types/src/collect.js
+++ b/packages/transformers/typescript-types/src/collect.js
@@ -64,19 +64,19 @@ export function collect(
 
     if (ts.isExportDeclaration(node)) {
       if (node.exportClause) {
-        for (let element of node.exportClause.elements) {
-          if (node.moduleSpecifier) {
-            currentModule.addExport(
-              element.name.text,
-              (element.propertyName ?? element.name).text,
-              node.moduleSpecifier.text,
-            );
-          } else {
-            currentModule.addExport(
-              element.name.text,
-              (element.propertyName ?? element.name).text,
-            );
+        if (ts.isNamedExports(node.exportClause)) {
+          for (let element of node.exportClause.elements) {
+            const imported = (element.propertyName ?? element.name).text;
+            const specifier = node.moduleSpecifier?.text;
+            currentModule.addExport(element.name.text, imported, specifier);
           }
+        } else if (ts.isNamespaceExport(node.exportClause)) {
+          // Namespace export, e.g. export * as Something from "./something-else".
+          currentModule.addExport(
+            node.exportClause.name.text,
+            '*',
+            node.moduleSpecifier.text,
+          );
         }
       } else {
         currentModule.addWildcardExport(node.moduleSpecifier.text);

--- a/packages/transformers/typescript-types/src/shake.js
+++ b/packages/transformers/typescript-types/src/shake.js
@@ -59,7 +59,8 @@ export function shake(
 
       moduleStack.push(_currentModule);
       let isFirstModule = !_currentModule;
-      _currentModule = moduleGraph.getModule(node.name.text);
+      const nodeModule = moduleGraph.getModule(node.name.text);
+      _currentModule = nodeModule;
       let statements = ts.visitEachChild(node, visit, context).body.statements;
       _currentModule = moduleStack.pop();
 
@@ -68,6 +69,13 @@ export function shake(
         addedGeneratedImports = true;
       }
 
+      const exportedName = nodeModule.names.get('*');
+      if (exportedName) {
+        node = ts.getMutableClone(node);
+        node.name = ts.createIdentifier(exportedName);
+        node.modifiers.unshift(ts.createModifier(ts.SyntaxKind.ExportKeyword));
+        statements.push(node);
+      }
       return statements;
     }
 


### PR DESCRIPTION


<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This is a proposal for resolving https://github.com/parcel-bundler/parcel/issues/5911.

It allows to specify the following in an index.ts file:

```ts
export * as SomeExportName from "./some-other-file";
```

It does not support 1) the case:
```ts
import * as SomeExportName from "./some-other-file";
export { SomeExportName };
```
and, it does not supported 2) nested exports.

If someone can update the test cases for the two unsupported cases so that I can see the expected result, then let me know.


## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
