### PR TITLE
Apply @mjog's patch so that Vue SFC errors are actually displayed

### DIFF
--- a/packages/core/utils/src/prettyDiagnostic.js
+++ b/packages/core/utils/src/prettyDiagnostic.js
@@ -6,7 +6,6 @@ import formatCodeFrame from '@parcel/codeframe';
 import mdAnsi from '@parcel/markdown-ansi';
 import chalk from 'chalk';
 import path from 'path';
-import nullthrows from 'nullthrows';
 // $FlowFixMe
 import terminalLink from 'terminal-link';
 
@@ -60,10 +59,10 @@ export default async function prettyDiagnostic(
       }
 
       let highlights = codeFrame.codeHighlights;
-      let code =
-        codeFrame.code ??
-        (options &&
-          (await options.inputFS.readFile(nullthrows(filePath), 'utf8')));
+      let code = codeFrame.code;
+      if (code == null && options && filePath != null) {
+        code = await options.inputFS.readFile(filePath, 'utf8');
+      }
 
       let formattedCodeFrame = '';
       if (code != null) {


### PR DESCRIPTION
See #7395

# ↪️ Pull Request

Applies the proposed patch from @mjog in #7395

## 🚨 Test instructions

- Deliberately cause a Vue compile error in an SFC - e.g. `<template v-for> key should be placed on the <template> tag.`

- Prior to applying the patch, you will get a useless `Error: Got unexpected undefined` message which doesn't tell you what the problem is:

```
Error: Got unexpected undefined
    at $812806c6461f2963$var$nullthrows (/home/adam/Documents/project/node_modules/@parcel/utils/lib/index.js:3485:17)
    at $f02d6a9d30f55938$export$2e2bcd8739ae039 (/home/adam/Documents/project/node_modules/@parcel/utils/lib/index.js:32342:195)
    at $7c213f7c22b64117$var$writeDiagnostic (/home/adam/Documents/project/node_modules/@parcel/reporter-cli/lib/CLIReporter.js:7435:167)
    at $7c213f7c22b64117$export$12358408d9820617 (/home/adam/Documents/project/node_modules/@parcel/reporter-cli/lib/CLIReporter.js:7401:19)
```

- After the patch, observe that a better error is generated (note though that the name of the component is absent)

```
Build failed.

@parcel/transformer-vue: <template v-for> key should be placed on the <template> tag.

  SyntaxError: <template v-for> key should be placed on the <template> tag.
      at createCompilerError (/home/adam/Documents/project/node_modules/@vue/compiler-core/dist/compiler-core.cjs.prod.js:18:19)
      at /home/adam/Documents/project/node_modules/@vue/compiler-core/dist/compiler-core.cjs.prod.js:3767:45
      at Array.some (<anonymous>)
```


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
