### PR TITLE
Fix transformation of import/requires wrapped into Promise.resolve().

### DIFF
--- a/packages/core/integration-tests/test/integration/require-async/resolve-chain.js
+++ b/packages/core/integration-tests/test/integration/require-async/resolve-chain.js
@@ -1,0 +1,1 @@
+module.exports = Promise.resolve(require('./async')).then(x => x + 1335);

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4630,6 +4630,29 @@ describe('javascript', function () {
     assert.equal(await run(b), 5);
   });
 
+  it('should properly chain a dynamic import wrapped in a Promise.resolve()', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/require-async/resolve-chain.js'),
+    );
+
+    assertBundles(b, [
+      {
+        name: 'resolve-chain.js',
+        assets: [
+          'resolve-chain.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
+      },
+      {
+        assets: ['async.js'],
+      },
+    ]);
+
+    assert.equal(await run(b), 1337);
+  });
+
   it('should detect parcel style async requires in commonjs', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/require-async/parcel.js'),

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -467,7 +467,7 @@ impl<'a> Fold for DependencyCollector<'a> {
                       // Make sure the arglist is empty.
                       // I.e. do not proceed with the below unless Promise.resolve has an empty arglist
                       // because build_promise_chain() will not work in this case.                   
-                      !call.args.get(0).is_some()
+                      call.args.is_empty()
                     {
                       if let MemberProp::Ident(id) = &member.prop {
                         if id.sym.to_string().as_str() == "then" {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
Previously we noticed that parcel incorrectly transforms `Promise.resolve(import('foo')).then(...)` as described in https://github.com/parcel-bundler/parcel/issues/8116.

The transformer that rewrites the nodes of the code `Promise.resolve().then(() => return require('foo'))` erroneously restructures the above code too.
However, there is no need to transform this require/import statement, when wrapped into `Promise.resolve()` because it is used to promisify the import in the first place.

This PR adds a unit test to illustrate the issue, and a condition that prevents the incorrect processing of the statement. 
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples
```javascript
// main.js
module.exports = Promise.resolve(require('./async')).then(x => x + 1335);
```

```javascript
// async.js
module.exports = 2;
```

### Expected behaviour
```javascript
const n = await import('./main');
n === 1337
```

### Current behaviour
The current code causes the runtime to crash because it injects a variable called `res` incorrectly, and thus destroys the code.


<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
```
yarn workspace @parcel/integration-tests test -g Promise.resolve
```

Or use the minimal reproduction code [here](https://parcel2-repl-mischnic.vercel.app/#JTdCJTIyZmlsZXMlMjIlM0ElNUIlNUIlMjIlMkZzcmMlMkZpbmRleC5qcyUyMiUyQyU3QiUyMnZhbHVlJTIyJTNBJTIyUHJvbWlzZS5yZXNvbHZlKGltcG9ydCgnLiUyRm90aGVyJykpLnRoZW4oeCUyMCUzRCUzRSUyMGNvbnNvbGUubG9nKHgpKSU1Q24lMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCU1RCUyQyU1QiUyMiUyRnNyYyUyRm90aGVyLmpzJTIyJTJDJTdCJTIydmFsdWUlMjIlM0ElMjJleHBvcnQlMjBjb25zdCUyMHglMjAlM0QlMjAyJTNCJTIyJTdEJTVEJTVEJTJDJTIyb3B0aW9ucyUyMiUzQSU3QiUyMmVudHJpZXMlMjIlM0ElNUIlNUQlMkMlMjJtaW5pZnklMjIlM0FmYWxzZSUyQyUyMnNjb3BlSG9pc3QlMjIlM0FmYWxzZSUyQyUyMnNvdXJjZU1hcHMlMjIlM0FmYWxzZSUyQyUyMnB1YmxpY1VybCUyMiUzQSUyMiUyRl9fcmVwbF9kaXN0JTIyJTJDJTIydGFyZ2V0VHlwZSUyMiUzQSUyMmJyb3dzZXJzJTIyJTJDJTIydGFyZ2V0RW52JTIyJTNBJTIyQ2hyb21lJTIwOTUlMjIlMkMlMjJvdXRwdXRGb3JtYXQlMjIlM0ElMjJlc21vZHVsZSUyMiUyQyUyMmhtciUyMiUzQWZhbHNlJTJDJTIybW9kZSUyMiUzQSUyMmRldmVsb3BtZW50JTIyJTJDJTIycmVuZGVyR3JhcGhzJTIyJTNBZmFsc2UlMkMlMjJ2aWV3U291cmNlbWFwcyUyMiUzQWZhbHNlJTJDJTIyZGVwZW5kZW5jaWVzJTIyJTNBJTVCJTVEJTJDJTIybnVtV29ya2VycyUyMiUzQTAlN0QlMkMlMjJ1c2VUYWJzJTIyJTNBZmFsc2UlMkMlMjJicm93c2VyQ29sbGFwc2VkJTIyJTNBJTVCJTVEJTJDJTIydmlld3MlMjIlM0ElNUIlMjIlMkZzcmMlMkZpbmRleC5qcyUyMiUyQyUyMiUyRnNyYyUyRm90aGVyLmpzJTIyJTJDJTIyT3B0aW9ucyUyMiU1RCUyQyUyMmN1cnJlbnRWaWV3JTIyJTNBMiU3RA==)

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
