### PR TITLE
Respect NODE_PATH environment variable

### DIFF
--- a/packages/core/package-manager/src/NodeResolverBase.js
+++ b/packages/core/package-manager/src/NodeResolverBase.js
@@ -139,6 +139,19 @@ export class NodeResolverBase<T> {
     let dir = path.dirname(sourceFile);
     let moduleDir = this.fs.findNodeModule(moduleName, dir);
 
+    if (!moduleDir && process.env.NODE_PATH != null) {
+       for (const dir of process.env.NODE_PATH.split(path.delimiter)) {
+          try {
+            let nodePathDir = path.join(dir, moduleName);
+            let stats = this.fs.statSync(nodePathDir);
+            if (stats.isDirectory()) {
+              moduleDir = nodePathDir;
+              break;
+            };
+          } catch (err) {}
+       }
+    }
+
     ctx.invalidateOnFileCreate.push({
       fileName: `node_modules/${moduleName}`,
       aboveFilePath: sourceFile,

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -748,6 +748,20 @@ export default class NodeResolver {
 
     let dir = path.dirname(sourceFile);
     let moduleDir = this.fs.findNodeModule(moduleName, dir);
+    
+    if (!moduleDir && process.env.NODE_PATH != null) {
+       for (const dir of process.env.NODE_PATH.split(path.delimiter)) {
+          try {
+            let nodePathDir = path.join(dir, moduleName);
+            let stats = this.fs.statSync(nodePathDir);
+            if (stats.isDirectory()) {
+              moduleDir = nodePathDir;
+              break;
+            };
+          } catch (err) {}
+       }
+    }
+    
     if (moduleDir) {
       return {
         moduleName,


### PR DESCRIPTION
Respect NODE_PATH environment variable

## 💻 Examples
1. `find .`
 .
./src
./src/App.tsx
./src/index.html
./3rd
./3rd/web
./3rd/web/vender

2. `pushd ./3rd/web/vender`
   install modules `npm install parcel react react-dom`

3. `export NODE_PATH="$(pwd)/3rd/web/vender/node_modules"`

    run parcel like this ` node 3rd/web/vender/node_modules/parcel/lib/cli.js src/index.html`
    - before this patch, parcel will complain "Failed to resolve XXXX"
    - after this patch, parcel will work fine with respect NODE_PATH setting for module resolving.


fix this https://github.com/parcel-bundler/parcel/issues/6111#issue-855203386

