### PR TITLE
chore: fix types and optimizer-image packages dep warning

### DIFF
--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@parcel/cache": "2.7.0",
+    "@parcel/core": "2.7.0",
     "@parcel/diagnostic": "2.7.0",
     "@parcel/fs": "2.7.0",
     "@parcel/package-manager": "2.7.0",

--- a/packages/optimizers/image/package.json
+++ b/packages/optimizers/image/package.json
@@ -32,6 +32,7 @@
     "build-release": "napi build --platform --release"
   },
   "dependencies": {
+    "@parcel/core": "2.7.0",
     "@parcel/diagnostic": "2.7.0",
     "@parcel/plugin": "2.7.0",
     "@parcel/utils": "2.7.0",


### PR DESCRIPTION
# ↪️ Pull Request

fix @parcel/types and @parcel/optimizer-image packages dependencies warning.

currently @parcel/core peer dependency it's not met in some packages like @parcel/types and @parcel/optimizer-image

## 💻 Examples

example with yarn v3:
```
➤ YN0002: │ @parcel/optimizer-image@npm:2.7.0 doesn't provide @parcel/core (pf9360), requested by @parcel/workers
➤ YN0002: │ @parcel/types@npm:2.7.0 doesn't provide @parcel/core (pa5a51), requested by @parcel/fs
➤ YN0002: │ @parcel/types@npm:2.7.0 doesn't provide @parcel/core (p94745), requested by @parcel/workers
➤ YN0002: │ @parcel/types@npm:2.7.0 doesn't provide @parcel/core (p655b2), requested by @parcel/cache
➤ YN0002: │ @parcel/types@npm:2.7.0 doesn't provide @parcel/core (pdf45c), requested by @parcel/package-manager
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
```

Note: I haven't tested others package managers like npm or pnpm, but warning might appear as well 

## 🚨 Test instructions

how to repro?
1. start new project with yarn v3 https://yarnpkg.com/getting-started/install
2. install parcel
3. expect warning to appear

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
