### PR TITLE
Disable splitting dependencies on symbols for non-scope hoisted bundles

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -181,7 +181,11 @@ export default class BundleGraph {
       walkVisited.add(nodeId);
 
       let node = nullthrows(assetGraph.getNode(nodeId));
-      if (node.type === 'dependency' && node.value.symbols != null) {
+      if (
+        node.type === 'dependency' &&
+        node.value.symbols != null &&
+        node.value.env.shouldScopeHoist
+      ) {
         // asset -> symbols that should be imported directly from that asset
         let targets = new DefaultMap<ContentKey, Map<Symbol, Symbol>>(
           () => new Map(),

--- a/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/Icon.js
+++ b/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/Icon.js
@@ -1,0 +1,3 @@
+export function Icon() {
+  return 'Icon';
+}

--- a/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/UIIcon.js
+++ b/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/UIIcon.js
@@ -1,0 +1,3 @@
+export function UIIcon() {
+  return 'UIIcon';
+}

--- a/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/index.js
+++ b/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/index.js
@@ -1,0 +1,2 @@
+export {Icon} from './Icon';
+export {UIIcon} from './UIIcon';

--- a/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/package.json
+++ b/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/node_modules/icon/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "icon",
+  "version": "1.0.0",
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/package.json
+++ b/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/package.json
@@ -1,0 +1,15 @@
+{
+  "source": "test.js",
+  "scope-hoist": "dist/scope-hoist.js",
+  "no-scope-hoist": "dist/no-scope-hoist.js",
+  "targets": {
+    "scope-hoist": {
+      "scopeHoist": true,
+      "optimize": false
+    },
+    "no-scope-hoist": {
+      "scopeHoist": false,
+      "optimize": false
+    }
+  }
+}

--- a/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/test.js
+++ b/packages/core/integration-tests/test/integration/re-export-no-scope-hoist/test.js
@@ -1,0 +1,3 @@
+import {UIIcon, Icon} from 'icon';
+
+output(UIIcon(), Icon());

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -6219,6 +6219,30 @@ describe('javascript', function () {
     assert.strictEqual(output.default, '4returned from bar');
   });
 
+  it('should produce working output with both scope hoisting and non scope hoisting targets', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/re-export-no-scope-hoist'),
+      {
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+        },
+      },
+    );
+    let bundles = b.getBundles();
+
+    let o1, o2;
+    await runBundle(b, bundles[0], {
+      output: (...o) => (o1 = o),
+    });
+
+    await runBundle(b, bundles[1], {
+      output: (...o) => (o2 = o),
+    });
+
+    assert.deepEqual(o1, ['UIIcon', 'Icon']);
+    assert.deepEqual(o2, ['UIIcon', 'Icon']);
+  });
+
   for (let shouldScopeHoist of [false, true]) {
     let options = {
       defaultTargetOptions: {


### PR DESCRIPTION
Fixes #8564.

Dependencies that don't have `shouldScopeHoist` enabled in their environment are no longer split based on symbol data, which broken the non-scope hoisting packager.