### PR TITLE
Verify version when resolving Node builtin polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha-multi-reporters": "^1.5.1",
     "prettier": "2.4.1",
+    "punycode": "^1.4.1",
     "rimraf": "^3.0.2",
     "semver": "^5.7.1",
     "sinon": "^7.3.1"

--- a/packages/core/package-manager/src/NodeResolverBase.js
+++ b/packages/core/package-manager/src/NodeResolverBase.js
@@ -13,7 +13,7 @@ import type {ResolveResult} from './types';
 import Module from 'module';
 import path from 'path';
 import invariant from 'assert';
-import {normalizeSeparators} from '@parcel/utils';
+import {getModuleParts} from '@parcel/utils';
 
 const builtins = {pnpapi: true};
 for (let builtin of Module.builtinModules) {
@@ -102,22 +102,6 @@ export class NodeResolverBase<T> {
       });
   }
 
-  getModuleParts(name: string): [FilePath, ?string] {
-    name = path.normalize(name);
-    let splitOn = name.indexOf(path.sep);
-    if (name.charAt(0) === '@') {
-      splitOn = name.indexOf(path.sep, splitOn + 1);
-    }
-    if (splitOn < 0) {
-      return [normalizeSeparators(name), undefined];
-    } else {
-      return [
-        normalizeSeparators(name.substring(0, splitOn)),
-        name.substring(splitOn + 1) || undefined,
-      ];
-    }
-  }
-
   isBuiltin(name: DependencySpecifier): boolean {
     return !!(builtins[name] || name.startsWith('node:'));
   }
@@ -135,7 +119,7 @@ export class NodeResolverBase<T> {
       };
     }
 
-    let [moduleName, subPath] = this.getModuleParts(id);
+    let [moduleName, subPath] = getModuleParts(id);
     let dir = path.dirname(sourceFile);
     let moduleDir = this.fs.findNodeModule(moduleName, dir);
 

