### PR TITLE
Bump swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ast_node"
-version = "0.7.7"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4c00309ed1c8104732df4a5fa9acc3b796b6f8531dfbd5ce0078c86f997244"
+checksum = "87549fcb780f81054407f313a1693d102396c223f5c49ccc5d90b46a6cbef34a"
 dependencies = [
  "darling",
  "pmutil",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -381,23 +381,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.9.3",
+ "strsim 0.10.0",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core",
  "quote",
@@ -1684,15 +1684,15 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4447e91cfebfe09f630f909358998fe6621afd10389ba5d6d7711e26105dc87c"
+checksum = "0d99c0ac33707dd1162a3665d6ca1a28b2f6594e9c37c4703e417fc5e1ce532e"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -1718,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.18.9"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7fd4917e5f1f563e475d7adf1cb343f9275ffa602f168b896b0ea8f35d70895"
+checksum = "345cb0a3ca943351d3471aecf10df205f7d99c0932aea664edb1b5c15615ac8b"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1737,6 +1737,7 @@ dependencies = [
  "siphasher",
  "sourcemap",
  "string_cache",
+ "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1773,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.79.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f559057f0a573fe3575605cdb5f6d6523b090995e0022444c24e4d206eb4bd57"
+checksum = "f3dc53b4ea576cb006aba07a82cff74b901041569970539b530ffaece6fffa69"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1790,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.109.1"
+version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305da34eaf4d8ec3f908003304d6305fbb455053df9a538c8a491872d167483d"
+checksum = "b293051dd6a60c65d6437262836f8570e606d414bd2e3d02f1d2881901b8efa0"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1821,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.30.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917dcd19c429254113981e746e3f6b46446145c8e4d353a8727f92bc8fa307cc"
+checksum = "872861eab97ab6e10691740a592a951778e3f9d21eae1c2cafb8bc62a93384bf"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1840,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.105.0"
+version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336980822a7b4a5bff756a6cd8eca3b8e1d96d3d6fc5afd2475524290fac7c3e"
+checksum = "fb75203b42b644a1098a4f589110986aea4e0e0d4148e8646f1b431a8d3ddf40"
 dependencies = [
  "either",
  "enum_kind",
@@ -1859,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.135.0"
+version = "0.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1622bbe51049f066f53a8498a42d69ee157d43453dc992647dbd5a62daa5990a"
+checksum = "28c726de0d7d8a44f669fe2ceb54d26c5b0f1295e90e49026d4776e19d286f7c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1884,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.160.0"
+version = "0.170.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a167f29ffc4fba57c8ef1719f95a4d5b22d37945e0e60ddd4744a8c420a787"
+checksum = "f31246d8d5aa030a5fb1bcd0b0fc3373336ca06c210c8cd3e84b7d59cbbd5d00"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1904,11 +1905,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.89.3"
+version = "0.94.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b401d6cd3bdc714837acd30c1eeae5da126b1482f449abda0c8f2c1e39a053"
+checksum = "abaab07c402f7f671b4f1ed2b548ac151a3cd51b40b3ae58f94130ac57a671ee"
 dependencies = [
  "better_scoped_tls",
+ "bitflags",
  "num_cpus",
  "once_cell",
  "phf",
@@ -1926,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.77.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44cc21dcecfa8d566ef4b7daf77c4e11087d5799dada6592fcdb414f05d9474"
+checksum = "c54405da0c022e156d5b40f51b4344ce2bd2fecf1f204eebb973aac1e2941aac"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1940,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.104.1"
+version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4f7739a82047c74eeb6cdfa0c6b93599c1e35afcba44b826877217ff912c89"
+checksum = "e582838cb48c86193f4e60b057cc6c873dff910e5d28d8ab3cb8a3692f6e07bc"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1980,14 +1982,16 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.118.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172037f798f58614fdc01e5df667ee37af66c1b7ae559a5c4c46745bb174b53a"
+checksum = "f772c16c9bef156a5716e2c57107e1937743f133793a051f8fe034d4a3a03cb4"
 dependencies = [
  "Inflector",
  "ahash",
  "anyhow",
+ "bitflags",
  "indexmap",
+ "is-macro",
  "path-clean",
  "pathdiff",
  "serde",
@@ -2005,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.130.0"
+version = "0.139.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8081a64271041a199dd399ef50543130e4e28330c3c7592c4c5f958d330596"
+checksum = "2c3e9819e409879ceb69f8133a3a049521e823515eb63851322e815bb64ef7c7"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2028,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.112.0"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101817a33d344ab1e8afe898743972324b4d0641aca46a124b5d4620d561244c"
+checksum = "7a0c4bd45190dcf2099b0e58b10a23abc4da24c36a06f4b2390c09519fbd2a99"
 dependencies = [
  "either",
  "serde",
@@ -2047,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.120.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae89d33f52f9d0a6ca30d3ff1151c69a97793a2847c5ed5642f75ac8da2af30"
+checksum = "73ff1847dfceb7944a0227e73b37453d9ddc278f6e70029eafc6c2acfbbacb7d"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -2073,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.123.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ce88b6efe1c1cca74d1d41af744f3c101869ce568fe371ee4686aad4ae3e84"
+checksum = "6fc828f5b5ffd344dfc5b6c1505712bccc994a65e02ca7fd6487e8503f47c423"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2089,9 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.86.1"
+version = "0.90.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36a6646bc1d343a6bd24bf5564dba3235f006b07fd64d74f37ef0a2eb222f5f"
+checksum = "024921880a38c2768aebd754ef473c9d902683d2ef3b6ef79d74e526e65bbb3d"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2100,13 +2104,14 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_visit",
  "tracing",
+ "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.65.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066077ce3279b593cbdbbb379735e230a794df7aef7206ba142850eb7197e91f"
+checksum = "d1e40517622d404e3f2fdb064d2982d46fee0e2ec097f3cf196fa4d128fb095b"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2118,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.164.0"
+version = "0.175.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bddc3ca2e380a16cb2fb870999cb240feebb3ec9fcc00a84212a0e7feedd17f"
+checksum = "6846fa2093febbcd6ab7c0475313899d964d71cd196e955fc34520936529188b"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3832f3c4886200cac7a165e7ca5b465dc28b6b295eee86438c1e9e5d2f89f3c"
+checksum = "dbde2726605dc5c72c04483a181595481d6e774b301194163c811eac6ae32df8"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.81.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dc53b4ea576cb006aba07a82cff74b901041569970539b530ffaece6fffa69"
+checksum = "f998d288db60b25d0ed0f1f54c67946f27632c7b20633db239068c65a50c448f"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.112.1"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0bad5ba2ba068bac47969b4c4fa424d282e9b28b89019cacf458373c83677e3"
+checksum = "299c5fcbe7663905385e03d79e33ddc1959d3ac714fd5025f20ce2a55c0465d0"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872861eab97ab6e10691740a592a951778e3f9d21eae1c2cafb8bc62a93384bf"
+checksum = "4b9648733e70fbe72f17762289fa52343b33427502dc9e9801e9321b7cc68ff3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.108.1"
+version = "0.109.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb75203b42b644a1098a4f589110986aea4e0e0d4148e8646f1b431a8d3ddf40"
+checksum = "f661cb664a13d0a950042c214737e571b0b2565c7b051643581bcf78fa66f551"
 dependencies = [
  "either",
  "enum_kind",
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.145.0"
+version = "0.146.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c726de0d7d8a44f669fe2ceb54d26c5b0f1295e90e49026d4776e19d286f7c"
+checksum = "76437794374848cad8bf28954797ea46abef173c75fb5e4251f49acfce0cb36e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1885,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.170.0"
+version = "0.171.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31246d8d5aa030a5fb1bcd0b0fc3373336ca06c210c8cd3e84b7d59cbbd5d00"
+checksum = "d4cb5725bbd8fb666d8b1858bc31bb1c79cfac35042ee5917453af05ddf67fbf"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.94.2"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a93d87a2338abbf438431eb979f8714ca75b380117fc52eb41ffbec4afae66"
+checksum = "340cc66985195bf7a4b0c5e1193151fbbfaea48ffbe22412d809893d583a732e"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1928,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.82.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54405da0c022e156d5b40f51b4344ce2bd2fecf1f204eebb973aac1e2941aac"
+checksum = "32ce60afed61d333b1fa9c34e13e46f7ecb6b535da30bda1e5f3331c53bfe40f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.110.1"
+version = "0.111.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce88ba162aa99d295ac86f5a099b675c121ee71103383a03a857a32ba83456f"
+checksum = "c2ff7f3cdefb01d85a5569eab244be531a2918f53427a7d6f8f8bb885a4c1c4b"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.126.2"
+version = "0.127.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aa10828d89673612d7c0e6783097df0b5a05ac68b2d7cb150e0a28d16f89b45"
+checksum = "fcab1c0663d12006fb3421cc3c4920d03b154db95820bef0deb7c4a052882c4e"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.139.0"
+version = "0.140.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3e9819e409879ceb69f8133a3a049521e823515eb63851322e815bb64ef7c7"
+checksum = "8330e6d824bc3c364a31aae71e777d430436505ecdba04a501e76e7ee52d512c"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2033,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.118.0"
+version = "0.119.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0c4bd45190dcf2099b0e58b10a23abc4da24c36a06f4b2390c09519fbd2a99"
+checksum = "76034a0dbb7f17bef08fbf37e67748d84e55645d9ca10a772ea41a31bb0f96bd"
 dependencies = [
  "either",
  "serde",
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.128.1"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95847eb307922d012ed4973912b4baae367344999ba893027cb56eec9814626d"
+checksum = "0bc58381a372604a1f0535515af81883060f7b32667c53645f3424ca06ba97a4"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -2078,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.132.0"
+version = "0.133.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fc828f5b5ffd344dfc5b6c1505712bccc994a65e02ca7fd6487e8503f47c423"
+checksum = "e3fce16ff57e8056940011a0a5b4891d6e6a9584f8260228addbaf2e353501de"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.90.0"
+version = "0.91.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024921880a38c2768aebd754ef473c9d902683d2ef3b6ef79d74e526e65bbb3d"
+checksum = "8decd530962326caffef0071fbe2d8ab1a75bf737ca814b8e2e9d01a68924a89"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.67.1"
+version = "0.68.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8abef878e395ffc2348cdc885e9a37eab3c082e9fa7a675e9ef17b614f297c"
+checksum = "cfee2460244b220be0a9cbc68390d3bce128759aec4ed8d19cef400a8d66b727"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.175.0"
+version = "0.176.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6846fa2093febbcd6ab7c0475313899d964d71cd196e955fc34520936529188b"
+checksum = "34be3336ff87a24fab05fb634f65a5126aba8a450ac47aac563d754295842e47"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345cb0a3ca943351d3471aecf10df205f7d99c0932aea664edb1b5c15615ac8b"
+checksum = "b3832f3c4886200cac7a165e7ca5b465dc28b6b295eee86438c1e9e5d2f89f3c"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.112.0"
+version = "0.112.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b293051dd6a60c65d6437262836f8570e606d414bd2e3d02f1d2881901b8efa0"
+checksum = "b0bad5ba2ba068bac47969b4c4fa424d282e9b28b89019cacf458373c83677e3"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.94.0"
+version = "0.94.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abaab07c402f7f671b4f1ed2b548ac151a3cd51b40b3ae58f94130ac57a671ee"
+checksum = "c9a93d87a2338abbf438431eb979f8714ca75b380117fc52eb41ffbec4afae66"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.110.0"
+version = "0.110.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e582838cb48c86193f4e60b057cc6c873dff910e5d28d8ab3cb8a3692f6e07bc"
+checksum = "cce88ba162aa99d295ac86f5a099b675c121ee71103383a03a857a32ba83456f"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.126.0"
+version = "0.126.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f772c16c9bef156a5716e2c57107e1937743f133793a051f8fe034d4a3a03cb4"
+checksum = "3aa10828d89673612d7c0e6783097df0b5a05ac68b2d7cb150e0a28d16f89b45"
 dependencies = [
  "Inflector",
  "ahash",
@@ -1994,6 +1994,7 @@ dependencies = [
  "is-macro",
  "path-clean",
  "pathdiff",
+ "regex",
  "serde",
  "swc_atoms",
  "swc_cached",
@@ -2051,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.128.0"
+version = "0.128.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ff1847dfceb7944a0227e73b37453d9ddc278f6e70029eafc6c2acfbbacb7d"
+checksum = "95847eb307922d012ed4973912b4baae367344999ba893027cb56eec9814626d"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -2109,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.67.0"
+version = "0.67.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e40517622d404e3f2fdb064d2982d46fee0e2ec097f3cf196fa4d128fb095b"
+checksum = "fa8abef878e395ffc2348cdc885e9a37eab3c082e9fa7a675e9ef17b614f297c"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2173,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c639379dd2a8a0221fa1e12fafbdd594ba53a0cace6560054da52409dfcc1a"
+checksum = "d2ea2fec8c610a61dd33cc03f752d0cdb76d6c000c47478d3221bee409a47627"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -2183,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b9b72892df873972549838bf84d6c56234c7502148a7e23b5a3da6e0fedfb8"
+checksum = "b39199e92e2ab6eed9a7c2f1e76d9a3205479625ea28e7da90958ce1a7bb631b"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbde2726605dc5c72c04483a181595481d6e774b301194163c811eac6ae32df8"
+checksum = "68e76a324fa0d7240e790c78914f39fdecfa9d87ef4efed591124b58607a4a4a"
 dependencies = [
  "ahash",
  "ast_node",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.82.0"
+version = "0.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f998d288db60b25d0ed0f1f54c67946f27632c7b20633db239068c65a50c448f"
+checksum = "cce1fb31e3a100feb31f94647fe27e457bc13b17a8931204fdc9bc58a15c936a"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1791,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.113.0"
+version = "0.115.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299c5fcbe7663905385e03d79e33ddc1959d3ac714fd5025f20ce2a55c0465d0"
+checksum = "d09abf1639f76d3d174225fdb608805f9c21d4c455f4dd2ef6ab156701f1f82a"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1822,9 +1822,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9648733e70fbe72f17762289fa52343b33427502dc9e9801e9321b7cc68ff3"
+checksum = "710c86eb2b253160d4a02fa77057f1c493b3932d1b83430cbbc1e7823eb47e8c"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1841,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.109.1"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f661cb664a13d0a950042c214737e571b0b2565c7b051643581bcf78fa66f551"
+checksum = "cc1766e5b969c59e51a5dfe9337755d7380a891e579dd6b0eb7816587c7ea7aa"
 dependencies = [
  "either",
  "enum_kind",
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.146.0"
+version = "0.149.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76437794374848cad8bf28954797ea46abef173c75fb5e4251f49acfce0cb36e"
+checksum = "d27c37e693b1deda42bc2f70254234d79d2c10797701f261cbb7797b8f37bb2d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1885,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.171.0"
+version = "0.174.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4cb5725bbd8fb666d8b1858bc31bb1c79cfac35042ee5917453af05ddf67fbf"
+checksum = "a30f3386dbaa8490ac3ed65240c057ea3a3b20d37c4dba50c876adce5201f673"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.95.0"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "340cc66985195bf7a4b0c5e1193151fbbfaea48ffbe22412d809893d583a732e"
+checksum = "66b316a99dde0ef85f1878aaa9f4bf9b15f16e999c56ed31a1433928c754ae4e"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1928,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.83.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ce60afed61d333b1fa9c34e13e46f7ecb6b535da30bda1e5f3331c53bfe40f"
+checksum = "c853c4366e81092d38b746e71adffc1150c694f02c1068c9fa24abbdc373a65f"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1942,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.111.1"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ff7f3cdefb01d85a5569eab244be531a2918f53427a7d6f8f8bb885a4c1c4b"
+checksum = "ace2890c492568b47abb6eecbbb2dcb8f2218adcf0d8a3b73d84b88fddc7d87f"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.127.0"
+version = "0.130.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcab1c0663d12006fb3421cc3c4920d03b154db95820bef0deb7c4a052882c4e"
+checksum = "66810e70c1386e75a86a5ecdcfeb2150ec9f7b32a9213beedff60c33a46c7947"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.140.0"
+version = "0.143.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8330e6d824bc3c364a31aae71e777d430436505ecdba04a501e76e7ee52d512c"
+checksum = "a9def3dc7a6afe6b44cacd61c200181507396ee3c21a3751299718fecebce51d"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2033,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.119.0"
+version = "0.122.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76034a0dbb7f17bef08fbf37e67748d84e55645d9ca10a772ea41a31bb0f96bd"
+checksum = "78ebc6e03a51f9adcbc40ec144c9bbe78de872bf6f8f581f3abd51187ec6e648"
 dependencies = [
  "either",
  "serde",
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.129.0"
+version = "0.132.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc58381a372604a1f0535515af81883060f7b32667c53645f3424ca06ba97a4"
+checksum = "438ffd11b17c3c6565e44a9a0d596687459de9f13b9ea302f5baf8e20c07a860"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -2078,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.133.0"
+version = "0.136.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3fce16ff57e8056940011a0a5b4891d6e6a9584f8260228addbaf2e353501de"
+checksum = "8d8c061e8ad8a3f47e9d49f85cea3ab1edca0a6585354ea23923d18e75368eb4"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.91.0"
+version = "0.93.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8decd530962326caffef0071fbe2d8ab1a75bf737ca814b8e2e9d01a68924a89"
+checksum = "70981d5ef10c0ff0a002e21decbca9dde5b40c2fc0d0bc6eaebb219a8e0a5f7d"
 dependencies = [
  "indexmap",
  "once_cell",
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfee2460244b220be0a9cbc68390d3bce128759aec4ed8d19cef400a8d66b727"
+checksum = "fcd081250d664808fcd23110202728811236c87f527656ffc1db7f00ac1a06dd"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2124,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.176.0"
+version = "0.179.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34be3336ff87a24fab05fb634f65a5126aba8a450ac47aac563d754295842e47"
+checksum = "44e4fa994e933838459cfbfce2913f34b054ff3ecc4988e6f1eb993d7bb1a7ef"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2174,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea2fec8c610a61dd33cc03f752d0cdb76d6c000c47478d3221bee409a47627"
+checksum = "fafa6c946bdbe601f5511140776d59e82a03f52a5e5039192b4b96f3ca639d88"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39199e92e2ab6eed9a7c2f1e76d9a3205479625ea28e7da90958ce1a7bb631b"
+checksum = "cad1b8e0b2d48660bc454f70495e9bb583f9bf501f28165568569946e62f44a2"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -2198,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.164.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.18.9", features = ["tty-emitter", "sourcemap"] }
-swc_atoms = "0.2.12"
+swc_ecmascript = { version = "0.175.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.20.1", features = ["tty-emitter", "sourcemap"] }
+swc_atoms = "0.2.13"
 indoc = "1.0.3"
 serde = "1.0.123"
 serde_bytes = "0.11.5"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.176.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.21.0", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.179.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.23.0", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.13"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.175.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.20.2", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.176.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.21.0", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.13"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 swc_ecmascript = { version = "0.175.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.20.1", features = ["tty-emitter", "sourcemap"] }
+swc_common = { version = "0.20.2", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.2.13"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -288,7 +288,7 @@ impl<'a> Fold for DependencyCollector<'a> {
     );
 
     if let Some(rewritten) = rewritten {
-      node.src.value = rewritten.into();
+      node.src.value = rewritten;
     }
 
     node
@@ -310,7 +310,7 @@ impl<'a> Fold for DependencyCollector<'a> {
       );
 
       if let Some(rewritten) = rewritten {
-        src.value = rewritten.into();
+        src.value = rewritten;
       }
     }
 
@@ -328,7 +328,7 @@ impl<'a> Fold for DependencyCollector<'a> {
     );
 
     if let Some(rewritten) = rewritten {
-      node.src.value = rewritten.into();
+      node.src.value = rewritten;
     }
 
     node
@@ -495,7 +495,7 @@ impl<'a> Fold for DependencyCollector<'a> {
                     if match_member_expr(m, vec!["Promise", "resolve"], self.decls) &&
                       // Make sure the arglist is empty.
                       // I.e. do not proceed with the below unless Promise.resolve has an empty arglist
-                      // because build_promise_chain() will not work in this case.                   
+                      // because build_promise_chain() will not work in this case.
                       call.args.is_empty()
                     {
                       if let MemberProp::Ident(id) = &member.prop {

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -2211,11 +2211,7 @@ mod tests {
     }
   }
 
-  fn emit(
-    source_map: Lrc<SourceMap>,
-    comments: SingleThreadedComments,
-    program: &Module,
-  ) -> String {
+  fn emit(source_map: Lrc<SourceMap>, comments: SingleThreadedComments, module: &Module) -> String {
     let mut src_map_buf = vec![];
     let mut buf = vec![];
     {
@@ -2237,7 +2233,7 @@ mod tests {
         wr: writer,
       };
 
-      emitter.emit_module(program).unwrap();
+      emitter.emit_module(module).unwrap();
     }
 
     String::from_utf8(buf).unwrap()

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -379,6 +379,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                       Some(&comments),
                       preset_env_config,
                       Default::default(),
+                      &mut Default::default(),
                     ),
                     should_run_preset_env,
                   ),

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use swc_common::comments::SingleThreadedComments;
 use swc_common::errors::{DiagnosticBuilder, Emitter, Handler};
 use swc_common::{chain, sync::Lrc, FileName, Globals, Mark, SourceMap};
-use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::{Module, ModuleItem, Program};
 use swc_ecmascript::codegen::text_writer::JsWriter;
 use swc_ecmascript::parser::lexer::Lexer;
 use swc_ecmascript::parser::{EsConfig, PResult, Parser, StringInput, Syntax, TsConfig};
@@ -174,12 +174,9 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
     }
     Ok((module, comments)) => {
       let mut module = module;
-      result.shebang = match module.shebang {
-        Some(shebang) => {
-          module.shebang = None;
-          Some(shebang.to_string())
-        }
-        None => None,
+      result.shebang = match &mut module {
+        Program::Module(module) => module.shebang.take().map(|s| s.to_string()),
+        Program::Script(script) => script.shebang.take().map(|s| s.to_string()),
       };
 
       let mut global_deps = vec![];
@@ -229,49 +226,57 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
 
               let global_mark = Mark::fresh(Mark::root());
               let unresolved_mark = Mark::fresh(Mark::root());
-              module = {
-                let mut passes = chain!(
-                  // Decorators can use type information, so must run before the TypeScript pass.
-                  Optional::new(
-                    decorators::decorators(decorators::Config {
-                      legacy: true,
-                      use_define_for_class_fields: config.use_define_for_class_fields,
-                      // Always disabled for now, SWC's implementation doesn't match TSC.
-                      emit_metadata: false,
-                    }),
-                    config.decorators
+              let module = module.fold_with(&mut chain!(
+                // Decorators can use type information, so must run before the TypeScript pass.
+                Optional::new(
+                  decorators::decorators(decorators::Config {
+                    legacy: true,
+                    use_define_for_class_fields: config.use_define_for_class_fields,
+                    // Always disabled for now, SWC's implementation doesn't match TSC.
+                    emit_metadata: false,
+                  }),
+                  config.decorators
+                ),
+                Optional::new(
+                  typescript::strip_with_jsx(
+                    source_map.clone(),
+                    typescript::Config {
+                      pragma: react_options.pragma.clone(),
+                      pragma_frag: react_options.pragma_frag.clone(),
+                      ..Default::default()
+                    },
+                    Some(&comments),
+                    global_mark,
                   ),
-                  Optional::new(
-                    typescript::strip_with_jsx(
-                      source_map.clone(),
-                      typescript::Config {
-                        pragma: react_options.pragma.clone(),
-                        pragma_frag: react_options.pragma_frag.clone(),
-                        ..Default::default()
-                      },
-                      Some(&comments),
-                      global_mark,
-                    ),
-                    config.is_type_script && config.is_jsx
-                  ),
-                  Optional::new(
-                    typescript::strip(global_mark),
-                    config.is_type_script && !config.is_jsx
-                  ),
-                  resolver(unresolved_mark, global_mark, config.is_type_script),
-                  Optional::new(
-                    react::react(
-                      source_map.clone(),
-                      Some(&comments),
-                      react_options,
-                      global_mark
-                    ),
-                    config.is_jsx
-                  ),
-                );
+                  config.is_type_script && config.is_jsx
+                ),
+                Optional::new(
+                  typescript::strip(global_mark),
+                  config.is_type_script && !config.is_jsx
+                ),
+                resolver(unresolved_mark, global_mark, config.is_type_script),
+              ));
 
-                module.fold_with(&mut passes)
+              // If it's a script, convert into module. This needs to happen after
+              // the resolver (which behaves differently for non-/strict mode).
+              let module = match module {
+                Program::Module(module) => module,
+                Program::Script(script) => Module {
+                  span: script.span,
+                  shebang: None,
+                  body: script.body.into_iter().map(ModuleItem::Stmt).collect(),
+                },
               };
+
+              let module = module.fold_with(&mut Optional::new(
+                react::react(
+                  source_map.clone(),
+                  Some(&comments),
+                  react_options,
+                  global_mark,
+                ),
+                config.is_jsx,
+              ));
 
               let mut decls = collect_decls(&module);
 
@@ -505,7 +510,7 @@ fn parse(
   filename: &str,
   source_map: &Lrc<SourceMap>,
   config: &Config,
-) -> PResult<(Module, SingleThreadedComments)> {
+) -> PResult<(Program, SingleThreadedComments)> {
   // Attempt to convert the path to be relative to the project root.
   // If outside the project root, use an absolute path so that if the project root moves the path still works.
   let filename: PathBuf = if let Ok(relative) = Path::new(filename).strip_prefix(project_root) {
@@ -539,7 +544,7 @@ fn parse(
   );
 
   let mut parser = Parser::new_from(lexer);
-  match parser.parse_module() {
+  match parser.parse_program() {
     Err(err) => Err(err),
     Ok(module) => Ok((module, comments)),
   }
@@ -548,7 +553,7 @@ fn parse(
 fn emit(
   source_map: Lrc<SourceMap>,
   comments: SingleThreadedComments,
-  program: &Module,
+  module: &Module,
   source_maps: bool,
 ) -> Result<(Vec<u8>, SourceMapBuffer), std::io::Error> {
   let mut src_map_buf = vec![];
@@ -576,7 +581,7 @@ fn emit(
       wr: writer,
     };
 
-    emitter.emit_module(program)?;
+    emitter.emit_module(module)?;
   }
 
   Ok((buf, src_map_buf))

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -100,7 +100,7 @@ impl<'a> Fold for NodeReplacer<'a> {
               }))),
             })
           };
-          if self.update_binding(id, expr) {
+          if self.update_binding(id, "__parcel_filename".into(), expr) {
             self.items.push(DependencyDescriptor {
               kind: DependencyKind::Require,
               loc: SourceLocation::from(self.source_map, id.span),
@@ -119,7 +119,7 @@ impl<'a> Fold for NodeReplacer<'a> {
           let specifier = swc_atoms::JsWord::from("path");
           let replace_me_value = swc_atoms::JsWord::from("$parcel$dirnameReplace");
 
-          if self.update_binding(id, |_| {
+          if self.update_binding(id, "__parcel_dirname".into(), |_| {
             ast::Expr::Call(ast::CallExpr {
               span: DUMMY_SP,
               type_args: None,
@@ -184,20 +184,22 @@ impl<'a> Fold for NodeReplacer<'a> {
 }
 
 impl NodeReplacer<'_> {
-  fn update_binding<F>(&mut self, id: &mut ast::Ident, expr: F) -> bool
+  fn update_binding<F>(&mut self, id_ref: &mut ast::Ident, new_name: JsWord, expr: F) -> bool
   where
     F: FnOnce(&Self) -> ast::Expr,
   {
-    if let Some((ctxt, _)) = self.globals.get(&id.sym) {
-      id.span.ctxt = *ctxt;
+    if let Some((ctxt, _)) = self.globals.get(&new_name) {
+      id_ref.sym = new_name;
+      id_ref.span.ctxt = *ctxt;
       false
     } else {
-      let (decl, ctxt) = create_global_decl_stmt(id.sym.clone(), expr(self), self.global_mark);
+      id_ref.sym = new_name;
 
-      id.span.ctxt = ctxt;
+      let (decl, ctxt) = create_global_decl_stmt(id_ref.sym.clone(), expr(self), self.global_mark);
+      id_ref.span.ctxt = ctxt;
 
-      self.globals.insert(id.sym.clone(), (ctxt, decl));
-      self.decls.insert(id.to_id());
+      self.globals.insert(id_ref.sym.clone(), (ctxt, decl));
+      self.decls.insert(id_ref.to_id());
 
       true
     }

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -100,7 +100,7 @@ impl<'a> Fold for NodeReplacer<'a> {
               }))),
             })
           };
-          if self.update_binding(id, "__parcel_filename".into(), expr) {
+          if self.update_binding(id, "$parcel$__filename".into(), expr) {
             self.items.push(DependencyDescriptor {
               kind: DependencyKind::Require,
               loc: SourceLocation::from(self.source_map, id.span),
@@ -119,7 +119,7 @@ impl<'a> Fold for NodeReplacer<'a> {
           let specifier = swc_atoms::JsWord::from("path");
           let replace_me_value = swc_atoms::JsWord::from("$parcel$dirnameReplace");
 
-          if self.update_binding(id, "__parcel_dirname".into(), |_| {
+          if self.update_binding(id, "$parcel$__dirname".into(), |_| {
             ast::Expr::Call(ast::CallExpr {
               span: DUMMY_SP,
               type_args: None,


### PR DESCRIPTION
Fixes https://github.com/parcel-bundler/parcel/issues/8277
Fixes https://github.com/parcel-bundler/parcel/issues/8281

- [x] Something is broken once again with the inserted `var __dirname` declarations...
The problem here was that we generated `var __dirname = require("path").resolve(__dirname, "../src");`, which only worked by coincidence when swc renamed it to `var __dirname1 = ...`. But after the upgrade, it wasn't renamed anymore. I've changed it to use new variables instead (and then also rename all id references to that):
```js
// inserted by Parcel:
var $parcel$__dirname = require("path").resolve(__dirname, "../src");
var $parcel$__filename = require("path").resolve(__dirname, "../src", "index.js");
// source with renamed ids:
const fs = require("fs");
const path = require("path");
const firstDirnameTest = path.join($parcel$__dirname, "data");
const secondDirnameTest = path.join($parcel$__dirname, "other-data");
const firstFilenameTest = $parcel$__filename;
const secondFilenameTest = `${$parcel$__filename}?query-string=test`;
```

- [x] swc's resolver now takes into account module/script mode (strict/nonstrict). So 
```js
console.log(typeof bar, typeof baz);
if (true) {
  console.log(typeof bar, typeof baz);
  function bar() {}
  class Test {}
}
console.log(typeof bar, typeof baz);

class Foo {}
function baz() {}

console.log(typeof bar)
```
will be parsed as this in module mode (what we did so far):
```js
console.log(typeof bar, typeof baz);
if (true) {
    console.log(typeof bar1, typeof baz);
    function bar1() {}
    class Test {
    }
}
console.log(typeof bar, typeof baz);
class Foo {
}
function baz() {}
```
using a script, it behaves as it did before bumping
Solution: parse as program (automatically detect script/module), and convert to module after resolving (so that the other passes can insert import statements)