### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ on: pull_request
 
 name: Continuous Integration
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+permissions:
+  contents: write # for yarn nightly release
 jobs:
   build:
     strategy:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 permissions:
-  contents: write # for yarn nightly release
+  contents: read  #  for actions/checkout
 jobs:
   build:
     strategy:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,8 +5,13 @@ on:
   issue_comment:
     types: [created]
 
+permissions: {}
 jobs:
   stale:
+    permissions:
+      issues: write # to comment on issues
+      pull-requests: write # to comment on pull requests
+
     runs-on: ubuntu-latest
     steps:
       - uses: DeMoorJasper/stale@master

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
   workflow_dispatch:
 permissions:
-  contents: write # for yarn release
+  contents: read  #  for actions/checkout
 jobs:
   build:
     strategy:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -3,6 +3,8 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+permissions:
+  contents: write # for yarn release
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.