### PR TITLE
Fix #8498, add Vue filePath to error codeFrames

### DIFF
--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -188,6 +188,7 @@ function createDiagnostic(err, filePath) {
   if (err.loc) {
     diagnostic.codeFrames = [
       {
+        filePath,
         codeHighlights: [
           {
             start: {


### PR DESCRIPTION
Closes #8498 

# ↪️ Pull Request

- Passes through the filePath into the codeFrame when reporting a compiler error. This enables the end-user to actually see which component the error came from.

It doesn't appear to show a preview of the code, so possible I'm doing something wrong there - but for my purposes it at least allows me to work out where the problems in my code lie.

## 🚨 Test instructions

- Prerequisite: apply #8497 first, so that errors actually get reported properly
- Deliberately cause an error in an SFC
- Observe that Parcel's errors don't display the component path and it's therefore impossible to know which component is at fault
- Apply the patch, observe that paths are reported afterwards

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
