### PR TITLE
Fix #8500 by not adding offset to line numbers

### DIFF
--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -192,11 +192,11 @@ function createDiagnostic(err, filePath) {
         codeHighlights: [
           {
             start: {
-              line: err.loc.start.line + err.loc.start.offset,
+              line: err.loc.start.line,
               column: err.loc.start.column,
             },
             end: {
-              line: err.loc.end.line + err.loc.end.offset,
+              line: err.loc.end.line,
               column: err.loc.end.column,
             },
           },


### PR DESCRIPTION
Closes #8500 

Code snippet previews work after applying this patch, and the line numbers make sense again:

![image](https://user-images.githubusercontent.com/2552726/191946463-a969c1fc-b09d-4a37-b5c8-020f75d3c083.png)