--- a/packages/core/utils/src/getModuleParts.js
+++ b/packages/core/utils/src/getModuleParts.js
@@ -1,0 +1,23 @@
+// @flow strict-local
+import path from 'path';
+
+import {normalizeSeparators} from './path';
+
+/**
+ * Returns the package name and the optional subpath
+ */
+export default function getModuleParts(_name: string): [string, ?string] {
+  let name = path.normalize(_name);
+  let splitOn = name.indexOf(path.sep);
+  if (name.charAt(0) === '@') {
+    splitOn = name.indexOf(path.sep, splitOn + 1);
+  }
+  if (splitOn < 0) {
+    return [normalizeSeparators(name), undefined];
+  } else {
+    return [
+      normalizeSeparators(name.substring(0, splitOn)),
+      name.substring(splitOn + 1) || undefined,
+    ];
+  }
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -11,6 +11,7 @@ export {default as countLines} from './countLines';
 export {default as generateBuildMetrics} from './generateBuildMetrics';
 export {default as generateCertificate} from './generateCertificate';
 export {default as getCertificate} from './getCertificate';
+export {default as getModuleParts} from './getModuleParts';
 export {default as getRootDir} from './getRootDir';
 export {default as isDirectoryInside} from './isDirectoryInside';
 export {default as isURL} from './is-url';

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -25,9 +25,8 @@ export default (new Resolver({
           ? ['ts', 'tsx', 'js', 'jsx', 'json']
           : [],
       mainFields: ['source', 'browser', 'module', 'main'],
-      packageManager: options.shouldAutoInstall
-        ? options.packageManager
-        : undefined,
+      packageManager: options.packageManager,
+      shouldAutoInstall: options.shouldAutoInstall,
       logger,
     });
 

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -275,7 +275,7 @@ export default class NodeResolver {
     let builtin = this.findBuiltin(filename, env);
     if (builtin === null) {
       return null;
-    } else if (builtin === empty) {
+    } else if (builtin && builtin.name === empty) {
       return {filePath: empty};
     } else if (builtin !== undefined) {
       filename = builtin.name;
@@ -293,7 +293,7 @@ export default class NodeResolver {
     try {
       resolved = this.findNodeModulePath(
         filename,
-        builtin == null ? sourceFile : this.projectRoot + '/index',
+        !builtin ? sourceFile : this.projectRoot + '/index',
         ctx,
       );
     } catch (err) {

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -291,7 +291,11 @@ export default class NodeResolver {
     // Resolve the module in node_modules
     let resolved: ?Module;
     try {
-      resolved = this.findNodeModulePath(filename, sourceFile, ctx);
+      resolved = this.findNodeModulePath(
+        filename,
+        builtin == null ? sourceFile : this.projectRoot + '/index',
+        ctx,
+      );
     } catch (err) {
       // ignore
     }

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -300,9 +300,11 @@ export default class NodeResolver {
       // ignore
     }
 
-    if (builtin != null) {
+    // Autoinstall/verify version of builtin polyfills
+    if (builtin?.range != null) {
       // This assumes that there are no polyfill packages that are scoped
-      let packageName = builtin.name.split('/')[0];
+      // Append '/' to force this.packageManager to look up the package in node_modules
+      let packageName = builtin.name.split('/')[0] + '/';
       let packageManager = this.packageManager;
       if (resolved == null) {
         // Auto install the Node builtin polyfills
@@ -383,7 +385,7 @@ export default class NodeResolver {
           this.projectRoot + '/index',
           {
             saveDev: true,
-            shouldAutoInstall: true,
+            shouldAutoInstall: this.shouldAutoInstall,
             range: builtin.range,
           },
         );

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -293,7 +293,7 @@ export default class NodeResolver {
     try {
       resolved = this.findNodeModulePath(
         filename,
-        !builtin ? sourceFile : this.projectRoot + '/index',
+        !builtin ? sourceFile : path.join(this.projectRoot, 'index'),
         ctx,
       );
     } catch (err) {

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -295,13 +295,12 @@ export default class NodeResolver {
       // ignore
     }
 
-    // Auto install node builtin polyfills if not already available or check that the correct
-    // version is installed
     if (builtin != null) {
       // This assumes that there are no polyfill packages that are scoped
       let packageName = builtin.name.split('/')[0];
       let packageManager = this.packageManager;
       if (resolved == null) {
+        // Auto install the Node builtin polyfills
         if (this.shouldAutoInstall && packageManager) {
           this.logger?.warn({
             message: md`Auto installing polyfill for Node builtin module "${specifier}"...`,
@@ -323,15 +322,23 @@ export default class NodeResolver {
               'https://parceljs.org/features/node-emulation/#polyfilling-%26-excluding-builtin-node-modules',
           });
 
-          await packageManager.resolve(packageName, sourceFile, {
-            saveDev: true,
-            shouldAutoInstall: true,
-            range: builtin.range,
-          });
+          await packageManager.resolve(
+            packageName,
+            this.projectRoot + '/index',
+            {
+              saveDev: true,
+              shouldAutoInstall: true,
+              range: builtin.range,
+            },
+          );
 
           // Re-resolve
           try {
-            resolved = this.findNodeModulePath(filename, sourceFile, ctx);
+            resolved = this.findNodeModulePath(
+              filename,
+              this.projectRoot + '/index',
+              ctx,
+            );
           } catch (err) {
             // ignore
           }
@@ -362,13 +369,19 @@ export default class NodeResolver {
           });
         }
       } else if (builtin.range != null) {
+        // Assert correct version
+
         // TODO packageManager can be null for backwards compatibility, but that could cause invalid
         // resolutions in monorepos
-        await packageManager?.resolve(packageName, sourceFile, {
-          saveDev: true,
-          shouldAutoInstall: true,
-          range: builtin.range,
-        });
+        await packageManager?.resolve(
+          packageName,
+          this.projectRoot + '/index',
+          {
+            saveDev: true,
+            shouldAutoInstall: true,
+            range: builtin.range,
+          },
+        );
       }
     }
 

--- a/packages/utils/node-resolver-core/src/builtins.js
+++ b/packages/utils/node-resolver-core/src/builtins.js
@@ -4,35 +4,36 @@ import {builtinModules} from 'module';
 
 export const empty: string = require.resolve('./_empty.js');
 
-// $FlowFixMe
-let builtins: {[string]: any, ...} = Object.create(null);
+let builtins: {[string]: {|name: string, range: ?string|}, ...} =
+  // $FlowFixMe
+  Object.create(null);
 // use definite (current) list of Node builtins
 for (let key of builtinModules) {
-  builtins[key] = empty;
+  builtins[key] = {name: empty, range: null};
 }
 
-builtins.assert = 'assert/';
-builtins.buffer = 'buffer/';
-builtins.console = 'console-browserify';
-builtins.constants = 'constants-browserify';
-builtins.crypto = 'crypto-browserify';
-builtins.domain = 'domain-browser';
-builtins.events = 'events/';
-builtins.http = 'stream-http';
-builtins.https = 'https-browserify';
-builtins.os = 'os-browserify/browser.js';
-builtins.path = 'path-browserify';
-builtins.process = 'process/browser.js';
-builtins.punycode = 'punycode/';
-builtins.querystring = 'querystring-es3/';
-builtins.stream = 'stream-browserify';
-builtins.string_decoder = 'string_decoder/';
-builtins.sys = 'util/util.js';
-builtins.timers = 'timers-browserify';
-builtins.tty = 'tty-browserify';
-builtins.url = 'url/';
-builtins.util = 'util/util.js';
-builtins.vm = 'vm-browserify';
-builtins.zlib = 'browserify-zlib';
+builtins.assert = {name: 'assert/', range: '^2.0.0'};
+builtins.buffer = {name: 'buffer/', range: '^5.5.0'};
+builtins.console = {name: 'console-browserify', range: '^1.2.0'};
+builtins.constants = {name: 'constants-browserify', range: '^1.0.0'};
+builtins.crypto = {name: 'crypto-browserify', range: '^3.12.0'};
+builtins.domain = {name: 'domain-browser', range: '^3.5.0'};
+builtins.events = {name: 'events/', range: '^3.1.0'};
+builtins.http = {name: 'stream-http', range: '^3.1.0'};
+builtins.https = {name: 'https-browserify', range: '^1.0.0'};
+builtins.os = {name: 'os-browserify/browser.js', range: '^0.3.0'};
+builtins.path = {name: 'path-browserify', range: '^1.0.0'};
+builtins.process = {name: 'process/browser.js', range: '^0.11.10'};
+builtins.punycode = {name: 'punycode/', range: '^1.4.1'};
+builtins.querystring = {name: 'querystring-es3/', range: '^0.2.1'};
+builtins.stream = {name: 'stream-browserify', range: '^3.0.0'};
+builtins.string_decoder = {name: 'string_decoder/', range: '^1.3.0'};
+builtins.sys = {name: 'util/util.js', range: '^0.12.3'};
+builtins.timers = {name: 'timers-browserify', range: '^2.0.11'};
+builtins.tty = {name: 'tty-browserify', range: '^0.0.1'};
+builtins.url = {name: 'url/', range: '^0.11.0'};
+builtins.util = {name: 'util/util.js', range: '^0.12.3'};
+builtins.vm = {name: 'vm-browserify', range: '^1.1.2'};
+builtins.zlib = {name: 'browserify-zlib', range: '^0.2.0'};
 
 export default builtins;

--- a/packages/utils/node-resolver-core/src/builtins.js
+++ b/packages/utils/node-resolver-core/src/builtins.js
@@ -7,11 +7,14 @@ export const empty: string = require.resolve('./_empty.js');
 let builtins: {[string]: {|name: string, range: ?string|}, ...} =
   // $FlowFixMe
   Object.create(null);
+
 // use definite (current) list of Node builtins
 for (let key of builtinModules) {
   builtins[key] = {name: empty, range: null};
 }
 
+// These are mostly the versions considered "new enough" by
+// https://www.npmjs.com/package/node-libs-browser (with a few version bumps)
 builtins.assert = {name: 'assert/', range: '^2.0.0'};
 builtins.buffer = {name: 'buffer/', range: '^5.5.0'};
 builtins.console = {name: 'console-browserify', range: '^1.2.0'};

--- a/packages/utils/node-resolver-core/src/builtins.js
+++ b/packages/utils/node-resolver-core/src/builtins.js
@@ -1,6 +1,9 @@
 // @flow strict-local
 // $FlowFixMe this is untyped
 import {builtinModules} from 'module';
+import nullthrows from 'nullthrows';
+// flowlint-next-line untyped-import:off
+import packageJson from '../package.json';
 
 export const empty: string = require.resolve('./_empty.js');
 
@@ -13,30 +16,38 @@ for (let key of builtinModules) {
   builtins[key] = {name: empty, range: null};
 }
 
-// These are mostly the versions considered "new enough" by
-// https://www.npmjs.com/package/node-libs-browser (with a few version bumps)
-builtins.assert = {name: 'assert/', range: '^2.0.0'};
-builtins.buffer = {name: 'buffer/', range: '^5.5.0'};
-builtins.console = {name: 'console-browserify', range: '^1.2.0'};
-builtins.constants = {name: 'constants-browserify', range: '^1.0.0'};
-builtins.crypto = {name: 'crypto-browserify', range: '^3.12.0'};
-builtins.domain = {name: 'domain-browser', range: '^3.5.0'};
-builtins.events = {name: 'events/', range: '^3.1.0'};
-builtins.http = {name: 'stream-http', range: '^3.1.0'};
-builtins.https = {name: 'https-browserify', range: '^1.0.0'};
-builtins.os = {name: 'os-browserify/browser.js', range: '^0.3.0'};
-builtins.path = {name: 'path-browserify', range: '^1.0.0'};
-builtins.process = {name: 'process/browser.js', range: '^0.11.10'};
-builtins.punycode = {name: 'punycode/', range: '^1.4.1'};
-builtins.querystring = {name: 'querystring-es3/', range: '^0.2.1'};
-builtins.stream = {name: 'stream-browserify', range: '^3.0.0'};
-builtins.string_decoder = {name: 'string_decoder/', range: '^1.3.0'};
-builtins.sys = {name: 'util/util.js', range: '^0.12.3'};
-builtins.timers = {name: 'timers-browserify', range: '^2.0.11'};
-builtins.tty = {name: 'tty-browserify', range: '^0.0.1'};
-builtins.url = {name: 'url/', range: '^0.11.0'};
-builtins.util = {name: 'util/util.js', range: '^0.12.3'};
-builtins.vm = {name: 'vm-browserify', range: '^1.1.2'};
-builtins.zlib = {name: 'browserify-zlib', range: '^0.2.0'};
+let polyfills = {
+  assert: 'assert',
+  buffer: 'buffer',
+  console: 'console-browserify',
+  constants: 'constants-browserify',
+  crypto: 'crypto-browserify',
+  domain: 'domain-browser',
+  events: 'events',
+  http: 'stream-http',
+  https: 'https-browserify',
+  os: 'os-browserify',
+  path: 'path-browserify',
+  process: 'process',
+  punycode: 'punycode',
+  querystring: 'querystring-es3',
+  stream: 'stream-browserify',
+  string_decoder: 'string_decoder',
+  sys: 'util',
+  timers: 'timers-browserify',
+  tty: 'tty-browserify',
+  url: 'url',
+  util: 'util',
+  vm: 'vm-browserify',
+  zlib: 'browserify-zlib',
+};
+
+for (let k in polyfills) {
+  let polyfill = polyfills[k];
+  builtins[k] = {
+    name: polyfill + (builtinModules.includes(polyfill) ? '/' : ''),
+    range: nullthrows(packageJson.devDependencies[polyfill]),
+  };
+}
 
 export default builtins;

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -305,7 +305,7 @@ describe('resolver', function () {
           },
           {
             fileName: 'node_modules/browserify-zlib',
-            aboveFilePath: path.join(rootDir, 'foo.js'),
+            aboveFilePath: path.join(rootDir, 'index'),
           },
           {
             fileName: 'package.json',
@@ -341,7 +341,7 @@ describe('resolver', function () {
           },
           {
             fileName: 'node_modules/browserify-zlib',
-            aboveFilePath: path.join(rootDir, 'foo.js'),
+            aboveFilePath: path.join(rootDir, 'index'),
           },
           {
             fileName: 'package.json',


### PR DESCRIPTION
This will call `packageManager.resolve` for every resolution of a Node builtin with the correct range that should be used to catch cases where another instance of some Node builtin polyfill was pulled in by some other dependency, be it in the same package, or in a monorepo situation

If it's the wrong version, it will either autoinstall, or error (using the existing autoinstall logic):
```
@parcel/core: Failed to resolve 'util' from './a/index.js'
  /Users/nmischkulnig/Desktop/monorepo-builtin-versioning/a/index.js:1:20
  > 1 | import * as x from "util";
  >   |                    ^^^^^^
    2 |
    3 | console.log(x);


@parcel/package-manager: Could not find module "util" satisfying ^0.12.3.

  /Users/nmischkulnig/Desktop/monorepo-builtin-versioning/a/package.json:6:3
    5 |   "dependencies": {
  > 6 |     "util": "^0.4.9"
  >   |     ^^^^^^ Found this conflicting local requirement.
    7 |   }
    8 | }

```

Questions:
- [x] ~Previously, the polyfill was resolved from the actual source file but autoinstalled into the project root. We either need to install it into the local package (what I've done now), or resolve it relative from the monorepo root. (So that resolution base = autoinstall target)~ Now, all builtin polyfills are resolved from the project root
- [ ] Is it a concern that `packageManager.resolve` is slow? I suspect there won't be that many Node builtins anyway