### PR TITLE
Importing Node native modules

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -39,9 +39,12 @@
     "script:*.vue": ["@parcel/transformer-vue"],
     "style:*.vue": ["@parcel/transformer-vue"],
     "custom:*.vue": ["@parcel/transformer-vue"],
-    "*.{png,jpg,jpeg,webp,gif,tiff,avif,heic,heif}": ["@parcel/transformer-image"],
+    "*.{png,jpg,jpeg,webp,gif,tiff,avif,heic,heif}": [
+      "@parcel/transformer-image"
+    ],
     "*.svg": ["@parcel/transformer-svg"],
     "*.{xml,rss,atom}": ["@parcel/transformer-xml"],
+    "*.node": ["@parcel/transformer-raw"],
     "url:*": ["...", "@parcel/transformer-raw"]
   },
   "namers": ["@parcel/namer-default"],

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -61,6 +61,8 @@ export function bundleToInternalBundleGraph(bundle: IBundle): BundleGraph {
 // preventing others from using them. They should use the static `get` method.
 let _private = {};
 
+const inspect = Symbol.for('nodejs.util.inspect.custom');
+
 export class Bundle implements IBundle {
   #bundle /*: InternalBundle */;
   #bundleGraph /*: BundleGraph */;
@@ -237,6 +239,11 @@ export class NamedBundle extends Bundle implements INamedBundle {
     existingMap.set(internalBundle, namedBundle);
 
     return namedBundle;
+  }
+
+  // $FlowFixMe[unsupported-syntax]
+  [inspect](): string {
+    return `NamedBundle(${this.name})`;
   }
 
   get name(): string {

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -42,6 +42,7 @@ const LOADERS = {
     html: './helpers/node/html-loader',
     js: './helpers/node/js-loader',
     wasm: './helpers/node/wasm-loader',
+    node: './helpers/node/require-loader',
     IMPORT_POLYFILL: null,
   },
 };
@@ -184,6 +185,24 @@ export default (new Runtime({
       // Skip URL runtimes for library builds. This is handled in packaging so that
       // the url is inlined and statically analyzable.
       if (bundle.env.isLibrary && dependency.meta?.placeholder != null) {
+        continue;
+      }
+
+      // Native node addons
+      if (bundle.env.isNode() && mainBundle.type === 'node') {
+        if (!bundle.env.shouldScopeHoist) {
+          assets.push(
+            nullthrows(
+              getLoaderRuntime({
+                bundle,
+                dependency,
+                bundleGraph,
+                bundleGroup: resolved.value,
+                options,
+              }),
+            ),
+          );
+        }
         continue;
       }
 

--- a/packages/runtimes/js/src/helpers/node/require-loader.js
+++ b/packages/runtimes/js/src/helpers/node/require-loader.js
@@ -1,0 +1,5 @@
+const url = require('url');
+
+module.exports = function loadNodeModule(bundle) {
+  return require(url.fileURLToPath(bundle));
+};


### PR DESCRIPTION
Bundle native modules in situations like these
```js
const x = require("./x.node");
console.log(x);
console.log(x.transform);


const {transform} = require("./x.node");
console.log(transform);


import * as x from "./x.node";
console.log(x.transform);
```

- [ ] Not sure if we actually want this, because this doesn't handle dynamic selection at runtime with non-static specifiers. (One idea however is to reduce this dynamic selection into multiple requires at runtime. So this PR would be the foundation)
- [ ] One problem is that without any special handling in the esmodule output format, this will emit imports to native modules, which is actually not supported by Node: https://nodejs.org/api/esm.html#no-native-module-loading
- [ ] Tests