### PR TITLE
Dedupe unhoisted node_modules using package-based hashing

### DIFF
--- a/packages/core/core/src/UncommittedAsset.js
+++ b/packages/core/core/src/UncommittedAsset.js
@@ -38,6 +38,7 @@ import {
   createAssetIdFromOptions,
   getInvalidationId,
   getInvalidationHash,
+  generateIdBase,
 } from './assetUtils';
 import {BundleBehaviorNames} from './types';
 import {invalidateOnFileCreateToInternal} from './utils';
@@ -50,7 +51,7 @@ type UncommittedAssetOptions = {|
   mapBuffer?: ?Buffer,
   ast?: ?AST,
   isASTDirty?: ?boolean,
-  idBase?: ?string,
+  idBase: string,
   invalidations?: Map<string, RequestInvalidation>,
   fileCreateInvalidations?: Array<InternalFileCreateInvalidation>,
 |};
@@ -64,7 +65,7 @@ export default class UncommittedAsset {
   map: ?SourceMap;
   ast: ?AST;
   isASTDirty: boolean;
-  idBase: ?string;
+  idBase: string;
   invalidations: Map<string, RequestInvalidation>;
   fileCreateInvalidations: Array<InternalFileCreateInvalidation>;
   generate: ?() => Promise<GenerateOutput>;
@@ -379,6 +380,7 @@ export default class UncommittedAsset {
     let asset = new UncommittedAsset({
       value: createAsset(this.options.projectRoot, {
         idBase: this.idBase,
+        virtual: this.value.virtual,
         hash: this.value.hash,
         filePath: this.value.filePath,
         type: result.type,
@@ -390,6 +392,7 @@ export default class UncommittedAsset {
         isBundleSplittable:
           result.isBundleSplittable ?? this.value.isBundleSplittable,
         isSource: this.value.isSource,
+        key: this.value.key,
         env: mergeEnvironments(
           this.options.projectRoot,
           this.value.env,
@@ -442,7 +445,24 @@ export default class UncommittedAsset {
   }
 
   updateId() {
-    // $FlowFixMe - this is fine
-    this.value.id = createAssetIdFromOptions(this.value);
+    this.value.id = createAssetIdFromOptions({
+      idBase: generateIdBase({
+        filePath: this.value.filePath,
+        hash: this.value.hash,
+        isSource: this.value.isSource,
+        key: this.value.key,
+        virtual: this.value.virtual,
+      }),
+      filePath: this.value.filePath,
+      type: this.value.type,
+      hash: this.value.hash,
+      isSource: this.value.isSource,
+      key: this.value.key,
+      stats: this.value.stats,
+      env: this.value.env,
+      uniqueKey: this.value.uniqueKey,
+      pipeline: this.value.pipeline,
+      query: this.value.query,
+    });
   }
 }

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -36,6 +36,7 @@ import {
   BundleBehaviorNames,
 } from '../types';
 import {toInternalSourceLocation} from '../utils';
+import {generateIdBase} from '../assetUtils';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
@@ -72,6 +73,13 @@ export function assetFromValue(
     value.committed
       ? new CommittedAsset(value, options)
       : new UncommittedAsset({
+          idBase: generateIdBase({
+            virtual: value.virtual,
+            filePath: value.filePath,
+            hash: value.hash,
+            isSource: value.isSource,
+            key: value.key,
+          }),
           value,
           options,
         }),

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -261,6 +261,7 @@ export class ResolverRunner {
                     ? pipeline ?? dependency.pipeline
                     : result.pipeline,
                 isURL: dep.specifierType === 'url',
+                key: result.key,
               },
               invalidateOnFileCreate,
               invalidateOnFileChange,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -155,13 +155,16 @@ export const BundleBehaviorNames: Array<$Keys<typeof BundleBehavior>> =
 export type Asset = {|
   id: ContentKey,
   committed: boolean,
-  hash: ?string,
+  // the asset's code was returned by a resolver and not loaded from disk
+  virtual: boolean,
+  hash: string,
   filePath: ProjectPath,
   query: ?string,
   type: string,
   dependencies: Map<string, Dependency>,
   bundleBehavior: ?$Values<typeof BundleBehavior>,
   isBundleSplittable: boolean,
+  key: ?string,
   isSource: boolean,
   env: Environment,
   meta: Meta,
@@ -332,6 +335,7 @@ export type AssetRequestInput = {|
   optionsRef: SharedReference,
   isURL?: boolean,
   query?: ?string,
+  key?: ?string,
 |};
 
 export type AssetRequestResult = Array<Asset>;

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -1,4 +1,6 @@
 // @flow strict-local
+import type {AssetOptions} from '../src/assetUtils';
+
 import assert from 'assert';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -15,7 +17,7 @@ import {toProjectPath as _toProjectPath} from '../src/projectPath';
 
 const stats = {size: 0, time: 0};
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
@@ -321,6 +323,7 @@ describe('AssetGraph', () => {
     graph.resolveDependency(dep, req, '3');
     let assets = [
       createAsset({
+        idBase: '',
         id: '1',
         filePath,
         type: 'js',
@@ -341,6 +344,7 @@ describe('AssetGraph', () => {
         env: DEFAULT_ENV,
       }),
       createAsset({
+        idBase: '',
         id: '2',
         filePath,
         type: 'js',
@@ -361,6 +365,7 @@ describe('AssetGraph', () => {
         env: DEFAULT_ENV,
       }),
       createAsset({
+        idBase: '',
         id: '3',
         filePath,
         type: 'js',
@@ -402,6 +407,7 @@ describe('AssetGraph', () => {
 
     let assets2 = [
       createAsset({
+        idBase: '',
         id: '1',
         filePath,
         type: 'js',
@@ -422,6 +428,7 @@ describe('AssetGraph', () => {
         env: DEFAULT_ENV,
       }),
       createAsset({
+        idBase: '',
         id: '2',
         filePath,
         type: 'js',
@@ -500,6 +507,7 @@ describe('AssetGraph', () => {
     });
     let assets = [
       createAsset({
+        idBase: '',
         id: '1',
         filePath,
         type: 'js',
@@ -510,6 +518,7 @@ describe('AssetGraph', () => {
         env: DEFAULT_ENV,
       }),
       createAsset({
+        idBase: '',
         id: '2',
         uniqueKey: 'dependent-asset-1',
         filePath,
@@ -521,6 +530,7 @@ describe('AssetGraph', () => {
         env: DEFAULT_ENV,
       }),
       createAsset({
+        idBase: '',
         id: '3',
         uniqueKey: 'dependent-asset-2',
         filePath,
@@ -579,6 +589,7 @@ describe('AssetGraph', () => {
       sourcePath: '/index.js',
     });
     let indexAsset = createAsset({
+      idBase: '',
       id: 'assetIndex',
       filePath: toProjectPath('/index.js'),
       type: 'js',
@@ -608,6 +619,7 @@ describe('AssetGraph', () => {
     });
     let fooUtilsDepNode = nodeFromDep(fooUtilsDep);
     let fooAsset = createAsset({
+      idBase: '',
       id: 'assetFoo',
       filePath: toProjectPath('/foo.js'),
       type: 'js',
@@ -651,6 +663,7 @@ describe('AssetGraph', () => {
       sourcePath: '/bar.js',
     });
     let barAsset = createAsset({
+      idBase: '',
       id: 'assetBar',
       filePath: toProjectPath('/bar.js'),
       type: 'js',

--- a/packages/core/core/test/BundleGraph.test.js
+++ b/packages/core/core/test/BundleGraph.test.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+import type {AssetOptions} from '../src/assetUtils';
 
 import assert from 'assert';
 import BundleGraph from '../src/BundleGraph';
@@ -8,7 +9,7 @@ import {createAsset as _createAsset} from '../src/assetUtils';
 import {createDependency as _createDependency} from '../src/Dependency';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
@@ -95,6 +96,7 @@ function createMockAssetGraph(ids: [string, string]) {
 
   let assets = [
     createAsset({
+      idBase: ids[0],
       id: ids[0],
       filePath,
       type: 'js',
@@ -105,6 +107,7 @@ function createMockAssetGraph(ids: [string, string]) {
       env: DEFAULT_ENV,
     }),
     createAsset({
+      idBase: ids[1],
       id: ids[1],
       filePath,
       type: 'js',

--- a/packages/core/core/test/InternalAsset.test.js
+++ b/packages/core/core/test/InternalAsset.test.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+import type {AssetOptions} from '../src/assetUtils';
 
 import assert from 'assert';
 import UncommittedAsset from '../src/UncommittedAsset';
@@ -7,7 +8,7 @@ import {createEnvironment} from '../src/Environment';
 import {DEFAULT_OPTIONS} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
@@ -16,8 +17,11 @@ const stats = {time: 0, size: 0};
 describe('InternalAsset', () => {
   it('only includes connected files once per filePath', () => {
     let asset = new UncommittedAsset({
+      idBase: '',
       value: createAsset({
+        idBase: '',
         filePath: toProjectPath('/', '/foo/asset.js'),
+        hash: '',
         env: createEnvironment(),
         stats,
         type: 'js',
@@ -37,8 +41,11 @@ describe('InternalAsset', () => {
 
   it('only includes dependencies once per id', () => {
     let asset = new UncommittedAsset({
+      idBase: '',
       value: createAsset({
+        idBase: '',
         filePath: toProjectPath('/', '/foo/asset.js'),
+        hash: '',
         env: createEnvironment(),
         stats,
         type: 'js',
@@ -56,8 +63,11 @@ describe('InternalAsset', () => {
 
   it('includes different dependencies if their id differs', () => {
     let asset = new UncommittedAsset({
+      idBase: '',
       value: createAsset({
+        idBase: '',
         filePath: toProjectPath('/', '/foo/asset.js'),
+        hash: '',
         env: createEnvironment(),
         stats,
         type: 'js',

--- a/packages/core/core/test/PublicAsset.test.js
+++ b/packages/core/core/test/PublicAsset.test.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+import type {AssetOptions} from '../src/assetUtils';
 
 import assert from 'assert';
 import {Asset, MutableAsset} from '../src/public/Asset';
@@ -8,7 +9,7 @@ import {createEnvironment} from '../src/Environment';
 import {DEFAULT_OPTIONS} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
@@ -16,9 +17,12 @@ describe('Public Asset', () => {
   let internalAsset;
   beforeEach(() => {
     internalAsset = new UncommittedAsset({
+      idBase: '',
       options: DEFAULT_OPTIONS,
       value: createAsset({
+        idBase: '',
         filePath: toProjectPath('/', '/does/not/exist'),
+        hash: '',
         type: 'js',
         env: createEnvironment({}),
         isSource: true,

--- a/packages/core/core/test/PublicMutableBundleGraph.test.js
+++ b/packages/core/core/test/PublicMutableBundleGraph.test.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+import type {AssetOptions} from '../src/assetUtils';
 
 import type {Dependency} from '@parcel/types';
 
@@ -13,7 +14,7 @@ import {createDependency as _createDependency} from '../src/Dependency';
 import nullthrows from 'nullthrows';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
@@ -157,6 +158,7 @@ function createMockAssetGraph() {
     req1,
     [
       createAsset({
+        idBase: '',
         id: id1,
         filePath,
         type: 'js',
@@ -176,6 +178,7 @@ function createMockAssetGraph() {
     req2,
     [
       createAsset({
+        idBase: '',
         id: id2,
         filePath,
         type: 'js',

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1495,6 +1495,8 @@ export type ResolveResult = {|
   +isExcluded?: boolean,
   /** Overrides the priority set on the dependency. */
   +priority?: DependencyPriority,
+  /** An unique string to be used instead of the project root-relative filepath when deduplicating assets, e.g. `${pkgName}@${version}/${subPath}` */
+  +key?: string,
   /** Corresponds to BaseAsset's <code>sideEffects</code>. */
   +sideEffects?: boolean,
   /** The code of the resolved asset. If provided, this is used rather than reading the file from disk. */

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -194,6 +194,16 @@ export default class NodeResolver {
             _resolved.pkg && !this.hasSideEffects(_resolved.path, _resolved.pkg)
               ? false
               : undefined,
+          key:
+            _resolved.pkg?.name && _resolved.pkg?.version
+              ? _resolved.pkg.name +
+                '@' +
+                _resolved.pkg.version +
+                '/' +
+                normalizeSeparators(
+                  path.relative(_resolved.pkg.pkgdir, resolved.path),
+                )
+              : undefined,
           invalidateOnFileCreate: ctx.invalidateOnFileCreate,
           invalidateOnFileChange: [...ctx.invalidateOnFileChange],
           query: module.query,

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/.pnpm/source-pnpm@1.0.0/node_modules/source-pnpm/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/.pnpm/source-pnpm@1.0.0/node_modules/source-pnpm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "source-pnpm",
+  "version": "0.0.0",
   "main": "dist.js",
   "source": "source.js"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/@scope/pkg/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/@scope/pkg/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "scope-pkg"
+  "name": "scope-pkg",
+  "version": "0.0.0"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/aliased-file/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/aliased-file/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "aliased"
+  "name": "aliased",
+  "version": "0.0.0"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/aliased/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/aliased/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "aliased"
+  "name": "aliased",
+  "version": "0.0.0"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/foo/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/foo/package.json
@@ -1,3 +1,4 @@
 {
-  "name": "foo"
+  "name": "foo",
+  "version": "0.0.0"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-alias-exclude/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-alias-exclude/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-alias-exclude",
+  "version": "0.0.0",
   "main": "main.js",
   "alias": {
     "./main.js": false

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-alias-glob/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-alias-glob/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-alias-glob",
+  "version": "0.0.0",
   "alias": {
     "./lib/*": "./src/$1"
   }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-alias/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-alias/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-alias",
+  "version": "0.0.0",
   "main": "main.js",
   "alias": {
     "./main.js": "./browser.js",

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-browser-alias/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-browser-alias/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-browser-alias",
+  "version": "0.0.0",
   "main": "main.js",
   "browser": {
     "./main.js": "./browser.js",

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-browser-exclude/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-browser-exclude/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-browser-exclude",
+  "version": "0.0.0",
   "main": "main.js",
   "browser": {
     "./main.js": false

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-browser/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-browser/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-browser",
+  "version": "0.0.0",
   "main": "main.js",
   "browser": "browser.js"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-fallback/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-fallback/package.json
@@ -1,4 +1,5 @@
 {
   "name": "package-fallback",
+  "version": "0.0.0",
   "main": "main.js"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-main-directory/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-main-directory/package.json
@@ -1,4 +1,5 @@
 {
   "name": "package-main-directory",
+  "version": "0.0.0",
   "main": "nested"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-main/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-main/package.json
@@ -1,4 +1,5 @@
 {
   "name": "package-main",
+  "version": "0.0.0",
   "main": "main.js"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-module-fallback/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-module-fallback/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-module-fallback",
+  "version": "0.0.0",
   "main": "main.js",
   "module": "module.js"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-module/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-module/package.json
@@ -1,5 +1,6 @@
 {
   "name": "package-module",
+  "version": "0.0.0",
   "main": "main.js",
   "module": "module.js"
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-false-glob/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-false-glob/package.json
@@ -1,5 +1,6 @@
 {
   "name": "side-effects-false-glob",
+  "version": "0.0.0",
   "sideEffects": [
     "a/*.js",
     "./sub/*.js",

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-false/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-false/package.json
@@ -1,5 +1,6 @@
 {
   "name": "side-effects-false",
+  "version": "0.0.0",
   "main": "src/index.js",
   "sideEffects": false
 }

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-package-redirect-down/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-package-redirect-down/package.json
@@ -1,1 +1,4 @@
-{}
+{
+  "name": "side-effects-package-redirect-down",
+  "version": "0.0.0"
+}

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-package-redirect-up/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/side-effects-package-redirect-up/package.json
@@ -1,1 +1,4 @@
-{}
+{
+  "name": "side-effects-package-redirect-up",
+  "version": "0.0.0"
+}

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/source-not-symlinked/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/source-not-symlinked/package.json
@@ -1,5 +1,6 @@
 {
   "name": "source-not-symlinked",
+  "version": "0.0.0",
   "main": "dist.js",
   "source": "source.js"
 }

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -8,6 +8,10 @@ import {loadConfig as configCache} from '@parcel/utils';
 import {createEnvironment} from '@parcel/core/src/Environment';
 import Environment from '@parcel/core/src/public/Environment';
 import {DEFAULT_OPTIONS} from '@parcel/core/test/test-utils';
+// flowlint-next-line untyped-import:off
+import pkg from '../package.json';
+
+const VERSION = pkg.version;
 
 const rootDir = path.join(__dirname, 'fixture');
 
@@ -294,6 +298,7 @@ describe('resolver', function () {
         filePath: require.resolve('browserify-zlib'),
         sideEffects: undefined,
         query: undefined,
+        key: 'browserify-zlib@0.2.0/lib/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -330,6 +335,7 @@ describe('resolver', function () {
         filePath: require.resolve('browserify-zlib'),
         sideEffects: undefined,
         query: undefined,
+        key: 'browserify-zlib@0.2.0/lib/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -366,6 +372,7 @@ describe('resolver', function () {
         filePath: path.join(__dirname, '..', 'src', '_empty.js'),
         sideEffects: undefined,
         query: undefined,
+        key: `@parcel/node-resolver-core@${VERSION}/src/_empty.js`,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -432,6 +439,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'foo', 'index.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'foo@0.0.0/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -464,6 +472,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'package-main', 'main.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-main@0.0.0/main.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -501,6 +510,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-module@0.0.0/module.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -538,6 +548,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser@0.0.0/browser.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -575,6 +586,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser@0.0.0/main.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -612,6 +624,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-fallback@0.0.0/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -687,6 +700,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-main-directory@0.0.0/nested/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -759,6 +773,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'foo', 'nested', 'baz.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'foo@0.0.0/nested/baz.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -801,6 +816,7 @@ describe('resolver', function () {
         filePath: path.resolve(rootDir, 'node_modules/@scope/pkg/index.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'scope-pkg@0.0.0/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -833,6 +849,7 @@ describe('resolver', function () {
         filePath: path.resolve(rootDir, 'node_modules/@scope/pkg/foo/bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'scope-pkg@0.0.0/foo/bar.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -880,6 +897,7 @@ describe('resolver', function () {
           ),
           sideEffects: false,
           query: undefined,
+          key: 'side-effects-false@0.0.0/src/index.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -930,6 +948,7 @@ describe('resolver', function () {
           ),
           sideEffects: false,
           query: undefined,
+          key: 'side-effects-false@0.0.0/src/index.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -980,6 +999,7 @@ describe('resolver', function () {
           ),
           sideEffects: false,
           query: undefined,
+          key: 'side-effects-false@0.0.0/src/index.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -1049,6 +1069,7 @@ describe('resolver', function () {
           ),
           sideEffects: false,
           query: undefined,
+          key: 'side-effects-false@0.0.0/src/index.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -1118,6 +1139,7 @@ describe('resolver', function () {
           ),
           sideEffects: false,
           query: undefined,
+          key: 'side-effects-package-redirect-up@0.0.0/foo/real-bar.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -1198,6 +1220,7 @@ describe('resolver', function () {
           ),
           sideEffects: false,
           query: undefined,
+          key: 'side-effects-package-redirect-down@0.0.0/foo/bar/baz/real-bar.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -1446,6 +1469,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser-alias@0.0.0/browser.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1488,6 +1512,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser-alias@0.0.0/bar.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1535,6 +1560,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser-alias@0.0.0/bar.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1587,6 +1613,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser-alias@0.0.0/foo.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1634,6 +1661,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-browser-alias@0.0.0/subfolder1/subfolder2/subfile.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1692,6 +1720,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'package-alias', 'bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-alias@0.0.0/bar.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1729,6 +1758,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'package-alias', 'bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-alias@0.0.0/bar.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1782,6 +1812,7 @@ describe('resolver', function () {
         ),
         sideEffects: undefined,
         query: undefined,
+        key: 'package-alias-glob@0.0.0/src/test.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1840,6 +1871,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'foo', 'index.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'foo@0.0.0/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1872,6 +1904,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'foo', 'index.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'foo@0.0.0/index.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1915,6 +1948,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'node_modules', 'foo', 'bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: 'foo@0.0.0/bar.js',
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1958,6 +1992,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -1987,6 +2022,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2024,6 +2060,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'test.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2057,6 +2094,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'index.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2099,6 +2137,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'test.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2132,6 +2171,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'index.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2174,6 +2214,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'bar.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2203,6 +2244,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'test.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2236,6 +2278,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'test.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2269,6 +2312,7 @@ describe('resolver', function () {
         filePath: path.join(rootDir, 'nested', 'test.js'),
         sideEffects: undefined,
         query: undefined,
+        key: undefined,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2310,6 +2354,7 @@ describe('resolver', function () {
         filePath: path.join(__dirname, '..', 'src', '_empty.js'),
         sideEffects: undefined,
         query: undefined,
+        key: `@parcel/node-resolver-core@${VERSION}/src/_empty.js`,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2352,6 +2397,7 @@ describe('resolver', function () {
         filePath: path.join(__dirname, '..', 'src', '_empty.js'),
         sideEffects: undefined,
         query: undefined,
+        key: `@parcel/node-resolver-core@${VERSION}/src/_empty.js`,
         invalidateOnFileCreate: [
           {
             fileName: 'package.json',
@@ -2397,6 +2443,7 @@ describe('resolver', function () {
           filePath: path.join(rootDir, 'packages', 'source', 'source.js'),
           sideEffects: undefined,
           query: undefined,
+          key: undefined,
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -2437,6 +2484,7 @@ describe('resolver', function () {
           ),
           sideEffects: undefined,
           query: undefined,
+          key: 'source-pnpm@0.0.0/dist.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',
@@ -2476,6 +2524,7 @@ describe('resolver', function () {
           ),
           sideEffects: undefined,
           query: undefined,
+          key: 'source-not-symlinked@0.0.0/dist.js',
           invalidateOnFileCreate: [
             {
               fileName: 'package.json',


### PR DESCRIPTION
# ↪️ Pull Request

Essentially a rebase of https://github.com/parcel-bundler/parcel/pull/4981

Don't use `resolveResult.filePath` for hashing, but `pkgName@pkgVersion/relativePath` inside node_modules.

Do we actually want this (by default)?

- This system also applies to local monorepo packages
- Would deduplicate cases where Yarn wasn't able to do it (smaller bundles)
- patch-package has to be considered

### TODO

- [x] Add test
- [ ] factor input contents into cache key?
	- currently only with `isSource: false`
	- this might have some consequences for HMR which relies on stable asset ids
- [ ] cascading bundle invalidation (and/or changing package versions might change asset ids but not content)
	- don't make this the actual (asset) id, only use for deduplicating asset group ids
- [ ] it currently just uses the nearest package.json, not the "root" package.json of the package. so there can potentially be some un-deduplicated packages (with the case of having a sub-package.json for specifying some main/module/... variants)
	- the failing tests are asserting this
- [ ] One potential (likely but untested): it's not deterministic which of the asset paths is chosen when deduplicating (e.g. whether `/node_modules/duplicated/index.js` or `/node_modules/foo/node_modules/duplicated/index.js` wins)