### PR TITLE
Make vscode extension package private

### DIFF
--- a/packages/utils/parcelforvscode/package.json
+++ b/packages/utils/parcelforvscode/package.json
@@ -4,6 +4,7 @@
   "parcel-lsp.trace.server": "verbose",
   "description": "",
   "version": "2.7.0",
+  "private": true,
   "engines": {
     "vscode": "^1.46.0"
   },


### PR DESCRIPTION
Eventually, we'll publish this to the VS Code extension marketplace, but we don't want to publish this to npm.

