### PR TITLE
Fixup env.support for ChromeAndroid

### DIFF
--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -52,6 +52,7 @@ const ALL_BROWSERS = [
   'kaios',
 ];
 
+// See require("caniuse-api").getSupport(<feature name>)
 const supportData = {
   esmodules: {
     edge: '16',
@@ -119,6 +120,7 @@ const supportData = {
     qq: '10.4',
     baidu: '7.12',
     kaios: '2.5',
+    and_chr: '50',
     and_qq: '12.12',
     op_mob: '64',
   },

--- a/packages/core/core/test/PublicEnvironment.test.js
+++ b/packages/core/core/test/PublicEnvironment.test.js
@@ -1,0 +1,27 @@
+// @flow strict-local
+
+import assert from 'assert';
+import {createEnvironment} from '../src/Environment';
+import PublicEnvironment from '../src/public/Environment';
+import {DEFAULT_OPTIONS} from './test-utils';
+
+describe('Public Environment', () => {
+  it('has correct support data for ChromeAndroid', () => {
+    let env = new PublicEnvironment(
+      createEnvironment({
+        context: 'browser',
+        engines: {
+          browsers: ['last 1 Chrome version', 'last 1 ChromeAndroid version'],
+        },
+        outputFormat: 'esmodule',
+      }),
+      DEFAULT_OPTIONS,
+    );
+
+    assert(env.supports('esmodules'));
+    assert(env.supports('dynamic-import'));
+    assert(env.supports('worker-module'));
+    assert(env.supports('import-meta-url'));
+    assert(env.supports('arrow-functions'));
+  });
+});


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/8444

Browser support data for mobile browsers [is a sham](https://github.com/browserslist/browserslist/issues/453#issuecomment-587026876) anyway (e.g. https://caniuse.com/arrow-functions), but with this adding a query with `ChromeAndroid` to browserslist at least doesn't break `env.support("arrow-functions")` anymore. And I'm not even sure what the correct version for that added entry is, so I just used the conservative 50 from `android`. Now every feature has an entry for `and_chr`

That problem manifested here:
https://github.com/parcel-bundler/parcel/blob/527e477d15441219216ed05b220cf8d48fa2d258/packages/packagers/js/src/ScopeHoistingPackager.js#L1232-L1236

MDN actually has historical data: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#browser_compatibility

- [ ] Makes me wonder if we should behave like Browserslist `mobileToDesktop` setting?