### PR TITLE
Dont merge isolated child assets

### DIFF
--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -512,7 +512,8 @@ function createIdealGraph(
             if (
               entries.has(bundleGroupRootAsset) &&
               bundleGroupRootAsset.type === childAsset.type &&
-              childAsset.bundleBehavior !== 'inline'
+              childAsset.bundleBehavior !== 'inline' &&
+              childAsset.bundleBehavior !== 'isolated'
             ) {
               bundleId = bundleGroupNodeId;
             }

--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -513,7 +513,7 @@ function createIdealGraph(
               entries.has(bundleGroupRootAsset) &&
               bundleGroupRootAsset.type === childAsset.type &&
               childAsset.bundleBehavior !== 'inline' &&
-              childAsset.bundleBehavior !== 'isolated'
+              dependency.bundleBehavior !== 'isolated'
             ) {
               bundleId = bundleGroupNodeId;
             }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes html element "examples" not rendering in markdown page. Problem was that two bundles of the same type were merged. One was isolated which we determined by dependency, and thus should not be merged ever.

I thought this whole branch 

> /**
             * If this is an entry bundlegroup, we only allow one bundle per type in those groups
             * So attempt to add the asset to the entry bundle if it's of the same type.
             * This asset will be created by other dependency if it's in another bundlegroup
             * and bundles of other types should be merged in the next step
             */

could be redundant code since we have a dedicated step to merging bundles of different types. **However**, it's not because we actually only attempt to merge bundles that have been created due to type change. So, entries are not considered in that, nor are any other code split bundles..... CC: @devongovett I think this is okay for now, but it looks like the `defaultbundler` maintains **all** bundles by type to determine where to merge. This seems like a big difference between the two bundlers that maybe needs to be fixed ? 



## 💻 Examples

Before:
![Screen Shot 2022-10-06 at 12 52 44 PM](https://user-images.githubusercontent.com/29166446/194372800-405dad5d-82f8-4044-9c55-9f8f198ebec1.png)

After: 
<img width="919" alt="Screen Shot 2022-09-30 at 8 00 28 AM" src="https://user-images.githubusercontent.com/29166446/194371745-1c321802-e631-4d12-8def-80f99e29c7b7.png">

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Tests
- [x] Tested on large app(s)
