### PR TITLE
Ensure edge exists before removal in `Graph.removeEdge`

### DIFF
--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -142,7 +142,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     }
 
     for (let {type, from} of this.adjacencyList.getInboundEdgesByType(nodeId)) {
-      this.removeEdge(
+      this._removeEdge(
         from,
         nodeId,
         type,
@@ -153,7 +153,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     }
 
     for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
-      this.removeEdge(nodeId, to, type);
+      this._removeEdge(nodeId, to, type);
     }
 
     let wasRemoved = this.nodes.delete(nodeId);
@@ -166,12 +166,27 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     }
 
     for (let to of this.getNodeIdsConnectedFrom(nodeId, type)) {
-      this.removeEdge(nodeId, to, type);
+      this._removeEdge(nodeId, to, type);
     }
   }
 
-  // Removes edge and node the edge is to if the node is orphaned
   removeEdge(
+    from: NodeId,
+    to: NodeId,
+    type: TEdgeType | NullEdgeType = 1,
+    removeOrphans: boolean = true,
+  ) {
+    if (!this.adjacencyList.hasEdge(from, to, type)) {
+      throw new Error(
+        `Edge from ${fromNodeId(from)} to ${fromNodeId(to)} not found!`,
+      );
+    }
+
+    this._removeEdge(from, to, type, removeOrphans);
+  }
+
+  // Removes edge and node the edge is to if the node is orphaned
+  _removeEdge(
     from: NodeId,
     to: NodeId,
     type: TEdgeType | NullEdgeType = 1,
@@ -249,7 +264,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     }
 
     for (let child of childrenToRemove) {
-      this.removeEdge(fromNodeId, child, type);
+      this._removeEdge(fromNodeId, child, type);
     }
   }
 

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -89,6 +89,16 @@ describe('Graph', () => {
     assert(!graph.isOrphanedNode(nodeC));
   });
 
+  it("removeEdge should throw if the edge doesn't exist", () => {
+    let graph = new Graph();
+    let nodeA = graph.addNode('a');
+    let nodeB = graph.addNode('b');
+
+    assert.throws(() => {
+      graph.removeEdge(nodeA, nodeB);
+    }, /Edge from 0 to 1 not found!/);
+  });
+
   it('removeEdge should prune the graph at that edge', () => {
     //         a
     //        / \


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Prior to PR #7927, `removeEdge` validated that an edge existed  before attempting to remove it. The assertions were removed as the recursive nature of `removeEdge` could lead to edges being deleted twice. 

While ignoring double removals makes sense when orphaned nodes/edges are being cleaned up, it's not ideal when calling into `removeEdge` externally. It can lead to a confusing developer experience where `removeEdge` is called incorrectly on edges that don't exist but the Graph just silently ignores the request. 

This PR splits `removeEdge` into separate private and public APIs. 
- `_removeEdge` - only used internally to the Graph, ignores edge delete requests that don't exist
- `removeEdge` - validates the edge exists and then calls `_removeEdge`,  throws if the edge doesn't exist

One drawback of this approach is that calls to `removeEdge` validate that the edge exists twice.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

```js
let graph = new Graph();
let nodeA = graph.addNode('a');
let nodeB = graph.addNode('b');

assert.throws(() => {
  graph.removeEdge(nodeA, nodeB);
}, /Edge from 0 to 1 not found!/);
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
