### PR TITLE
fix: force the use of posix path separators for ts module graphs

### DIFF
--- a/packages/core/integration-tests/test/integration/ts-types/windows-paths/expected.d.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/windows-paths/expected.d.ts
@@ -1,0 +1,18 @@
+type Params = {
+    hello: number;
+};
+interface Hello {
+    yo: string;
+}
+export class Test {
+    test(hello: Hello): string;
+}
+export function test(params: Params): number;
+export function foo(): number;
+export var x: number;
+export var hi: number;
+export declare module mod {
+    function bar(): number;
+}
+
+//# sourceMappingURL=types.d.ts.map

--- a/packages/core/integration-tests/test/integration/ts-types/windows-paths/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/windows-paths/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/index';

--- a/packages/core/integration-tests/test/integration/ts-types/windows-paths/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/windows-paths/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/index';
+export * from './src/index';

--- a/packages/core/integration-tests/test/integration/ts-types/windows-paths/package.json
+++ b/packages/core/integration-tests/test/integration/ts-types/windows-paths/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ts-types-main",
+  "private": true,
+  "main": "dist/main.js",
+  "types": "dist/types.d.ts"
+}

--- a/packages/core/integration-tests/test/integration/ts-types/windows-paths/src/index.ts
+++ b/packages/core/integration-tests/test/integration/ts-types/windows-paths/src/index.ts
@@ -1,0 +1,31 @@
+type Params = {
+  hello: number;
+};
+
+interface Hello {
+  yo: string;
+}
+
+export class Test {
+  test(hello: Hello) {
+    return hello.yo;
+  }
+}
+
+export function test(params: Params) {
+  return params.hello;
+}
+
+export function foo() {
+  return 2;
+}
+
+var x = 2;
+var p = x + 2, q = 3;
+export {p as hi, x};
+
+export module mod {
+  export function bar() {
+    return 2;
+  }
+}

--- a/packages/core/integration-tests/test/integration/ts-types/windows-paths/tsconfig.json
+++ b/packages/core/integration-tests/test/integration/ts-types/windows-paths/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "removeComments": true,
+    "baseUrl": ".",
+    "paths": {
+      "@parcel/*": ["../../*"]
+    }
+  }
+}

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -388,4 +388,26 @@ describe('typescript types', function () {
     );
     assert.equal(dist, expected);
   });
+
+  it('should handle a tsconfig file with paths on windows', async function () {
+    await bundle(
+      path.join(__dirname, '/integration/ts-types/windows-paths/index.ts'),
+    );
+
+    let dist = (
+      await outputFS.readFile(
+        path.join(
+          __dirname,
+          '/integration/ts-types/windows-paths/dist/types.d.ts',
+        ),
+        'utf8',
+      )
+    ).replace(/\r\n/g, '\n');
+
+    let expected = await inputFS.readFile(
+      path.join(__dirname, '/integration/ts-types/windows-paths/expected.d.ts'),
+      'utf8',
+    );
+    assert.equal(dist, expected);
+  });
 });

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -24,6 +24,7 @@
     "@parcel/plugin": "2.6.0",
     "@parcel/source-map": "^2.0.0",
     "@parcel/ts-utils": "2.6.0",
+    "@parcel/utils": "2.6.0",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -53,7 +53,9 @@ export default (new Transformer({
 
     let mainModuleName = path
       .relative(program.getCommonSourceDirectory(), asset.filePath)
-      .slice(0, -path.extname(asset.filePath).length);
+      .slice(0, -path.extname(asset.filePath).length)
+      .split(path.sep)
+      .join(path.posix.sep);
     let moduleGraph = new TSModuleGraph(mainModuleName);
 
     let emitResult = program.emit(undefined, undefined, undefined, true, {

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -8,6 +8,7 @@ import type {CompilerOptions} from 'typescript';
 
 import ts from 'typescript';
 import {CompilerHost, loadTSConfig} from '@parcel/ts-utils';
+import {normalizeSeparators} from '@parcel/utils';
 import {escapeMarkdown} from '@parcel/diagnostic';
 import {TSModuleGraph} from './TSModuleGraph';
 import nullthrows from 'nullthrows';
@@ -51,11 +52,11 @@ export default (new Transformer({
       }
     }
 
-    let mainModuleName = path
-      .relative(program.getCommonSourceDirectory(), asset.filePath)
-      .slice(0, -path.extname(asset.filePath).length)
-      .split(path.sep)
-      .join(path.posix.sep);
+    let mainModuleName = normalizeSeparators(
+      path
+        .relative(program.getCommonSourceDirectory(), asset.filePath)
+        .slice(0, -path.extname(asset.filePath).length),
+    );
     let moduleGraph = new TSModuleGraph(mainModuleName);
 
     let emitResult = program.emit(undefined, undefined, undefined, true, {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

When resolving the name of the main module for use in TS module graphs, ensure we force the usage of posix paths as this is what `typescript` uses and returns.

This fixes an issue when running on Windows, where an assert would be thrown as a result of two identical paths using different path separators being compared for equality.

For some reason I'm unaware of, this only occurs if a `tsconfig.json` file with a `paths` entry is present in the root folder.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

The main module name for ts module graphs is resolved here:
https://github.com/parcel-bundler/parcel/blob/f2d0a3a27d6e493b23ddc2edbc8a4c0053ff34ab/packages/transformers/typescript-types/src/TSTypesTransformer.js#L54-L57

On windows, this returns a path with dos path separators `\`. 

Subsequently in `collect.js` when we use `typescript` to visit a node,  it returns the node's name using posix separators `/`, when we add that node to the module graph:

https://github.com/parcel-bundler/parcel/blob/f2d0a3a27d6e493b23ddc2edbc8a4c0053ff34ab/packages/transformers/typescript-types/src/collect.js#L26

It then attempts to compare it to the main module name resolved in `TSTypesTransformer` earlier:

https://github.com/parcel-bundler/parcel/blob/f2d0a3a27d6e493b23ddc2edbc8a4c0053ff34ab/packages/transformers/typescript-types/src/TSModuleGraph.js#L19-L24

Which fails due to the path separator mismatch.

Fast forward a bit, and `getAllExports` is called, and the assert is thrown due to `nullthrows(this.mainModule),` still being undefined/ null.

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

* Ensure you are running on windows.
* Follow the instructions for building a library (source, main and types entries in package.json)
* Ensure your source file is a typescript file that exports from another module, for example:

```
export * from './library.ts';
```

* Have `tsconfig.json` file in the same directory as your package.json. This file can contain anything, as long as it contains an arbitrary entry for `compilerOptions.paths`
* Run `parcel build`


## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
