### PR TITLE
Fix glob resolver package issue with deep entry points

### DIFF
--- a/packages/core/integration-tests/test/integration/glob-package/node_modules/@scope/pkg/package.json
+++ b/packages/core/integration-tests/test/integration/glob-package/node_modules/@scope/pkg/package.json
@@ -1,4 +1,4 @@
 {
     "name": "@scope/pkg",
-    "module": "index.js"
+    "module": "deep/entry/point.js"
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This is a follow-up from #8097 - when trying to implement the change in my repository I realised there was a step missed, if the package entry point resolves to a file not in the root, then the paths for the glob import will need to be relative to the entry point, where they should be able to be relative to the package root.

This change adds an additional step to perform a `findPackage` on the resulting `filePath` in order to resolve to the root of the package.

## 💻 Examples

Before if you had a package `@scope/pkg` with an entry point of `./dist/index.js` then the glob resolver would resolve the root to `@scope/pkg/dist/`, so if you used a path like `@scope/pkg/src/foo*.js` it would actually resolve to `@scope/pkg/dist/src/foo*.js` which is incorrect.  With this change the path resolves as expected.

## 🚨 Test instructions

Failing integration test with a deep entry point was added, change was made and confirmed all integration tests still pass.

## ✔️ PR Todo

- [x] Added/updated ~~unit~~ integration tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
