### PR TITLE
Fix dumpGraphToGraphViz for experimentalBundler

### DIFF
--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -37,7 +37,7 @@ export default async function dumpGraphToGraphViz(
     | Graph<AssetGraphNode>
     | Graph<{|
         assets: Array<Asset>,
-        sourceBundles: Array<number>,
+        sourceBundles: Set<number>,
         bundleBehavior?: ?BundleBehavior,
       |}>
     | Graph<BundleGraphNode>,
@@ -72,9 +72,9 @@ export default async function dumpGraphToGraphViz(
           let arr = a.filePath.split('/');
           return arr[arr.length - 1];
         })
-        .join(', ')}) (sourceBundles: ${node.sourceBundles.join(', ')}) (bb ${
-        node.bundleBehavior ?? 'none'
-      })`;
+        .join(', ')}) (sourceBundles: ${[...node.sourceBundles].join(
+        ', ',
+      )}) (bb ${node.bundleBehavior ?? 'none'})`;
     } else if (node.type) {
       label = `[${fromNodeId(id)}] ${node.type || 'No Type'}: [${node.id}]: `;
       if (node.type === 'dependency') {

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -36,7 +36,7 @@ export default async function dumpGraphToGraphViz(
   graph:
     | Graph<AssetGraphNode>
     | Graph<{|
-        assets: Array<Asset>,
+        assets: Set<Asset>,
         sourceBundles: Set<number>,
         bundleBehavior?: ?BundleBehavior,
       |}>

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -67,16 +67,12 @@ export default async function dumpGraphToGraphViz(
     if (typeof node === 'string') {
       label = node;
     } else if (node.assets) {
-      let sourceBundles = node.sourceBundles;
-      if (!Array.isArray(node.sourceBundles)) {
-        sourceBundles = [...node.sourceBundles];
-      }
       label = `(${nodeId(id)}), (assetIds: ${[...node.assets]
         .map(a => {
           let arr = a.filePath.split('/');
           return arr[arr.length - 1];
         })
-        .join(', ')}) (sourceBundles: ${sourceBundles.join(', ')}) (bb ${
+        .join(', ')}) (sourceBundles: ${node.sourceBundles.join(', ')}) (bb ${
         node.bundleBehavior ?? 'none'
       })`;
     } else if (node.type) {

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -67,12 +67,16 @@ export default async function dumpGraphToGraphViz(
     if (typeof node === 'string') {
       label = node;
     } else if (node.assets) {
+      let sourceBundles = node.sourceBundles;
+      if (!Array.isArray(node.sourceBundles)) {
+        sourceBundles = [...node.sourceBundles];
+      }
       label = `(${nodeId(id)}), (assetIds: ${[...node.assets]
         .map(a => {
           let arr = a.filePath.split('/');
           return arr[arr.length - 1];
         })
-        .join(', ')}) (sourceBundles: ${node.sourceBundles.join(', ')}) (bb ${
+        .join(', ')}) (sourceBundles: ${sourceBundles.join(', ')}) (bb ${
         node.bundleBehavior ?? 'none'
       })`;
     } else if (node.type) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR fixes dumpGraphToGraphViz when dumping `BundleGraph` from within `ExperimentalBundler` since sourceBundles are now type `Set` and not `Array`

This is for debugging purposes.


