### PR TITLE
Force dev server clients to revalidate assets and use if-last-modified

### DIFF
--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -37,6 +37,7 @@
     "@parcel/types": "2.6.0",
     "connect": "^3.7.0",
     "ejs": "^3.1.6",
+    "fresh": "^0.5.2",
     "http-proxy-middleware": "^2.0.1",
     "launch-editor": "^2.3.0",
     "mime-types": "2.1.18",

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -33,6 +33,7 @@ import {getHotAssetContents} from './HMRServer';
 import nullthrows from 'nullthrows';
 import mime from 'mime-types';
 import launchEditor from 'launch-editor';
+import fresh from 'fresh';
 
 function setHeaders(res: Response) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -44,6 +45,7 @@ function setHeaders(res: Response) {
     'Access-Control-Allow-Headers',
     'Origin, X-Requested-With, Content-Type, Accept, Content-Type',
   );
+  res.setHeader('Cache-Control', 'max-age=0, must-revalidate');
 }
 
 const SOURCES_ENDPOINT = '/__parcel_source_root';
@@ -339,6 +341,12 @@ export default class Server {
     }
 
     if (req.method === 'HEAD') {
+      res.end();
+      return;
+    }
+
+    if (fresh(req.headers, {'last-modified': stat.mtime.toUTCString()})) {
+      res.statusCode = 304;
       res.end();
       return;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6095,6 +6095,11 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fresh@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
 from2@^2.1.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7546

Set `Cache-Control: max-age=0, must-revalidate`. AFAICT, this effectively means "never reuse cached assets".

For files in the dist dir, we already send a `last-modified` header for assets, so send 304s in case they haven't changed.
For all other endpoints, it will just send the full response (and behave like `no-store`).

Not sure if we want to add tests for this...

Webpack (or at least create-react-app) does the same thing, but based on etags instead of mtime.