### PR TITLE
Add missing imports for external dependencies in skipped assets

### DIFF
--- a/packages/core/integration-tests/test/integration/formats/esm-external/child.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-external/child.js
@@ -1,0 +1,1 @@
+export {add} from 'lodash';

--- a/packages/core/integration-tests/test/integration/formats/esm-external/re-export-child.js
+++ b/packages/core/integration-tests/test/integration/formats/esm-external/re-export-child.js
@@ -1,0 +1,1 @@
+export {add} from './child';

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -725,6 +725,24 @@ describe('output formats', function () {
       );
     });
 
+    it('should support esmodule output with external modules (re-export child)', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/formats/esm-external/re-export-child.js',
+        ),
+      );
+
+      await assertESMExports(
+        b,
+        3,
+        {
+          lodash: () => lodash,
+        },
+        ns => ns.add(1, 2),
+      );
+    });
+
     it('should support importing sibling bundles in library mode', async function () {
       let b = await bundle(
         path.join(__dirname, '/integration/formats/esm-siblings/a.js'),


### PR DESCRIPTION
A library with `sideEffects: false` might have a re-export of an external dependency. If this dependency was in a skipped asset, the external import was never added, resulting in a `$id$re_export$foo` is not defined error at the `export` site. This makes sure to add dependencies of a skipped asset as externals when not resolved.