### PR TITLE
Cache invalidations for packagers when reading other bundles

### DIFF
--- a/packages/core/core/src/InternalConfig.js
+++ b/packages/core/core/src/InternalConfig.js
@@ -25,6 +25,7 @@ type ConfigOpts = {|
   invalidateOnOptionChange?: Set<string>,
   devDeps?: Array<InternalDevDepOptions>,
   invalidateOnStartup?: boolean,
+  invalidateOnBuild?: boolean,
 |};
 
 export function createConfig({
@@ -39,6 +40,7 @@ export function createConfig({
   invalidateOnOptionChange,
   devDeps,
   invalidateOnStartup,
+  invalidateOnBuild,
 }: ConfigOpts): Config {
   let environment = env ?? createEnvironment();
   return {
@@ -59,5 +61,6 @@ export function createConfig({
     invalidateOnOptionChange: invalidateOnOptionChange ?? new Set(),
     devDeps: devDeps ?? [],
     invalidateOnStartup: invalidateOnStartup ?? false,
+    invalidateOnBuild: invalidateOnBuild ?? false,
   };
 }

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -51,7 +51,7 @@ import {
   loadPluginConfig,
   getConfigHash,
   getConfigRequests,
-  type PluginWithLoadConfigGlobalInfo,
+  type PluginWithBundleConfig,
 } from './requests/ConfigRequest';
 import {
   createDevDependency,
@@ -216,7 +216,7 @@ export default class PackagerRunner {
     }
   }
 
-  async loadPluginConfig<T: PluginWithLoadConfigGlobalInfo>(
+  async loadPluginConfig<T: PluginWithBundleConfig>(
     bundleGraph: InternalBundleGraph,
     bundle: InternalBundle,
     plugin: LoadedPlugin<T>,

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -260,7 +260,10 @@ export default class PackagerRunner {
     if (!bundleConfigs.has(plugin.name) && loadBundleConfig != null) {
       let config = createConfig({
         plugin: plugin.name,
-        searchPath: toProjectPathUnsafe('index'),
+        searchPath: joinProjectPath(
+          bundle.target.distDir,
+          bundle.name ?? bundle.id,
+        ),
       });
       config.result = await loadBundleConfig({
         bundle: NamedBundle.get(bundle, bundleGraph, this.options),
@@ -273,8 +276,6 @@ export default class PackagerRunner {
         options: new PluginOptions(this.options),
         logger: new PluginLogger({origin: plugin.name}),
       });
-      // TODO expose config and let plugin set key?
-      config.cacheKey = hashString(JSON.stringify(config.result) ?? '');
       bundleConfigs.set(plugin.name, config);
     }
   }

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -38,6 +38,7 @@ import BundleGraph, {
   bundleGraphToInternalBundleGraph,
 } from './public/BundleGraph';
 import PluginOptions from './public/PluginOptions';
+import PublicConfig from './public/Config';
 import {PARCEL_VERSION, HASH_REF_PREFIX, HASH_REF_REGEX} from './constants';
 import {
   fromProjectPath,
@@ -268,6 +269,7 @@ export default class PackagerRunner {
           NamedBundle.get.bind(NamedBundle),
           this.options,
         ),
+        config: new PublicConfig(config, this.options),
         options: new PluginOptions(this.options),
         logger: new PluginLogger({origin: plugin.name}),
       });

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -261,6 +261,8 @@ export default class Parcel {
         type: 'buildStart',
       });
 
+      this.#requestTracker.graph.invalidateOnBuildNodes();
+
       let request = createParcelBuildRequest({
         optionsRef: this.#optionsRef,
         requestedAssetIds: this.#requestedAssetIds,

--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -253,7 +253,7 @@ export default class ParcelConfig {
 
   async getPackager(
     filePath: FilePath,
-  ): Promise<LoadedPlugin<Packager<mixed>>> {
+  ): Promise<LoadedPlugin<Packager<mixed, mixed>>> {
     let packager = this.matchGlobMap(
       toProjectPathUnsafe(filePath),
       this.packagers,
@@ -265,7 +265,7 @@ export default class ParcelConfig {
         '/packagers',
       );
     }
-    return this.loadPlugin<Packager<mixed>>(packager);
+    return this.loadPlugin<Packager<mixed, mixed>>(packager);
   }
 
   _getOptimizerNodes(
@@ -298,13 +298,13 @@ export default class ParcelConfig {
   getOptimizers(
     filePath: FilePath,
     pipeline: ?string,
-  ): Promise<Array<LoadedPlugin<Optimizer<mixed>>>> {
+  ): Promise<Array<LoadedPlugin<Optimizer<mixed, mixed>>>> {
     let optimizers = this._getOptimizerNodes(filePath, pipeline);
     if (optimizers.length === 0) {
       return Promise.resolve([]);
     }
 
-    return this.loadPlugins<Optimizer<mixed>>(optimizers);
+    return this.loadPlugins<Optimizer<mixed, mixed>>(optimizers);
   }
 
   async getCompressors(

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -70,6 +70,7 @@ type RequestGraphOpts = {|
   envNodeIds: Set<NodeId>,
   optionNodeIds: Set<NodeId>,
   unpredicatableNodeIds: Set<NodeId>,
+  invalidateOnBuildNodeIds: Set<NodeId>,
 |};
 
 type SerializedRequestGraph = {|
@@ -80,6 +81,7 @@ type SerializedRequestGraph = {|
   envNodeIds: Set<NodeId>,
   optionNodeIds: Set<NodeId>,
   unpredicatableNodeIds: Set<NodeId>,
+  invalidateOnBuildNodeIds: Set<NodeId>,
 |};
 
 type FileNode = {|id: ContentKey, +type: 'file', value: InternalFile|};
@@ -229,6 +231,7 @@ export class RequestGraph extends ContentGraph<
     deserialized.envNodeIds = opts.envNodeIds;
     deserialized.optionNodeIds = opts.optionNodeIds;
     deserialized.unpredicatableNodeIds = opts.unpredicatableNodeIds;
+    deserialized.invalidateOnBuildNodeIds = opts.invalidateOnBuildNodeIds;
     return deserialized;
   }
 
@@ -242,6 +245,7 @@ export class RequestGraph extends ContentGraph<
       envNodeIds: this.envNodeIds,
       optionNodeIds: this.optionNodeIds,
       unpredicatableNodeIds: this.unpredicatableNodeIds,
+      invalidateOnBuildNodeIds: this.invalidateOnBuildNodeIds,
     };
   }
 
@@ -269,6 +273,7 @@ export class RequestGraph extends ContentGraph<
     this.incompleteNodeIds.delete(nodeId);
     this.incompleteNodePromises.delete(nodeId);
     this.unpredicatableNodeIds.delete(nodeId);
+    this.invalidateOnBuildNodeIds.delete(nodeId);
     let node = nullthrows(this.getNode(nodeId));
     if (node.type === 'glob') {
       this.globNodeIds.delete(nodeId);
@@ -329,7 +334,7 @@ export class RequestGraph extends ContentGraph<
   }
 
   invalidateOnBuildNodes() {
-    for (let nodeId of this.unpredicatableNodeIds) {
+    for (let nodeId of this.invalidateOnBuildNodeIds) {
       let node = nullthrows(this.getNode(nodeId));
       invariant(node.type !== 'file' && node.type !== 'glob');
       this.invalidateNode(nodeId, STARTUP);
@@ -567,6 +572,7 @@ export class RequestGraph extends ContentGraph<
 
   clearInvalidations(nodeId: NodeId) {
     this.unpredicatableNodeIds.delete(nodeId);
+    this.invalidateOnBuildNodeIds.delete(nodeId);
     this.replaceNodeIdsConnectedTo(
       nodeId,
       [],

--- a/packages/core/core/src/public/Config.js
+++ b/packages/core/core/src/public/Config.js
@@ -112,6 +112,10 @@ export default class PublicConfig implements IConfig {
     this.#config.invalidateOnStartup = true;
   }
 
+  invalidateOnBuild() {
+    this.#config.invalidateOnBuild = true;
+  }
+
   async getConfigFrom<T>(
     searchPath: FilePath,
     fileNames: Array<string>,

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -4,6 +4,8 @@ import type {
   Config as IConfig,
   PluginOptions as IPluginOptions,
   PluginLogger as IPluginLogger,
+  NamedBundle as INamedBundle,
+  BundleGraph as IBundleGraph,
 } from '@parcel/types';
 import type {
   Config,
@@ -26,6 +28,21 @@ import {Hash} from '@parcel/hash';
 export type PluginWithLoadConfig = {
   loadConfig?: ({|
     config: IConfig,
+    options: IPluginOptions,
+    logger: IPluginLogger,
+  |}) => Async<mixed>,
+  ...
+};
+
+export type PluginWithLoadConfigGlobalInfo = {
+  loadConfig?: ({|
+    config: IConfig,
+    options: IPluginOptions,
+    logger: IPluginLogger,
+  |}) => Async<mixed>,
+  loadGlobalInfo?: ({|
+    bundle: INamedBundle,
+    bundleGraph: IBundleGraph<INamedBundle>,
     options: IPluginOptions,
     logger: IPluginLogger,
   |}) => Async<mixed>,

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -34,7 +34,7 @@ export type PluginWithLoadConfig = {
   ...
 };
 
-export type PluginWithLoadConfigGlobalInfo = {
+export type PluginWithBundleConfig = {
   loadConfig?: ({|
     config: IConfig,
     options: IPluginOptions,

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -57,6 +57,7 @@ export type ConfigRequest = {
   invalidateOnEnvChange: Set<string>,
   invalidateOnOptionChange: Set<string>,
   invalidateOnStartup: boolean,
+  invalidateOnBuild: boolean,
   ...
 };
 
@@ -99,6 +100,7 @@ export async function runConfigRequest(
     invalidateOnEnvChange,
     invalidateOnOptionChange,
     invalidateOnStartup,
+    invalidateOnBuild,
   } = configRequest;
 
   // If there are no invalidations, then no need to create a node.
@@ -106,7 +108,8 @@ export async function runConfigRequest(
     invalidateOnFileChange.size === 0 &&
     invalidateOnFileCreate.length === 0 &&
     invalidateOnOptionChange.size === 0 &&
-    !invalidateOnStartup
+    !invalidateOnStartup &&
+    !invalidateOnBuild
   ) {
     return;
   }
@@ -134,6 +137,10 @@ export async function runConfigRequest(
 
       if (invalidateOnStartup) {
         api.invalidateOnStartup();
+      }
+
+      if (invalidateOnBuild) {
+        api.invalidateOnBuild();
       }
     },
     input: null,
@@ -196,7 +203,8 @@ export function getConfigRequests(
         config.invalidateOnFileCreate.length > 0 ||
         config.invalidateOnEnvChange.size > 0 ||
         config.invalidateOnOptionChange.size > 0 ||
-        config.invalidateOnStartup
+        config.invalidateOnStartup ||
+        config.invalidateOnBuild
       );
     })
     .map(config => ({
@@ -206,5 +214,6 @@ export function getConfigRequests(
       invalidateOnEnvChange: config.invalidateOnEnvChange,
       invalidateOnOptionChange: config.invalidateOnOptionChange,
       invalidateOnStartup: config.invalidateOnStartup,
+      invalidateOnBuild: config.invalidateOnBuild,
     }));
 }

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -43,6 +43,7 @@ export type PluginWithLoadConfigGlobalInfo = {
   loadBundleConfig?: ({|
     bundle: INamedBundle,
     bundleGraph: IBundleGraph<INamedBundle>,
+    config: IConfig,
     options: IPluginOptions,
     logger: IPluginLogger,
   |}) => Async<mixed>,

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -40,7 +40,7 @@ export type PluginWithLoadConfigGlobalInfo = {
     options: IPluginOptions,
     logger: IPluginLogger,
   |}) => Async<mixed>,
-  loadGlobalInfo?: ({|
+  loadBundleConfig?: ({|
     bundle: INamedBundle,
     bundleGraph: IBundleGraph<INamedBundle>,
     options: IPluginOptions,

--- a/packages/core/core/src/requests/PackageRequest.js
+++ b/packages/core/core/src/requests/PackageRequest.js
@@ -7,7 +7,7 @@ import type {SharedReference} from '@parcel/workers';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {Bundle} from '../types';
 import type BundleGraph from '../BundleGraph';
-import type {BundleInfo} from '../PackagerRunner';
+import type {BundleInfo, PackageRequestResult} from '../PackagerRunner';
 import type {ConfigAndCachePath} from './ParcelConfigRequest';
 
 import nullthrows from 'nullthrows';
@@ -55,7 +55,7 @@ async function run({input, api, farm}: RunInput) {
     await api.runRequest<null, ConfigAndCachePath>(createParcelConfigRequest()),
   );
   let {devDepRequests, configRequests, bundleInfo, invalidations} =
-    await runPackage({
+    (await runPackage({
       bundle,
       bundleGraphReference,
       optionsRef,
@@ -63,7 +63,7 @@ async function run({input, api, farm}: RunInput) {
       previousDevDeps: devDeps,
       invalidDevDeps,
       previousInvalidations: api.getInvalidations(),
-    });
+    }): PackageRequestResult);
 
   for (let devDepRequest of devDepRequests) {
     await runDevDepRequest(api, devDepRequest);
@@ -90,6 +90,7 @@ async function run({input, api, farm}: RunInput) {
     }
   }
 
+  // $FlowFixMe[cannot-write] time is marked read-only, but this is the exception
   bundleInfo.time = Date.now() - start;
 
   api.storeResult(bundleInfo);

--- a/packages/core/core/src/requests/ValidationRequest.js
+++ b/packages/core/core/src/requests/ValidationRequest.js
@@ -47,12 +47,13 @@ export default function createValidationRequest(
       });
 
       // Schedule validations on workers for all plugins that implement the one-asset-at-a-time "validate" method.
-      let promises = trackedRequestsDesc.map(async request =>
-        (await farm.createHandle('runValidate'))({
-          requests: [request],
-          optionsRef: optionsRef,
-          configCachePath: cachePath,
-        }),
+      let promises = trackedRequestsDesc.map(
+        async request =>
+          ((await farm.createHandle('runValidate'))({
+            requests: [request],
+            optionsRef: optionsRef,
+            configCachePath: cachePath,
+          }): void),
       );
 
       // Skip sending validation requests if no validators were configured

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -92,7 +92,10 @@ async function run({input, api, farm, options}: RunInput) {
           bundleGraphReference: ref,
           optionsRef,
         });
-        let info = await api.runRequest(request);
+
+        // TODO remove?
+        // force to ensure that loadConfig runs for all packagers/optimizers
+        let info = await api.runRequest(request, {force: true});
 
         bundleInfoMap[bundle.id] = info;
         if (!info.hashReferences.length) {

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -93,9 +93,7 @@ async function run({input, api, farm, options}: RunInput) {
           optionsRef,
         });
 
-        // TODO remove?
-        // force to ensure that loadConfig runs for all packagers/optimizers
-        let info = await api.runRequest(request, {force: true});
+        let info = await api.runRequest(request);
 
         bundleInfoMap[bundle.id] = info;
         if (!info.hashReferences.length) {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -436,6 +436,7 @@ export type Config = {|
   invalidateOnOptionChange: Set<string>,
   devDeps: Array<InternalDevDepOptions>,
   invalidateOnStartup: boolean,
+  invalidateOnBuild: boolean,
 |};
 
 export type EntryRequest = {|

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -77,6 +77,7 @@ describe('TargetResolver', () => {
     invalidateOnEnvChange() {},
     invalidateOnOptionChange() {},
     invalidateOnStartup() {},
+    invalidateOnBuild() {},
     getInvalidations() {
       return [];
     },

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/.parcelrc
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/.parcelrc
@@ -1,0 +1,9 @@
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.txt": ["@parcel/transformer-raw"]
+  },
+  "packagers": {
+    "*.txt": "parcel-packager-config"
+  }
+}

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/a.txt
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/a.txt
@@ -1,0 +1,1 @@
+Hello from a

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/b.txt
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/b.txt
@@ -1,0 +1,1 @@
+Hello from b

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/index.2.html
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/index.2.html
@@ -1,0 +1,2 @@
+<a href="a.txt">a</a>
+<a href="b.txt">a</a>

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/index.html
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/index.html
@@ -1,0 +1,1 @@
+<a href="a.txt">a</a>

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/node_modules/parcel-packager-config/index.js
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/node_modules/parcel-packager-config/index.js
@@ -1,0 +1,24 @@
+// @flow strict-local
+
+const invariant = require('assert');
+const {Packager} = require('@parcel/plugin');
+
+module.exports = (new Packager({
+  loadBundleConfig({bundle, bundleGraph, config}) {
+    config.invalidateOnBuild();
+    let x = bundleGraph
+      .getBundles()
+      .filter(b => b.type === 'txt' && b.needsStableName)
+      .map(b => b.name);
+    console.log(bundle.name, x);
+    return x;
+  },
+  async package({bundle, bundleConfig}) {
+    let contents = await bundle.getMainEntry()?.getCode();
+    invariant(contents != null);
+
+    return {
+      contents: `Bundles: ${bundleConfig.join(',')}. Contents: ${contents}`,
+    };
+  },
+}) /*: Packager */);

--- a/packages/core/integration-tests/test/integration/packager-loadBundleConfig/node_modules/parcel-packager-config/package.json
+++ b/packages/core/integration-tests/test/integration/packager-loadBundleConfig/node_modules/parcel-packager-config/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "parcel-packager-config",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "engines": {
+    "parcel": "^2.0.0-beta.1"
+  },
+  "dependencies": {
+    "@parcel/plugin": "^2.0.0-beta.1",
+    "@parcel/utils": "^2.0.0-beta.1"
+  }
+}

--- a/packages/core/integration-tests/test/plugin.js
+++ b/packages/core/integration-tests/test/plugin.js
@@ -119,7 +119,6 @@ parcel-transformer-b`,
         `Bundles: a.txt. Contents: Hello from a\n`,
       );
 
-      console.log('copy');
       await overlayFS.copyFile(path.join(fixture, 'index.2.html'), entry);
 
       bundleEvent = await getNextBuild(b);

--- a/packages/core/plugin/src/PluginAPI.js
+++ b/packages/core/plugin/src/PluginAPI.js
@@ -58,14 +58,14 @@ export class Validator {
 }
 
 export class Packager {
-  constructor<T>(opts: PackagerOpts<T>) {
+  constructor<T, U>(opts: PackagerOpts<T, U>) {
     // $FlowFixMe
     this[CONFIG] = opts;
   }
 }
 
 export class Optimizer {
-  constructor<T>(opts: OptimizerOpts<T>) {
+  constructor<T, U>(opts: OptimizerOpts<T, U>) {
     // $FlowFixMe
     this[CONFIG] = opts;
   }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1591,18 +1591,25 @@ export type Runtime<ConfigType> = {|
 /**
  * @section packager
  */
-export type Packager<ConfigType> = {|
+export type Packager<ConfigType, GlobalInfoType> = {|
   loadConfig?: ({|
     config: Config,
     options: PluginOptions,
     logger: PluginLogger,
-  |}) => Promise<ConfigType> | ConfigType,
+  |}) => Async<ConfigType>,
+  loadGlobalInfo?: ({|
+    bundle: NamedBundle,
+    bundleGraph: BundleGraph<NamedBundle>,
+    options: PluginOptions,
+    logger: PluginLogger,
+  |}) => Async<GlobalInfoType>,
   package({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
     config: ConfigType,
+    globalInfo: GlobalInfoType,
     getInlineBundleContents: (
       Bundle,
       BundleGraph<NamedBundle>,
@@ -1614,12 +1621,18 @@ export type Packager<ConfigType> = {|
 /**
  * @section optimizer
  */
-export type Optimizer<ConfigType> = {|
+export type Optimizer<ConfigType, GlobalInfoType> = {|
   loadConfig?: ({|
     config: Config,
     options: PluginOptions,
     logger: PluginLogger,
-  |}) => Promise<ConfigType> | ConfigType,
+  |}) => Async<ConfigType>,
+  loadGlobalInfo?: ({|
+    bundle: NamedBundle,
+    bundleGraph: BundleGraph<NamedBundle>,
+    options: PluginOptions,
+    logger: PluginLogger,
+  |}) => Async<GlobalInfoType>,
   optimize({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
@@ -1628,6 +1641,7 @@ export type Optimizer<ConfigType> = {|
     options: PluginOptions,
     logger: PluginLogger,
     config: ConfigType,
+    globalInfo: GlobalInfoType,
     getSourceMapReference: (map: ?SourceMap) => Async<?string>,
   |}): Async<BundleResult>,
 |};

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1591,25 +1591,25 @@ export type Runtime<ConfigType> = {|
 /**
  * @section packager
  */
-export type Packager<ConfigType, GlobalInfoType> = {|
+export type Packager<ConfigType, BundleConfigType> = {|
   loadConfig?: ({|
     config: Config,
     options: PluginOptions,
     logger: PluginLogger,
   |}) => Async<ConfigType>,
-  loadGlobalInfo?: ({|
+  loadBundleConfig?: ({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
-  |}) => Async<GlobalInfoType>,
+  |}) => Async<BundleConfigType>,
   package({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
     config: ConfigType,
-    globalInfo: GlobalInfoType,
+    bundleConfig: BundleConfigType,
     getInlineBundleContents: (
       Bundle,
       BundleGraph<NamedBundle>,
@@ -1621,18 +1621,18 @@ export type Packager<ConfigType, GlobalInfoType> = {|
 /**
  * @section optimizer
  */
-export type Optimizer<ConfigType, GlobalInfoType> = {|
+export type Optimizer<ConfigType, BundleConfigType> = {|
   loadConfig?: ({|
     config: Config,
     options: PluginOptions,
     logger: PluginLogger,
   |}) => Async<ConfigType>,
-  loadGlobalInfo?: ({|
+  loadBundleConfig?: ({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
     options: PluginOptions,
     logger: PluginLogger,
-  |}) => Async<GlobalInfoType>,
+  |}) => Async<BundleConfigType>,
   optimize({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
@@ -1641,7 +1641,7 @@ export type Optimizer<ConfigType, GlobalInfoType> = {|
     options: PluginOptions,
     logger: PluginLogger,
     config: ConfigType,
-    globalInfo: GlobalInfoType,
+    bundleConfig: BundleConfigType,
     getSourceMapReference: (map: ?SourceMap) => Async<?string>,
   |}): Async<BundleResult>,
 |};

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1600,6 +1600,7 @@ export type Packager<ConfigType, BundleConfigType> = {|
   loadBundleConfig?: ({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
+    config: Config,
     options: PluginOptions,
     logger: PluginLogger,
   |}) => Async<BundleConfigType>,
@@ -1630,6 +1631,7 @@ export type Optimizer<ConfigType, BundleConfigType> = {|
   loadBundleConfig?: ({|
     bundle: NamedBundle,
     bundleGraph: BundleGraph<NamedBundle>,
+    config: Config,
     options: PluginOptions,
     logger: PluginLogger,
   |}) => Async<BundleConfigType>,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -808,8 +808,10 @@ export interface Config {
   invalidateOnFileCreate(FileCreateInvalidation): void;
   /** Invalidates the config when the given environment variable changes. */
   invalidateOnEnvChange(string): void;
-  /** Invalidates the config when Parcel restarts. */
+  /** Invalidates the config only when Parcel restarts. */
   invalidateOnStartup(): void;
+  /** Invalidates the config on every build. */
+  invalidateOnBuild(): void;
   /**
    * Adds a dev dependency to the config. If the dev dependency or any of its
    * dependencies change, the config will be invalidated.


### PR DESCRIPTION
~`loadGlobalInfo` is probably not a good name~ `loadBundleConfig`, same API as `loadConfig` (plus `bundle` and `bundleGraph`)

- [x] Test case