### PR TITLE
Codesplitting across reexports using symbol data

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -32,8 +32,9 @@ import {type ProjectPath, fromProjectPathRelative} from './projectPath';
 
 export const assetGraphEdgeTypes = {
   null: 1,
-  //TODO
-  original: 2,
+  // In addition to the null edge, a dependency can be connected to the asset containing the symbols
+  // that the dependency requested (after reexports were skipped).
+  redirected: 2,
 };
 
 export type AssetGraphEdgeType = $Values<typeof assetGraphEdgeTypes>;

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -68,7 +68,7 @@ export function nodeFromDep(dep: Dependency): DependencyNode {
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirtyDown: true,
     usedSymbolsUpDirtyUp: true,
-    symbolTarget: new Map(),
+    symbolTarget: null,
   };
 }
 

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -30,6 +30,14 @@ import {ContentGraph} from '@parcel/graph';
 import {createDependency} from './Dependency';
 import {type ProjectPath, fromProjectPathRelative} from './projectPath';
 
+export const assetGraphEdgeTypes = {
+  null: 1,
+  //TODO
+  original: 2,
+};
+
+export type AssetGraphEdgeType = $Values<typeof assetGraphEdgeTypes>;
+
 type InitOpts = {|
   entries?: Array<ProjectPath>,
   targets?: Array<Target>,
@@ -43,7 +51,7 @@ type AssetGraphOpts = {|
 |};
 
 type SerializedAssetGraph = {|
-  ...SerializedContentGraph<AssetGraphNode>,
+  ...SerializedContentGraph<AssetGraphNode, AssetGraphEdgeType>,
   hash?: ?string,
   symbolPropagationRan: boolean,
 |};
@@ -110,7 +118,10 @@ export function nodeFromEntryFile(entry: Entry): EntryFileNode {
   };
 }
 
