### PR TITLE
Fix verbose warning: reexport all doesn't include default

### DIFF
--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -481,6 +481,10 @@ export class AssetGraphBuilder {
 
         if (outgoingDepSymbols.get('*')?.local === '*') {
           outgoingDep.usedSymbolsUp.forEach((sResolved, s) => {
+            if (s === 'default') {
+              return;
+            }
+
             // If the symbol could come from multiple assets at runtime, assetNode's
             // namespace will be needed at runtime to perform the lookup on.
             if (reexportedSymbols.has(s)) {


### PR DESCRIPTION
Fixes some verbose warnings that were false positives such as:
`@parcel/core: node_modules/ky-universal/browser.js reexports "default", which could be resolved either to the dependency "ky" or "ky" at runtime. Adding a namespace object to fall back on.`

Test case (but not added because the symbol data is identical and asserting log messages is hard)


```js
// index.js
import a from "./a.js";
console.log(a);

// a.js
export { default } from "./b.js";
export * from "./b.js";

// b.js
export default "def";
export const b = "b";
```