### PR TITLE
Fix SW packaging in web extensions

### DIFF
--- a/packages/packagers/webextension/src/WebExtensionPackager.js
+++ b/packages/packagers/webextension/src/WebExtensionPackager.js
@@ -25,7 +25,7 @@ export default (new Packager({
     const manifest = JSON.parse(await asset.getCode());
 
     if (manifest.background?.type === 'module') {
-      // service workers are build with output format 'global'
+      // service workers are built with output format 'global'
       // see: https://github.com/parcel-bundler/parcel/blob/3329469f50de9326c5b02ef0ab1c0ce41393279c/packages/transformers/js/src/JSTransformer.js#L577
       delete manifest.background.type;
     }

--- a/packages/packagers/webextension/src/WebExtensionPackager.js
+++ b/packages/packagers/webextension/src/WebExtensionPackager.js
@@ -23,6 +23,13 @@ export default (new Packager({
       relativeBundlePath(bundle, b, {leadingDotSlash: false});
 
     const manifest = JSON.parse(await asset.getCode());
+
+    if (manifest.background?.type === 'module') {
+      // service workers are build with output format 'global'
+      // see: https://github.com/parcel-bundler/parcel/blob/3329469f50de9326c5b02ef0ab1c0ce41393279c/packages/transformers/js/src/JSTransformer.js#L577
+      delete manifest.background.type;
+    }
+
     const deps = asset.getDependencies();
     const war = [];
     for (const contentScript of manifest.content_scripts || []) {


### PR DESCRIPTION
# ↪️ Pull Request

This PR fixes the packaging of Service Workers using ES Modules in the `webextension` config. 

The JS transform does not support ES Modules for service workers:

https://github.com/parcel-bundler/parcel/blob/3329469f50de9326c5b02ef0ab1c0ce41393279c/packages/transformers/js/src/JSTransformer.js#L575-L577

Instead, it sets `outputFormat` to `global` ([docs](https://parceljs.org/features/targets/#outputformat)). For that reason, the `type=module` is removed when packaging the extension.

Related issue: https://github.com/parcel-bundler/parcel/issues/1747.

## 🚨 Test instructions

Here's a repo in which builds fail with `2.7.0` but pass with this PR:

https://github.com/olistic/parcel-webextension-repro

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
