### PR TITLE
Use stream#pipeline instead of stream.pipe

### DIFF
--- a/packages/core/cache/src/FSCache.js
+++ b/packages/core/cache/src/FSCache.js
@@ -1,6 +1,6 @@
 // @flow strict-local
 
-import type {Readable} from 'stream';
+import type {Readable, Writable} from 'stream';
 import type {FilePath} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import type {Cache} from './types';
@@ -13,7 +13,9 @@ import {serialize, deserialize, registerSerializableClass} from '@parcel/core';
 // flowlint-next-line untyped-import:off
 import packageJson from '../package.json';
 
-const pipeline = promisify(stream.pipeline);
+const pipeline: (Readable, Writable) => Promise<void> = promisify(
+  stream.pipeline,
+);
 
 export class FSCache implements Cache {
   fs: FileSystem;

--- a/packages/core/cache/src/FSCache.js
+++ b/packages/core/cache/src/FSCache.js
@@ -5,11 +5,15 @@ import type {FilePath} from '@parcel/types';
 import type {FileSystem} from '@parcel/fs';
 import type {Cache} from './types';
 
+import stream from 'stream';
 import path from 'path';
+import {promisify} from 'util';
 import logger from '@parcel/logger';
 import {serialize, deserialize, registerSerializableClass} from '@parcel/core';
 // flowlint-next-line untyped-import:off
 import packageJson from '../package.json';
+
+const pipeline = promisify(stream.pipeline);
 
 export class FSCache implements Cache {
   fs: FileSystem;
@@ -45,12 +49,10 @@ export class FSCache implements Cache {
   }
 
   setStream(key: string, stream: Readable): Promise<void> {
-    return new Promise((resolve, reject) => {
-      stream
-        .pipe(this.fs.createWriteStream(this._getCachePath(`${key}-large`)))
-        .on('error', reject)
-        .on('finish', resolve);
-    });
+    return pipeline(
+      stream,
+      this.fs.createWriteStream(this._getCachePath(`${key}-large`)),
+    );
   }
 
   has(key: string): Promise<boolean> {

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -1,15 +1,19 @@
 // @flow strict-local
 import type {FilePath} from '@parcel/types';
 import type {Cache} from './types';
+import type {Readable} from 'stream';
 
-import {Readable} from 'stream';
+import stream from 'stream';
 import path from 'path';
+import {promisify} from 'util';
 import {serialize, deserialize, registerSerializableClass} from '@parcel/core';
 import {NodeFS} from '@parcel/fs';
 // flowlint-next-line untyped-import:off
 import packageJson from '../package.json';
 // $FlowFixMe
 import lmdb from 'lmdb';
+
+const pipeline = promisify(stream.pipeline);
 
 export class LMDBCache implements Cache {
   fs: NodeFS;
@@ -64,12 +68,10 @@ export class LMDBCache implements Cache {
   }
 
   setStream(key: string, stream: Readable): Promise<void> {
-    return new Promise((resolve, reject) => {
-      stream
-        .pipe(this.fs.createWriteStream(path.join(this.dir, key)))
-        .on('error', reject)
-        .on('finish', resolve);
-    });
+    return pipeline(
+      stream,
+      this.fs.createWriteStream(path.join(this.dir, key)),
+    );
   }
 
   getBlob(key: string): Promise<Buffer> {

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 import type {FilePath} from '@parcel/types';
 import type {Cache} from './types';
-import type {Readable} from 'stream';
+import type {Readable, Writable} from 'stream';
 
 import stream from 'stream';
 import path from 'path';
@@ -13,7 +13,9 @@ import packageJson from '../package.json';
 // $FlowFixMe
 import lmdb from 'lmdb';
 
-const pipeline = promisify(stream.pipeline);
+const pipeline: (Readable, Writable) => Promise<void> = promisify(
+  stream.pipeline,
+);
 
 export class LMDBCache implements Cache {
   fs: NodeFS;

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -1,6 +1,8 @@
 // @flow strict-local
 import type {FileSystem} from './types';
 import type {FilePath} from '@parcel/types';
+import type {Readable, Writable} from 'stream';
+
 import path from 'path';
 import stream from 'stream';
 import {promisify} from 'util';
@@ -10,7 +12,9 @@ export * from './NodeFS';
 export * from './MemoryFS';
 export * from './OverlayFS';
 
-const pipeline = promisify(stream.pipeline);
+const pipeline: (Readable, Writable) => Promise<void> = promisify(
+  stream.pipeline,
+);
 
 // Recursively copies a directory from the sourceFS to the destinationFS
 export async function ncp(

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -2,11 +2,15 @@
 import type {FileSystem} from './types';
 import type {FilePath} from '@parcel/types';
 import path from 'path';
+import stream from 'stream';
+import {promisify} from 'util';
 
 export type * from './types';
 export * from './NodeFS';
 export * from './MemoryFS';
 export * from './OverlayFS';
+
+const pipeline = promisify(stream.pipeline);
 
 // Recursively copies a directory from the sourceFS to the destinationFS
 export async function ncp(
@@ -22,13 +26,10 @@ export async function ncp(
     let destPath = path.join(destination, file);
     let stats = await sourceFS.stat(sourcePath);
     if (stats.isFile()) {
-      await new Promise((resolve, reject) => {
-        sourceFS
-          .createReadStream(sourcePath)
-          .pipe(destinationFS.createWriteStream(destPath))
-          .on('finish', () => resolve())
-          .on('error', reject);
-      });
+      await pipeline(
+        sourceFS.createReadStream(sourcePath),
+        destinationFS.createWriteStream(destPath),
+      );
     } else if (stats.isDirectory()) {
       await ncp(sourceFS, sourcePath, destinationFS, destPath);
     }


### PR DESCRIPTION
Fixes `No such file: "../.parcel-cache/283921823"`
A regression from https://github.com/parcel-bundler/parcel/pull/8194

Apparently this call would still return even though the stream wasn't fully written yet (and therefore the file wasn't renamed):
```js
    await new Promise((resolve, reject) => {
      stream
        .pipe(this.fs.createWriteStream(this._getCachePath(`${key}-large`)))
        .on('error', reject)
        .on('finish', resolve);
    });
```
Using `stream.pipeline` works (which also has official promise capabilities).

Tested in a project that would previously fail deterministically with that error on every build. Now I don't see the error anymore
