### PR TITLE
Normalize object literal shorthand even when wrapped

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/a.js
@@ -1,0 +1,3 @@
+const v = require("./b.js");
+
+output = v;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/b.js
@@ -1,0 +1,7 @@
+const value = require("./c.js");
+
+const obj = {
+  value,
+};
+
+exports = module.exports = obj.value;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/c.js
@@ -1,0 +1,1 @@
+module.exports = 1234;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -3705,8 +3705,6 @@ describe('scope hoisting', function () {
         ),
       );
 
-      // console.log(await outputFS.readFile(b.getBundles()[0].filePath, 'utf8'));
-
       let output = await run(b);
       assert.equal(output, 1);
     });
@@ -3769,6 +3767,18 @@ describe('scope hoisting', function () {
 
       let output = await run(b);
       assert.deepEqual(output, {foo: 2});
+    });
+
+    it('should support referencing a require in object literal shorthands when wrapped', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/wrap-module-obj-literal-require/a.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, 1234);
     });
 
     it('should support typeof require when wrapped', async function () {

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -914,10 +914,6 @@ impl<'a> Fold for Hoist<'a> {
   }
 
   fn fold_prop(&mut self, node: Prop) -> Prop {
-    if self.collect.should_wrap {
-      return node.fold_children_with(self);
-    }
-
     match node {
       Prop::Shorthand(ident) => Prop::KeyValue(KeyValueProp {
         key: PropName::Ident(Ident::new(ident.sym.clone(), DUMMY_SP)),

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -28,11 +28,10 @@ use std::str::FromStr;
 
 use path_slash::PathExt;
 use serde::{Deserialize, Serialize};
-use swc_atoms::JsWord;
 use swc_common::comments::SingleThreadedComments;
 use swc_common::errors::{DiagnosticBuilder, Emitter, Handler};
 use swc_common::{chain, sync::Lrc, FileName, Globals, Mark, SourceMap};
-use swc_ecmascript::ast::{Ident, Module};
+use swc_ecmascript::ast::Module;
 use swc_ecmascript::codegen::text_writer::JsWriter;
 use swc_ecmascript::parser::lexer::Lexer;
 use swc_ecmascript::parser::{EsConfig, PResult, Parser, StringInput, Syntax, TsConfig};
@@ -44,7 +43,7 @@ use swc_ecmascript::transforms::{
   optimization::simplify::dead_branch_remover, optimization::simplify::expr_simplifier,
   pass::Optional, proposals::decorators, react, typescript,
 };
-use swc_ecmascript::visit::{Fold, FoldWith, VisitWith};
+use swc_ecmascript::visit::{FoldWith, VisitWith};
 
 use decl_collector::*;
 use dependency_collector::*;


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7955

Even when the asset is wrapped because of `exports = `, object literal shorthands need to be normlized otherwise 
```js
const cjsA = require("./cjsA.js");
const registry = {
  cjsA,
};
exports = module.exports = registry.cjsA;
```
becomes
```js
var $dbGhw = parcelRequire("dbGhw");
const registry = {
  $dbGhw
};
exports = module.exports = registry.cjsA;
```