### PR TITLE
Fix broken CI lint check

### DIFF
--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.6.2",
+    "@parcel/utils": "2.6.2",
     "@parcel/workers": "2.6.2",
     "nullthrows": "^1.1.1"
   },

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -18,10 +18,10 @@ function shouldExclude(asset, options) {
         v =>
           v.specifier === 'react' ||
           v.specifier === 'react/jsx-runtime' ||
-          v.specifier === 'react/jsx-dev-runtime'||
+          v.specifier === 'react/jsx-dev-runtime' ||
           v.specifier === '@emotion/react' ||
           v.specifier === '@emotion/react/jsx-runtime' ||
-          v.specifier === '@emotion/react/jsx-dev-runtime'
+          v.specifier === '@emotion/react/jsx-dev-runtime',
       )
   );
 }


### PR DESCRIPTION
- The formatting change came from https://github.com/parcel-bundler/parcel/pull/8205
- Not sure why I only got the undeclared dependency eslint error locally:  https://github.com/parcel-bundler/parcel/blob/90126160b4d29ef4bd77e6a3620d08e1f36faf9c/packages/transformers/image/src/validateConfig.js#L3