### PR TITLE
fix: disallow typescript@4.8 peer dep

### DIFF
--- a/packages/transformers/typescript-tsc/package.json
+++ b/packages/transformers/typescript-tsc/package.json
@@ -25,9 +25,9 @@
     "@parcel/ts-utils": "2.7.0"
   },
   "devDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "~4.7"
   },
   "peerDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "3.0.0 - 4.7"
   }
 }

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -28,9 +28,9 @@
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "~4.7"
   },
   "peerDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "3.0.0 - 4.7"
   }
 }

--- a/packages/utils/parcel-lsp/package.json
+++ b/packages/utils/parcel-lsp/package.json
@@ -50,6 +50,6 @@
     "@typescript-eslint/parser": "^4.14.1",
     "eslint": "^7.19.0",
     "glob": "^7.1.6",
-    "typescript": "^4.6.4"
+    "typescript": "~4.7"
   }
 }

--- a/packages/utils/parcelforvscode/package.json
+++ b/packages/utils/parcelforvscode/package.json
@@ -33,7 +33,7 @@
     "eslint": "^7.19.0",
     "glob": "^7.1.6",
     "mocha": "^8.2.1",
-    "typescript": "^4.6.4",
+    "typescript": "~4.7",
     "vscode-test": "^1.5.0"
   },
   "dependencies": {

--- a/packages/utils/ts-utils/package.json
+++ b/packages/utils/ts-utils/package.json
@@ -22,9 +22,9 @@
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "~4.7"
   },
   "peerDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "3.0.0 - 4.7"
   }
 }

--- a/packages/validators/typescript/package.json
+++ b/packages/validators/typescript/package.json
@@ -27,9 +27,9 @@
     "@parcel/utils": "2.7.0"
   },
   "devDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "~4.7"
   },
   "peerDependencies": {
-    "typescript": ">=3.0.0"
+    "typescript": "3.0.0 - 4.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13256,10 +13256,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@>=3.0.0, typescript@^4.6.4:
-  version "4.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
-  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+typescript@~4.7:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 uglify-js@^3.1.4:
   version "3.7.6"


### PR DESCRIPTION
remove typescript@4.8 from the peer dependency range
since typescript@4.8 is incompatible with parcel at this time.
make sure we use typescript 4.7 for development everywhere.

See https://github.com/parcel-bundler/parcel/issues/8419#issuecomment-1230066100
