### PR TITLE
Fix CommonJS symbol collection without scope hoisting

### DIFF
--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -856,8 +856,18 @@ export default (new Transformer({
           }
         }
 
-        for (let {source, local, imported, loc} of symbol_result.imports) {
-          let dep = deps.get(source + 'esm');
+        for (let {
+          source,
+          local,
+          imported,
+          kind,
+          loc,
+        } of symbol_result.imports) {
+          let specifierType = '';
+          if (kind === 'Import' || kind === 'Export') {
+            specifierType = 'esm';
+          }
+          let dep = deps.get(source + specifierType);
           if (!dep) continue;
           dep.symbols.ensure();
           dep.symbols.set(imported, local, convertLoc(loc));


### PR DESCRIPTION
This fixes an issue building the React Spectrum docs website with the latest version of parcel, which appears to have been introduced by https://github.com/parcel-bundler/parcel/pull/7991. We have a weird setup that disables scope hoisting in production builds for "server" bundles, but symbol propagation still runs. The linked PR changed some things regarding how dependencies are tracked, and the non-scope hoisting case didn't correctly handle non ESM. This led to an asset being omitted as unused. Unfortunately, I didn't manage to produce a smaller reproduction, but this code mirrors the logic in the scope hoisting case, and does fix the issue.