### PR TITLE
Apply unresolved mark to inserted `undefined` identifiers

### DIFF
--- a/packages/core/integration-tests/test/integration/env-unused-require/index.js
+++ b/packages/core/integration-tests/test/integration/env-unused-require/index.js
@@ -1,0 +1,7 @@
+module.exports = function () {
+  if(process.env.ABC === 'a') {
+    return require("./unused.js");
+  } else {
+    return "ok";
+  }
+};

--- a/packages/core/integration-tests/test/integration/env-unused-require/unused.js
+++ b/packages/core/integration-tests/test/integration/env-unused-require/unused.js
@@ -1,0 +1,1 @@
+module.exports = "unused";

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -347,6 +347,28 @@ describe('javascript', function () {
     assert(!contents.includes('import'));
   });
 
+  it('should ignore unused requires after process.env inlining', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/env-unused-require/index.js'),
+      {
+        env: {ABC: 'XYZ'},
+      },
+    );
+
+    assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['index.js'],
+      },
+    ]);
+
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(!contents.includes('unused'));
+
+    let output = await run(b);
+    assert.strictEqual(output(), 'ok');
+  });
+
   it('should produce a basic JS bundle with object rest spread support', async function () {
     let b = await bundle(
       path.join(

--- a/packages/transformers/js/core/src/decl_collector.rs
+++ b/packages/transformers/js/core/src/decl_collector.rs
@@ -1,14 +1,12 @@
 use std::collections::HashSet;
 
-use swc_atoms::JsWord;
-use swc_common::SyntaxContext;
-use swc_ecmascript::ast;
+use swc_ecmascript::ast::{self, Id};
 use swc_ecmascript::visit::{Visit, VisitWith};
 
 /// This pass collects all declarations in a module into a single HashSet of tuples
 /// containing identifier names and their associated syntax context (scope).
 /// This is used later to determine whether an identifier references a declared variable.
-pub fn collect_decls(module: &ast::Module) -> HashSet<(JsWord, SyntaxContext)> {
+pub fn collect_decls(module: &ast::Module) -> HashSet<Id> {
   let mut c = DeclCollector {
     decls: HashSet::new(),
     in_var: false,
@@ -18,7 +16,7 @@ pub fn collect_decls(module: &ast::Module) -> HashSet<(JsWord, SyntaxContext)> {
 }
 
 struct DeclCollector {
-  decls: HashSet<(JsWord, SyntaxContext)>,
+  decls: HashSet<Id>,
   in_var: bool,
 }
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -1139,6 +1139,7 @@ impl<'a> DependencyCollector<'a> {
     None
   }
 
+  #[allow(clippy::wrong_self_convention)]
   fn is_import_meta_url(&mut self, expr: &ast::Expr) -> bool {
     use ast::*;
 
@@ -1175,6 +1176,7 @@ impl<'a> DependencyCollector<'a> {
     }
   }
 
+  #[allow(clippy::wrong_self_convention)]
   fn is_import_meta(&mut self, expr: &ast::Expr) -> bool {
     use ast::*;
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 use swc_atoms::JsWord;
-use swc_common::{Mark, SourceMap, Span, SyntaxContext, DUMMY_SP};
-use swc_ecmascript::ast::{self, Callee, MemberProp};
+use swc_common::{Mark, SourceMap, Span, DUMMY_SP};
+use swc_ecmascript::ast::{self, Callee, Id, MemberProp};
 use swc_ecmascript::visit::{Fold, FoldWith};
 
 use crate::fold_member_expr_skip_prop;
@@ -59,7 +59,7 @@ pub struct DependencyDescriptor {
 pub fn dependency_collector<'a>(
   source_map: &'a SourceMap,
   items: &'a mut Vec<DependencyDescriptor>,
-  decls: &'a HashSet<(JsWord, SyntaxContext)>,
+  decls: &'a HashSet<Id>,
   ignore_mark: swc_common::Mark,
   config: &'a Config,
   diagnostics: &'a mut Vec<Diagnostic>,
@@ -84,7 +84,7 @@ struct DependencyCollector<'a> {
   in_try: bool,
   in_promise: bool,
   require_node: Option<ast::CallExpr>,
-  decls: &'a HashSet<(JsWord, SyntaxContext)>,
+  decls: &'a HashSet<Id>,
   ignore_mark: swc_common::Mark,
   config: &'a Config,
   diagnostics: &'a mut Vec<Diagnostic>,
@@ -1096,7 +1096,7 @@ impl<'a> DependencyCollector<'a> {
   fn match_new_url(
     &mut self,
     expr: &ast::Expr,
-    decls: &HashSet<(JsWord, SyntaxContext)>,
+    decls: &HashSet<Id>,
   ) -> Option<(JsWord, swc_common::Span)> {
     use ast::*;
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -61,6 +61,7 @@ pub fn dependency_collector<'a>(
   items: &'a mut Vec<DependencyDescriptor>,
   decls: &'a HashSet<Id>,
   ignore_mark: swc_common::Mark,
+  unresolved_mark: swc_common::Mark,
   config: &'a Config,
   diagnostics: &'a mut Vec<Diagnostic>,
 ) -> impl Fold + 'a {
@@ -72,6 +73,7 @@ pub fn dependency_collector<'a>(
     require_node: None,
     decls,
     ignore_mark,
+    unresolved_mark,
     config,
     diagnostics,
     import_meta: None,
@@ -86,6 +88,7 @@ struct DependencyCollector<'a> {
   require_node: Option<ast::CallExpr>,
   decls: &'a HashSet<Id>,
   ignore_mark: swc_common::Mark,
+  unresolved_mark: swc_common::Mark,
   config: &'a Config,
   diagnostics: &'a mut Vec<Diagnostic>,
   import_meta: Option<ast::VarDecl>,
@@ -828,7 +831,7 @@ impl<'a> Fold for DependencyCollector<'a> {
     };
 
     if is_require {
-      return ast::Expr::Ident(ast::Ident::new("undefined".into(), DUMMY_SP));
+      return ast::Expr::Ident(get_undefined_ident(self.unresolved_mark));
     }
 
     node.fold_children_with(self)

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::vec;
 
 use swc_atoms::JsWord;
-use swc_common::{SyntaxContext, DUMMY_SP};
+use swc_common::DUMMY_SP;
 use swc_ecmascript::ast;
 use swc_ecmascript::visit::{Fold, FoldWith};
 
@@ -13,7 +13,7 @@ pub struct EnvReplacer<'a> {
   pub replace_env: bool,
   pub is_browser: bool,
   pub env: &'a HashMap<swc_atoms::JsWord, swc_atoms::JsWord>,
-  pub decls: &'a HashSet<(JsWord, SyntaxContext)>,
+  pub decls: &'a HashSet<Id>,
   pub used_env: &'a mut HashSet<JsWord>,
   pub source_map: &'a swc_common::SourceMap,
   pub diagnostics: &'a mut Vec<Diagnostic>,

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -1,7 +1,7 @@
 use crate::dependency_collector::{DependencyDescriptor, DependencyKind};
 use crate::hoist::{Collect, Import};
 use crate::id;
-use crate::utils::{IdentId, SourceLocation};
+use crate::utils::SourceLocation;
 use data_encoding::{BASE64, HEXLOWER};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -13,7 +13,7 @@ use swc_ecmascript::visit::{Fold, FoldWith, VisitWith};
 pub fn inline_fs<'a>(
   filename: &str,
   source_map: swc_common::sync::Lrc<swc_common::SourceMap>,
-  decls: HashSet<IdentId>,
+  decls: HashSet<Id>,
   global_mark: Mark,
   project_root: &'a str,
   deps: &'a mut Vec<DependencyDescriptor>,

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use swc_atoms::JsWord;
 use swc_common::{Mark, SourceMap, SyntaxContext, DUMMY_SP};
-use swc_ecmascript::ast::{self, ComputedPropName};
+use swc_ecmascript::ast::{self, ComputedPropName, Id};
 use swc_ecmascript::visit::{Fold, FoldWith};
 
 use crate::dependency_collector::{DependencyDescriptor, DependencyKind};
@@ -17,7 +17,7 @@ pub struct GlobalReplacer<'a> {
   pub globals: HashMap<JsWord, (SyntaxContext, ast::Stmt)>,
   pub project_root: &'a Path,
   pub filename: &'a Path,
-  pub decls: &'a mut HashSet<(JsWord, SyntaxContext)>,
+  pub decls: &'a mut HashSet<Id>,
   pub scope_hoist: bool,
 }
 

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -11,7 +11,7 @@ use swc_ecmascript::visit::{Fold, FoldWith, Visit, VisitWith};
 use crate::id;
 use crate::utils::{
   match_import, match_member_expr, match_require, Bailout, BailoutReason, CodeHighlight,
-  Diagnostic, DiagnosticSeverity, IdentId, SourceLocation,
+  Diagnostic, DiagnosticSeverity, SourceLocation,
 };
 
 macro_rules! hash {
@@ -1097,7 +1097,7 @@ pub struct Export {
 
 pub struct Collect {
   pub source_map: Lrc<swc_common::SourceMap>,
-  pub decls: HashSet<IdentId>,
+  pub decls: HashSet<Id>,
   pub ignore_mark: Mark,
   pub global_mark: Mark,
   pub static_cjs_exports: bool,
@@ -1105,14 +1105,14 @@ pub struct Collect {
   pub is_esm: bool,
   pub should_wrap: bool,
   // local name -> descriptor
-  pub imports: HashMap<IdentId, Import>,
+  pub imports: HashMap<Id, Import>,
   // exported name -> descriptor
   pub exports: HashMap<JsWord, Export>,
   // local name -> exported name
-  pub exports_locals: HashMap<IdentId, JsWord>,
+  pub exports_locals: HashMap<Id, JsWord>,
   pub exports_all: HashMap<JsWord, SourceLocation>,
-  pub non_static_access: HashMap<IdentId, Vec<Span>>,
-  pub non_const_bindings: HashMap<IdentId, Vec<Span>>,
+  pub non_static_access: HashMap<Id, Vec<Span>>,
+  pub non_const_bindings: HashMap<Id, Vec<Span>>,
   pub non_static_requires: HashSet<JsWord>,
   pub wrapped_requires: HashSet<JsWord>,
   pub bailouts: Option<Vec<Bailout>>,
@@ -1156,7 +1156,7 @@ pub struct CollectResult {
 impl Collect {
   pub fn new(
     source_map: Lrc<swc_common::SourceMap>,
-    decls: HashSet<IdentId>,
+    decls: HashSet<Id>,
     ignore_mark: Mark,
     global_mark: Mark,
     trace_bailouts: bool,
@@ -2067,7 +2067,7 @@ impl Collect {
   }
 }
 
-fn has_binding_identifier(node: &Pat, sym: &JsWord, decls: &HashSet<IdentId>) -> bool {
+fn has_binding_identifier(node: &Pat, sym: &JsWord, decls: &HashSet<Id>) -> bool {
   match node {
     Pat::Ident(ident) => {
       if ident.id.sym == *sym && !decls.contains(&id!(ident.id)) {

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -388,7 +388,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                 module.fold_with(&mut passes)
               };
 
-              // Flush (JsWord, SyntaxContexts) into unique names and reresolve to
+              // Flush Id=(JsWord, SyntaxContexts) into unique names and reresolve to
               // set global_mark for all nodes, even generated ones.
               // - This changes the syntax context ids and therefore invalidates decls
               // - This will also remove any other other marks (like ignore_mark)

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -28,10 +28,11 @@ use std::str::FromStr;
 
 use path_slash::PathExt;
 use serde::{Deserialize, Serialize};
+use swc_atoms::JsWord;
 use swc_common::comments::SingleThreadedComments;
 use swc_common::errors::{DiagnosticBuilder, Emitter, Handler};
 use swc_common::{chain, sync::Lrc, FileName, Globals, Mark, SourceMap};
-use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::{Ident, Module};
 use swc_ecmascript::codegen::text_writer::JsWriter;
 use swc_ecmascript::parser::lexer::Lexer;
 use swc_ecmascript::parser::{EsConfig, PResult, Parser, StringInput, Syntax, TsConfig};
@@ -43,7 +44,7 @@ use swc_ecmascript::transforms::{
   optimization::simplify::dead_branch_remover, optimization::simplify::expr_simplifier,
   pass::Optional, proposals::decorators, react, typescript,
 };
-use swc_ecmascript::visit::{FoldWith, VisitWith};
+use swc_ecmascript::visit::{Fold, FoldWith, VisitWith};
 
 use decl_collector::*;
 use dependency_collector::*;
@@ -310,7 +311,8 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                       decls: &decls,
                       used_env: &mut result.used_env,
                       source_map: &source_map,
-                      diagnostics: &mut diagnostics
+                      diagnostics: &mut diagnostics,
+                      unresolved_mark
                     },
                     config.source_type != SourceType::Script
                   ),
@@ -412,6 +414,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                   &mut result.dependencies,
                   &decls,
                   ignore_mark,
+                  unresolved_mark,
                   &config,
                   &mut diagnostics,
                 ),
@@ -440,7 +443,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
               }
 
               let module = if config.scope_hoist {
-                let res = hoist(module, config.module_id.as_str(), &collect);
+                let res = hoist(module, config.module_id.as_str(), unresolved_mark, &collect);
                 match res {
                   Ok((module, hoist_result, hoist_diagnostics)) => {
                     result.hoist_result = Some(hoist_result);
@@ -458,7 +461,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                   result.symbol_result = Some(collect.into());
                 }
 
-                let (module, needs_helpers) = esm2cjs(module, versions);
+                let (module, needs_helpers) = esm2cjs(module, unresolved_mark, versions);
                 result.needs_esm_helpers = needs_helpers;
                 module
               };

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -1,5 +1,5 @@
 use crate::id;
-use crate::utils::{match_export_name, match_export_name_ident, IdentId};
+use crate::utils::{match_export_name, match_export_name_ident};
 use inflector::Inflector;
 use std::collections::{HashMap, HashSet};
 use swc_atoms::JsWord;
@@ -30,7 +30,7 @@ pub fn esm2cjs(node: Module, versions: Option<Versions>) -> (Module, bool) {
 
 struct ESMFold {
   // Map of imported identifier to (source, specifier)
-  imports: HashMap<IdentId, (JsWord, JsWord)>,
+  imports: HashMap<Id, (JsWord, JsWord)>,
   // Map of source to (require identifier, mark)
   require_names: HashMap<JsWord, (JsWord, Mark)>,
   // Set of declared default interops, by source.

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -1,5 +1,5 @@
 use crate::id;
-use crate::utils::{match_export_name, match_export_name_ident};
+use crate::utils::{get_undefined_ident, match_export_name, match_export_name_ident};
 use inflector::Inflector;
 use std::collections::{HashMap, HashSet};
 use swc_atoms::JsWord;
@@ -10,7 +10,7 @@ use swc_ecmascript::visit::{Fold, FoldWith};
 
 use crate::fold_member_expr_skip_prop;
 
-pub fn esm2cjs(node: Module, versions: Option<Versions>) -> (Module, bool) {
+pub fn esm2cjs(node: Module, unresolved_mark: Mark, versions: Option<Versions>) -> (Module, bool) {
   let mut fold = ESMFold {
     imports: HashMap::new(),
     require_names: HashMap::new(),
@@ -21,6 +21,7 @@ pub fn esm2cjs(node: Module, versions: Option<Versions>) -> (Module, bool) {
     in_export_decl: false,
     in_function_scope: false,
     mark: Mark::fresh(Mark::root()),
+    unresolved_mark,
     versions,
   };
 
@@ -43,6 +44,7 @@ struct ESMFold {
   in_export_decl: bool,
   in_function_scope: bool,
   mark: Mark,
+  unresolved_mark: Mark,
   versions: Option<Versions>,
 }
 
@@ -590,7 +592,7 @@ impl Fold for ESMFold {
       }
       Expr::This(_this) => {
         if !self.in_function_scope {
-          Expr::Ident(Ident::new(js_word!("undefined"), DUMMY_SP))
+          Expr::Ident(get_undefined_ident(self.unresolved_mark))
         } else {
           node
         }

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use swc_atoms::JsWord;
 use swc_common::{Mark, SourceMap, SyntaxContext, DUMMY_SP};
-use swc_ecmascript::ast::{self};
+use swc_ecmascript::ast::{self, Id};
 use swc_ecmascript::visit::{Fold, FoldWith};
 
 use crate::dependency_collector::{DependencyDescriptor, DependencyKind};
@@ -17,7 +17,7 @@ pub struct NodeReplacer<'a> {
   pub globals: HashMap<JsWord, (SyntaxContext, ast::Stmt)>,
   pub project_root: &'a Path,
   pub filename: &'a Path,
-  pub decls: &'a mut HashSet<(JsWord, SyntaxContext)>,
+  pub decls: &'a mut HashSet<Id>,
   pub scope_hoist: bool,
   pub has_node_replacements: &'a mut bool,
 }

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -1,14 +1,13 @@
 use std::collections::HashSet;
 
 use swc_atoms::js_word;
-use swc_ecmascript::ast::{Expr, Lit, Str, UnaryOp};
+use swc_ecmascript::ast::{Expr, Id, Lit, Str, UnaryOp};
 use swc_ecmascript::visit::{Fold, FoldWith};
 
 use crate::id;
-use crate::utils::IdentId;
 
 pub struct TypeofReplacer<'a> {
-  pub decls: &'a HashSet<IdentId>,
+  pub decls: &'a HashSet<Id>,
 }
 
 impl<'a> Fold for TypeofReplacer<'a> {

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -1,16 +1,13 @@
 use std::cmp::Ordering;
 use std::collections::HashSet;
 
+use crate::id;
 use serde::{Deserialize, Serialize};
 use swc_atoms::JsWord;
 use swc_common::{Mark, Span, SyntaxContext, DUMMY_SP};
-use swc_ecmascript::ast;
+use swc_ecmascript::ast::{self, Id};
 
-pub fn match_member_expr(
-  expr: &ast::MemberExpr,
-  idents: Vec<&str>,
-  decls: &HashSet<(JsWord, SyntaxContext)>,
-) -> bool {
+pub fn match_member_expr(expr: &ast::MemberExpr, idents: Vec<&str>, decls: &HashSet<Id>) -> bool {
   use ast::{Expr, Ident, Lit, MemberProp, Str};
 
   let mut member = expr;
@@ -35,10 +32,8 @@ pub fn match_member_expr(
 
     match &*member.obj {
       Expr::Member(m) => member = m,
-      Expr::Ident(Ident { ref sym, span, .. }) => {
-        return idents.len() == 1
-          && sym == idents.pop().unwrap()
-          && !decls.contains(&(sym.clone(), span.ctxt()));
+      Expr::Ident(id) => {
+        return idents.len() == 1 && &id.sym == idents.pop().unwrap() && !decls.contains(&id!(id));
       }
       _ => return false,
     }
@@ -119,11 +114,7 @@ pub fn match_export_name_ident(name: &ast::ModuleExportName) -> &ast::Ident {
   }
 }
 
-pub fn match_require(
-  node: &ast::Expr,
-  decls: &HashSet<(JsWord, SyntaxContext)>,
-  ignore_mark: Mark,
-) -> Option<JsWord> {
+pub fn match_require(node: &ast::Expr, decls: &HashSet<Id>, ignore_mark: Mark) -> Option<JsWord> {
   use ast::*;
 
   match node {
@@ -385,8 +376,6 @@ macro_rules! fold_member_expr_skip_prop {
 #[macro_export]
 macro_rules! id {
   ($ident: expr) => {
-    ($ident.sym.clone(), $ident.span.ctxt)
+    $ident.to_id()
   };
 }
-
-pub type IdentId = (JsWord, SyntaxContext);

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -192,6 +192,10 @@ pub fn create_global_decl_stmt(
   )
 }
 
+pub fn get_undefined_ident(unresolved_mark: Mark) -> ast::Ident {
+  ast::Ident::new(js_word!("undefined"), DUMMY_SP.apply_mark(unresolved_mark))
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct SourceLocation {
   pub start_line: usize,


### PR DESCRIPTION
Fixes #8143

- swc already has a type alias for `(JsWord, SyntaxContext)`, so just use that instead of our own
- Apply unresolved mark to inserted `undefined` identifiers. swc's DCE pass relies on this 