### PR TITLE
Do not merge isolated bundles in experimental bundler

### DIFF
--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -540,7 +540,6 @@ function createIdealGraph(
                 typeChangeIds.add(bundleId);
               }
             } else {
-              // Otherwise, merge.
               bundle = bundleGraph.getNode(bundleId);
               invariant(bundle != null && bundle !== 'root');
 

--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -603,8 +603,8 @@ function createIdealGraph(
         b !== 'root' &&
         a !== b &&
         typeChangeIds.has(nodeIdB) &&
-        a.bundleBehavior !== 'inline' &&
-        b.bundleBehavior !== 'inline' &&
+        a.bundleBehavior == null &&
+        b.bundleBehavior == null &&
         a.type === b.type
       ) {
         let bundleBbundleGroups = getBundleGroupsForBundle(nodeIdB);

--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -511,9 +511,8 @@ function createIdealGraph(
             let bundleGroupRootAsset = nullthrows(bundleGroup.mainEntryAsset);
             if (
               entries.has(bundleGroupRootAsset) &&
-              bundleGroupRootAsset.type === childAsset.type &&
-              childAsset.bundleBehavior !== 'inline' &&
-              dependency.bundleBehavior !== 'isolated'
+              canMerge(bundleGroupRootAsset, childAsset) &&
+              dependency.bundleBehavior == null
             ) {
               bundleId = bundleGroupNodeId;
             }
@@ -523,7 +522,8 @@ function createIdealGraph(
                 asset: childAsset,
                 type: childAsset.type,
                 env: childAsset.env,
-                bundleBehavior: childAsset.bundleBehavior,
+                bundleBehavior:
+                  dependency.bundleBehavior ?? childAsset.bundleBehavior,
                 target: referencingBundle.target,
                 needsStableName:
                   childAsset.bundleBehavior === 'inline' ||
@@ -534,8 +534,16 @@ function createIdealGraph(
                     : referencingBundle.needsStableName,
               });
               bundleId = bundleGraph.addNode(bundle);
+
               // Store Type-Change bundles for later since we need to know ALL bundlegroups they are part of to reduce/combine them
-              typeChangeIds.add(bundleId);
+              if (parentAsset.type !== childAsset.type) {
+                typeChangeIds.add(bundleId);
+              }
+            } else {
+              // Otherwise, merge.
+              bundle = bundleGraph.getNode(bundleId);
+              invariant(bundle != null && bundle !== 'root');
+
               if (
                 // If this dependency requests isolated, but the bundle is not,
                 // make the bundle isolated for all uses.
@@ -544,10 +552,6 @@ function createIdealGraph(
               ) {
                 bundle.bundleBehavior = dependency.bundleBehavior;
               }
-            } else {
-              // Otherwise, merge.
-              bundle = bundleGraph.getNode(bundleId);
-              invariant(bundle != null && bundle !== 'root');
             }
 
             bundles.set(childAsset.id, bundleId);
@@ -603,9 +607,7 @@ function createIdealGraph(
         b !== 'root' &&
         a !== b &&
         typeChangeIds.has(nodeIdB) &&
-        a.bundleBehavior == null &&
-        b.bundleBehavior == null &&
-        a.type === b.type
+        canMerge(a, b)
       ) {
         let bundleBbundleGroups = getBundleGroupsForBundle(nodeIdB);
         if (setEqual(bundleBbundleGroups, bundleABundleGroups)) {
@@ -670,8 +672,9 @@ function createIdealGraph(
             );
             if (
               bundle !== 'root' &&
-              bundle.bundleBehavior !== 'inline' &&
-              !bundle.env.isIsolated()
+              bundle.bundleBehavior == null &&
+              !bundle.env.isIsolated() &&
+              bundle.env.context === root.env.context
             ) {
               bundleRootGraph.addEdge(
                 bundleRootGraph.getNodeIdByContentKey(root.id),
@@ -691,11 +694,7 @@ function createIdealGraph(
       }
       //asset node type
       let asset = node.value;
-      if (
-        asset.bundleBehavior === 'isolated' ||
-        asset.bundleBehavior === 'inline' ||
-        root.type !== asset.type
-      ) {
+      if (asset.bundleBehavior != null || root.type !== asset.type) {
         actions.skipChildren();
         return;
       }
@@ -748,10 +747,7 @@ function createIdealGraph(
       ]) {
         let bundleInGroup = nullthrows(bundleGraph.getNode(bundleIdInGroup));
         invariant(bundleInGroup !== 'root');
-        if (
-          bundleInGroup.bundleBehavior === 'isolated' ||
-          bundleInGroup.bundleBehavior === 'inline'
-        ) {
+        if (bundleInGroup.bundleBehavior != null) {
           continue;
         }
 
@@ -784,7 +780,7 @@ function createIdealGraph(
       let child = bundleRootGraph.getNode(childId);
       invariant(child !== 'root' && child != null);
       let bundleBehavior = getBundleFromBundleRoot(child).bundleBehavior;
-      if (bundleBehavior === 'isolated' || bundleBehavior === 'inline') {
+      if (bundleBehavior != null) {
         continue;
       }
       let isParallel = bundleRootGraph.hasEdge(
@@ -1344,4 +1340,15 @@ function getEntryByTarget(
     },
   });
   return targets;
+}
+
+function canMerge(a, b) {
+  // Bundles can be merged if they have the same type and environment,
+  // unless they are explicitly marked as isolated or inline.
+  return (
+    a.type === b.type &&
+    a.env.context === b.env.context &&
+    a.bundleBehavior == null &&
+    b.bundleBehavior == null
+  );
 }

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5800,6 +5800,8 @@ describe('javascript', function () {
             'other.js',
             'esmodule-helpers.js',
             'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
           ],
         },
         {

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5800,8 +5800,9 @@ describe('javascript', function () {
             'other.js',
             'esmodule-helpers.js',
             'bundle-url.js',
-            'cacheLoader.js',
-            'js-loader.js',
+            ...(process.env.PARCEL_TEST_EXPERIMENTAL_BUNDLER
+              ? ['cacheLoader.js', 'js-loader.js']
+              : []),
           ],
         },
         {


### PR DESCRIPTION
This make handling of `bundleBehavior` more consistent, and fixes bundle merging logic with isolated bundles. In addition, bundles of different contexts should not be merged. This fixes the react spectrum site