### PR TITLE
New context type for non-browser, non-node environments

### DIFF
--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -75,6 +75,7 @@ export function createEnvironment({
       case 'browser':
       case 'web-worker':
       case 'service-worker':
+      case 'edge':
       default:
         includeNodeModules = true;
         break;
@@ -87,6 +88,9 @@ export function createEnvironment({
       case 'electron-main':
       case 'electron-renderer':
         outputFormat = 'commonjs';
+        break;
+      case 'edge':
+        outputFormat = 'esmodule';
         break;
       default:
         outputFormat = 'global';

--- a/packages/core/core/src/TargetDescriptor.schema.js
+++ b/packages/core/core/src/TargetDescriptor.schema.js
@@ -36,6 +36,7 @@ export const PACKAGE_DESCRIPTOR_SCHEMA: SchemaObject = {
         'electron-main',
         'electron-renderer',
         'service-worker',
+        'edge',
       ],
     },
     includeNodeModules: {

--- a/packages/core/integration-tests/test/integration/edge/index.js
+++ b/packages/core/integration-tests/test/integration/edge/index.js
@@ -1,8 +1,8 @@
 import library from "./library";
 import process from "process";
 
-module.exports = {
+output({
   global: Buffer.from("abc").toString("hex"),
   builtin: process.cwd(),
   browserResolution: library
-}
+});

--- a/packages/core/integration-tests/test/integration/edge/index.js
+++ b/packages/core/integration-tests/test/integration/edge/index.js
@@ -1,0 +1,8 @@
+import library from "./library";
+import process from "process";
+
+module.exports = {
+  global: Buffer.from("abc").toString("hex"),
+  builtin: process.cwd(),
+  browserResolution: library
+}

--- a/packages/core/integration-tests/test/integration/edge/library/browser.js
+++ b/packages/core/integration-tests/test/integration/edge/library/browser.js
@@ -1,0 +1,1 @@
+export default "browser";

--- a/packages/core/integration-tests/test/integration/edge/library/main.js
+++ b/packages/core/integration-tests/test/integration/edge/library/main.js
@@ -1,0 +1,1 @@
+export default "main";

--- a/packages/core/integration-tests/test/integration/edge/library/package.json
+++ b/packages/core/integration-tests/test/integration/edge/library/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "main.js",
+  "browser": "browser.js"
+}

--- a/packages/core/integration-tests/test/integration/edge/package.json
+++ b/packages/core/integration-tests/test/integration/edge/package.json
@@ -1,0 +1,7 @@
+{
+  "targets": {
+    "default": {
+      "context": "edge"
+    }
+  }
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -795,6 +795,18 @@ describe('javascript', function () {
     ]);
   });
 
+  it('should support edge context', async function () {
+    let b = await bundle(path.join(__dirname, '/integration/edge/index.js'));
+
+    let res = await run(b);
+    assert(process.cwd() !== '/');
+    assert.deepEqual(res, {
+      browserResolution: 'main',
+      builtin: '/',
+      global: '616263',
+    });
+  });
+
   it('should support bundling workers', async function () {
     let b = await bundle(path.join(__dirname, '/integration/workers/index.js'));
 

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -798,9 +798,15 @@ describe('javascript', function () {
   it('should support edge context', async function () {
     let b = await bundle(path.join(__dirname, '/integration/edge/index.js'));
 
-    let res = await run(b);
+    let result;
+    await run(b, {
+      output(v) {
+        result = v;
+      },
+    });
+
     assert(process.cwd() !== '/');
-    assert.deepEqual(res, {
+    assert.deepEqual(result, {
       browserResolution: 'main',
       builtin: '/',
       global: '616263',

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -318,7 +318,8 @@ export async function runBundles(
       break;
     }
     case 'web-worker':
-    case 'service-worker': {
+    case 'service-worker':
+    case 'edge': {
       let prepared = prepareWorkerContext(parent.filePath, globals);
       ctx = prepared.ctx;
       promises = prepared.promises;

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -113,7 +113,8 @@ export type EnvironmentContext =
   | 'worklet'
   | 'node'
   | 'electron-main'
-  | 'electron-renderer';
+  | 'electron-renderer'
+  | 'edge';
 
 /** The JS module format for the bundle output */
 export type OutputFormat = 'esmodule' | 'commonjs' | 'global';

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -53,6 +53,7 @@ const GLOBALS_BY_CONTEXT = {
     ...Object.keys(globals.node),
     ...Object.keys(globals.browser),
   ]),
+  edge: new Set([...BUILTINS, ...Object.keys(globals.worker)]),
 };
 
 const OUTPUT_FORMATS = {


### PR DESCRIPTION
```
{
  "targets": {
    "default": {
      "context": "edge"
    }
  }
}
```

For something like https://edge-runtime.vercel.app/ or https://developers.cloudflare.com/workers/learning/how-workers-works/

This enables building with the usual polyfills for the browser (Node builtins, replacing globals like `Buffer`, inlining readFileSync) while also not using the `browser` field for resolution (which is a problem for e.g. `react-dom/server`) and also by default having `includeNodeModules: true`

- [ ] Better ideas for naming? Alternatively `bare`?
- [ ] Look at places where env is used, e.g. JSTransformer doesn't apply any target for non-electron,non-node,non-browser contexts
- [ ] Any prior discussions regarding adding V8/JSC itself to browserslist? (Because there's no "browser" name that maps 1:1 and it's neither `engines.browser` nor `engines.node`