### PR TITLE
Error when dependency on external helpers is incompatible

### DIFF
--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -6,6 +6,7 @@ import type {
   SourceLocation,
   Symbol,
   BundleBehavior as IBundleBehavior,
+  SemverRange,
 } from '@parcel/types';
 import type {Dependency, Environment, Target} from './types';
 import {hashString} from '@parcel/hash';
@@ -29,6 +30,7 @@ type DependencyOpts = {|
   env: Environment,
   meta?: Meta,
   resolveFrom?: FilePath,
+  range?: SemverRange,
   target?: Target,
   symbols?: Map<
     Symbol,
@@ -69,6 +71,7 @@ export function createDependency(
     isEntry: opts.isEntry ?? false,
     isOptional: opts.isOptional ?? false,
     meta: opts.meta || {},
+    range: opts.range,
     symbols:
       opts.symbols &&
       new Map(

--- a/packages/core/core/src/public/Dependency.js
+++ b/packages/core/core/src/public/Dependency.js
@@ -135,6 +135,10 @@ export default class Dependency implements IDependency {
     );
   }
 
+  get range(): ?string {
+    return this.#dep.range;
+  }
+
   get pipeline(): ?string {
     return this.#dep.pipeline;
   }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -131,6 +131,7 @@ export type Dependency = {|
   sourcePath: ?ProjectPath,
   sourceAssetType?: ?string,
   resolveFrom: ?ProjectPath,
+  range: ?SemverRange,
   symbols: ?Map<
     Symbol,
     {|

--- a/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
+++ b/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
@@ -3,6 +3,6 @@
   "module": "dist/module.js",
   "browserslist": "IE >= 11",
   "dependencies": {
-    "@swc/helpers": "*"
+    "@swc/helpers": "^0.4.2"
   }
 }

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5639,6 +5639,96 @@ describe('javascript', function () {
     );
   });
 
+  it('should error on mismatched helpers version for libraries', async function () {
+    let fixture = path.join(
+      __dirname,
+      'integration/undeclared-external/helpers.js',
+    );
+    let pkg = path.join(
+      __dirname,
+      'integration/undeclared-external/package.json',
+    );
+    let pkgContents = JSON.stringify(
+      {
+        ...JSON.parse(await overlayFS.readFile(pkg, 'utf8')),
+        dependencies: {
+          '@swc/helpers': '^0.3.0',
+        },
+      },
+      false,
+      2,
+    );
+    await overlayFS.mkdirp(path.dirname(pkg));
+    await overlayFS.writeFile(pkg, pkgContents);
+    await assert.rejects(
+      () =>
+        bundle(fixture, {
+          mode: 'production',
+          inputFS: overlayFS,
+          defaultTargetOptions: {
+            shouldOptimize: false,
+          },
+        }),
+      {
+        name: 'BuildError',
+        diagnostics: [
+          {
+            message: md`Failed to resolve '${'@swc/helpers/lib/_class_call_check.js'}' from '${normalizePath(
+              require.resolve('@parcel/transformer-js/src/JSTransformer.js'),
+            )}'`,
+            origin: '@parcel/core',
+            codeFrames: [
+              {
+                code: await inputFS.readFile(fixture, 'utf8'),
+                filePath: fixture,
+                codeHighlights: [
+                  {
+                    start: {
+                      line: 1,
+                      column: 1,
+                    },
+                    end: {
+                      line: 1,
+                      column: 1,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            message:
+              'External dependency "@swc/helpers" does not satisfy required semver range "^0.4.2".',
+            origin: '@parcel/resolver-default',
+            codeFrames: [
+              {
+                code: pkgContents,
+                filePath: pkg,
+                language: 'json',
+                codeHighlights: [
+                  {
+                    message: 'Found this conflicting requirement.',
+                    start: {
+                      line: 6,
+                      column: 21,
+                    },
+                    end: {
+                      line: 6,
+                      column: 28,
+                    },
+                  },
+                ],
+              },
+            ],
+            hints: [
+              'Update the dependency on "@swc/helpers" to satisfy "^0.4.2".',
+            ],
+          },
+        ],
+      },
+    );
+  });
+
   describe('multiple import types', function () {
     it('supports both static and dynamic imports to the same specifier in the same file', async function () {
       let b = await bundle(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -525,6 +525,8 @@ export type DependencyOptions = {|
    * By default, this is the path of the source file where the dependency was specified.
    */
   +resolveFrom?: FilePath,
+  /** The semver version range expected for the dependency. */
+  +range?: SemverRange,
   /** The symbols within the resolved module that the source file depends on. */
   +symbols?: $ReadOnlyMap<
     Symbol,
@@ -601,6 +603,8 @@ export interface Dependency {
    * By default, this is the path of the source file where the dependency was specified.
    */
   +resolveFrom: ?FilePath;
+  /** The semver version range expected for the dependency. */
+  +range: ?SemverRange;
   /** The pipeline defined in .parcelrc that the dependency should be processed with. */
   +pipeline: ?string;
 

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -34,6 +34,7 @@ export default (new Resolver({
     return resolver.resolve({
       filename: specifier,
       specifierType: dependency.specifierType,
+      range: dependency.range,
       parent: dependency.resolveFrom,
       env: dependency.env,
       sourcePath: dependency.sourcePath,

--- a/packages/resolvers/glob/src/GlobResolver.js
+++ b/packages/resolvers/glob/src/GlobResolver.js
@@ -99,6 +99,7 @@ export default (new Resolver({
         invalidateOnFileChange,
         specifierType: dependency.specifierType,
         loc: dependency.loc,
+        range: dependency.range,
       };
 
       let result;

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -12,6 +12,7 @@ import nullthrows from 'nullthrows';
 import ThrowableDiagnostic, {encodeJSONKeyComponent} from '@parcel/diagnostic';
 import {validateSchema, remapSourceLocation, isGlobMatch} from '@parcel/utils';
 import WorkerFarm from '@parcel/workers';
+import pkg from '../package.json';
 
 const JSX_EXTENSIONS = {
   jsx: true,
@@ -689,6 +690,17 @@ export default (new Transformer({
           };
         }
 
+        // Add required version range for helpers.
+        let range;
+        if (isHelper) {
+          let idx = dep.specifier.indexOf('/');
+          if (dep.specifier[0] === '@') {
+            idx = dep.specifier.indexOf('/', idx + 1);
+          }
+          let module = idx >= 0 ? dep.specifier.slice(0, idx) : dep.specifier;
+          range = pkg.dependencies[module];
+        }
+
         asset.addDependency({
           specifier: dep.specifier,
           specifierType: dep.kind === 'Require' ? 'commonjs' : 'esm',
@@ -697,6 +709,7 @@ export default (new Transformer({
           isOptional: dep.is_optional,
           meta,
           resolveFrom: isHelper ? __filename : undefined,
+          range,
           env,
         });
       }

--- a/packages/utils/node-resolver-core/package.json
+++ b/packages/utils/node-resolver-core/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@parcel/diagnostic": "2.6.0",
     "@parcel/utils": "2.6.0",
-    "nullthrows": "^1.1.1"
+    "nullthrows": "^1.1.1",
+    "semver": "^5.7.1"
   },
   "devDependencies": {
     "assert": "^2.0.0",

--- a/packages/utils/node-resolver-core/test/fixture/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/package.json
@@ -11,7 +11,7 @@
     "glob/*/*": "./nested/$2"
   },
   "dependencies": {
-    "foo": "*"
+    "foo": "^0.3.4"
   },
   "peerDependencies": {
     "bar": "*"

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -2679,6 +2679,29 @@ describe('resolver', function () {
 
       assert.deepEqual(result, {isExcluded: true});
     });
+
+    it('should error when a library has an incorrect external dependency version', async function () {
+      let result = await resolver.resolve({
+        env: new Environment(
+          createEnvironment({
+            context: 'browser',
+            isLibrary: true,
+            includeNodeModules: false,
+          }),
+          DEFAULT_OPTIONS,
+        ),
+        filename: 'foo',
+        specifierType: 'esm',
+        range: '^0.4.0',
+        parent: path.join(rootDir, 'foo.js'),
+        sourcePath: path.join(rootDir, 'foo.js'),
+      });
+
+      assert.equal(
+        result?.diagnostics?.[0].message,
+        'External dependency "foo" does not satisfy required semver range "^0.4.0".',
+      );
+    });
   });
 
   describe('urls', function () {


### PR DESCRIPTION
`@swc/helpers` had a breaking change, so libraries will need to bump their dependency to remain compatible. This PR adds a diagnostic for that case.

<img width="899" alt="image" src="https://user-images.githubusercontent.com/19409/174345093-61f925a2-5cc7-48ff-b1d9-0905732efa72.png">

Dependencies can now have a `range` option similar to dev dependencies, which specifies the semver requirement. Currently, it is only checked for external dependencies, but we could add support for checking it for other cases as well if needed. Doing it this way was easier than duplicating all the logic for detecting externals etc. in the transformer, and I think more flexible for future use cases.