### PR TITLE
Remove duplicate script downloads in firefox

### DIFF
--- a/packages/runtimes/js/src/helpers/browser/js-loader.js
+++ b/packages/runtimes/js/src/helpers/browser/js-loader.js
@@ -22,7 +22,6 @@ module.exports = cacheLoader(function loadJSBundle(bundle) {
     var script = document.createElement('script');
     script.async = true;
     script.type = 'text/javascript';
-    script.charset = 'utf-8';
     script.src = bundle;
     script.onerror = function (e) {
       var error = new TypeError(


### PR DESCRIPTION

# ↪️ Pull Request

In Firefox, we notice duplicate `.js` scripts being downloaded. Once from preload, and then second as the async script. Even though Firefox does support `link rel=preload`, removing the `charset` seemed to fix it.  `script.charset` is also deprecated.

This might be a bug with mozilla, so I'll file that and link it here once created. 

## 💻 Examples

Tested with medium sized app, will add smaller repro.

<img width="469" alt="duplicate_assets" src="https://user-images.githubusercontent.com/29166446/181848007-ccd450b4-94d3-4b4e-ae7f-26127fa2f6c3.png">

The first is a result of `document.head.appendChild(preloadLink);` in the jsloader and the second, from `document.getElementsByTagName('head')[0].appendChild(script);` also in the jsloader.
## 🚨 Test instructions

None of our tests test this, repro to be added. Also I didn't see any issues in Chrome with this change

## ✔️ PR Todo

- [ ] Included links to related issues/PRs
- [ ] Add repro
