### PR TITLE
Replace imported values in computed optional member expressions

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/rename-member-prop/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/rename-member-prop/a.js
@@ -1,5 +1,7 @@
+import {B} from "./b.js";
+
 export function foo(x) {
-  return [x.foo, x?.foo];
+  return [x.foo, x?.foo, x[B], x?.[B]];
 }
 
 output = foo;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/rename-member-prop/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/rename-member-prop/b.js
@@ -1,0 +1,1 @@
+export const B = "bar";

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -186,7 +186,7 @@ describe('scope hoisting', function () {
       assert.deepEqual(output, ['1', '2']);
     });
 
-    it("doesn't rename member expression properties", async function () {
+    it('correctly renames member expression properties', async function () {
       let b = await bundle(
         path.join(
           __dirname,
@@ -195,7 +195,7 @@ describe('scope hoisting', function () {
       );
 
       let output = await run(b);
-      assert.deepEqual(output({foo: 12}), [12, 12]);
+      assert.deepEqual(output({foo: 12, bar: 34}), [12, 12, 34, 34]);
     });
 
     it('supports renaming imports', async function () {


### PR DESCRIPTION
Closes #8186
Regression from https://github.com/parcel-bundler/parcel/pull/8121

This return that we have for member expressions was missing from the optional member expression codepath

https://github.com/parcel-bundler/parcel/blob/3b3b13557dba9d1a403c86550915c6013dd78dfe/packages/transformers/js/core/src/hoist.rs#L546-L549

(so before, it always skipped `member.prop` when it should only skip it for static cases)