### PR TITLE
[WIP] missing symbol from .mjs dependency

### DIFF
--- a/packages/core/integration-tests/test/_test.js
+++ b/packages/core/integration-tests/test/_test.js
@@ -1,0 +1,27 @@
+import assert from 'assert';
+import path from 'path';
+import {bundle as _bundle, run, mergeParcelOptions} from '@parcel/test-utils';
+
+const bundle = (name, opts = {}) => {
+  return _bundle(
+    name,
+    // $FlowFixMe
+    mergeParcelOptions(
+      {
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+        },
+      },
+      opts,
+    ),
+  );
+};
+
+describe('_test', function () {
+  it('_test', async function () {
+    let b = await bundle(path.join(__dirname, '/integration/_test/index.js'));
+
+    let output = await run(b);
+    assert.strictEqual(output, 'foo');
+  });
+});

--- a/packages/core/integration-tests/test/integration/_test/.parcelrc
+++ b/packages/core/integration-tests/test/integration/_test/.parcelrc
@@ -1,0 +1,6 @@
+{
+  "extends": "@parcel/config-default",
+  "transformers": {
+    "*.js": ["parcel-transformer-passthrough", "..."]
+  }
+}

--- a/packages/core/integration-tests/test/integration/_test/foo.mjs
+++ b/packages/core/integration-tests/test/integration/_test/foo.mjs
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/core/integration-tests/test/integration/_test/index.js
+++ b/packages/core/integration-tests/test/integration/_test/index.js
@@ -1,0 +1,3 @@
+import {foo} from './foo.mjs';
+
+output = foo;

--- a/packages/core/integration-tests/test/integration/_test/node_modules/parcel-transformer-passthrough/index.js
+++ b/packages/core/integration-tests/test/integration/_test/node_modules/parcel-transformer-passthrough/index.js
@@ -1,0 +1,7 @@
+const Transformer = require('@parcel/plugin').Transformer;
+
+module.exports = new Transformer({
+  async transform({asset}) {
+    return [asset];
+  },
+});

--- a/packages/core/integration-tests/test/integration/_test/node_modules/parcel-transformer-passthrough/package.json
+++ b/packages/core/integration-tests/test/integration/_test/node_modules/parcel-transformer-passthrough/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "parcel-transformer-passthrough",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
```shell
 ❯ yarn test:integration --grep "_test"
yarn run v1.22.19
$ yarn workspace @parcel/integration-tests test --grep _test
$ cross-env NODE_OPTIONS=--experimental-vm-modules NODE_ENV=test PARCEL_BUILD_ENV=test mocha --grep _test


  _test
    1) _test


  0 passing (728ms)
  1 failing

  1) _test
       _test:
     index.js:5
output = (0, $7bc6ca355356f8dc$export$6a5cdcad01c973fa);
^

ReferenceError: $7bc6ca355356f8dc$export$6a5cdcad01c973fa is not defined
      at index.js:5:1
      at index.js:7:3
      at Script.runInContext (vm.js:144:12)
      at runBundles (/Users/eeldredge/Code/parcel-upstream/packages/core/test-utils/src/utils.js:383:10)
      at runBundle (/Users/eeldredge/Code/parcel-upstream/packages/core/test-utils/src/utils.js:465:12)
      at run (/Users/eeldredge/Code/parcel-upstream/packages/core/test-utils/src/utils.js:486:10)
      at Context.<anonymous> (test/_test.js:24:24)
```