### PR TITLE
Bump swc to fix ESM helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,10 +1690,13 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8735ce37e421749498e038955abc1135eec6a4af0b54a173e55d2e5542d472"
+checksum = "4447e91cfebfe09f630f909358998fe6621afd10389ba5d6d7711e26105dc87c"
 dependencies = [
+ "once_cell",
+ "rustc-hash",
+ "serde",
  "string_cache",
  "string_cache_codegen",
 ]
@@ -1715,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.18.8"
+version = "0.18.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d1703c3fc183343c7bc9e7fda99054f4de373ddbab773dde507280660b622"
+checksum = "a7fd4917e5f1f563e475d7adf1cb343f9275ffa602f168b896b0ea8f35d70895"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1856,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.133.0"
+version = "0.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5873cb32b3b9bdc7f603a4093f1d39f4ab2ff2900553e6a91493c0f25a1409"
+checksum = "1622bbe51049f066f53a8498a42d69ee157d43453dc992647dbd5a62daa5990a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1881,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.158.0"
+version = "0.160.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b77e699ba2cbefeeb9963709f35756cef7f4aa8609ab3880b56d71893821de"
+checksum = "d2a167f29ffc4fba57c8ef1719f95a4d5b22d37945e0e60ddd4744a8c420a787"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1901,11 +1904,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.87.3"
+version = "0.89.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d4c2de9eb84fd9f259938a03736b96f76f2e410285fca364780922a19fca426"
+checksum = "f2b401d6cd3bdc714837acd30c1eeae5da126b1482f449abda0c8f2c1e39a053"
 dependencies = [
  "better_scoped_tls",
+ "num_cpus",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -1922,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.75.0"
+version = "0.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0c6d1bcd890b4cf4684ca54ceaf9800170ae9f3dcd8dc1490925c1d9740a8f"
+checksum = "a44cc21dcecfa8d566ef4b7daf77c4e11087d5799dada6592fcdb414f05d9474"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1936,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.102.0"
+version = "0.104.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd61fb6ded7f05c2e61b97a2dadf5ebc63ac553a90bd051b820becb8cf97bb8"
+checksum = "2f4f7739a82047c74eeb6cdfa0c6b93599c1e35afcba44b826877217ff912c89"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1963,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_macros"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19a8b4208f7bda35974b182cd779dcd0094f57619cf6d19cfd1941401c733a1"
+checksum = "ebf907935ec5492256b523ae7935a824d9fdc0368dcadc41375bad0dca91cd8b"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1976,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.116.0"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c49585fe5fa719f459fb07296b64916bf10d827d0e30318e161dc9896d2f0b"
+checksum = "172037f798f58614fdc01e5df667ee37af66c1b7ae559a5c4c46745bb174b53a"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2001,9 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.128.0"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31ad6684756fc92e38cb94e085dbaea90d5df0cedc43949ff3e97bcb97f3be1"
+checksum = "ff8081a64271041a199dd399ef50543130e4e28330c3c7592c4c5f958d330596"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2024,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.110.0"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92dbb580e4aab82a754e9448e94684010de7dfc8b65516a13b3dde630caf3e9b"
+checksum = "101817a33d344ab1e8afe898743972324b4d0641aca46a124b5d4620d561244c"
 dependencies = [
  "either",
  "serde",
@@ -2043,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.118.0"
+version = "0.120.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb85e7f45dc604766e97d76a0cd903cdd6e54ddb712be336581bf400857aa3d"
+checksum = "eae89d33f52f9d0a6ca30d3ff1151c69a97793a2847c5ed5642f75ac8da2af30"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -2069,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.121.0"
+version = "0.123.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5614306cb75ce906a8347b9e973abf8e5d5e7acad2360d8ceabc7a4aeba08082"
+checksum = "f9ce88b6efe1c1cca74d1d41af744f3c101869ce568fe371ee4686aad4ae3e84"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2114,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.161.0"
+version = "0.164.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76600601af30c232157d51f5de3e13244fd933c8a1b06acc2509fbcbccd53839"
+checksum = "9bddc3ca2e380a16cb2fb870999cb240feebb3ec9fcc00a84212a0e7feedd17f"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/packages/core/integration-tests/test/integration/js-export-arrow-support/index.js
+++ b/packages/core/integration-tests/test/integration/js-export-arrow-support/index.js
@@ -1,4 +1,4 @@
-import * as helpers from "@swc/helpers/src/_async_generator.mjs";
+import * as helpers from "@swc/helpers";
 import * as bar from "./bar";
 import * as foo from "foo";
 

--- a/packages/core/integration-tests/test/integration/js-export-arrow-support/index.js
+++ b/packages/core/integration-tests/test/integration/js-export-arrow-support/index.js
@@ -1,4 +1,4 @@
-import * as helpers from "@swc/helpers";
+import * as helpers from "@swc/helpers/src/_async_generator.mjs";
 import * as bar from "./bar";
 import * as foo from "foo";
 

--- a/packages/core/integration-tests/test/integration/swc-helpers-library/index.js
+++ b/packages/core/integration-tests/test/integration/swc-helpers-library/index.js
@@ -1,0 +1,1 @@
+class Test {}

--- a/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
+++ b/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "browserslist": "IE >= 11",
+  "dependencies": {
+    "@swc/helpers": "*"
+  }
+}

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -355,6 +355,43 @@ describe('transpilation', function () {
     });
   });
 
