### PR TITLE
Add  parcel-query function to locate a symbol by local name

### DIFF
--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -155,16 +155,20 @@ function findAssetWithSymbol(local: string) {
   );
 
   let asset;
-  outer: for (let node of assetGraph.nodes.values()) {
-    if (node.type === 'asset') {
-      // Search against the id used by the JSTransformer and ScopeHoistingPackager,
-      // not the final asset id, as it may have changed with further transformation.
-      if (node.value.meta.id === assetId) {
-        asset = node;
-        break;
-      } else if (node.value.symbols) {
-        // If the asset couldn't be found by searching for the id,
-        // search for the local name in asset used symbols.
+  // Search against the id used by the JSTransformer and ScopeHoistingPackager,
+  // not the final asset id, as it may have changed with further transformation.
+  for (let node of assetGraph.nodes.values()) {
+    if (node.type === 'asset' && node.value.meta.id === assetId) {
+      asset = node;
+      break;
+    }
+  }
+
+  // If the asset couldn't be found by searching for the id,
+  // search for the local name in asset used symbols.
+  if (asset == null) {
+    outer: for (let node of assetGraph.nodes.values()) {
+      if (node.type === 'asset' && node.value.symbols) {
         for (let symbol of node.value.symbols.values()) {
           if (symbol.local === local) {
             asset = node;

--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -121,22 +121,29 @@ function getAsset(v: string) {
   }
 }
 
-function findAsset(v: string) {
+function _findAssetNode(v: string) {
   let assetRegex = new RegExp(v);
   for (let node of assetGraph.nodes.values()) {
     if (
       node.type === 'asset' &&
       assetRegex.test(fromProjectPathRelative(node.value.filePath))
     ) {
-      try {
-        console.log(
-          `${bundleGraph.getAssetPublicId(
-            bundleGraph.getAssetById(node.id),
-          )} ${fromProjectPathRelative(node.value.filePath)}`,
-        );
-      } catch (e) {
-        console.log(fromProjectPathRelative(node.value.filePath));
-      }
+      return node;
+    }
+  }
+}
+
+function findAsset(v: string) {
+  let node = _findAssetNode(v);
+  if (node) {
+    try {
+      console.log(
+        `${bundleGraph.getAssetPublicId(
+          bundleGraph.getAssetById(node.id),
+        )} ${fromProjectPathRelative(node.value.filePath)}`,
+      );
+    } catch (e) {
+      console.log(fromProjectPathRelative(node.value.filePath));
     }
   }
 }

--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -154,13 +154,17 @@ function findAssetWithSymbol(local: string) {
     `symbol ${local} could not be resolved`,
   );
 
-  let asset = bundleGraph._graph.getNodeByContentKey(assetId);
-
-  // If the asset couldn't be found by extracting a content key from the name,
-  // search for the local name in asset used symbols.
-  if (asset == null) {
-    outer: for (let node of assetGraph.nodes.values()) {
-      if (node.type === 'asset' && node.value.symbols) {
+  let asset;
+  outer: for (let node of assetGraph.nodes.values()) {
+    if (node.type === 'asset') {
+      // Search against the id used by the JSTransformer and ScopeHoistingPackager,
+      // not the final asset id, as it may have changed with further transformation.
+      if (node.value.meta.id === assetId) {
+        asset = node;
+        break;
+      } else if (node.value.symbols) {
+        // If the asset couldn't be found by searching for the id,
+        // search for the local name in asset used symbols.
         for (let symbol of node.value.symbols.values()) {
           if (symbol.local === local) {
             asset = node;


### PR DESCRIPTION
Based on the output for `findAsset`.

Some examples of how it works:

An imported symbol:
```
> .findAssetWithSymbol $8f94277571a64835$export$e08c7d021b829b7a
bRRst node_modules/stylis/dist/stylis.mjs
imported as prefixer from node_modules/stylis/src/Enum.js
```

A declared symbol:
```
> .findAssetWithSymbol $3780a8199c4f575f$var$mapping
4LrcW node_modules/@parcel/runtime-js/lib/helpers/bundle-manifest.js
possibly defined as mapping
```