### PR TITLE
Fix atomic writestream handling on Windows

### DIFF
--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -14,7 +14,7 @@ import nativeFS from 'fs';
 import ncp from 'ncp';
 import {promisify} from 'util';
 import {registerSerializableClass} from '@parcel/core';
-import {hashStream} from '@parcel/utils';
+import {hashFile} from '@parcel/utils';
 import watcher from '@parcel/watcher';
 import packageJSON from '../package.json';
 
@@ -77,11 +77,11 @@ export class NodeFS implements FileSystem {
             e.code === 'EPERM'
           ) {
             let [hashTmp, hashTarget] = await Promise.all([
-              hashStream(writeStream.__atomicTmp),
-              hashStream(writeStream.__atomicTarget),
+              hashFile(tmpFilePath),
+              hashFile(filePath),
             ]);
 
-            await this.unlink(writeStream.__atomicTmp);
+            await this.unlink(tmpFilePath);
 
             if (hashTmp != hashTarget) {
               throw e;

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -77,8 +77,8 @@ export class NodeFS implements FileSystem {
             e.code === 'EPERM'
           ) {
             let [hashTmp, hashTarget] = await Promise.all([
-              hashFile(tmpFilePath),
-              hashFile(filePath),
+              hashFile(this, tmpFilePath),
+              hashFile(this, filePath),
             ]);
 
             await this.unlink(tmpFilePath);


### PR DESCRIPTION
These `__...` properties were never defined...

Might be related to https://github.com/parcel-bundler/parcel/issues/8257