+  it('should support commonjs and esm versions of @swc/helpers', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/swc-helpers-library/index.js'),
+    );
+
+    let file = await outputFS.readFile(
+      b.getBundles().find(b => b.env.outputFormat === 'commonjs').filePath,
+      'utf8',
+    );
+    assert(file.includes('@swc/helpers/lib/_class_call_check.js'));
+
+    file = await outputFS.readFile(
+      b.getBundles().find(b => b.env.outputFormat === 'esmodule').filePath,
+      'utf8',
+    );
+    assert(file.includes('@swc/helpers/src/_class_call_check.mjs'));
+  });
+
+  it('should support commonjs versions of @swc/helpers without scope hoisting', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/swc-helpers-library/index.js'),
+      {
+        targets: {
+          test: {
+            distDir,
+            isLibrary: true,
+            scopeHoist: false,
+          },
+        },
+      },
+    );
+
+    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(file.includes('@swc/helpers/lib/_class_call_check.js'));
+    await run(b);
+  });
+
   it('should print errors from transpilation', async function () {
     let source = path.join(
       __dirname,

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -11,6 +11,7 @@ import {
   ncp,
 } from '@parcel/test-utils';
 import {symlinkSync} from 'fs';
+import nullthrows from 'nullthrows';
 
 const inputDir = path.join(__dirname, '/input');
 
@@ -361,13 +362,15 @@ describe('transpilation', function () {
     );
 
     let file = await outputFS.readFile(
-      b.getBundles().find(b => b.env.outputFormat === 'commonjs').filePath,
+      nullthrows(b.getBundles().find(b => b.env.outputFormat === 'commonjs'))
+        .filePath,
       'utf8',
     );
     assert(file.includes('@swc/helpers/lib/_class_call_check.js'));
 
     file = await outputFS.readFile(
-      b.getBundles().find(b => b.env.outputFormat === 'esmodule').filePath,
+      nullthrows(b.getBundles().find(b => b.env.outputFormat === 'esmodule'))
+        .filePath,
       'utf8',
     );
     assert(file.includes('@swc/helpers/src/_class_call_check.mjs'));

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.161.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.18.8", features = ["tty-emitter", "sourcemap"] }
-swc_atoms = "0.2.11"
+swc_ecmascript = { version = "0.164.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.18.9", features = ["tty-emitter", "sourcemap"] }
+swc_atoms = "0.2.12"
 indoc = "1.0.3"
 serde = "1.0.123"
 serde_bytes = "0.11.5"

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -97,19 +97,36 @@ struct DependencyCollector<'a> {
 impl<'a> DependencyCollector<'a> {
   fn add_dependency(
     &mut self,
-    specifier: JsWord,
+    mut specifier: JsWord,
     span: swc_common::Span,
     kind: DependencyKind,
     attributes: Option<HashMap<swc_atoms::JsWord, bool>>,
     is_optional: bool,
     source_type: SourceType,
   ) -> Option<JsWord> {
+    // Rewrite SWC helpers from ESM to CJS for library output.
+    let mut is_specifier_rewritten = false;
+    if self.config.is_library && !self.config.is_esm_output {
+      if let Some(suffix) = specifier.strip_prefix("@swc/helpers/src/") {
+        if let Some(prefix) = suffix.strip_suffix(".mjs") {
+          specifier = format!("@swc/helpers/lib/{}.js", prefix).into();
+          is_specifier_rewritten = true;
+        }
+      }
+    }
+
     // For normal imports/requires, the specifier will remain unchanged.
     // For other types of dependencies, the specifier will be changed to a hash
     // that also contains the dependency kind. This way, multiple kinds of dependencies
     // to the same specifier can be used within the same file.
     let placeholder = match kind {
-      DependencyKind::Import | DependencyKind::Export | DependencyKind::Require => None,
+      DependencyKind::Import | DependencyKind::Export | DependencyKind::Require => {
+        if is_specifier_rewritten {
+          Some(specifier.as_ref().to_owned())
+        } else {
+          None
+        }
+      }
       _ => Some(format!(
         "{:x}",
         hash!(format!("{}:{}:{}", self.config.filename, specifier, kind))
@@ -256,12 +273,12 @@ impl<'a> Fold for DependencyCollector<'a> {
     node.fold_children_with(self)
   }
 
-  fn fold_import_decl(&mut self, node: ast::ImportDecl) -> ast::ImportDecl {
+  fn fold_import_decl(&mut self, mut node: ast::ImportDecl) -> ast::ImportDecl {
     if node.type_only {
       return node;
     }
 
-    self.add_dependency(
+    let rewritten = self.add_dependency(
       node.src.value.clone(),
       node.src.span,
       DependencyKind::Import,
@@ -270,16 +287,20 @@ impl<'a> Fold for DependencyCollector<'a> {
       self.config.source_type,
     );
 
+    if let Some(rewritten) = rewritten {
+      node.src.value = rewritten.into();
+    }
+
     node
   }
 
-  fn fold_named_export(&mut self, node: ast::NamedExport) -> ast::NamedExport {
-    if let Some(src) = &node.src {
+  fn fold_named_export(&mut self, mut node: ast::NamedExport) -> ast::NamedExport {
+    if let Some(src) = &mut node.src {
       if node.type_only {
         return node;
       }
 
-      self.add_dependency(
+      let rewritten = self.add_dependency(
         src.value.clone(),
         src.span,
         DependencyKind::Export,
@@ -287,13 +308,17 @@ impl<'a> Fold for DependencyCollector<'a> {
         false,
         self.config.source_type,
       );
+
+      if let Some(rewritten) = rewritten {
+        src.value = rewritten.into();
+      }
     }
 
     node
   }
 
-  fn fold_export_all(&mut self, node: ast::ExportAll) -> ast::ExportAll {
-    self.add_dependency(
+  fn fold_export_all(&mut self, mut node: ast::ExportAll) -> ast::ExportAll {
+    let rewritten = self.add_dependency(
       node.src.value.clone(),
       node.src.span,
       DependencyKind::Export,
@@ -301,6 +326,10 @@ impl<'a> Fold for DependencyCollector<'a> {
       false,
       self.config.source_type,
     );
+
+    if let Some(rewritten) = rewritten {
+      node.src.value = rewritten.into();
+    }
 
     node
   }

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -35,7 +35,7 @@
     "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.6.0",
     "@parcel/workers": "2.6.0",
-    "@swc/helpers": "^0.3.15",
+    "@swc/helpers": "^0.4.0",
     "browserslist": "^4.6.6",
     "detect-libc": "^1.0.3",
     "nullthrows": "^1.1.1",

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -35,7 +35,7 @@
     "@parcel/source-map": "^2.0.0",
     "@parcel/utils": "2.6.0",
     "@parcel/workers": "2.6.0",
-    "@swc/helpers": "^0.4.0",
+    "@swc/helpers": "^0.4.2",
     "browserslist": "^4.6.6",
     "detect-libc": "^1.0.3",
     "nullthrows": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,10 +2357,10 @@
     "@swc/core-win32-ia32-msvc" "^1.2.106"
     "@swc/core-win32-x64-msvc" "^1.2.106"
 
-"@swc/helpers@^0.3.15":
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.3.15.tgz#02abb377c91c39e0a6034f1161870c18621b9129"
-  integrity sha512-rpZHDdzwhfe06gF98SUAi7TfI344zKb1Pd2D9gxUMTNnhMobDHrv2UiVVcbDXmkx84U5AaXJmBrmfT9g1TPasQ==
+"@swc/helpers@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.0.tgz#c9a18f86a14faed42607c700a9cc2511f1609e6d"
+  integrity sha512-xqKzPexulVWhXKs8nf7LqjwOF4l6iob3/es6I4RlF6ThkAXXmel9fiVmv8ec7g0rFh9ujpVXnX3o68AWA3R0Hg==
   dependencies:
     tslib "^2.4.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,10 +2357,10 @@
     "@swc/core-win32-ia32-msvc" "^1.2.106"
     "@swc/core-win32-x64-msvc" "^1.2.106"
 
-"@swc/helpers@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.0.tgz#c9a18f86a14faed42607c700a9cc2511f1609e6d"
-  integrity sha512-xqKzPexulVWhXKs8nf7LqjwOF4l6iob3/es6I4RlF6ThkAXXmel9fiVmv8ec7g0rFh9ujpVXnX3o68AWA3R0Hg==
+"@swc/helpers@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.2.tgz#ed1f6997ffbc22396665d9ba74e2a5c0a2d782f8"
+  integrity sha512-556Az0VX7WR6UdoTn4htt/l3zPQ7bsQWK+HqdG4swV7beUCxo/BqmvbOpUkTIm/9ih86LIf1qsUnywNL3obGHw==
   dependencies:
     tslib "^2.4.0"
 


### PR DESCRIPTION
Fixes an issue where SWC's helpers didn't work with Node ESM. SWC now generates `.mjs` imports, and rewrites them to the CommonJS version when transforming. Now we do the same. Based on https://github.com/swc-project/swc/pull/4962