### PR TITLE
Use placeholder expression when replacing unused symbols

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/index.js
@@ -1,0 +1,1 @@
+output = import("./library").then(({ a }) => a);

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/a.js
@@ -1,0 +1,1 @@
+export var foo = "foo";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/b.js
@@ -1,0 +1,3 @@
+class b {}
+
+export { b as default };

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/index.js
@@ -1,0 +1,4 @@
+import * as a from "./a";
+import b from "./b";
+export { a, b };
+export var b2 = b;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/library/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -7025,6 +7025,19 @@ describe('javascript', function () {
         assert.deepEqual(res.output, 'bar');
       });
 
+      it('supports reexports via variable declaration (unused)', async function () {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/index.js',
+          ),
+          options,
+        );
+
+        let res = await run(b, {}, {require: false});
+        assert.deepEqual((await res.output).foo, 'foo');
+      });
+
       it('supports named and renamed reexports of the same asset (named used)', async function () {
         let b = await bundle(
           path.join(

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -764,7 +764,10 @@ ${code}
       symbol,
     } = this.bundleGraph.getSymbolResolution(resolved, imported, this.bundle);
 
-    if (resolvedAsset.type !== 'js' || this.shouldSkipAsset(resolvedAsset)) {
+    if (
+      resolvedAsset.type !== 'js' ||
+      (dep && this.bundleGraph.isDependencySkipped(dep))
+    ) {
       // Graceful fallback for non-js imports or when trying to resolve a symbol
       // that is actually unused but we still need a placeholder value.
       return '{}';

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -763,10 +763,13 @@ ${code}
       exportSymbol,
       symbol,
     } = this.bundleGraph.getSymbolResolution(resolved, imported, this.bundle);
-    if (resolvedAsset.type !== 'js') {
-      // Graceful fallback for non-js imports
+
+    if (resolvedAsset.type !== 'js' || this.shouldSkipAsset(resolvedAsset)) {
+      // Graceful fallback for non-js imports or when trying to resolve a symbol
+      // that is actually unused but we still need a placeholder value.
       return '{}';
     }
+
     let isWrapped =
       !this.bundle.hasAsset(resolvedAsset) ||
       (this.wrappedAssets.has(resolvedAsset.id) &&


### PR DESCRIPTION
This is a case where our currently limited form of inner-module tree shaking determined `b` and `b2` to be unused (since only `a` was imported). But then we still have the `var $id$export$id = $id$import$b;` declaration in the output.
```js
import * as a from "./a";
import b from "./b";
export { a, b };
export var b2 = b;
```

The RHS was previously replaced with a reference to an asset that doesn't exist (because is was skipped).
```js
parcelRequire.register("9lh8q", function(module, exports) {
	$parcel$export(module.exports, "a", () => (parcelRequire("e0WFk")));
	var $e0WFk = parcelRequire("e0WFk");

        // unused `export var b2 = b;`
	var $6cd35dda6492a1a0$export$2ec5befb9e6c97d4 = (0, $3nA9q.default);
});
```

After:

```js
parcelRequire.register("9lh8q", function(module, exports) {
	$parcel$export(module.exports, "a", () => (parcelRequire("e0WFk")));
	var $e0WFk = parcelRequire("e0WFk");

	var $6cd35dda6492a1a0$export$2ec5befb9e6c97d4 = (0, {});
});
```
(Also note that this is not the common case, for unused `export { ... }` declarations, there is nothing in the asset and the packager doesn't generate the `$parcel$export` call in the first place. So there is no problematic placeholder as in the added test case).