-export default class AssetGraph extends ContentGraph<AssetGraphNode> {
+export default class AssetGraph extends ContentGraph<
+  AssetGraphNode,
+  AssetGraphEdgeType,
+> {
   onNodeRemoved: ?(nodeId: NodeId) => mixed;
   hash: ?string;
   envCache: Map<string, Environment>;

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -60,7 +60,7 @@ export function nodeFromDep(dep: Dependency): DependencyNode {
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirtyDown: true,
     usedSymbolsUpDirtyUp: true,
-    symbolTarget: null,
+    symbolTarget: new Map(),
   };
 }
 

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -55,7 +55,7 @@ export function nodeFromDep(dep: Dependency): DependencyNode {
     value: dep,
     deferred: false,
     excluded: false,
-    usedSymbolsDown: new Map(),
+    usedSymbolsDown: new Set(),
     usedSymbolsUp: new Map(),
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirtyDown: true,
@@ -88,7 +88,7 @@ export function nodeFromAsset(asset: Asset): AssetNode {
     id: asset.id,
     type: 'asset',
     value: asset,
-    usedSymbols: new Map(),
+    usedSymbols: new Set(),
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirty: true,
   };
@@ -257,7 +257,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
 
       if (node.value.env.isLibrary) {
         // in library mode, all of the entry's symbols are "used"
-        node.usedSymbolsDown.set('*', new Set());
+        node.usedSymbolsDown.add('*');
       }
       return node;
     });

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -60,6 +60,7 @@ export function nodeFromDep(dep: Dependency): DependencyNode {
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirtyDown: true,
     usedSymbolsUpDirtyUp: true,
+    symbolTarget: null,
   };
 }
 

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -55,8 +55,8 @@ export function nodeFromDep(dep: Dependency): DependencyNode {
     value: dep,
     deferred: false,
     excluded: false,
-    usedSymbolsDown: new Set(),
-    usedSymbolsUp: new Set(),
+    usedSymbolsDown: new Map(),
+    usedSymbolsUp: new Map(),
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirtyDown: true,
     usedSymbolsUpDirtyUp: true,
@@ -87,7 +87,7 @@ export function nodeFromAsset(asset: Asset): AssetNode {
     id: asset.id,
     type: 'asset',
     value: asset,
-    usedSymbols: new Set(),
+    usedSymbols: new Map(),
     usedSymbolsDownDirty: true,
     usedSymbolsUpDirty: true,
   };
@@ -256,7 +256,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
 
       if (node.value.env.isLibrary) {
         // in library mode, all of the entry's symbols are "used"
-        node.usedSymbolsDown.add('*');
+        node.usedSymbolsDown.set('*', new Set());
       }
       return node;
     });

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1778,35 +1778,22 @@ export default class BundleGraph {
         let existingNode = nullthrows(this._graph.getNode(existingNodeId));
         // Merge symbols, recompute dep.exluded based on that
 
-        // eslint-disable-next-line no-inner-declarations
-        function merge<K, V>(
-          a: Map<K, Set<V>>,
-          b: Map<K, Set<V>>,
-        ): Map<K, Set<V>> {
-          let result = new Map(a);
-          for (let [k, v] of b) {
-            let existing = result.get(k);
-            result.set(k, existing ? new Set([...existing, ...v]) : v);
-          }
-          return result;
-        }
-
         if (existingNode.type === 'asset') {
           invariant(otherNode.type === 'asset');
-          existingNode.usedSymbols = merge(
-            existingNode.usedSymbols,
-            otherNode.usedSymbols,
-          );
+          existingNode.usedSymbols = new Set([
+            ...existingNode.usedSymbols,
+            ...otherNode.usedSymbols,
+          ]);
         } else if (existingNode.type === 'dependency') {
           invariant(otherNode.type === 'dependency');
-          existingNode.usedSymbolsDown = merge(
-            existingNode.usedSymbolsDown,
-            otherNode.usedSymbolsDown,
-          );
-          existingNode.usedSymbolsUp = merge(
-            existingNode.usedSymbolsUp,
-            otherNode.usedSymbolsUp,
-          );
+          existingNode.usedSymbolsDown = new Set([
+            ...existingNode.usedSymbolsDown,
+            ...otherNode.usedSymbolsDown,
+          ]);
+          existingNode.usedSymbolsUp = new Map([
+            ...existingNode.usedSymbolsUp,
+            ...otherNode.usedSymbolsUp,
+          ]);
 
           existingNode.excluded =
             (existingNode.excluded || Boolean(existingNode.hasDeferred)) &&

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -860,7 +860,7 @@ export default class BundleGraph {
 
   getDependenciesWithSymbolTarget(
     asset: Asset,
-  ): Array<[Dependency, Map<Symbol, Symbol>]> {
+  ): Array<[Dependency, ?Map<Symbol, Symbol>]> {
     let nodeId = this._graph.getNodeIdByContentKey(asset.id);
     return this._graph.getNodeIdsConnectedFrom(nodeId).map(id => {
       let node = nullthrows(this._graph.getNode(id));
@@ -1427,7 +1427,7 @@ export default class BundleGraph {
       );
       let depSymbol =
         identifier != null
-          ? symbolLookup.get(symbolTarget.get(identifier) ?? identifier)
+          ? symbolLookup.get(symbolTarget?.get(identifier) ?? identifier)
           : undefined;
       if (depSymbol != null) {
         let resolved = this.getResolvedAsset(dep);
@@ -1759,10 +1759,12 @@ export default class BundleGraph {
     let node = this._graph.getNodeByContentKey(dep.id);
     invariant(node && node.type === 'dependency');
     let result = new Set(node.usedSymbolsUp.keys());
-    for (let [k, v] of node.symbolTarget) {
-      if (result.has(k)) {
-        result.delete(k);
-        result.add(v);
+    if (node.symbolTarget) {
+      for (let [k, v] of node.symbolTarget) {
+        if (result.has(k)) {
+          result.delete(k);
+          result.add(v);
+        }
       }
     }
     return this._symbolPropagationRan ? makeReadOnlySet(result) : null;

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -858,7 +858,9 @@ export default class BundleGraph {
     });
   }
 
-  getDependenciesWithSymbolTarget(asset: Asset): Array<[Dependency, ?Symbol]> {
+  getDependenciesWithSymbolTarget(
+    asset: Asset,
+  ): Array<[Dependency, Map<Symbol, Symbol>]> {
     let nodeId = this._graph.getNodeIdByContentKey(asset.id);
     return this._graph.getNodeIdsConnectedFrom(nodeId).map(id => {
       let node = nullthrows(this._graph.getNode(id));
@@ -1423,7 +1425,10 @@ export default class BundleGraph {
       let symbolLookup = new Map(
         [...depSymbols].map(([key, val]) => [val.local, key]),
       );
-      let depSymbol = symbolLookup.get(symbolTarget ?? identifier);
+      let depSymbol =
+        identifier != null
+          ? symbolLookup.get(symbolTarget.get(identifier) ?? identifier)
+          : undefined;
       if (depSymbol != null) {
         let resolved = this.getResolvedAsset(dep);
         if (!resolved || resolved.id === asset.id) {
@@ -1753,9 +1758,14 @@ export default class BundleGraph {
   getUsedSymbolsDependency(dep: Dependency): ?$ReadOnlySet<Symbol> {
     let node = this._graph.getNodeByContentKey(dep.id);
     invariant(node && node.type === 'dependency');
-    return this._symbolPropagationRan
-      ? makeReadOnlySet(new Set(node.usedSymbolsUp.keys()))
-      : null;
+    let result = new Set(node.usedSymbolsUp.keys());
+    for (let [k, v] of node.symbolTarget) {
+      if (result.has(k)) {
+        result.delete(k);
+        result.add(v);
+      }
+    }
+    return this._symbolPropagationRan ? makeReadOnlySet(result) : null;
   }
 
   merge(other: BundleGraph) {

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -23,12 +23,15 @@ const COLORS = {
 };
 
 const TYPE_COLORS = {
+  // bundle graph
   bundle: 'blue',
   contains: 'grey',
   internal_async: 'orange',
   references: 'red',
   sibling: 'green',
-  original: 'grey',
+  // asset graph
+  redirected: 'grey',
+  // request graph
   invalidated_by_create: 'green',
   invalidated_by_create_above: 'orange',
   invalidate_by_update: 'cyan',

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -114,12 +114,7 @@ export default async function dumpGraphToGraphViz(
             }
             if (node.usedSymbolsDown.size > 0) {
               label +=
-                '\\nusedSymbolsDown: ' +
-                [...node.usedSymbolsDown]
-                  .map(([s, sDeps]) =>
-                    sDeps.size > 0 ? `${s}(${[...sDeps].join(',')})` : s,
-                  )
-                  .join(',');
+                '\\nusedSymbolsDown: ' + [...node.usedSymbolsDown].join(',');
             }
           } else {
             label += '\\nsymbols: cleared';
@@ -141,14 +136,7 @@ export default async function dumpGraphToGraphViz(
                 .join(';');
           }
           if (node.usedSymbols.size) {
-            label +=
-              '\\nusedSymbols: ' +
-              [...node.usedSymbols]
-
-                .map(([s, sDeps]) =>
-                  sDeps.size > 0 ? `${s}(${[...sDeps].join(',')})` : s,
-                )
-                .join(',');
+            label += '\\nusedSymbols: ' + [...node.usedSymbols].join(',');
           }
         } else {
           label += '\\nsymbols: cleared';

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -111,9 +111,10 @@ export default async function dumpGraphToGraphViz(
               label +=
                 '\\nusedSymbolsUp: ' +
                 [...node.usedSymbolsUp]
-                  .map(
-                    ([s, sAsset]) =>
-                      `${s}(${sAsset.asset}.${sAsset.symbol ?? ''})`,
+                  .map(([s, sAsset]) =>
+                    sAsset
+                      ? `${s}(${sAsset.asset}.${sAsset.symbol ?? ''})`
+                      : `${s}(external)`,
                   )
                   .join(',');
             }

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -103,11 +103,22 @@ export default async function dumpGraphToGraphViz(
               label += '\\nweakSymbols: ' + weakSymbols.join(',');
             }
             if (node.usedSymbolsUp.size > 0) {
-              label += '\\nusedSymbolsUp: ' + [...node.usedSymbolsUp].join(',');
+              label +=
+                '\\nusedSymbolsUp: ' +
+                [...node.usedSymbolsUp]
+                  .map(([s, sDeps]) =>
+                    sDeps.size > 0 ? `${s}(${[...sDeps].join(',')})` : s,
+                  )
+                  .join(',');
             }
             if (node.usedSymbolsDown.size > 0) {
               label +=
-                '\\nusedSymbolsDown: ' + [...node.usedSymbolsDown].join(',');
+                '\\nusedSymbolsDown: ' +
+                [...node.usedSymbolsDown]
+                  .map(([s, sDeps]) =>
+                    sDeps.size > 0 ? `${s}(${[...sDeps].join(',')})` : s,
+                  )
+                  .join(',');
             }
           } else {
             label += '\\nsymbols: cleared';
@@ -129,7 +140,14 @@ export default async function dumpGraphToGraphViz(
                 .join(';');
           }
           if (node.usedSymbols.size) {
-            label += '\\nusedSymbols: ' + [...node.usedSymbols].join(',');
+            label +=
+              '\\nusedSymbols: ' +
+              [...node.usedSymbols]
+
+                .map(([s, sDeps]) =>
+                  sDeps.size > 0 ? `${s}(${[...sDeps].join(',')})` : s,
+                )
+                .join(',');
           }
         } else {
           label += '\\nsymbols: cleared';

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -3,6 +3,8 @@
 import type {Asset, BundleBehavior} from '@parcel/types';
 import type {Graph} from '@parcel/graph';
 import type {AssetGraphNode, BundleGraphNode, Environment} from './types';
+import type {AssetGraphEdgeType} from './AssetGraph';
+import {assetGraphEdgeTypes} from './AssetGraph';
 import {bundleGraphEdgeTypes} from './BundleGraph';
 import {requestGraphEdgeTypes} from './RequestTracker';
 
@@ -26,6 +28,7 @@ const TYPE_COLORS = {
   internal_async: 'orange',
   references: 'red',
   sibling: 'green',
+  original: 'grey',
   invalidated_by_create: 'green',
   invalidated_by_create_above: 'orange',
   invalidate_by_update: 'cyan',
@@ -34,7 +37,7 @@ const TYPE_COLORS = {
 
 export default async function dumpGraphToGraphViz(
   graph:
-    | Graph<AssetGraphNode>
+    | Graph<AssetGraphNode, AssetGraphEdgeType>
     | Graph<{|
         assets: Set<Asset>,
         sourceBundles: Set<number>,
@@ -42,7 +45,10 @@ export default async function dumpGraphToGraphViz(
       |}>
     | Graph<BundleGraphNode>,
   name: string,
-  edgeTypes?: typeof bundleGraphEdgeTypes | typeof requestGraphEdgeTypes,
+  edgeTypes?:
+    | typeof assetGraphEdgeTypes
+    | typeof bundleGraphEdgeTypes
+    | typeof requestGraphEdgeTypes,
 ): Promise<void> {
   if (
     process.env.PARCEL_BUILD_ENV === 'production' ||

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -131,6 +131,11 @@ export default async function dumpGraphToGraphViz(
               label +=
                 '\\nusedSymbolsDown: ' + [...node.usedSymbolsDown].join(',');
             }
+            if (node.symbolTarget && node.symbolTarget?.size > 0) {
+              label +=
+                '\\nsymbolTarget: ' +
+                [...node.symbolTarget].map(([a, b]) => `${a}:${b}`).join(',');
+            }
           } else {
             label += '\\nsymbols: cleared';
           }

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -106,8 +106,9 @@ export default async function dumpGraphToGraphViz(
               label +=
                 '\\nusedSymbolsUp: ' +
                 [...node.usedSymbolsUp]
-                  .map(([s, sDeps]) =>
-                    sDeps.size > 0 ? `${s}(${[...sDeps].join(',')})` : s,
+                  .map(
+                    ([s, sAsset]) =>
+                      `${s}(${sAsset.asset}.${sAsset.symbol ?? ''})`,
                   )
                   .join(',');
             }

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -80,8 +80,13 @@ export default async function dumpGraphToGraphViz(
       if (node.type === 'dependency') {
         label += node.value.specifier;
         let parts = [];
-        if (node.value.priority !== Priority.sync)
-          parts.push(node.value.priority);
+        if (node.value.priority !== Priority.sync) {
+          parts.push(
+            Object.entries(Priority).find(
+              ([, v]) => v === node.value.priority,
+            )?.[0],
+          );
+        }
         if (node.value.isOptional) parts.push('optional');
         if (node.value.specifierType === SpecifierType.url) parts.push('url');
         if (node.hasDeferred) parts.push('deferred');

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -236,6 +236,14 @@ export default class BundleGraph<TBundle: IBundle>
     };
   }
 
+  getDependencySymbolTarget(dependency: IDependency): ?Symbol {
+    let node = nullthrows(
+      this.#graph._graph.getNodeByContentKey(dependency.id),
+    );
+    invariant(node.type === 'dependency');
+    return node.symbolTarget;
+  }
+
   getExportedSymbols(
     asset: IAsset,
     boundary: ?IBundle,

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -238,14 +238,6 @@ export default class BundleGraph<TBundle: IBundle>
     };
   }
 
-  getDependencySymbolTarget(dependency: IDependency): Map<Symbol, Symbol> {
-    let node = nullthrows(
-      this.#graph._graph.getNodeByContentKey(dependency.id),
-    );
-    invariant(node.type === 'dependency');
-    return node.symbolTarget;
-  }
-
   getExportedSymbols(
     asset: IAsset,
     boundary: ?IBundle,

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -10,6 +10,7 @@ import type {
   ExportSymbolResolution,
   FilePath,
   GraphVisitor,
+  DependencySymbols as IDependencySymbols,
   Symbol,
   SymbolResolution,
   Target,
@@ -27,6 +28,7 @@ import Dependency, {dependencyToInternalDependency} from './Dependency';
 import {targetToInternalTarget} from './Target';
 import {fromInternalSourceLocation} from '../utils';
 import BundleGroup, {bundleGroupToInternalBundleGroup} from './BundleGroup';
+import {DependencySymbols} from './Symbols';
 
 // Friendly access for other modules within this package that need access
 // to the internal bundle.
@@ -236,7 +238,7 @@ export default class BundleGraph<TBundle: IBundle>
     };
   }
 
-  getDependencySymbolTarget(dependency: IDependency): ?Symbol {
+  getDependencySymbolTarget(dependency: IDependency): Map<Symbol, Symbol> {
     let node = nullthrows(
       this.#graph._graph.getNodeByContentKey(dependency.id),
     );
@@ -314,6 +316,12 @@ export default class BundleGraph<TBundle: IBundle>
         dependencyToInternalDependency(v),
       );
     }
+  }
+
+  getSymbols(dep: IDependency): IDependencySymbols {
+    let node = this.#graph._graph.getNodeByContentKey(dep.id);
+    invariant(node && node.type === 'dependency');
+    return new DependencySymbols(this.#options, node.value, node.symbolTarget);
   }
 
   getEntryRoot(target: Target): FilePath {

--- a/packages/core/core/src/public/Symbols.js
+++ b/packages/core/core/src/public/Symbols.js
@@ -200,12 +200,12 @@ export class DependencySymbols implements IDependencySymbols {
   */
   #value: Dependency;
   #options: ParcelOptions;
-  #symbolTarget: Map<ISymbol, ISymbol>;
+  #symbolTarget: ?Map<ISymbol, ISymbol>;
 
   constructor(
     options: ParcelOptions,
     dep: Dependency,
-    symbolTarget: Map<ISymbol, ISymbol>,
+    symbolTarget: ?Map<ISymbol, ISymbol>,
   ): DependencySymbols {
     let existing = valueToDependencySymbols.get(dep);
     if (existing != null) {
@@ -218,7 +218,7 @@ export class DependencySymbols implements IDependencySymbols {
   }
 
   #translateExportSymbol(exportSymbol: ISymbol): ISymbol {
-    return this.#symbolTarget.get(exportSymbol) ?? exportSymbol;
+    return this.#symbolTarget?.get(exportSymbol) ?? exportSymbol;
   }
 
   // immutable:

--- a/packages/core/core/src/public/Symbols.js
+++ b/packages/core/core/src/public/Symbols.js
@@ -278,7 +278,7 @@ export class DependencySymbols implements IDependencySymbols {
       return result[Symbol.iterator]();
     } else {
       // $FlowFixMe
-      return EMPTY_ITERABLE;
+      return EMPTY_ITERATOR;
     }
   }
 

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -965,13 +965,17 @@ export class AssetGraphBuilder {
   }
 }
 
-function equalMap<K, V>(a: $ReadOnlyMap<K, V>, b: $ReadOnlyMap<K, V>) {
-  return (
-    a.size === b.size &&
-    [...a].every(([k, v]) => {
-      return b.has(k) && b.get(k) === v;
-    })
-  );
+function equalMap<K>(
+  a: $ReadOnlyMap<K, {|asset: ContentKey, symbol: ?Symbol|}>,
+  b: $ReadOnlyMap<K, {|asset: ContentKey, symbol: ?Symbol|}>,
+) {
+  if (a.size !== b.size) return false;
+  for (let [k, v] of a) {
+    let vB = b.get(k);
+    if (vB == null) return false;
+    if (vB?.asset !== v.asset || vB?.symbol !== v.symbol) return false;
+  }
+  return true;
 }
 
 function equalSet<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>) {

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -718,9 +718,13 @@ export class AssetGraphBuilder {
         let assetGroupId;
         if (assetParents.length === 1) {
           [assetGroupId] = assetParents;
-          invariant(
-            this.assetGraph.getNode(assetGroupId)?.type === 'asset_group',
-          );
+          let type = this.assetGraph.getNode(assetGroupId)?.type;
+          // Parent is either an asset group, or a dependency when transformer returned multiple
+          // connected assets.
+          if (type !== 'asset_group') {
+            invariant(type === 'dependency');
+            assetGroupId = undefined;
+          }
         }
 
         this.assetGraph.addEdge(

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -583,12 +583,16 @@ export class AssetGraphBuilder {
             assetSymbols == null || // Assume everything could be provided if symbols are cleared
             assetNode.value.bundleBehavior === BundleBehavior.isolated ||
             assetNode.value.bundleBehavior === BundleBehavior.inline ||
-            assetNode.usedSymbols.has(s) ||
-            reexportedSymbols.has(s) ||
-            s === '*'
+            s === '*' ||
+            assetNode.usedSymbols.has(s)
           ) {
+            incomingDep.usedSymbolsUp.set(s, {
+              asset: assetNode.id,
+              symbol: s,
+            });
+          } else if (reexportedSymbols.has(s)) {
             // Forward a reexport only if the current asset is side-effect free.
-            if (reexportedSymbols.has(s) && !assetNode.value.sideEffects) {
+            if (!assetNode.value.sideEffects) {
               incomingDep.usedSymbolsUp.set(
                 s,
                 nullthrows(reexportedSymbols.get(s)),

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -209,6 +209,10 @@ export class AssetGraphBuilder {
       d => d.value.env.shouldScopeHoist,
     );
     if (this.assetGraph.symbolPropagationRan) {
+      dumpToGraphViz(
+        this.assetGraph,
+        'AssetGraph_' + this.name + '_before_prop',
+      );
       try {
         this.propagateSymbols();
       } catch (e) {
@@ -659,6 +663,13 @@ export class AssetGraphBuilder {
 
     // Do after the fact to not disrupt traversal
     for (let [dep, {asset, targets}] of replacements) {
+      if (
+        process.env.PARCEL_BUILD_ENV !== 'production' &&
+        // $FlowFixMe
+        process.env.PARCEL_SYMBOLS_CODESPLIT == false
+      ) {
+        break;
+      }
       let parents = this.assetGraph.getNodeIdsConnectedTo(
         this.assetGraph.getNodeIdByContentKey(asset),
       );

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -612,10 +612,7 @@ export class AssetGraphBuilder {
           } else if (reexportedSymbols.has(s)) {
             // Forward a reexport only if the current asset is side-effect free.
             if (!assetNode.value.sideEffects) {
-              incomingDep.usedSymbolsUp.set(
-                s,
-                nullthrows(reexportedSymbols.get(s)),
-              );
+              incomingDep.usedSymbolsUp.set(s, reexportedSymbols.get(s));
             } else {
               incomingDep.usedSymbolsUp.set(s, {
                 asset: assetNode.id,

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -569,7 +569,15 @@ export class AssetGraphBuilder {
             outgoingDepReplacements.set(s, sResolved.symbol ?? s);
           }
         }
-        if (outgoingDepResolved != null) {
+        if (
+          // TODO we currently can't replace async imports from
+          //      (parcelRequire("4pwI8")).then(({ a: a  })=>a);
+          // to
+          //      (parcelRequire("4pwI8")).then((a)=>a);
+          // if symbolTarget == { a -> * }
+          outgoingDep.value.priority == Priority.sync &&
+          outgoingDepResolved != null
+        ) {
           replacements.set(outgoingDep.id, {
             asset: outgoingDepResolved,
             targets: outgoingDepReplacements,

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -495,7 +495,13 @@ export class AssetGraphBuilder {
               assetNode.usedSymbols.add('*');
               reexportedSymbols.set(s, {asset: assetNode.id, symbol: s});
             } else {
-              reexportedSymbols.set(s, sResolved);
+              reexportedSymbols.set(
+                s,
+                // Forward a reexport only if the current asset is side-effect free.
+                !assetNode.value.sideEffects
+                  ? sResolved
+                  : {asset: assetNode.id, symbol: s},
+              );
               reexportedSymbolsSource.set(s, outgoingDep);
             }
           });
@@ -531,7 +537,13 @@ export class AssetGraphBuilder {
                 assetNode.usedSymbols.add('*');
                 reexportedSymbols.set(s, {asset: assetNode.id, symbol: s});
               } else {
-                reexportedSymbols.set(s, sResolved);
+                reexportedSymbols.set(
+                  s,
+                  // Forward a reexport only if the current asset is side-effect free.
+                  !assetNode.value.sideEffects
+                    ? sResolved
+                    : {asset: assetNode.id, symbol: s},
+                );
                 reexportedSymbolsSource.set(s, outgoingDep);
               }
             });
@@ -575,7 +587,8 @@ export class AssetGraphBuilder {
             reexportedSymbols.has(s) ||
             s === '*'
           ) {
-            if (reexportedSymbols.has(s)) {
+            // Forward a reexport only if the current asset is side-effect free.
+            if (reexportedSymbols.has(s) && !assetNode.value.sideEffects) {
               incomingDep.usedSymbolsUp.set(
                 s,
                 nullthrows(reexportedSymbols.get(s)),

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -308,7 +308,8 @@ export type DependencyNode = {|
   hasDeferred?: boolean,
   // symbol -> the dependency that originally requested it
   usedSymbolsDown: Map<Symbol, Set<ContentKey>>,
-  usedSymbolsUp: Map<Symbol, Set<ContentKey>>,
+  // a requested symbol -> the asset it resolved to, and the potentially renamed export name
+  usedSymbolsUp: Map<Symbol, {|asset: ContentKey, symbol: ?Symbol|}>,
   /** for the "down" pass, the dependency resolution asset needs to be updated */
   usedSymbolsDownDirty: boolean,
   /** for the "up" pass, the parent asset needs to be updated */
@@ -317,6 +318,9 @@ export type DependencyNode = {|
   usedSymbolsUpDirtyDown: boolean,
   /** dependency was excluded (= no used symbols (globally) & side-effect free) */
   excluded: boolean,
+  /** a dependency importing a single symbol is rewritten to point to the reexported target asset
+   * instead, this is the name of the export (might have been renamed by reexports) */
+  symbolTarget: ?Symbol,
 |};
 
 export type RootNode = {|id: ContentKey, +type: 'root', value: string | null|};

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -319,7 +319,7 @@ export type DependencyNode = {|
   excluded: boolean,
   /** a dependency importing a single symbol is rewritten to point to the reexported target asset
    * instead, this is the name of the export (might have been renamed by reexports) */
-  symbolTarget: ?Symbol,
+  symbolTarget: Map<Symbol, Symbol>,
 |};
 
 export type RootNode = {|id: ContentKey, +type: 'root', value: string | null|};

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -290,7 +290,7 @@ export type AssetNode = {|
   id: ContentKey,
   +type: 'asset',
   value: Asset,
-  usedSymbols: Map<Symbol, Set<ContentKey>>,
+  usedSymbols: Set<Symbol>,
   hasDeferred?: boolean,
   usedSymbolsDownDirty: boolean,
   usedSymbolsUpDirty: boolean,
@@ -306,8 +306,7 @@ export type DependencyNode = {|
   deferred: boolean,
   /** dependency was deferred (= no used symbols (in immediate parents) & side-effect free) */
   hasDeferred?: boolean,
-  // symbol -> the dependency that originally requested it
-  usedSymbolsDown: Map<Symbol, Set<ContentKey>>,
+  usedSymbolsDown: Set<Symbol>,
   // a requested symbol -> the asset it resolved to, and the potentially renamed export name
   usedSymbolsUp: Map<Symbol, {|asset: ContentKey, symbol: ?Symbol|}>,
   /** for the "down" pass, the dependency resolution asset needs to be updated */

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -290,7 +290,7 @@ export type AssetNode = {|
   id: ContentKey,
   +type: 'asset',
   value: Asset,
-  usedSymbols: Set<Symbol>,
+  usedSymbols: Map<Symbol, Set<ContentKey>>,
   hasDeferred?: boolean,
   usedSymbolsDownDirty: boolean,
   usedSymbolsUpDirty: boolean,
@@ -306,8 +306,9 @@ export type DependencyNode = {|
   deferred: boolean,
   /** dependency was deferred (= no used symbols (in immediate parents) & side-effect free) */
   hasDeferred?: boolean,
-  usedSymbolsDown: Set<Symbol>,
-  usedSymbolsUp: Set<Symbol>,
+  // symbol -> the dependency that originally requested it
+  usedSymbolsDown: Map<Symbol, Set<ContentKey>>,
+  usedSymbolsUp: Map<Symbol, Set<ContentKey>>,
   /** for the "down" pass, the dependency resolution asset needs to be updated */
   usedSymbolsDownDirty: boolean,
   /** for the "up" pass, the parent asset needs to be updated */

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -319,7 +319,7 @@ export type DependencyNode = {|
   excluded: boolean,
   /** a dependency importing a single symbol is rewritten to point to the reexported target asset
    * instead, this is the name of the export (might have been renamed by reexports) */
-  symbolTarget: Map<Symbol, Symbol>,
+  symbolTarget: ?Map<Symbol, Symbol>,
 |};
 
 export type RootNode = {|id: ContentKey, +type: 'root', value: string | null|};

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -307,8 +307,8 @@ export type DependencyNode = {|
   /** dependency was deferred (= no used symbols (in immediate parents) & side-effect free) */
   hasDeferred?: boolean,
   usedSymbolsDown: Set<Symbol>,
-  // a requested symbol -> the asset it resolved to, and the potentially renamed export name
-  usedSymbolsUp: Map<Symbol, {|asset: ContentKey, symbol: ?Symbol|}>,
+  // a requested symbol -> the asset it resolved to, and the potentially renamed export name (null if external)
+  usedSymbolsUp: Map<Symbol, ?{|asset: ContentKey, symbol: ?Symbol|}>,
   /** for the "down" pass, the dependency resolution asset needs to be updated */
   usedSymbolsDownDirty: boolean,
   /** for the "up" pass, the parent asset needs to be updated */

--- a/packages/core/integration-tests/test/integration/resolver-canDefer/index.js
+++ b/packages/core/integration-tests/test/integration/resolver-canDefer/index.js
@@ -1,3 +1,3 @@
-import {a} from "./library";
+import {a, index} from "./library";
 
-output = a;
+output = [a, index];

--- a/packages/core/integration-tests/test/integration/resolver-canDefer/library/index.js
+++ b/packages/core/integration-tests/test/integration/resolver-canDefer/library/index.js
@@ -2,3 +2,4 @@ sideEffect("index");
 export {a} from "./a.js";
 export {b} from "./b.js";
 export {c} from "./c.js";
+export const index = "Index";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/index.js
@@ -1,0 +1,3 @@
+import { Context } from "./library";
+
+output = [Context, () => import("./library/dynamic")];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/a.js
@@ -1,0 +1,2 @@
+sideEffect("a");
+export const Ctx = 1;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/b.js
@@ -1,0 +1,2 @@
+sideEffect("b");
+export const Ctx = 2;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/dynamic.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/dynamic.js
@@ -1,0 +1,4 @@
+sideEffect("dynamic");
+import { Ctx } from "./a.js";
+import { id } from "./index.js";
+export default [Ctx, id];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/index.js
@@ -1,0 +1,4 @@
+sideEffect("index");
+export { Ctx } from "./a.js";
+export { Ctx as Context } from "./b.js";
+export const id = 3;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/library/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -7186,6 +7186,43 @@ describe('javascript', function () {
         assert.deepEqual(res.output, ['foo', 'bar']);
       });
 
+      it('supports partially used reexporting index file', async function () {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/side-effects-re-exports-partially-used/index.js',
+          ),
+          options,
+        );
+
+        let calls = [];
+        let res = (
+          await run(
+            b,
+            {
+              sideEffect: caller => {
+                calls.push(caller);
+              },
+            },
+            {require: false},
+          )
+        ).output;
+
+        let [v, async] = res;
+
+        assert.deepEqual(calls, shouldScopeHoist ? ['b'] : ['a', 'b', 'index']);
+        assert.deepEqual(v, 2);
+
+        v = await async();
+        assert.deepEqual(
+          calls,
+          shouldScopeHoist
+            ? ['b', 'a', 'index', 'dynamic']
+            : ['a', 'b', 'index', 'dynamic'],
+        );
+        assert.deepEqual(v.default, [1, 3]);
+      });
+
       it('supports deferring non-weak dependencies that are not used', async function () {
         let b = await bundle(
           path.join(

--- a/packages/core/integration-tests/test/plugin.js
+++ b/packages/core/integration-tests/test/plugin.js
@@ -123,10 +123,7 @@ parcel-transformer-b`,
       },
     );
 
-    assert.deepStrictEqual(
-      new Set(b.getUsedSymbols(nullthrows(findAsset(b, 'index.js')))),
-      new Set([]),
-    );
+    assert.deepStrictEqual(!findAsset(b, 'index.js'));
     assert.deepStrictEqual(
       new Set(b.getUsedSymbols(nullthrows(findAsset(b, 'a.js')))),
       new Set(['a']),

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -6,7 +6,6 @@ import {createWorkerFarm} from '@parcel/core';
 import {md} from '@parcel/diagnostic';
 import {
   assertBundles,
-  assertDependencyWasExcluded,
   bundle as _bundle,
   bundler as _bundler,
   distDir,
@@ -2441,12 +2440,6 @@ describe('scope hoisting', function () {
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [123]);
 
-          assertDependencyWasExcluded(
-            bundleEvent.bundleGraph,
-            'a.js',
-            './c.js',
-          );
-
           await overlayFS.copyFile(
             path.join(testDir, 'index.2.js'),
             path.join(testDir, 'index.js'),
@@ -2674,18 +2667,6 @@ describe('scope hoisting', function () {
             ),
             new Set(['gridSize']),
           );
-          assert.deepStrictEqual(
-            new Set(
-              bundleEvent.bundleGraph.getUsedSymbols(
-                findDependency(
-                  bundleEvent.bundleGraph,
-                  'theme.js',
-                  './themeColors',
-                ),
-              ),
-            ),
-            new Set(),
-          );
           assert(!findAsset(bundleEvent.bundleGraph, 'themeColors.js'));
 
           await overlayFS.copyFile(
@@ -2725,6 +2706,7 @@ describe('scope hoisting', function () {
             ),
             new Set('*'),
           );
+          assert(findAsset(bundleEvent.bundleGraph, 'themeColors.js'));
 
           await overlayFS.copyFile(
             path.join(testDir, 'index.1.js'),
@@ -2748,18 +2730,7 @@ describe('scope hoisting', function () {
             ),
             new Set(['gridSize']),
           );
-          assert.deepStrictEqual(
-            new Set(
-              bundleEvent.bundleGraph.getUsedSymbols(
-                findDependency(
-                  bundleEvent.bundleGraph,
-                  'theme.js',
-                  './themeColors',
-                ),
-              ),
-            ),
-            new Set(),
-          );
+          assert(!findAsset(bundleEvent.bundleGraph, 'themeColors.js'));
         } finally {
           await subscription.unsubscribe();
         }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1438,6 +1438,7 @@ export interface BundleGraph<TBundle: Bundle> {
     symbol: Symbol,
     boundary: ?Bundle,
   ): SymbolResolution;
+  getDependencySymbolTarget(dependency: Dependency): ?Symbol;
   /** Returns a list of symbols that are exported by the asset, including re-exports. */
   getExportedSymbols(
     asset: Asset,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -465,6 +465,29 @@ export interface MutableDependencySymbols // eslint-disable-next-line no-undef
   delete(exportSymbol: Symbol): void;
 }
 
+export interface DependencySymbols // eslint-disable-next-line no-undef
+  extends Iterable<
+    [
+      Symbol,
+      {|local: Symbol, loc: ?SourceLocation, isWeak: boolean, meta?: ?Meta|},
+    ],
+  > {
+  /**
+   * The symbols taht are imports are unknown, rather than just empty.
+   * This is the default state.
+   */
+  +isCleared: boolean;
+  get(exportSymbol: Symbol): ?{|
+    local: Symbol,
+    loc: ?SourceLocation,
+    isWeak: boolean,
+    meta?: ?Meta,
+  |};
+  hasExportSymbol(exportSymbol: Symbol): boolean;
+  hasLocalSymbol(local: Symbol): boolean;
+  exportSymbols(): Iterable<Symbol>;
+}
+
 export type DependencyPriority = 'sync' | 'parallel' | 'lazy';
 export type SpecifierType = 'commonjs' | 'esm' | 'url' | 'custom';
 
@@ -1438,7 +1461,7 @@ export interface BundleGraph<TBundle: Bundle> {
     symbol: Symbol,
     boundary: ?Bundle,
   ): SymbolResolution;
-  getDependencySymbolTarget(dependency: Dependency): ?Symbol;
+  getDependencySymbolTarget(dependency: Dependency): Map<Symbol, Symbol>;
   /** Returns a list of symbols that are exported by the asset, including re-exports. */
   getExportedSymbols(
     asset: Asset,
@@ -1450,6 +1473,7 @@ export interface BundleGraph<TBundle: Bundle> {
    * Returns null if symbol propagation didn't run (so the result is unknown).
    */
   getUsedSymbols(Asset | Dependency): ?$ReadOnlySet<Symbol>;
+  getSymbols(Dependency): DependencySymbols;
   /** Returns the common root directory for the entry assets of a target. */
   getEntryRoot(target: Target): FilePath;
 }

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -1461,7 +1461,6 @@ export interface BundleGraph<TBundle: Bundle> {
     symbol: Symbol,
     boundary: ?Bundle,
   ): SymbolResolution;
-  getDependencySymbolTarget(dependency: Dependency): Map<Symbol, Symbol>;
   /** Returns a list of symbols that are exported by the asset, including re-exports. */
   getExportedSymbols(
     asset: Asset,

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -79,7 +79,9 @@ export default (new Packager({
                 if (asset.meta.hasReferences) {
                   let replacements = new Map();
                   for (let dep of asset.getDependencies()) {
-                    for (let [exported, {local}] of dep.symbols) {
+                    for (let [exported, {local}] of bundleGraph.getSymbols(
+                      dep,
+                    )) {
                       let resolved = bundleGraph.getResolvedAsset(dep, bundle);
                       if (resolved) {
                         let resolution = bundleGraph.getSymbolResolution(
@@ -216,9 +218,11 @@ async function processCSSModule(
     let defaultImport = null;
     if (usedSymbols.has('default')) {
       let incoming = bundleGraph.getIncomingDependencies(asset);
-      defaultImport = incoming.find(d => d.symbols.hasExportSymbol('default'));
+      defaultImport = incoming.find(d =>
+        bundleGraph.getSymbols(d).hasExportSymbol('default'),
+      );
       if (defaultImport) {
-        let loc = defaultImport.symbols.get('default')?.loc;
+        let loc = bundleGraph.getSymbols(defaultImport).get('default')?.loc;
         logger.warn({
           message:
             'CSS modules cannot be tree shaken when imported with a default specifier',

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -758,6 +758,10 @@ ${code}
     imported: string,
     dep?: Dependency,
   ): string {
+    if (dep != null) {
+      imported = this.bundleGraph.getDependencySymbolTarget(dep) ?? imported;
+    }
+
     let {
       asset: resolvedAsset,
       exportSymbol,

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -620,7 +620,7 @@ ${code}
         continue;
       }
 
-      for (let [imported, {local}] of dep.symbols) {
+      for (let [imported, {local}] of this.bundleGraph.getSymbols(dep)) {
         if (local === '*') {
           continue;
         }
@@ -695,7 +695,7 @@ ${code}
       this.externals.set(dep.specifier, external);
     }
 
-    for (let [imported, {local}] of dep.symbols) {
+    for (let [imported, {local}] of this.bundleGraph.getSymbols(dep)) {
       // If already imported, just add the already renamed variable to the mapping.
       let renamed = external.get(imported);
       if (renamed && local !== '*' && replacements) {
@@ -758,10 +758,6 @@ ${code}
     imported: string,
     dep?: Dependency,
   ): string {
-    if (dep != null) {
-      imported = this.bundleGraph.getDependencySymbolTarget(dep) ?? imported;
-    }
-
     let {
       asset: resolvedAsset,
       exportSymbol,
@@ -1045,7 +1041,7 @@ ${code}
 
         let isWrapped = resolved && resolved.meta.shouldWrap;
 
-        for (let [imported, {local}] of dep.symbols) {
+        for (let [imported, {local}] of this.bundleGraph.getSymbols(dep)) {
           if (imported === '*' && local === '*') {
             if (!resolved) {
               // Re-exporting an external module. This should have already been handled in buildReplacements.
@@ -1206,7 +1202,7 @@ ${code}
         dep =>
           this.bundle.hasDependency(dep) &&
           // dep.meta.isES6Module &&
-          dep.symbols.hasExportSymbol('default'),
+          this.bundleGraph.getSymbols(dep).hasExportSymbol('default'),
       );
     }
 


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7392

Symbol propagation already does the traversals anyway, so now it just always tracks for each symbol in a dependency, what that symbol should resolve to.

Then, once it encounters a non-reexport dependency, it checks if all symbols in that dependency resolve to the same asset, and rewrites the edge from the dependency to the asset to point to the original asset that has the symbol (or at least as far down as possible, in case some deopt or non-static situation was encountered).

Since it's possible to rename symbols via reexports, I've had to add an additional map to the dependency node, e.g. a dependency to a side-effect-free asset that does `export {foo as bar} from "y";` would then be rewritten to point directly to `y` instead, and the `symbolTarget` map then has `foo -> bar` which is applied transparently in `bundleGraph.getUsedSymbols` and `bundleGraph.getSymbols` (which I think is a better solution compared to mutating the actual DependencyValue symbols entry).

- [x] The major outstanding known issue: if we rewrite the dependency edge proper, we don't have the original edge anymore on the next build (if it's cached). So I think we have to have another edge type, which would be used instead of the untyped edge when converting the asset graph into the bundle graph.
- [ ] This currently only works if a dependency imports symbols that all eventually resolve to the same asset, otherwise it behaves just as before. So I think splitting up the imports to be per-symbol should happen in the JS transformer, otherwise we'd have a single dependency (id) that actually resolves to different assets. We might have to change how the dependency id is derived for that
- [ ] add tests for new behaviour
- [ ] real world testing

A pleasant surprise:
Doing `import("lodash-es").then(({add}) => add(1,2))` will be redirected to behave like `import("lodash-es/add").then(...)`