### PR TITLE
Don't store dependencies in asset nodes

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -284,7 +284,7 @@ export default class Parcel {
         changedAssets: new Map(
           Array.from(changedAssets).map(([id, asset]) => [
             id,
-            assetFromValue(asset, options),
+            assetFromValue(asset, bundleGraph, options),
           ]),
         ),
         bundleGraph: new BundleGraph<IPackagedBundle>(

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -207,6 +207,7 @@ export default class Validation {
         },
         sideEffects: sideEffects,
       }),
+      dependencyValues: [],
       options: this.options,
       content,
     });

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -15,7 +15,6 @@ import type {
 import type {
   Asset,
   RequestInvalidation,
-  Dependency,
   Environment,
   ParcelOptions,
 } from './types';
@@ -39,7 +38,7 @@ import {
 import {hashString} from '@parcel/hash';
 import {BundleBehavior as BundleBehaviorMap} from './types';
 
-type AssetOptions = {|
+export type AssetOptions = {|
   id?: string,
   committed?: boolean,
   hash?: ?string,
@@ -51,7 +50,7 @@ type AssetOptions = {|
   mapKey?: ?string,
   astKey?: ?string,
   astGenerator?: ?ASTGenerator,
-  dependencies?: Map<string, Dependency>,
+  dependencies?: Array<string>,
   bundleBehavior?: ?BundleBehavior,
   isBundleSplittable?: ?boolean,
   isSource: boolean,
@@ -106,7 +105,7 @@ export function createAsset(
     mapKey: options.mapKey,
     astKey: options.astKey,
     astGenerator: options.astGenerator,
-    dependencies: options.dependencies || new Map(),
+    dependencies: options.dependencies || [],
     isSource: options.isSource,
     outputHash: options.outputHash,
     pipeline: options.pipeline,

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -22,7 +22,9 @@ import type {
   BundleBehavior,
 } from '@parcel/types';
 import type {Asset as AssetValue, ParcelOptions} from '../types';
+import type InternalBundleGraph from '../BundleGraph';
 
+import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import Environment from './Environment';
 import Dependency from './Dependency';
@@ -66,13 +68,21 @@ export function mutableAssetToUncommittedAsset(
 
 export function assetFromValue(
   value: AssetValue,
+  graph: InternalBundleGraph,
   options: ParcelOptions,
 ): Asset {
   return new Asset(
     value.committed
-      ? new CommittedAsset(value, options)
+      ? new CommittedAsset(value, graph, options)
       : new UncommittedAsset({
           value,
+          dependencyValues: value.dependencies.map(id => {
+            let dep = nullthrows(
+              this.bundleGraph._graph.getNodeByContentKey(id),
+            );
+            invariant(dep.type === 'dependency');
+            return dep.value;
+          }),
           options,
         }),
   );

--- a/packages/core/core/src/public/Bundle.js
+++ b/packages/core/core/src/public/Bundle.js
@@ -151,7 +151,7 @@ export class Bundle implements IBundle {
     return this.#bundle.entryAssetIds.map(id => {
       let assetNode = this.#bundleGraph._graph.getNodeByContentKey(id);
       invariant(assetNode != null && assetNode.type === 'asset');
-      return assetFromValue(assetNode.value, this.#options);
+      return assetFromValue(assetNode.value, this.#bundleGraph, this.#options);
     });
   }
 
@@ -161,7 +161,7 @@ export class Bundle implements IBundle {
         this.#bundle.mainEntryId,
       );
       invariant(assetNode != null && assetNode.type === 'asset');
-      return assetFromValue(assetNode.value, this.#options);
+      return assetFromValue(assetNode.value, this.#bundleGraph, this.#options);
     }
   }
 
@@ -174,7 +174,7 @@ export class Bundle implements IBundle {
         if (node.type === 'asset') {
           return {
             type: 'asset',
-            value: assetFromValue(node.value, this.#options),
+            value: assetFromValue(node.value, this.#bundleGraph, this.#options),
           };
         } else if (node.type === 'dependency') {
           return {
@@ -192,7 +192,10 @@ export class Bundle implements IBundle {
   ): ?TContext {
     return this.#bundleGraph.traverseAssets(
       this.#bundle,
-      mapVisitor(asset => assetFromValue(asset, this.#options), visit),
+      mapVisitor(
+        asset => assetFromValue(asset, this.#bundleGraph, this.#options),
+        visit,
+      ),
       startAsset ? assetToAssetValue(startAsset) : undefined,
     );
   }

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -66,7 +66,11 @@ export default class BundleGraph<TBundle: IBundle>
   }
 
   getAssetById(id: string): Asset {
-    return assetFromValue(this.#graph.getAssetById(id), this.#options);
+    return assetFromValue(
+      this.#graph.getAssetById(id),
+      this.#graph,
+      this.#options,
+    );
   }
 
   getAssetPublicId(asset: IAsset): string {
@@ -83,7 +87,7 @@ export default class BundleGraph<TBundle: IBundle>
       bundle && bundleToInternalBundle(bundle),
     );
     if (resolution) {
-      return assetFromValue(resolution, this.#options);
+      return assetFromValue(resolution, this.#graph, this.#options);
     }
   }
 
@@ -98,7 +102,7 @@ export default class BundleGraph<TBundle: IBundle>
       dependencyToInternalDependency(dep),
     );
     if (asset) {
-      return assetFromValue(asset, this.#options);
+      return assetFromValue(asset, this.#graph, this.#options);
     }
   }
 
@@ -140,7 +144,7 @@ export default class BundleGraph<TBundle: IBundle>
 
     return {
       type: 'asset',
-      value: assetFromValue(resolved.value, this.#options),
+      value: assetFromValue(resolved.value, this.#graph, this.#options),
     };
   }
 
@@ -229,7 +233,7 @@ export default class BundleGraph<TBundle: IBundle>
       boundary ? bundleToInternalBundle(boundary) : null,
     );
     return {
-      asset: assetFromValue(res.asset, this.#options),
+      asset: assetFromValue(res.asset, this.#graph, this.#options),
       exportSymbol: res.exportSymbol,
       symbol: res.symbol,
       loc: fromInternalSourceLocation(this.#options.projectRoot, res.loc),
@@ -245,7 +249,7 @@ export default class BundleGraph<TBundle: IBundle>
       boundary ? bundleToInternalBundle(boundary) : null,
     );
     return res.map(e => ({
-      asset: assetFromValue(e.asset, this.#options),
+      asset: assetFromValue(e.asset, this.#graph, this.#options),
       exportSymbol: e.exportSymbol,
       symbol: e.symbol,
       loc: fromInternalSourceLocation(this.#options.projectRoot, e.loc),
@@ -261,7 +265,10 @@ export default class BundleGraph<TBundle: IBundle>
       mapVisitor(
         node =>
           node.type === 'asset'
-            ? {type: 'asset', value: assetFromValue(node.value, this.#options)}
+            ? {
+                type: 'asset',
+                value: assetFromValue(node.value, this.#graph, this.#options),
+              }
             : {
                 type: 'dependency',
                 value: new Dependency(node.value, this.#options),

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -268,7 +268,7 @@ export default class MutableBundleGraph
   getDependencyAssets(dependency: IDependency): Array<IAsset> {
     return this.#graph
       .getDependencyAssets(dependencyToInternalDependency(dependency))
-      .map(asset => assetFromValue(asset, this.#options));
+      .map(asset => assetFromValue(asset, this.#graph, this.#options));
   }
 
   getBundleGroupsContainingBundle(bundle: IBundle): Array<IBundleGroup> {

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -868,13 +868,13 @@ export class AssetGraphBuilder {
       name: this.name,
       optionsRef: this.optionsRef,
     });
-    let assets = await this.api.runRequest<AssetRequestInput, Array<Asset>>(
-      request,
-      {force: true},
-    );
+    let assets = await this.api.runRequest<
+      AssetRequestInput,
+      Array<{|asset: Asset, deps: Array<Dependency>|}>,
+    >(request, {force: true});
 
     if (assets != null) {
-      for (let asset of assets) {
+      for (let {asset} of assets) {
         this.changedAssets.set(asset.id, asset);
       }
       this.assetGraph.resolveAssetGroup(input, assets, request.id);

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -141,7 +141,7 @@ async function run({input, api, farm, invalidateReason, options}: RunInput) {
 
   let time = Date.now() - start;
   if (assets) {
-    for (let asset of assets) {
+    for (let {asset} of assets) {
       asset.stats.time = time;
     }
   }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -159,7 +159,7 @@ export type Asset = {|
   filePath: ProjectPath,
   query: ?string,
   type: string,
-  dependencies: Map<string, Dependency>,
+  dependencies: Array<ContentKey>,
   bundleBehavior: ?$Values<typeof BundleBehavior>,
   isBundleSplittable: boolean,
   isSource: boolean,
@@ -334,7 +334,10 @@ export type AssetRequestInput = {|
   query?: ?string,
 |};
 
-export type AssetRequestResult = Array<Asset>;
+export type AssetRequestResult = Array<{|
+  asset: Asset,
+  deps: Array<Dependency>,
+|}>;
 // Asset group nodes are essentially used as placeholders for the results of an asset request
 export type AssetGroup = $Rest<
   AssetRequestInput,

--- a/packages/core/core/test/BundleGraph.test.js
+++ b/packages/core/core/test/BundleGraph.test.js
@@ -1,5 +1,7 @@
 // @flow strict-local
 
+import type {AssetOptions} from '../src/assetUtils';
+
 import assert from 'assert';
 import BundleGraph from '../src/BundleGraph';
 import {DEFAULT_ENV, DEFAULT_TARGETS} from './test-utils';
@@ -8,7 +10,7 @@ import {createAsset as _createAsset} from '../src/assetUtils';
 import {createDependency as _createDependency} from '../src/Dependency';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
@@ -94,26 +96,32 @@ function createMockAssetGraph(ids: [string, string]) {
   });
 
   let assets = [
-    createAsset({
-      id: ids[0],
-      filePath,
-      type: 'js',
-      isSource: true,
-      hash: '#1',
-      stats,
-      dependencies: new Map([['dep1', dep1]]),
-      env: DEFAULT_ENV,
-    }),
-    createAsset({
-      id: ids[1],
-      filePath,
-      type: 'js',
-      isSource: true,
-      hash: '#2',
-      stats,
-      dependencies: new Map([['dep1', dep1]]),
-      env: DEFAULT_ENV,
-    }),
+    {
+      asset: createAsset({
+        id: ids[0],
+        filePath,
+        type: 'js',
+        isSource: true,
+        hash: '#1',
+        stats,
+        dependencies: [dep1.id],
+        env: DEFAULT_ENV,
+      }),
+      deps: [dep1],
+    },
+    {
+      asset: createAsset({
+        id: ids[1],
+        filePath,
+        type: 'js',
+        isSource: true,
+        hash: '#2',
+        stats,
+        dependencies: [dep1.id],
+        env: DEFAULT_ENV,
+      }),
+      deps: [dep1],
+    },
   ];
   graph.resolveAssetGroup(req, assets, '4');
 

--- a/packages/core/core/test/InternalAsset.test.js
+++ b/packages/core/core/test/InternalAsset.test.js
@@ -23,6 +23,7 @@ describe('InternalAsset', () => {
         type: 'js',
         isSource: true,
       }),
+      dependencyValues: [],
       options: DEFAULT_OPTIONS,
     });
     asset.invalidateOnFileChange(toProjectPath('/', '/foo/file'));
@@ -44,6 +45,7 @@ describe('InternalAsset', () => {
         type: 'js',
         isSource: true,
       }),
+      dependencyValues: [],
       options: DEFAULT_OPTIONS,
     });
 
@@ -63,6 +65,7 @@ describe('InternalAsset', () => {
         type: 'js',
         isSource: true,
       }),
+      dependencyValues: [],
       options: DEFAULT_OPTIONS,
     });
 

--- a/packages/core/core/test/PublicAsset.test.js
+++ b/packages/core/core/test/PublicAsset.test.js
@@ -17,6 +17,7 @@ describe('Public Asset', () => {
   beforeEach(() => {
     internalAsset = new UncommittedAsset({
       options: DEFAULT_OPTIONS,
+      dependencyValues: [],
       value: createAsset({
         filePath: toProjectPath('/', '/does/not/exist'),
         type: 'js',

--- a/packages/core/core/test/PublicMutableBundleGraph.test.js
+++ b/packages/core/core/test/PublicMutableBundleGraph.test.js
@@ -156,15 +156,18 @@ function createMockAssetGraph() {
   graph.resolveAssetGroup(
     req1,
     [
-      createAsset({
-        id: id1,
-        filePath,
-        type: 'js',
-        isSource: true,
-        hash: '#1',
-        stats,
-        env: DEFAULT_ENV,
-      }),
+      {
+        asset: createAsset({
+          id: id1,
+          filePath,
+          type: 'js',
+          isSource: true,
+          hash: '#1',
+          stats,
+          env: DEFAULT_ENV,
+        }),
+        deps: [],
+      },
     ],
     '6',
   );
@@ -175,15 +178,18 @@ function createMockAssetGraph() {
   graph.resolveAssetGroup(
     req2,
     [
-      createAsset({
-        id: id2,
-        filePath,
-        type: 'js',
-        isSource: true,
-        hash: '#2',
-        stats,
-        env: DEFAULT_ENV,
-      }),
+      {
+        asset: createAsset({
+          id: id2,
+          filePath,
+          type: 'js',
+          isSource: true,
+          hash: '#2',
+          stats,
+          env: DEFAULT_ENV,
+        }),
+        deps: [],
+      },
     ],
     '8',
   );


### PR DESCRIPTION
Now `Asset.dependencies` is just a list of node ids (so only use to retain order, and the dependency values themselves are retrieved from the child nodes in the graph).

Turns out this doesn't have any effect right now (neither performance nor cache size) because the v8 serializer deduplicates `Asset.dependencies.values()` with the `value` inside the dependency nodes anyway.

But this would be needed if we want to moves node values to some other representation (to be more compact and easier to share across threads).