### PR TITLE
Add more Flow annotations

### DIFF
--- a/flow-typed/npm/mocha_v8.x.x.js
+++ b/flow-typed/npm/mocha_v8.x.x.js
@@ -14,19 +14,19 @@ declare interface $npm$mocha$SetupOptions {
 
 declare type $npm$mocha$done = (error?: any) => any;
 
-// declare interface $npm$mocha$SuiteCallbackContext {
-//   timeout(ms: number): void;
-//   retries(n: number): void;
-//   slow(ms: number): void;
-// }
+declare interface $npm$mocha$SuiteCallbackContext {
+  timeout(ms: number): void;
+  retries(n: number): void;
+  slow(ms: number): void;
+}
 
-// declare interface $npm$mocha$TestCallbackContext {
-//   skip(): void;
-//   timeout(ms: number): void;
-//   retries(n: number): void;
-//   slow(ms: number): void;
-//   [index: string]: any;
-// }
+declare interface $npm$mocha$TestCallbackContext {
+  skip(): void;
+  timeout(ms: number): void;
+  retries(n: number): void;
+  slow(ms: number): void;
+  [index: string]: any;
+}
 
 declare interface $npm$mocha$Suite {
   parent: $npm$mocha$Suite;
@@ -35,16 +35,16 @@ declare interface $npm$mocha$Suite {
 }
 
 declare type $npm$mocha$ContextDefinition = {|
-  (description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
-  only(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): $npm$mocha$Suite;
-  skip(description: string, callback: (/* this: $npm$mocha$SuiteCallbackContext */) => void): void;
+  (description: string, callback: (this: $npm$mocha$SuiteCallbackContext) => void): $npm$mocha$Suite;
+  only(description: string, callback: (this: $npm$mocha$SuiteCallbackContext) => void): $npm$mocha$Suite;
+  skip(description: string, callback: (this: $npm$mocha$SuiteCallbackContext) => void): void;
   timeout(ms: number): void;
 |}
 
 declare type $npm$mocha$TestDefinition = {|
-  (expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
-  only(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): $npm$mocha$Test;
-  skip(expectation: string, callback?: (/* this: $npm$mocha$TestCallbackContext, */ done: $npm$mocha$done) => mixed): void;
+  (expectation: string, callback?: (this: $npm$mocha$TestCallbackContext, done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  only(expectation: string, callback?: (this: $npm$mocha$TestCallbackContext, done: $npm$mocha$done) => mixed): $npm$mocha$Test;
+  skip(expectation: string, callback?: (this: $npm$mocha$TestCallbackContext, done: $npm$mocha$done) => mixed): void;
   timeout(ms: number): void;
   state: 'failed' | 'passed';
 |}
@@ -145,11 +145,11 @@ declare class $npm$mocha$Mocha {
   };
 }
 
-// declare interface $npm$mocha$HookCallbackContext {
-//   skip(): void;
-//   timeout(ms: number): void;
-//   [index: string]: any;
-// }
+declare interface $npm$mocha$HookCallbackContext {
+  skip(): void;
+  timeout(ms: number): void;
+  [index: string]: any;
+}
 
 declare interface $npm$mocha$Runnable {
   title: string;
@@ -167,9 +167,9 @@ declare interface $npm$mocha$Test extends $npm$mocha$Runnable {
   timeout(ms: number): void;
 }
 
-// declare interface $npm$mocha$BeforeAndAfterContext extends $npm$mocha$HookCallbackContext {
-//   currentTest: $npm$mocha$Test;
-// }
+declare interface $npm$mocha$BeforeAndAfterContext extends $npm$mocha$HookCallbackContext {
+  currentTest: $npm$mocha$Test;
+}
 
 declare var mocha: $npm$mocha$Mocha;
 declare var describe: $npm$mocha$ContextDefinition;
@@ -185,22 +185,22 @@ type Run = () => void;
 
 declare var run: Run;
 
-type Setup = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
-type Teardown = (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
-type SuiteSetup = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
-type SuiteTeardown = (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+type Setup = (callback: (this: $npm$mocha$BeforeAndAfterContext, done: $npm$mocha$done) => mixed) => void;
+type Teardown = (callback: (this: $npm$mocha$BeforeAndAfterContext, done: $npm$mocha$done) => mixed) => void;
+type SuiteSetup = (callback: (this: $npm$mocha$HookCallbackContext, done: $npm$mocha$done) => mixed) => void;
+type SuiteTeardown = (callback: (this: $npm$mocha$HookCallbackContext, done: $npm$mocha$done) => mixed) => void;
 type Before =
-  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
-  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+  | (callback: (this: $npm$mocha$HookCallbackContext, done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (this: $npm$mocha$HookCallbackContext, done: $npm$mocha$done) => mixed) => void;
 type After =
-  | (callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void
-  | (description: string, callback: (/* this: $npm$mocha$HookCallbackContext, */ done: $npm$mocha$done) => mixed) => void;
+  | (callback: (this: $npm$mocha$HookCallbackContext, done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (this: $npm$mocha$HookCallbackContext, done: $npm$mocha$done) => mixed) => void;
 type BeforeEach =
-  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
-  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+  | (callback: (this: $npm$mocha$BeforeAndAfterContext, done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (this: $npm$mocha$BeforeAndAfterContext, done: $npm$mocha$done) => mixed) => void;
 type AfterEach =
-  | (callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void
-  | (description: string, callback: (/* this: $npm$mocha$BeforeAndAfterContext, */ done: $npm$mocha$done) => mixed) => void;
+  | (callback: (this: $npm$mocha$BeforeAndAfterContext, done: $npm$mocha$done) => mixed) => void
+  | (description: string, callback: (this: $npm$mocha$BeforeAndAfterContext, done: $npm$mocha$done) => mixed) => void;
 
 
 declare var setup: Setup;

--- a/packages/bundlers/experimental/src/ExperimentalBundler.js
+++ b/packages/bundlers/experimental/src/ExperimentalBundler.js
@@ -1136,7 +1136,7 @@ function createIdealGraph(
     });
     return bundleGroupBundleIds;
   }
-  function getBundlesForBundleGroup(bundleGroupId) {
+  function getBundlesForBundleGroup(bundleGroupId: NodeId) {
     let bundlesInABundleGroup = [];
     bundleGraph.traverse(nodeId => {
       bundlesInABundleGroup.push(nodeId);
@@ -1314,7 +1314,10 @@ async function loadBundlerConfig(
   };
 }
 
-function getReachableBundleRoots(asset, graph): Array<BundleRoot> {
+function getReachableBundleRoots(
+  asset: Asset,
+  graph: ContentGraph<Asset>,
+): Array<BundleRoot> {
   return graph
     .getNodeIdsConnectedTo(graph.getNodeIdByContentKey(asset.id))
     .map(nodeId => nullthrows(graph.getNode(nodeId)));

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -413,17 +413,19 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
       invariant(firstAsset.type === 'asset');
       let resolvedAsset = firstAsset.value;
       let deps = this.getIncomingDependencies(resolvedAsset);
-      defer = deps.every(
-        d =>
-          d.symbols &&
+      defer = deps.every(d => {
+        if (!d.symbols) return false;
+        let dsymbols = d.symbols;
+        return (
           !(d.env.isLibrary && d.isEntry) &&
-          !d.symbols.has('*') &&
-          ![...d.symbols.keys()].some(symbol => {
+          !dsymbols.has('*') &&
+          ![...dsymbols.keys()].some(symbol => {
             if (!resolvedAsset.symbols) return true;
             let assetSymbol = resolvedAsset.symbols?.get(symbol)?.local;
             return assetSymbol != null && symbols.has(assetSymbol);
-          }),
-      );
+          })
+        );
+      });
     }
     return defer;
   }
@@ -434,8 +436,9 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     correspondingRequest: ContentKey,
   ) {
     this.normalizeEnvironment(assetGroup);
-    let assetGroupNode = nodeFromAssetGroup(assetGroup);
-    assetGroupNode = this.getNodeByContentKey(assetGroupNode.id);
+    let assetGroupNode = this.getNodeByContentKey(
+      nodeFromAssetGroup(assetGroup).id,
+    );
     if (!assetGroupNode) {
       return;
     }

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -176,7 +176,7 @@ export default class BundleGraph {
     }
 
     let walkVisited = new Set();
-    function walk(nodeId) {
+    function walk(nodeId: NodeId) {
       if (walkVisited.has(nodeId)) return;
       walkVisited.add(nodeId);
 
@@ -512,7 +512,7 @@ export default class BundleGraph {
     }
   }
 
-  internalizeAsyncDependency(bundle: Bundle, dependency: Dependency) {
+  internalizeAsyncDependency(bundle: Bundle, dependency: Dependency): void {
     if (dependency.priority === Priority.sync) {
       throw new Error('Expected an async dependency');
     }
@@ -1653,7 +1653,7 @@ export default class BundleGraph {
       // ..., but if it does exist, it has to be behind this one reexport.
       return potentialResults[0];
     } else {
-      let result = identifier;
+      let result: Symbol | false | null | void = identifier;
       if (skipped) {
         // ... and it was excluded (by symbol propagation) or deferred.
         result = false;
@@ -1770,7 +1770,7 @@ export default class BundleGraph {
   getInlineBundles(bundle: Bundle): Array<Bundle> {
     let bundles = [];
     let seen = new Set();
-    let addReferencedBundles = bundle => {
+    let addReferencedBundles = (bundle: Bundle) => {
       if (seen.has(bundle.id)) {
         return;
       }

--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -25,7 +25,8 @@ export default class CommittedAsset {
   }
 
   getContent(): Blob | Promise<Buffer | string> {
-    if (this.content == null) {
+    let content = this.content;
+    if (content == null) {
       if (this.value.contentKey != null) {
         if (this.value.isLargeBlob) {
           return this.options.cache.getStream(this.value.contentKey);
@@ -46,7 +47,7 @@ export default class CommittedAsset {
       }
     }
 
-    return this.content;
+    return content;
   }
 
   async getCode(): Promise<string> {

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -15,7 +15,7 @@ import {SpecifierType, Priority, BundleBehavior} from './types';
 import {toInternalSourceLocation} from './utils';
 import {toProjectPath} from './projectPath';
 
-type DependencyOpts = {|
+export type DependencyOpts = {|
   id?: string,
   sourcePath?: FilePath,
   sourceAssetId?: string,

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -732,12 +732,13 @@ export default class PackagerRunner {
       let buffer = Buffer.from(contents);
       size = buffer.byteLength;
       hash = hashBuffer(buffer);
-      hashReferences = contents.match(HASH_REF_REGEX) ?? [];
+      hashReferences = contents.match(HASH_REF_REGEX) ?? ([]: Array<string>);
       await this.options.cache.setBlob(cacheKeys.content, buffer);
     } else {
       size = contents.length;
       hash = hashBuffer(contents);
-      hashReferences = contents.toString().match(HASH_REF_REGEX) ?? [];
+      hashReferences =
+        contents.toString().match(HASH_REF_REGEX) ?? ([]: Array<string>);
       await this.options.cache.setBlob(cacheKeys.content, contents);
     }
 

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -5,6 +5,7 @@ import type {
   BuildEvent,
   BuildSuccessEvent,
   InitialParcelOptions,
+  NamedBundle,
   PackagedBundle as IPackagedBundle,
 } from '@parcel/types';
 import type {ParcelOptions} from './types';
@@ -301,7 +302,7 @@ export default class Parcel {
           options,
         ),
         buildTime: Date.now() - startTime,
-        requestBundle: async bundle => {
+        requestBundle: async (bundle: NamedBundle) => {
           let bundleNode = bundleGraph._graph.getNodeByContentKey(bundle.id);
           invariant(bundleNode?.type === 'bundle', 'Bundle does not exist');
 

--- a/packages/core/core/src/ParcelConfig.js
+++ b/packages/core/core/src/ParcelConfig.js
@@ -477,12 +477,18 @@ export default class ParcelConfig {
   }
 }
 
-function getConfigPaths(options, nodes) {
+function getConfigPaths(
+  options: ParcelOptions,
+  nodes:
+    | Array<'...' | ParcelPluginNode>
+    | PureParcelConfigPipeline
+    | ExtendableParcelConfigPipeline,
+) {
   return nodes
     .map(node => (node !== '...' ? getConfigPath(options, node) : null))
     .filter(Boolean);
 }
 
-function getConfigPath(options, node) {
+function getConfigPath(options: ParcelOptions, node: ParcelPluginNode) {
   return fromProjectPath(options.projectRoot, node.resolveFrom);
 }

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -945,7 +945,7 @@ export default class RequestTracker {
     let hasValidResult = requestId != null && this.hasValidResult(requestId);
 
     if (!opts?.force && hasValidResult) {
-      // $FlowFixMe[incompatible-type]
+      // $FlowFixMe[incompatible-return]
       return this.getRequestResult<TResult>(request.id);
     }
 
@@ -955,7 +955,7 @@ export default class RequestTracker {
         // There is a another instance of this request already running, wait for its completion and reuse its result
         try {
           if (await incompletePromise) {
-            // $FlowFixMe[incompatible-type]
+            // $FlowFixMe[incompatible-return]
             return this.getRequestResult<TResult>(request.id);
           }
         } catch (e) {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -946,6 +946,7 @@ export default class RequestTracker {
 
     if (!opts?.force && hasValidResult) {
       // $FlowFixMe[incompatible-return]
+      // $FlowFixMe[incompatible-type]
       return this.getRequestResult<TResult>(request.id);
     }
 
@@ -956,6 +957,7 @@ export default class RequestTracker {
         try {
           if (await incompletePromise) {
             // $FlowFixMe[incompatible-return]
+            // $FlowFixMe[incompatible-type]
             return this.getRequestResult<TResult>(request.id);
           }
         } catch (e) {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -412,7 +412,7 @@ export class RequestGraph extends ContentGraph<
   invalidateOnFileCreate(
     requestNodeId: NodeId,
     input: InternalFileCreateInvalidation,
-  ) {
+  ): void {
     let node;
     if (input.glob != null) {
       node = nodeFromGlob(input.glob);
@@ -1118,11 +1118,11 @@ export function getWatcherOptions(options: ParcelOptions): WatcherOptions {
   return {ignore};
 }
 
-function getCacheKey(options) {
+function getCacheKey(options: ParcelOptions) {
   return `${PARCEL_VERSION}:${JSON.stringify(options.entries)}:${options.mode}`;
 }
 
-async function loadRequestGraph(options): Async<RequestGraph> {
+async function loadRequestGraph(options: ParcelOptions): Async<RequestGraph> {
   if (options.shouldDisableCache) {
     return new RequestGraph();
   }

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -892,7 +892,7 @@ type TransformerWithNameAndConfig = {|
 |};
 
 function normalizeAssets(
-  options,
+  options: ParcelOptions,
   results: Array<TransformerResult | MutableAsset>,
 ): Array<TransformerResult | UncommittedAsset> {
   return results.map(result => {

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -158,7 +158,7 @@ export default class Validation {
     );
   }
 
-  handleResults(validatorResults: Array<?ValidateResult>) {
+  handleResults(validatorResults: Array<?ValidateResult>): void {
     let warnings: Array<Diagnostic> = [];
     let errors: Array<Diagnostic> = [];
     validatorResults.forEach(result => {

--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -39,7 +39,7 @@ import {
 import {hashString} from '@parcel/hash';
 import {BundleBehavior as BundleBehaviorMap} from './types';
 
-type AssetOptions = {|
+export type AssetOptions = {|
   id?: string,
   committed?: boolean,
   hash?: ?string,

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {Asset, BundleBehavior} from '@parcel/types';
-import type {Graph} from '@parcel/graph';
+import type {Graph, NodeId} from '@parcel/graph';
 import type {AssetGraphNode, BundleGraphNode, Environment} from './types';
 import {bundleGraphEdgeTypes} from './BundleGraph';
 import {requestGraphEdgeTypes} from './RequestTracker';
@@ -197,7 +197,7 @@ export default async function dumpGraphToGraphViz(
   console.log('Dumped', tmp);
 }
 
-function nodeId(id) {
+function nodeId(id: NodeId) {
   // $FlowFixMe
   return `node${id}`;
 }

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -193,6 +193,7 @@ class BaseAsset {
 export class Asset extends BaseAsset implements IAsset {
   #asset /*: CommittedAsset | UncommittedAsset */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(asset: CommittedAsset | UncommittedAsset): Asset {
     let assetValueToAsset = asset.value.committed
       ? committedAssetValueToAsset
@@ -216,6 +217,7 @@ export class Asset extends BaseAsset implements IAsset {
 export class MutableAsset extends BaseAsset implements IMutableAsset {
   #asset /*: UncommittedAsset */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(asset: UncommittedAsset): MutableAsset {
     let existing = assetValueToMutableAsset.get(asset.value);
     if (existing != null) {

--- a/packages/core/core/src/public/BundleGroup.js
+++ b/packages/core/core/src/public/BundleGroup.js
@@ -29,6 +29,7 @@ export default class BundleGroup implements IBundleGroup {
   constructor(
     bundleGroup: InternalBundleGroup,
     options: ParcelOptions,
+    // $FlowFixMe(incompatible-return)
   ): BundleGroup {
     let existing = internalBundleGroupToBundleGroup.get(bundleGroup);
     if (existing != null) {

--- a/packages/core/core/src/public/Config.js
+++ b/packages/core/core/src/public/Config.js
@@ -26,6 +26,7 @@ export default class PublicConfig implements IConfig {
   #pkgFilePath /*: ?FilePath */;
   #options /*: ParcelOptions */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(config: Config, options: ParcelOptions): PublicConfig {
     let existing = internalConfigToConfig.get(options).get(config);
     if (existing != null) {

--- a/packages/core/core/src/public/Dependency.js
+++ b/packages/core/core/src/public/Dependency.js
@@ -42,6 +42,7 @@ export default class Dependency implements IDependency {
   #dep /*: InternalDependency */;
   #options /*: ParcelOptions */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(dep: InternalDependency, options: ParcelOptions): Dependency {
     let existing = internalDependencyToDependency.get(dep);
     if (existing != null) {

--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -144,6 +144,7 @@ export default class Environment implements IEnvironment {
   #environment /*: InternalEnvironment */;
   #options /*: ParcelOptions */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(env: InternalEnvironment, options: ParcelOptions): Environment {
     let existing = internalEnvironmentToEnvironment.get(env);
     if (existing != null) {

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -19,6 +19,7 @@ let parcelOptionsToPluginOptions: WeakMap<ParcelOptions, PluginOptions> =
 export default class PluginOptions implements IPluginOptions {
   #options /*: ParcelOptions */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(options: ParcelOptions): PluginOptions {
     let existing = parcelOptionsToPluginOptions.get(options);
     if (existing != null) {

--- a/packages/core/core/src/public/Symbols.js
+++ b/packages/core/core/src/public/Symbols.js
@@ -1,4 +1,5 @@
 // @flow
+import type {InternalSourceLocation} from '../types';
 import type {
   Symbol as ISymbol,
   MutableAssetSymbols as IMutableAssetSymbols,
@@ -293,7 +294,15 @@ export class MutableDependencySymbols implements IMutableDependencySymbols {
   }
 }
 
-function fromInternalAssetSymbol(projectRoot: string, value) {
+function fromInternalAssetSymbol(
+  projectRoot: string,
+  value: void | {
+    loc: ?InternalSourceLocation,
+    local: ISymbol,
+    meta?: ?Meta,
+    ...
+  },
+) {
   return (
     value && {
       local: value.local,
@@ -303,7 +312,16 @@ function fromInternalAssetSymbol(projectRoot: string, value) {
   );
 }
 
-function fromInternalDependencySymbol(projectRoot: string, value) {
+function fromInternalDependencySymbol(
+  projectRoot: string,
+  value: void | {
+    isWeak: boolean,
+    loc: ?InternalSourceLocation,
+    local: ISymbol,
+    meta?: ?Meta,
+    ...
+  },
+) {
   return (
     value && {
       local: value.local,

--- a/packages/core/core/src/public/Symbols.js
+++ b/packages/core/core/src/public/Symbols.js
@@ -35,6 +35,7 @@ export class AssetSymbols implements IAssetSymbols {
   #value: Asset;
   #options: ParcelOptions;
 
+  // $FlowFixMe(incompatible-return)
   constructor(options: ParcelOptions, asset: Asset): AssetSymbols {
     let existing = valueToSymbols.get(asset);
     if (existing != null) {
@@ -105,6 +106,7 @@ export class MutableAssetSymbols implements IMutableAssetSymbols {
   #value: Asset;
   #options: ParcelOptions;
 
+  // $FlowFixMe(incompatible-return)
   constructor(options: ParcelOptions, asset: Asset): MutableAssetSymbols {
     let existing = valueToMutableAssetSymbols.get(asset);
     if (existing != null) {
@@ -206,6 +208,7 @@ export class MutableDependencySymbols implements IMutableDependencySymbols {
   constructor(
     options: ParcelOptions,
     dep: Dependency,
+    // $FlowFixMe(incompatible-return)
   ): MutableDependencySymbols {
     let existing = valueToMutableDependencySymbols.get(dep);
     if (existing != null) {

--- a/packages/core/core/src/public/Target.js
+++ b/packages/core/core/src/public/Target.js
@@ -24,6 +24,7 @@ export default class Target implements ITarget {
   #target /*: TargetValue */;
   #options /*: ParcelOptions */;
 
+  // $FlowFixMe(incompatible-return)
   constructor(target: TargetValue, options: ParcelOptions): Target {
     let existing = internalTargetToTarget.get(target);
     if (existing != null) {

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -413,10 +413,10 @@ export class AssetGraphBuilder {
     });
 
     const logFallbackNamespaceInsertion = (
-      assetNode,
+      assetNode: AssetNode,
       symbol: Symbol,
-      depNode1,
-      depNode2,
+      depNode1: DependencyNode,
+      depNode2: DependencyNode,
     ) => {
       if (this.options.logLevel === 'verbose') {
         logger.warn({
@@ -543,7 +543,12 @@ export class AssetGraphBuilder {
 
       let errors: Array<Diagnostic> = [];
 
-      function usedSymbolsUpAmbiguous(old, current, s, value) {
+      function usedSymbolsUpAmbiguous(
+        old: Map<Symbol, ?{|asset: ContentKey, symbol: ?Symbol|}>,
+        current: Map<Symbol, ?{|asset: ContentKey, symbol: ?Symbol|}>,
+        s: Symbol,
+        value: {|asset: ContentKey, symbol: ?Symbol|},
+      ) {
         if (old.has(s)) {
           let valueOld = old.get(s);
           if (

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -1,5 +1,6 @@
 // @flow strict-local
 
+import type {TargetSourceMapOptions} from '../../../types/index';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {FileSystem} from '@parcel/fs';
 import type {
@@ -584,7 +585,10 @@ export class TargetResolver {
           }
         : mainContextLoc;
 
-    let getEnginesLoc = (targetName, descriptor): TargetKeyInfo => {
+    let getEnginesLoc = (
+      targetName: string,
+      descriptor: PackageTargetDescriptor,
+    ): TargetKeyInfo => {
       let enginesLoc = `/targets/${targetName}/engines`;
       switch (context) {
         case 'browser':
@@ -1324,7 +1328,12 @@ function parseCommonTargetDescriptor(
   return descriptor;
 }
 
-function assertNoDuplicateTargets(options, targets, pkgFilePath, pkgContents) {
+function assertNoDuplicateTargets(
+  options: ParcelOptions,
+  targets: Map<string, null | Target>,
+  pkgFilePath: ?FilePath,
+  pkgContents: void | string,
+) {
   // Detect duplicate targets by destination path and provide a nice error.
   // Without this, an assertion is thrown much later after naming the bundles and finding duplicates.
   let targetsByPath: Map<string, Array<string>> = new Map();
@@ -1385,7 +1394,10 @@ function assertNoDuplicateTargets(options, targets, pkgFilePath, pkgContents) {
   }
 }
 
-function normalizeSourceMap(options: ParcelOptions, sourceMap) {
+function normalizeSourceMap(
+  options: ParcelOptions,
+  sourceMap: void | boolean | TargetSourceMapOptions,
+) {
   if (options.defaultTargetOptions.sourceMaps) {
     if (typeof sourceMap === 'boolean') {
       return sourceMap ? {} : undefined;
@@ -1462,7 +1474,12 @@ function assertTargetsAreNotEntries(
   }
 }
 
-async function debugResolvedTargets(input, targets, targetInfo, options) {
+async function debugResolvedTargets(
+  input: Entry,
+  targets: Array<Target>,
+  targetInfo: Map<string, TargetInfo>,
+  options: ParcelOptions,
+) {
   for (let target of targets) {
     let info = targetInfo.get(target.name);
     let loc = target.loc;
@@ -1587,11 +1604,12 @@ async function debugResolvedTargets(input, targets, targetInfo, options) {
         );
     }
 
-    let format = v => (v.message != null ? md.italic(v.message) : '');
+    let format = (v: TargetKeyInfo) =>
+      v.message != null ? md.italic(v.message) : '';
     logger.verbose({
       origin: '@parcel/core',
       message: md`**Target** "${target.name}"
-      
+
                **Entry**: ${path.relative(
                  process.cwd(),
                  fromProjectPath(options.projectRoot, input.filePath),

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -1,6 +1,5 @@
 // @flow strict-local
 
-import type {TargetSourceMapOptions} from '../../../types/index';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {FileSystem} from '@parcel/fs';
 import type {
@@ -10,6 +9,7 @@ import type {
   PackageJSON,
   PackageTargetDescriptor,
   TargetDescriptor,
+  TargetSourceMapOptions,
   OutputFormat,
 } from '@parcel/types';
 import type {StaticRunOpts, RunAPI} from '../RequestTracker';

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -285,7 +285,7 @@ async function runCompressor(
   }
 }
 
-function replaceStream(hashRefToNameHash) {
+function replaceStream(hashRefToNameHash: Map<string, string>) {
   let boundaryStr = '';
   return new Transform({
     transform(chunk, encoding, cb) {
@@ -307,7 +307,7 @@ function replaceStream(hashRefToNameHash) {
   });
 }
 
-function cloneStream(readable) {
+function cloneStream(readable: Readable) {
   let res = new Readable();
   // $FlowFixMe
   res._read = () => {};

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -1,5 +1,6 @@
 // @flow strict-local
 
+import type {Bundle, ParcelOptions} from '../types';
 import type {ContentKey} from '@parcel/graph';
 import type {Async} from '@parcel/types';
 import type {SharedReference} from '@parcel/workers';
@@ -139,10 +140,10 @@ async function run({input, api, farm, options}: RunInput) {
 }
 
 function assignComplexNameHashes(
-  hashRefToNameHash,
-  bundles,
-  bundleInfoMap,
-  options,
+  hashRefToNameHash: Map<string, string>,
+  bundles: Array<Bundle>,
+  bundleInfoMap: {[string]: BundleInfo},
+  options: ParcelOptions,
 ) {
   for (let bundle of bundles) {
     if (hashRefToNameHash.get(bundle.hashReference) != null) {
@@ -162,9 +163,9 @@ function assignComplexNameHashes(
 }
 
 function getBundlesIncludedInHash(
-  bundleId,
-  bundleInfoMap,
-  included = new Set(),
+  bundleId: ContentKey,
+  bundleInfoMap: {[string]: BundleInfo},
+  included: Set<ContentKey> = new Set(),
 ) {
   included.add(bundleId);
   for (let hashRef of bundleInfoMap[bundleId].hashReferences) {

--- a/packages/core/core/src/serializer.js
+++ b/packages/core/core/src/serializer.js
@@ -49,7 +49,7 @@ function shallowCopy(object: any) {
   return object;
 }
 
-function isBuffer(object) {
+function isBuffer(object: any) {
   return (
     object.buffer instanceof ArrayBuffer ||
     (typeof SharedArrayBuffer !== 'undefined' &&
@@ -57,11 +57,15 @@ function isBuffer(object) {
   );
 }
 
-function shouldContinueMapping(value) {
+function shouldContinueMapping(value: any) {
   return value && typeof value === 'object' && value.$$raw !== true;
 }
 
-function mapObject(object: any, fn: (val: any) => any, preOrder = false): any {
+function mapObject(
+  object: any,
+  fn: (val: any) => any,
+  preOrder: boolean = false,
+): any {
   let cache = new Map();
   let memo = new Map();
 
@@ -78,7 +82,7 @@ function mapObject(object: any, fn: (val: any) => any, preOrder = false): any {
     return res;
   };
 
-  let walk = (object: any, shouldCopy = false) => {
+  let walk = (object: any, shouldCopy: boolean = false) => {
     // Check the cache first, both for performance and cycle detection.
     if (cache.has(object)) {
       return cache.get(object);

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -4,6 +4,7 @@ import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import type {
   FilePath,
   FileCreateInvalidation,
+  SemverRange,
   SourceLocation,
 } from '@parcel/types';
 import type {
@@ -140,7 +141,15 @@ function proxyPackageManager(
   packageManager: PackageManager,
   addDevDependency: (devDep: InternalDevDepOptions) => void,
 ): PackageManager {
-  let require = (id: string, from: string, opts) => {
+  let require = (
+    id: string,
+    from: string,
+    opts: ?{|
+      range?: ?SemverRange,
+      saveDev?: boolean,
+      shouldAutoInstall?: boolean,
+    |},
+  ) => {
     addDevDependency({
       specifier: id,
       resolveFrom: toProjectPath(projectRoot, from),

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -48,7 +48,7 @@ type WorkerValidationOpts = {|
 // TODO: this should eventually be replaced by an in memory cache layer
 let parcelConfigCache = new Map();
 
-function loadOptions(ref, workerApi) {
+function loadOptions(ref: SharedReference, workerApi: WorkerApi) {
   return nullthrows(
     ((workerApi.getSharedReference(
       ref,
@@ -57,7 +57,7 @@ function loadOptions(ref, workerApi) {
   );
 }
 
-async function loadConfig(cachePath, options) {
+async function loadConfig(cachePath: string, options: ParcelOptions) {
   let config = parcelConfigCache.get(cachePath);
   if (config && config.options === options) {
     return config;

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -8,22 +8,28 @@ import AssetGraph, {
   nodeFromEntryFile,
   nodeFromAsset,
 } from '../src/AssetGraph';
-import {createDependency as _createDependency} from '../src/Dependency';
-import {createAsset as _createAsset} from '../src/assetUtils';
+import {
+  createDependency as _createDependency,
+  type DependencyOpts,
+} from '../src/Dependency';
+import {
+  createAsset as _createAsset,
+  type AssetOptions,
+} from '../src/assetUtils';
 import {DEFAULT_ENV, DEFAULT_TARGETS} from './test-utils';
 import {toProjectPath as _toProjectPath} from '../src/projectPath';
 
 const stats = {size: 0, time: 0};
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
-function createDependency(opts) {
+function createDependency(opts: DependencyOpts) {
   return _createDependency('/', opts);
 }
 
-function toProjectPath(p) {
+function toProjectPath(p: string) {
   return _toProjectPath('/', p);
 }
 

--- a/packages/core/core/test/BundleGraph.test.js
+++ b/packages/core/core/test/BundleGraph.test.js
@@ -4,15 +4,21 @@ import assert from 'assert';
 import BundleGraph from '../src/BundleGraph';
 import {DEFAULT_ENV, DEFAULT_TARGETS} from './test-utils';
 import AssetGraph, {nodeFromAssetGroup} from '../src/AssetGraph';
-import {createAsset as _createAsset} from '../src/assetUtils';
-import {createDependency as _createDependency} from '../src/Dependency';
+import {
+  createAsset as _createAsset,
+  type AssetOptions,
+} from '../src/assetUtils';
+import {
+  createDependency as _createDependency,
+  type DependencyOpts,
+} from '../src/Dependency';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
-function createDependency(opts) {
+function createDependency(opts: DependencyOpts) {
   return _createDependency('/', opts);
 }
 
@@ -41,7 +47,7 @@ describe('BundleGraph', () => {
   });
 });
 
-function getAssets(bundleGraph) {
+function getAssets(bundleGraph: BundleGraph) {
   let assets = [];
   bundleGraph.traverse(node => {
     if (node.type === 'asset') {

--- a/packages/core/core/test/EntryRequest.test.js
+++ b/packages/core/core/test/EntryRequest.test.js
@@ -37,7 +37,8 @@ const INVALID_TARGET_SOURCE_NOT_FILE_FIXTURE_PATH = path.join(
 describe('EntryResolver', function () {
   let entryResolver = new EntryResolver({...DEFAULT_OPTIONS});
 
-  it('rejects missing source in package.json', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('rejects missing source in package.json', async function (this: $npm$mocha$SuiteCallbackContext) {
     this.timeout(10000);
     // $FlowFixMe assert.rejects is Node 10+
     await assert.rejects(
@@ -77,7 +78,8 @@ describe('EntryResolver', function () {
       },
     );
   });
-  it('rejects non-file source in package.json', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('rejects non-file source in package.json', async function (this: $npm$mocha$SuiteCallbackContext) {
     this.timeout(10000);
     // $FlowFixMe assert.rejects is Node 10+
     await assert.rejects(
@@ -116,7 +118,8 @@ describe('EntryResolver', function () {
       },
     );
   });
-  it('rejects missing target source in package.json', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('rejects missing target source in package.json', async function (this: $npm$mocha$SuiteCallbackContext) {
     this.timeout(10000);
     // $FlowFixMe assert.rejects is Node 10+
     await assert.rejects(
@@ -160,7 +163,8 @@ describe('EntryResolver', function () {
       },
     );
   });
-  it('rejects non-file target source in package.json', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('rejects non-file target source in package.json', async function (this: $npm$mocha$SuiteCallbackContext) {
     this.timeout(10000);
     // $FlowFixMe assert.rejects is Node 10+
     await assert.rejects(

--- a/packages/core/core/test/InternalAsset.test.js
+++ b/packages/core/core/test/InternalAsset.test.js
@@ -2,12 +2,15 @@
 
 import assert from 'assert';
 import UncommittedAsset from '../src/UncommittedAsset';
-import {createAsset as _createAsset} from '../src/assetUtils';
+import {
+  createAsset as _createAsset,
+  type AssetOptions,
+} from '../src/assetUtils';
 import {createEnvironment} from '../src/Environment';
 import {DEFAULT_OPTIONS} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 

--- a/packages/core/core/test/Parcel.test.js
+++ b/packages/core/core/test/Parcel.test.js
@@ -8,7 +8,8 @@ import assert from 'assert';
 import path from 'path';
 import Parcel, {createWorkerFarm} from '../src/Parcel';
 
-describe('Parcel', function () {
+// eslint-disable-next-line no-unused-vars
+describe('Parcel', function (this: $npm$mocha$SuiteCallbackContext) {
   this.timeout(75000);
 
   let workerFarm;

--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -533,8 +533,9 @@ describe('ParcelConfigRequest', () => {
     });
 
     it('should call a merger function if provided', () => {
-      let merger = (a, b) => [a, b];
+      let merger = (a: string, b: string) => [a, b];
       assert.deepEqual(
+        // $FlowFixMe[incompatible-call]
         mergeMaps({'*.js': 'base-js'}, {'*.js': 'ext-js'}, merger),
         {'*.js': ['base-js', 'ext-js']},
       );

--- a/packages/core/core/test/PublicAsset.test.js
+++ b/packages/core/core/test/PublicAsset.test.js
@@ -3,12 +3,15 @@
 import assert from 'assert';
 import {Asset, MutableAsset} from '../src/public/Asset';
 import UncommittedAsset from '../src/UncommittedAsset';
-import {createAsset as _createAsset} from '../src/assetUtils';
+import {
+  createAsset as _createAsset,
+  type AssetOptions,
+} from '../src/assetUtils';
 import {createEnvironment} from '../src/Environment';
 import {DEFAULT_OPTIONS} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 

--- a/packages/core/core/test/PublicMutableBundleGraph.test.js
+++ b/packages/core/core/test/PublicMutableBundleGraph.test.js
@@ -8,16 +8,22 @@ import InternalBundleGraph from '../src/BundleGraph';
 import MutableBundleGraph from '../src/public/MutableBundleGraph';
 import {DEFAULT_ENV, DEFAULT_TARGETS, DEFAULT_OPTIONS} from './test-utils';
 import AssetGraph, {nodeFromAssetGroup} from '../src/AssetGraph';
-import {createAsset as _createAsset} from '../src/assetUtils';
-import {createDependency as _createDependency} from '../src/Dependency';
+import {
+  createAsset as _createAsset,
+  type AssetOptions,
+} from '../src/assetUtils';
+import {
+  createDependency as _createDependency,
+  type DependencyOpts,
+} from '../src/Dependency';
 import nullthrows from 'nullthrows';
 import {toProjectPath} from '../src/projectPath';
 
-function createAsset(opts) {
+function createAsset(opts: AssetOptions) {
   return _createAsset('/', opts);
 }
 
-function createDependency(opts) {
+function createDependency(opts: DependencyOpts) {
   return _createDependency('/', opts);
 }
 

--- a/packages/core/core/test/serializer.test.js
+++ b/packages/core/core/test/serializer.test.js
@@ -6,7 +6,7 @@ import {
   unregisterSerializableClass,
 } from '../src/serializer';
 import assert from 'assert';
-import sinon from 'sinon';
+import sinon, {type SinonSpy} from 'sinon';
 
 describe('serializer', () => {
   it('should serialize a basic object', () => {
@@ -74,7 +74,7 @@ describe('serializer', () => {
         this.x = x;
       }
 
-      serialize() {
+      serialize(): {|x: number, serialized: true|} {
         return {
           x: this.x,
           serialized: true,
@@ -100,7 +100,7 @@ describe('serializer', () => {
         this.x = x;
       }
 
-      static deserialize(x: any) {
+      static deserialize(x: any): {|value: number, deserialized: true|} {
         return {
           deserialized: true,
           value: x,
@@ -255,11 +255,11 @@ describe('serializer', () => {
     class Outer {
       inner: Inner;
 
-      constructor(inner) {
+      constructor(inner: Inner) {
         this.inner = inner;
       }
 
-      serialize() {
+      serialize(): {|$$raw: true, inner: Inner|} {
         return {
           $$raw: true,
           inner: this.inner,
@@ -270,11 +270,11 @@ describe('serializer', () => {
     class Inner {
       x: number;
 
-      constructor(x) {
+      constructor(x: number) {
         this.x = x;
       }
 
-      static deserialize = sinon.spy();
+      static deserialize: SinonSpy = sinon.spy();
     }
 
     beforeEach(() => {

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -159,7 +159,7 @@ export class MemoryFS implements FileSystem {
     filePath: FilePath,
     contents: Buffer | string,
     options?: ?FileOptions,
-  ) {
+  ): Promise<void> {
     filePath = this._normalizePath(filePath);
     if (this.dirs.has(filePath)) {
       throw new FSError('EISDIR', filePath, 'is a directory');

--- a/packages/core/fs/src/OverlayFS.js
+++ b/packages/core/fs/src/OverlayFS.js
@@ -13,7 +13,8 @@ import {registerSerializableClass} from '@parcel/core';
 import packageJSON from '../package.json';
 import {findAncestorFile, findNodeModule, findFirstFile} from './find';
 
-function read(method) {
+function read(method: string) {
+  // $FlowFixMe[missing-this-annot]
   return async function (...args: Array<any>) {
     try {
       return await this.writable[method](...args);
@@ -23,7 +24,8 @@ function read(method) {
   };
 }
 
-function readSync(method) {
+function readSync(method: string) {
+  // $FlowFixMe[missing-this-annot]
   return function (...args: Array<any>) {
     try {
       return this.writable[method](...args);
@@ -33,13 +35,15 @@ function readSync(method) {
   };
 }
 
-function write(method) {
+function write(method: string) {
+  // $FlowFixMe[missing-this-annot]
   return function (...args: Array<any>) {
     return this.writable[method](...args);
   };
 }
 
-function checkExists(method) {
+function checkExists(method: string) {
+  // $FlowFixMe[missing-this-annot]
   return function (filePath: FilePath, ...args: Array<any>) {
     if (this.writable.existsSync(filePath)) {
       return this.writable[method](filePath, ...args);

--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -442,7 +442,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
       | NullEdgeType
       | Array<TEdgeType | NullEdgeType> = 1,
   ): NodeId[] {
-    let matches = node =>
+    let matches = (node: number) =>
       type === ALL_EDGE_TYPES ||
       (Array.isArray(type)
         ? type.includes(this.#nodes.typeOf(node))
@@ -478,7 +478,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
       | NullEdgeType
       | Array<TEdgeType | NullEdgeType> = 1,
   ): NodeId[] {
-    let matches = node =>
+    let matches = (node: number) =>
       type === ALL_EDGE_TYPES ||
       (Array.isArray(type)
         ? type.includes(this.#nodes.typeOf(node))

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -321,7 +321,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
       },
     };
 
-    let walk = (nodeId, context: ?TContext) => {
+    let walk = (nodeId: NodeId, context: ?TContext) => {
       if (!this.hasNode(nodeId)) return;
       visited.add(nodeId);
 
@@ -361,6 +361,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
         // Make sure the graph still has the node: it may have been removed between enter and exit
         this.hasNode(nodeId)
       ) {
+        // $FlowFixMe[not-a-function]
         let newContext = visit.exit(nodeId, context, actions);
         if (typeof newContext !== 'undefined') {
           // $FlowFixMe[reassign-const]
@@ -471,7 +472,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     return res;
   }
 
-  _assertHasNodeId(nodeId: NodeId) {
+  _assertHasNodeId(nodeId: NodeId): void {
     if (!this.hasNode(nodeId)) {
       throw new Error('Does not have node ' + fromNodeId(nodeId));
     }
@@ -482,8 +483,18 @@ export function mapVisitor<NodeId, TValue, TContext>(
   filter: (NodeId, TraversalActions) => ?TValue,
   visit: GraphVisitor<TValue, TContext>,
 ): GraphVisitor<NodeId, TContext> {
-  function makeEnter(visit) {
-    return function mappedEnter(nodeId, context, actions) {
+  function makeEnter(
+    visit: (
+      node: TValue,
+      context: ?TContext,
+      actions: TraversalActions,
+    ) => ?TContext,
+  ) {
+    return function mappedEnter(
+      nodeId: NodeId,
+      context: ?TContext,
+      actions: TraversalActions,
+    ) {
       let value = filter(nodeId, actions);
       if (value != null) {
         return visit(value, context, actions);

--- a/packages/core/graph/test/AdjacencyList.test.js
+++ b/packages/core/graph/test/AdjacencyList.test.js
@@ -258,7 +258,8 @@ describe('AdjacencyList', () => {
     assert.ok(graph.hasEdge(b, c, [2, 3]));
   });
 
-  describe('deserialize', function () {
+  // eslint-disable-next-line no-unused-vars
+  describe('deserialize', function (this: $npm$mocha$SuiteCallbackContext) {
     this.timeout(10000);
 
     it('should share the underlying data across worker threads', async () => {

--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -117,7 +117,7 @@ describe('babel', function () {
   });
 
   it.skip('should support compiling with babel using browserslist for different environments', async function () {
-    async function testBrowserListMultipleEnv(projectBasePath) {
+    async function testBrowserListMultipleEnv(projectBasePath: string) {
       // Transpiled destructuring, like r = p.prop1, o = p.prop2, a = p.prop3;
       const prodRegExp =
         /\S+ ?= ?\S+\.prop1,\s*?\S+ ?= ?\S+\.prop2,\s*?\S+ ?= ?\S+\.prop3;/;

--- a/packages/core/integration-tests/test/blob-url.js
+++ b/packages/core/integration-tests/test/blob-url.js
@@ -5,14 +5,14 @@ import path from 'path';
 import {bundle, distDir, outputFS, run} from '@parcel/test-utils';
 
 class Blob {
-  data;
-  constructor(data) {
+  data: string;
+  constructor(data: string) {
     this.data = data;
   }
 }
 
 const URL = {
-  createObjectURL(blob) {
+  createObjectURL(blob: Blob) {
     assert(blob instanceof Blob);
     return `data:application/javascript,${encodeURIComponent(blob.data)}`;
   },
@@ -25,7 +25,7 @@ describe('blob urls', () => {
     );
 
     class Worker {
-      constructor(src) {
+      constructor(src: string) {
         created.push(src);
       }
       postMessage() {}
@@ -68,7 +68,7 @@ describe('blob urls', () => {
     );
 
     class Worker {
-      constructor(src) {
+      constructor(src: string) {
         created.push(src);
       }
       postMessage() {}

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -1,5 +1,10 @@
 // @flow
-import type {InitialParcelOptions, BuildSuccessEvent} from '@parcel/types';
+import type {
+  BuildSuccessEvent,
+  BundleGraph,
+  InitialParcelOptions,
+  PackagedBundle,
+} from '@parcel/types';
 import assert from 'assert';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -31,13 +36,13 @@ import resolveOptions from '@parcel/core/src/resolveOptions';
 let inputDir: string;
 let packageManager = new NodePackageManager(inputFS, '/');
 
-function getEntries(entries = 'src/index.js') {
+function getEntries(entries: string | Array<string> = 'src/index.js') {
   return (Array.isArray(entries) ? entries : [entries]).map(entry =>
     path.resolve(inputDir, entry),
   );
 }
 
-function getOptions(opts) {
+function getOptions(opts?: InitialParcelOptions) {
   return mergeParcelOptions(
     {
       inputFS: overlayFS,
@@ -47,7 +52,10 @@ function getOptions(opts) {
   );
 }
 
-function runBundle(entries = 'src/index.js', opts) {
+function runBundle(
+  entries: string | Array<string> = 'src/index.js',
+  opts?: InitialParcelOptions,
+) {
   return bundler(getEntries(entries), getOptions(opts)).run();
 }
 
@@ -61,7 +69,7 @@ type TestConfig = {|
   update: UpdateFn,
 |};
 
-async function testCache(update: UpdateFn | TestConfig, integration) {
+async function testCache(update: UpdateFn | TestConfig, integration?: string) {
   await overlayFS.rimraf(path.join(__dirname, '/input'));
   await ncp(
     path.join(__dirname, '/integration', integration ?? 'cache'),
@@ -152,7 +160,10 @@ describe('cache', function () {
   });
 
   it('should support adding a dependency which changes the referenced bundles of a parent bundle', async function () {
-    async function exec(bundleGraph, bundle) {
+    async function exec(
+      bundleGraph: BundleGraph<PackagedBundle>,
+      bundle: PackagedBundle,
+    ) {
       let calls = [];
       await runSingleBundle(bundleGraph, nullthrows(bundle), {
         call(v) {
@@ -219,8 +230,8 @@ describe('cache', function () {
   });
 
   describe('babel', function () {
-    let json = config => JSON.stringify(config);
-    let cjs = config => `module.exports = ${JSON.stringify(config)}`;
+    let json = (config: any) => JSON.stringify(config);
+    let cjs = (config: any) => `module.exports = ${JSON.stringify(config)}`;
     // TODO: not sure how to invalidate the ESM cache in node...
     // let mjs = (config) => `export default ${JSON.stringify(config)}`;
     let configs = [
@@ -909,7 +920,8 @@ describe('cache', function () {
         assert(contents.includes('replaced'), 'string should be replaced');
       });
 
-      it('should invalidate when there are symlinked plugins', async function () {
+      // eslint-disable-next-line no-unused-vars
+      it('should invalidate when there are symlinked plugins', async function (this: $npm$mocha$TestCallbackContext) {
         // Symlinks don't work consistently on windows. Skip this test.
         if (process.platform === 'win32') {
           this.skip();
@@ -5881,7 +5893,8 @@ describe('cache', function () {
     assert.strictEqual(result3, 3);
   });
 
-  it('properly watches included files even after resaving them without changes', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('properly watches included files even after resaving them without changes', async function (this: $npm$mocha$TestCallbackContext) {
     this.timeout(15000);
     let subscription;
     let fixture = path.join(__dirname, '/integration/included-file');
@@ -5938,7 +5951,8 @@ describe('cache', function () {
     }
   });
 
-  it('properly handles included files even after when changing back to a cached state', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('properly handles included files even after when changing back to a cached state', async function (this: $npm$mocha$TestCallbackContext) {
     this.timeout(15000);
     let subscription;
     let fixture = path.join(__dirname, '/integration/included-file');
@@ -5985,7 +5999,8 @@ describe('cache', function () {
     }
   });
 
-  it('properly watches included files after a transformer error', async function () {
+  // eslint-disable-next-line no-unused-vars
+  it('properly watches included files after a transformer error', async function (this: $npm$mocha$TestCallbackContext) {
     this.timeout(15000);
     let subscription;
     let fixture = path.join(__dirname, '/integration/included-file');

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -42,7 +42,7 @@ function getEntries(entries: string | Array<string> = 'src/index.js') {
   );
 }
 
-function getOptions(opts?: InitialParcelOptions) {
+function getOptions(opts: ?InitialParcelOptions) {
   return mergeParcelOptions(
     {
       inputFS: overlayFS,
@@ -54,7 +54,7 @@ function getOptions(opts?: InitialParcelOptions) {
 
 function runBundle(
   entries: string | Array<string> = 'src/index.js',
-  opts?: InitialParcelOptions,
+  opts: ?InitialParcelOptions,
 ) {
   return bundler(getEntries(entries), getOptions(opts)).run();
 }

--- a/packages/core/integration-tests/test/plugin.js
+++ b/packages/core/integration-tests/test/plugin.js
@@ -244,7 +244,7 @@ parcel-transformer-b`,
   });
 
   it('should allow resolvers to invalidateOnEnvChange', async () => {
-    async function assertAsset(replacedCode) {
+    async function assertAsset(replacedCode: string) {
       let b = await bundle(
         path.join(
           __dirname,

--- a/packages/core/integration-tests/test/proxy.js
+++ b/packages/core/integration-tests/test/proxy.js
@@ -22,7 +22,8 @@ function apiServer() {
   return server;
 }
 
-function get(file, port, client = http) {
+// $FlowFixMe[unclear-type]
+function get(file: string, port: number, client: any = http) {
   return new Promise((resolve, reject) => {
     client.get(
       {

--- a/packages/core/integration-tests/test/react-refresh.js
+++ b/packages/core/integration-tests/test/react-refresh.js
@@ -12,7 +12,7 @@ import {
   getNextBuildSuccess,
 } from '@parcel/test-utils';
 import getPort from 'get-port';
-import type {BuildEvent, Asset} from '@parcel/types';
+import type {BuildEvent, Asset, AsyncSubscription} from '@parcel/types';
 // flowlint-next-line untyped-import:off
 import JSDOM from 'jsdom';
 import nullthrows from 'nullthrows';
@@ -257,7 +257,7 @@ if (MessageChannel) {
   });
 }
 
-async function setup(entry) {
+async function setup(entry: string) {
   let port = await getPort(),
     b,
     window,
@@ -326,7 +326,14 @@ async function setup(entry) {
   return {port, b, window, randoms, subscription, root};
 }
 
-async function cleanup({window, subscription}) {
+async function cleanup({
+  window,
+  subscription,
+}: {|
+  //$FlowFixMe[unclear-type]
+  window: any,
+  subscription: AsyncSubscription,
+|}) {
   if (window) {
     window.close();
   }

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -16,7 +16,7 @@ import {
 import {loadSourceMapUrl} from '@parcel/utils';
 import nullthrows from 'nullthrows';
 
-const bundle = (name, opts?: InitialParcelOptions) => {
+const bundle = (name: string, opts?: InitialParcelOptions) => {
   return _bundle(
     name,
     mergeParcelOptions(
@@ -30,7 +30,7 @@ const bundle = (name, opts?: InitialParcelOptions) => {
   );
 };
 
-function indexToLineCol(str, index) {
+function indexToLineCol(str: string, index: number) {
   let beforeIndex = str.slice(0, index);
   return {
     line: beforeIndex.split('\n').length,
@@ -616,7 +616,7 @@ describe('sourcemaps', function () {
   });
 
   it('should create a valid sourcemap for a CSS bundle', async function () {
-    async function test(minify) {
+    async function test(minify: boolean) {
       let inputFilePath = path.join(
         __dirname,
         '/integration/sourcemap-css/style.css',
@@ -664,7 +664,7 @@ describe('sourcemaps', function () {
   });
 
   it('should create a valid sourcemap for a CSS bundle with imports', async function () {
-    async function test(minify) {
+    async function test(minify: boolean) {
       let inputFilePath = path.join(
         __dirname,
         '/integration/sourcemap-css-import/style.css',
@@ -752,7 +752,7 @@ describe('sourcemaps', function () {
   });
 
   it('should create a valid sourcemap for a Sass asset', async function () {
-    async function test(shouldOptimize) {
+    async function test(shouldOptimize: boolean) {
       let inputFilePath = path.join(
         __dirname,
         '/integration/sourcemap-sass/style.scss',
@@ -847,7 +847,7 @@ describe('sourcemaps', function () {
   });
 
   it('should create a valid sourcemap when for a CSS asset importing Sass', async function () {
-    async function test(shouldOptimize) {
+    async function test(shouldOptimize: boolean) {
       let inputFilePath = path.join(
         __dirname,
         '/integration/sourcemap-sass-imported/style.css',
@@ -910,7 +910,7 @@ describe('sourcemaps', function () {
   });
 
   it('should create a valid sourcemap for a LESS asset', async function () {
-    async function test(shouldOptimize) {
+    async function test(shouldOptimize: boolean) {
       let inputFilePath = path.join(
         __dirname,
         '/integration/sourcemap-less/style.less',
@@ -1145,7 +1145,7 @@ describe('sourcemaps', function () {
   });
 
   it.skip('should load existing sourcemaps for CSS files', async function () {
-    async function test(minify) {
+    async function test(minify: boolean) {
       let sourceFilename = path.join(
         __dirname,
         '/integration/sourcemap-css-existing/style.css',

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -468,7 +468,8 @@ describe('transpilation', function () {
       }
     });
 
-    it('should compile node_modules when symlinked with a source field in package.json', async function () {
+    // eslint-disable-next-line no-unused-vars
+    it('should compile node_modules when symlinked with a source field in package.json', async function (this: any) {
       if (process.platform === 'win32') {
         this.skip();
         return;

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -344,7 +344,7 @@ export class NodePackageManager implements PackageManager {
     };
 
     let seen = new Set();
-    let addKey = (name, from) => {
+    let addKey = (name: string, from: string) => {
       let basedir = path.dirname(from);
       let key = basedir + ':' + name;
       if (seen.has(key)) {
@@ -380,7 +380,7 @@ export class NodePackageManager implements PackageManager {
   invalidate(name: DependencySpecifier, from: FilePath) {
     let seen = new Set();
 
-    let invalidate = (name, from) => {
+    let invalidate = (name: string, from: string) => {
       let basedir = path.dirname(from);
       let key = basedir + ':' + name;
       if (seen.has(key)) {

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -87,7 +87,7 @@ async function installPeerDependencies(
   module: ModuleRequest,
   from: FilePath,
   projectRoot: FilePath,
-  options,
+  options: InstallOptions,
 ) {
   const {resolved} = await packageManager.resolve(module.name, from);
   const modulePkg: PackageJSON = nullthrows(

--- a/packages/core/package-manager/test/NodePackageManager.test.js
+++ b/packages/core/package-manager/test/NodePackageManager.test.js
@@ -12,7 +12,8 @@ import {MockPackageInstaller, NodePackageManager} from '../src';
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
 
-describe('NodePackageManager', function () {
+// eslint-disable-next-line no-unused-vars
+describe('NodePackageManager', function (this: $npm$mocha$SuiteCallbackContext) {
   let fs;
   let packageManager;
   let packageInstaller;

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -51,7 +51,7 @@ async function logUncaughtError(e: mixed) {
   await new Promise(resolve => setTimeout(resolve, 100));
 }
 
-const handleUncaughtException = async exception => {
+const handleUncaughtException = async (exception: Error) => {
   try {
     await logUncaughtError(exception);
   } catch (err) {
@@ -78,7 +78,7 @@ const commonOptions = {
   '--no-source-maps': 'disable sourcemaps',
   '--target [name]': [
     'only build given target(s)',
-    (val, list) => list.concat([val]),
+    (val: string, list: Array<string>) => list.concat([val]),
     [],
   ],
   '--log-level <level>': new commander.Option(
@@ -96,7 +96,7 @@ const commonOptions = {
   ],
   '--reporter <name>': [
     'additional reporters to run',
-    (val, acc) => {
+    (val: string, acc: Array<string>) => {
       acc.push(val);
       return acc;
     },
@@ -119,7 +119,7 @@ var hmrOptions = {
   '--hmr-host <host>': ['hot module replacement host', process.env.HMR_HOST],
 };
 
-function applyOptions(cmd, options) {
+function applyOptions(cmd: any, options: any) {
   for (let opt in options) {
     const option = options[opt];
     if (option instanceof commander.Option) {
@@ -209,7 +209,7 @@ if (!args[2] || !program.commands.some(c => c.name() === args[2])) {
 
 program.parse(args);
 
-function runCommand(...args) {
+function runCommand(...args: Array<any>) {
   run(...args).catch(handleUncaughtException);
 }
 
@@ -369,7 +369,7 @@ function parsePort(portValue: string): number {
   return parsedPort;
 }
 
-function parseOptionInt(value) {
+function parseOptionInt(value: string) {
   const parsedValue = parseInt(value, 10);
   if (isNaN(parsedValue)) {
     throw new commander.InvalidOptionArgumentError('Must be an integer.');
@@ -378,8 +378,8 @@ function parseOptionInt(value) {
 }
 
 async function normalizeOptions(
-  command,
-  inputFS,
+  command: any,
+  inputFS: NodeFS,
 ): Promise<InitialParcelOptions> {
   let nodeEnv;
   if (command.name() === 'build') {

--- a/packages/core/register/src/register.js
+++ b/packages/core/register/src/register.js
@@ -51,7 +51,7 @@ function register(inputOpts?: InitialParcelOptions): IDisposable {
   let isProcessing = false;
 
   // As Parcel is pretty much fully asynchronous, create an async function and wrap it in a syncPromise later...
-  async function fileProcessor(code, filePath) {
+  async function fileProcessor(code: string, filePath: string) {
     if (isProcessing) {
       return code;
     }
@@ -84,9 +84,10 @@ function register(inputOpts?: InitialParcelOptions): IDisposable {
     return '';
   }
 
-  let hookFunction = (...args) => syncPromise(fileProcessor(...args));
+  let hookFunction = (...args: Array<string>) =>
+    syncPromise(fileProcessor(...args));
 
-  function resolveFile(currFile, targetFile) {
+  function resolveFile(currFile: string, targetFile: string) {
     try {
       isProcessing = true;
 

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -495,7 +495,11 @@ export function assertBundles(
     assets: Array<string>,
   |}>,
 ) {
-  let actualBundles = [];
+  let actualBundles: Array<{|
+    assets: Array<string>,
+    name: string,
+    type: string,
+  |}> = [];
   const byAlphabet = (a: string, b: string) =>
     a.toLowerCase() < b.toLowerCase() ? -1 : 1;
 
@@ -540,14 +544,7 @@ export function assertBundles(
     bundle.assets.sort(byAlphabet);
   }
 
-  const byName = (
-    a:
-      | {assets: Array<string>, name?: string | RegExp, type?: string, ...}
-      | {assets: Array<string>, name: string, type: string, ...},
-    b:
-      | {assets: Array<string>, name?: string | RegExp, type?: string, ...}
-      | {assets: Array<string>, name: string, type: string, ...},
-  ) => {
+  const byName = (a, b) => {
     if (typeof a.name === 'string' && typeof b.name === 'string') {
       return a.name.localeCompare(b.name);
     }
@@ -555,14 +552,8 @@ export function assertBundles(
     return 0;
   };
 
-  const byAssets = (
-    a:
-      | {assets: Array<string>, name?: string | RegExp, type?: string, ...}
-      | {assets: Array<string>, name: string, type: string, ...},
-    b:
-      | {assets: Array<string>, name?: string | RegExp, type?: string, ...}
-      | {assets: Array<string>, name: string, type: string, ...},
-  ) => a.assets.join(',').localeCompare(b.assets.join(','));
+  const byAssets = (a, b) =>
+    a.assets.join(',').localeCompare(b.assets.join(','));
   expectedBundles.sort(byName).sort(byAssets);
   actualBundles.sort(byName).sort(byAssets);
   assert.equal(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -964,13 +964,15 @@ export type ResolveFn = (from: FilePath, to: string) => Promise<FilePath>;
  * @section validator
  * @experimental
  */
-type ResolveConfigFn = (configNames: Array<FilePath>) => Promise<?FilePath>;
+export type ResolveConfigFn = (
+  configNames: Array<FilePath>,
+) => Promise<?FilePath>;
 
 /**
  * @section validator
  * @experimental
  */
-type ResolveConfigWithPathFn = (
+export type ResolveConfigWithPathFn = (
   configNames: Array<FilePath>,
   assetFilePath: string,
 ) => Promise<?FilePath>;

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -148,7 +148,7 @@ loadConfig.clear = () => {
   resolveCache.clear();
 };
 
-function getParser(extname) {
+function getParser(extname: string) {
   switch (extname) {
     case 'toml':
       return toml;

--- a/packages/core/utils/src/debounce.js
+++ b/packages/core/utils/src/debounce.js
@@ -4,7 +4,7 @@ export default function debounce<TArgs: Array<mixed>>(
   fn: (...args: TArgs) => mixed,
   delay: number,
 ): (...args: TArgs) => void {
-  let timeout;
+  let timeout: ?TimeoutID;
 
   return function (...args: TArgs) {
     if (timeout) {

--- a/packages/core/utils/src/replaceBundleReferences.js
+++ b/packages/core/utils/src/replaceBundleReferences.js
@@ -33,7 +33,7 @@ export function replaceURLReferences({
   bundleGraph,
   contents,
   map,
-  getReplacement = s => s,
+  getReplacement = (s: string) => s,
   relative = true,
 }: {|
   bundle: NamedBundle,

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -115,9 +115,9 @@ export type SchemaError =
 
 function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
   function walk(
-    schemaAncestors,
-    dataNode,
-    dataPath,
+    schemaAncestors: Array<SchemaEntity>,
+    dataNode: mixed,
+    dataPath: string,
   ): ?SchemaError | Array<SchemaError> {
     let [schemaNode] = schemaAncestors;
 

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -65,43 +65,43 @@ export type SchemaAny = {||};
 export type SchemaError =
   | {|
       type: 'type',
-      expectedTypes: Array<string>,
+      expectedTypes: $ReadOnlyArray<string>,
       dataType: ?'key' | 'value',
 
       dataPath: string,
-      ancestors: Array<SchemaEntity>,
+      ancestors: $ReadOnlyArray<SchemaEntity>,
       prettyType?: string,
     |}
   | {|
       type: 'enum',
-      expectedValues: Array<mixed>,
+      expectedValues: $ReadOnlyArray<mixed>,
       dataType: 'key' | 'value',
       actualValue: mixed,
 
       dataPath: string,
-      ancestors: Array<SchemaEntity>,
+      ancestors: $ReadOnlyArray<SchemaEntity>,
       prettyType?: string,
     |}
   | {|
       type: 'forbidden-prop',
       prop: string,
-      expectedProps: Array<string>,
-      actualProps: Array<string>,
+      expectedProps: $ReadOnlyArray<string>,
+      actualProps: $ReadOnlyArray<string>,
       dataType: 'key',
 
       dataPath: string,
-      ancestors: Array<SchemaEntity>,
+      ancestors: $ReadOnlyArray<SchemaEntity>,
       prettyType?: string,
     |}
   | {|
       type: 'missing-prop',
       prop: string,
-      expectedProps: Array<string>,
-      actualProps: Array<string>,
+      expectedProps: $ReadOnlyArray<string>,
+      actualProps: $ReadOnlyArray<string>,
       dataType: 'key' | 'value',
 
       dataPath: string,
-      ancestors: Array<SchemaEntity>,
+      ancestors: $ReadOnlyArray<SchemaEntity>,
       prettyType?: string,
     |}
   | {|
@@ -110,7 +110,7 @@ export type SchemaError =
       dataType: ?'key' | 'value',
       message?: string,
       dataPath: string,
-      ancestors: Array<SchemaEntity>,
+      ancestors: $ReadOnlyArray<SchemaEntity>,
     |};
 
 function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
@@ -161,7 +161,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   type: 'enum',
                   dataType: 'value',
                   dataPath,
-                  expectedValues: schemaNode.enum,
+                  expectedValues: nullthrows(schemaNode.enum),
                   actualValue: value,
                   ancestors: schemaAncestors,
                 };
@@ -190,7 +190,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   type: 'enum',
                   dataType: 'value',
                   dataPath,
-                  expectedValues: schemaNode.enum,
+                  expectedValues: nullthrows(schemaNode.enum),
                   actualValue: value,
                   ancestors: schemaAncestors,
                 };
@@ -204,9 +204,9 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
             if (schemaNode.__forbiddenProperties) {
               // $FlowFixMe type was already checked
               let keys = Object.keys(dataNode);
-              invalidProps = schemaNode.__forbiddenProperties.filter(val =>
-                keys.includes(val),
-              );
+              invalidProps = nullthrows(
+                schemaNode.__forbiddenProperties,
+              ).filter(val => keys.includes(val));
               results.push(
                 ...invalidProps.map(
                   k =>
@@ -225,7 +225,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
             if (schemaNode.required) {
               // $FlowFixMe type was already checked
               let keys = Object.keys(dataNode);
-              let missingKeys = schemaNode.required.filter(
+              let missingKeys = nullthrows(schemaNode.required).filter(
                 val => !keys.includes(val),
               );
               results.push(
@@ -236,7 +236,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                       dataPath,
                       dataType: 'value',
                       prop: k,
-                      expectedProps: schemaNode.required,
+                      expectedProps: nullthrows(schemaNode.required),
                       actualProps: keys,
                       ancestors: schemaAncestors,
                     }: SchemaError),
@@ -365,7 +365,7 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
 export default validateSchema;
 
 export function fuzzySearch(
-  expectedValues: Array<string>,
+  expectedValues: $ReadOnlyArray<string>,
   actualValue: string,
 ): Array<string> {
   let result = expectedValues

--- a/packages/core/utils/src/throttle.js
+++ b/packages/core/utils/src/throttle.js
@@ -6,6 +6,7 @@ export default function throttle<TArgs: Iterable<mixed>>(
 ): (...args: TArgs) => void {
   let lastCalled: ?number;
 
+  // $FlowFixMe[missing-this-annot]
   return function throttled(...args: TArgs) {
     if (lastCalled == null || lastCalled + delay <= Date.now()) {
       fn.call(this, ...args);

--- a/packages/core/utils/test/throttle.test.js
+++ b/packages/core/utils/test/throttle.test.js
@@ -34,6 +34,7 @@ describe('throttle', () => {
 
   it('preserves the `this` when throttled functions are invoked', () => {
     let result;
+    // $FlowFixMe[missing-this-annot]
     let throttled = throttle(function () {
       result = this.bar;
     }, 100);

--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -86,13 +86,13 @@ export default class Worker extends EventEmitter {
       }
     }
 
-    let onMessage = data => this.receive(data);
-    let onExit = code => {
+    let onMessage = (data: WorkerMessage) => this.receive(data);
+    let onExit = (code: number) => {
       this.exitCode = code;
       this.emit('exit', code);
     };
 
-    let onError = err => {
+    let onError = (err: Error) => {
       this.emit('error', err);
     };
 

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -205,7 +205,7 @@ export class Child {
     try {
       this.send(result);
     } catch (e) {
-      result = this.send(errorResponseFromError(e));
+      this.send(errorResponseFromError(e));
     }
   }
 

--- a/packages/dev/esm-fuzzer/generateExample.js
+++ b/packages/dev/esm-fuzzer/generateExample.js
@@ -113,11 +113,11 @@ const TEMPLATES /*: {|mjs: Templates|}*/ = {
   //   },
 };
 
-function getRandom(max) {
+function getRandom(max: number) {
   return Math.floor(Math.random() * max);
 }
 
-function getRandomModuleIndex(state) {
+function getRandomModuleIndex(state: State) {
   return getRandom(Object.keys(state.modules).length);
 }
 

--- a/packages/namers/default/src/DefaultNamer.js
+++ b/packages/namers/default/src/DefaultNamer.js
@@ -138,6 +138,6 @@ function nameFromContent(
   }
 }
 
-function basenameWithoutExtension(file) {
+function basenameWithoutExtension(file: FilePath) {
   return path.basename(file, path.extname(file));
 }

--- a/packages/optimizers/css/src/CSSOptimizer.js
+++ b/packages/optimizers/css/src/CSSOptimizer.js
@@ -192,7 +192,7 @@ Parcel\'s default CSS minifer changed from cssnano to @parcel/css, but a "cssnan
 
 let cache = new Map();
 
-function getTargets(browsers) {
+function getTargets(browsers: void | string | Array<string>) {
   if (browsers == null) {
     return undefined;
   }

--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -115,7 +115,7 @@ export default (new Optimizer({
 // So map lowercased tag and attribute names back to their case-sensitive equivalents.
 function mapSVG(
   node: string | PostHTMLNode | Array<string | PostHTMLNode>,
-  inSVG = false,
+  inSVG: boolean = false,
 ) {
   if (Array.isArray(node)) {
     for (let i = 0; i < node.length; i++) {

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -1,7 +1,15 @@
 // @flow
 
 import type {Root} from 'postcss';
-import type {Asset, Dependency} from '@parcel/types';
+import type {
+  Asset,
+  Dependency,
+  JSONValue,
+  NamedBundle,
+  BundleGraph,
+  PluginLogger,
+  PluginOptions,
+} from '@parcel/types';
 import typeof PostCSS from 'postcss';
 
 import path from 'path';
@@ -188,12 +196,12 @@ function escapeString(contents: string): string {
 }
 
 async function processCSSModule(
-  options,
-  logger,
-  bundleGraph,
-  bundle,
-  asset,
-  media,
+  options: PluginOptions,
+  logger: PluginLogger,
+  bundleGraph: BundleGraph<NamedBundle>,
+  bundle: NamedBundle,
+  asset: Asset,
+  media: Array<JSONValue>,
 ): Promise<[Asset, string, ?Buffer]> {
   let postcss: PostCSS = await options.packageManager.require(
     'postcss',
@@ -281,7 +289,7 @@ async function processCSSModule(
   return [asset, content, sourceMap?.toBuffer()];
 }
 
-function escapeDashedIdent(name) {
+function escapeDashedIdent(name: string) {
   // https://drafts.csswg.org/cssom/#serialize-an-identifier
   let res = '';
   for (let c of name) {

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -1,5 +1,11 @@
 // @flow strict-local
-import type {Bundle, BundleGraph, NamedBundle} from '@parcel/types';
+import type {
+  Async,
+  Blob,
+  Bundle,
+  BundleGraph,
+  NamedBundle,
+} from '@parcel/types';
 
 import assert from 'assert';
 import {Readable} from 'stream';
@@ -99,8 +105,11 @@ export default (new Packager({
 
 async function getAssetContent(
   bundleGraph: BundleGraph<NamedBundle>,
-  getInlineBundleContents,
-  assetId,
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph<NamedBundle>,
+  ) => Async<{|contents: Blob|}>,
+  assetId: string,
 ) {
   let inlineBundle: ?Bundle;
   bundleGraph.traverseBundles((bundle, context, {stop}) => {
@@ -125,8 +134,12 @@ async function getAssetContent(
 
 async function replaceInlineAssetContent(
   bundleGraph: BundleGraph<NamedBundle>,
-  getInlineBundleContents,
-  tree,
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph<NamedBundle>,
+  ) => Async<{|contents: Blob|}>,
+  // $FlowFixMe[unclear-type]
+  tree: any,
 ) {
   const inlineNodes = [];
   tree.walk(node => {
@@ -179,7 +192,8 @@ async function replaceInlineAssetContent(
   return tree;
 }
 
-function insertBundleReferences(siblingBundles, tree) {
+// $FlowFixMe[unclear-type]
+function insertBundleReferences(siblingBundles: Array<NamedBundle>, tree: any) {
   const bundles = [];
 
   for (let bundle of siblingBundles) {
@@ -211,7 +225,8 @@ function insertBundleReferences(siblingBundles, tree) {
   addBundlesToTree(bundles, tree);
 }
 
-function addBundlesToTree(bundles, tree) {
+// $FlowFixMe[unclear-type]
+function addBundlesToTree(bundles: Array<any>, tree: any) {
   const main = find(tree, 'head') || find(tree, 'html');
   const content = main ? main.content || (main.content = []) : tree;
   const index = findBundleInsertIndex(content);
@@ -219,7 +234,8 @@ function addBundlesToTree(bundles, tree) {
   content.splice(index, 0, ...bundles);
 }
 
-function find(tree, tag) {
+// $FlowFixMe[unclear-type]
+function find(tree: any, tag: string) {
   let res;
   tree.match({tag}, node => {
     res = node;
@@ -229,7 +245,8 @@ function find(tree, tag) {
   return res;
 }
 
-function findBundleInsertIndex(content) {
+// $FlowFixMe[unclear-type]
+function findBundleInsertIndex(content: Array<any>) {
   // HTML document order (https://html.spec.whatwg.org/multipage/syntax.html#writing)
   //   - Any number of comments and ASCII whitespace.
   //   - A DOCTYPE.
@@ -253,5 +270,5 @@ function findBundleInsertIndex(content) {
     }
   }
 
-  return doctypeIndex ? doctypeIndex + 1 : 0;
+  return doctypeIndex != null ? doctypeIndex + 1 : 0;
 }

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -137,7 +137,7 @@ export class ScopeHoistingPackager {
     let res = '';
     let lineCount = 0;
     let sourceMap = null;
-    let processAsset = asset => {
+    let processAsset = (asset: Asset) => {
       let [content, map, lines] = this.visitAsset(asset);
       if (sourceMap && map) {
         sourceMap.addSourceMap(map, lineCount);
@@ -672,7 +672,7 @@ ${code}
     return [depMap, replacements];
   }
 
-  addExternal(dep: Dependency, replacements?: Map<string, string>) {
+  addExternal(dep: Dependency, replacements?: Map<string, string>): void {
     if (this.bundle.env.outputFormat === 'global') {
       throw new ThrowableDiagnostic({
         diagnostic: {

--- a/packages/packagers/svg/src/SVGPackager.js
+++ b/packages/packagers/svg/src/SVGPackager.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type {Bundle, BundleGraph, NamedBundle} from '@parcel/types';
+import type {
+  Async,
+  Blob,
+  Bundle,
+  BundleGraph,
+  NamedBundle,
+} from '@parcel/types';
 import assert from 'assert';
 import {Packager} from '@parcel/plugin';
 import posthtml from 'posthtml';
@@ -77,8 +83,11 @@ export default (new Packager({
 
 async function replaceInlineAssetContent(
   bundleGraph: BundleGraph<NamedBundle>,
-  getInlineBundleContents,
-  tree,
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph<NamedBundle>,
+  ) => Async<{|contents: Blob|}>,
+  tree: any,
 ) {
   const inlineNodes = [];
   tree.walk(node => {
@@ -118,8 +127,11 @@ async function replaceInlineAssetContent(
 
 async function getAssetContent(
   bundleGraph: BundleGraph<NamedBundle>,
-  getInlineBundleContents,
-  assetId,
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph<NamedBundle>,
+  ) => Async<{|contents: Blob|}>,
+  assetId: string,
 ) {
   let inlineBundle: ?Bundle;
   bundleGraph.traverseBundles((bundle, context, {stop}) => {
@@ -139,7 +151,7 @@ async function getAssetContent(
   return {bundle: inlineBundle, contents: bundleResult.contents};
 }
 
-function insertBundleReferences(siblingBundles, tree) {
+function insertBundleReferences(siblingBundles: Array<NamedBundle>, tree: any) {
   let scripts = [];
   let stylesheets = [];
 

--- a/packages/packagers/webextension/src/WebExtensionPackager.js
+++ b/packages/packagers/webextension/src/WebExtensionPackager.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+import type {NamedBundle} from '@parcel/types';
 
 import assert from 'assert';
 import nullthrows from 'nullthrows';
@@ -19,7 +20,7 @@ export default (new Packager({
     );
     const asset = manifestAssets[0];
 
-    const relPath = b =>
+    const relPath = (b: NamedBundle) =>
       relativeBundlePath(bundle, b, {leadingDotSlash: false});
 
     const manifest = JSON.parse(await asset.getCode());

--- a/packages/packagers/xml/src/XMLPackager.js
+++ b/packages/packagers/xml/src/XMLPackager.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type {Bundle, BundleGraph, NamedBundle} from '@parcel/types';
+import type {
+  Async,
+  Blob,
+  Bundle,
+  BundleGraph,
+  NamedBundle,
+} from '@parcel/types';
 import assert from 'assert';
 import {Packager} from '@parcel/plugin';
 import {
@@ -87,8 +93,11 @@ export default (new Packager({
 
 async function getAssetContent(
   bundleGraph: BundleGraph<NamedBundle>,
-  getInlineBundleContents,
-  assetId,
+  getInlineBundleContents: (
+    Bundle,
+    BundleGraph<NamedBundle>,
+  ) => Async<{|contents: Blob|}>,
+  assetId: string,
 ) {
   let inlineBundle: ?Bundle;
   bundleGraph.traverseBundles((bundle, context, {stop}) => {

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -236,7 +236,11 @@ async function writeDiagnostic(
   }
 }
 
-function wrapWithIndent(string, indent = 0, initialIndent = indent) {
+function wrapWithIndent(
+  string: string,
+  indent: number = 0,
+  initialIndent: number = indent,
+) {
   let width = getTerminalWidth().columns;
   return indentString(
     wrapAnsi(string.trimEnd(), width - indent, {trim: false}),
@@ -245,7 +249,11 @@ function wrapWithIndent(string, indent = 0, initialIndent = indent) {
   );
 }
 
-function indentString(string, indent = 0, initialIndent = indent) {
+function indentString(
+  string: string,
+  indent: number = 0,
+  initialIndent: number = indent,
+) {
   return (
     ' '.repeat(initialIndent) + string.replace(/\n/g, '\n' + ' '.repeat(indent))
   );

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -90,7 +90,7 @@ export default async function bundleReport(
   table(COLUMNS, rows);
 }
 
-function prettifySize(size, isLarge) {
+function prettifySize(size: number, isLarge: boolean = false) {
   let res = filesize(size);
   if (isLarge) {
     return chalk.yellow(emoji.warning + '  ' + res);

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -49,7 +49,7 @@ export type HMRMessage =
       type: 'error',
       diagnostics: {|
         ansi: Array<AnsiDiagnosticResult>,
-        html: Array<$Rest<AnsiDiagnosticResult, {|codeframe: string|}>>,
+        html: Array<$Diff<AnsiDiagnosticResult, {|codeframe: string|}>>,
       |},
     |};
 

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -1,4 +1,5 @@
 // @flow
+import type {Request, Response} from './types.js.flow';
 
 import {Reporter} from '@parcel/plugin';
 import HMRServer from './HMRServer';
@@ -46,7 +47,9 @@ export default (new Reporter({
               port: serveOptions.port,
               host: hmrOptions.host,
               devServer,
-              addMiddleware: handler => {
+              addMiddleware: (
+                handler: (req: Request, res: Response) => boolean,
+              ) => {
                 server?.middleware.push(handler);
               },
               logger,

--- a/packages/resolvers/glob/src/GlobResolver.js
+++ b/packages/resolvers/glob/src/GlobResolver.js
@@ -1,4 +1,6 @@
 // @flow
+import type {Dependency} from '@parcel/types';
+
 import {Resolver} from '@parcel/plugin';
 import {
   isGlob,
@@ -13,7 +15,10 @@ import ThrowableDiagnostic from '@parcel/diagnostic';
 import NodeResolver from '@parcel/node-resolver-core';
 import invariant from 'assert';
 
-function errorToThrowableDiagnostic(error, dependency): ThrowableDiagnostic {
+function errorToThrowableDiagnostic(
+  error: string,
+  dependency: Dependency,
+): ThrowableDiagnostic {
   return new ThrowableDiagnostic({
     diagnostic: {
       message: error,
@@ -191,7 +196,7 @@ export default (new Resolver({
   },
 }): Resolver);
 
-function set(obj, path, value) {
+function set(obj: {...}, path: Array<string>, value: string) {
   for (let i = 0; i < path.length - 1; i++) {
     let part = path[i];
 
@@ -205,7 +210,12 @@ function set(obj, path, value) {
   obj[path[path.length - 1]] = value;
 }
 
-function generate(matches, isAsync, indent = '', count = 0) {
+function generate(
+  matches: {...},
+  isAsync: boolean,
+  indent: string = '',
+  count: number = 0,
+) {
   if (typeof matches === 'string') {
     if (isAsync) {
       return {

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -6,6 +6,8 @@ import type {
   HMRAsset,
   HMRMessage,
 } from '@parcel/reporter-dev-server/src/HMRServer.js';
+import type {AnsiDiagnosticResult} from '@parcel/utils';
+
 interface ParcelRequire {
   (string): mixed;
   cache: {|[string]: ParcelModule|};
@@ -52,16 +54,16 @@ var OVERLAY_ID = '__parcel__error__overlay__';
 
 var OldModule = module.bundle.Module;
 
-function Module(moduleName) {
+function Module(/*:: this: any,*/ moduleName /* : string */) {
   OldModule.call(this, moduleName);
   this.hot = {
     data: module.bundle.hotData,
     _acceptCallbacks: [],
     _disposeCallbacks: [],
-    accept: function (fn) {
+    accept: function (/*:: this: any, */ fn) {
       this._acceptCallbacks.push(fn || function () {});
     },
-    dispose: function (fn) {
+    dispose: function (/*:: this: any, */ fn) {
       this._disposeCallbacks.push(fn);
     },
   };
@@ -207,7 +209,9 @@ function removeErrorOverlay() {
   }
 }
 
-function createErrorOverlay(diagnostics) {
+function createErrorOverlay(
+  diagnostics /*: Array<$Rest<AnsiDiagnosticResult, {codeframe: string, ...}>> */,
+) {
   var overlay = document.createElement('div');
   overlay.id = OVERLAY_ID;
 
@@ -215,7 +219,7 @@ function createErrorOverlay(diagnostics) {
     '<div style="background: black; opacity: 0.85; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; font-family: Menlo, Consolas, monospace; z-index: 9999;">';
 
   for (let diagnostic of diagnostics) {
-    let stack = diagnostic.frames.length
+    let stack = diagnostic.frames?.length
       ? diagnostic.frames.reduce((p, frame) => {
           return `${p}
 <a href="/__parcel_launch_editor?file=${encodeURIComponent(
@@ -230,11 +234,15 @@ ${frame.code}`;
     errorHTML += `
       <div>
         <div style="font-size: 18px; font-weight: bold; margin-top: 20px;">
-          🚨 ${diagnostic.message}
+          🚨 ${String(diagnostic.message)}
         </div>
-        <pre>${stack}</pre>
+        <pre>${String(stack)}</pre>
         <div>
-          ${diagnostic.hints.map(hint => '<div>💡 ' + hint + '</div>').join('')}
+          ${String(
+            diagnostic.hints
+              ?.map(hint => '<div>💡 ' + hint + '</div>')
+              .join(''),
+          )}
         </div>
         ${
           diagnostic.documentation
@@ -260,7 +268,10 @@ function fullReload() {
   }
 }
 
-function getParents(bundle, id) /*: Array<[ParcelRequire, string]> */ {
+function getParents(
+  bundle /*: ParcelRequire */,
+  id /*: string */,
+) /*: Array<[ParcelRequire, string]> */ {
   var modules = bundle.modules;
   if (!modules) {
     return [];
@@ -286,7 +297,7 @@ function getParents(bundle, id) /*: Array<[ParcelRequire, string]> */ {
   return parents;
 }
 
-function updateLink(link) {
+function updateLink(link /* : HTMLElement */) {
   var newLink = link.cloneNode();
   newLink.onload = function () {
     if (link.parentNode !== null) {
@@ -334,7 +345,7 @@ function reloadCSS() {
   }, 50);
 }
 
-function hmrDownload(asset) {
+function hmrDownload(asset /*: HMRAsset */) {
   if (asset.type === 'js') {
     if (typeof document !== 'undefined') {
       let script = document.createElement('script');
@@ -365,7 +376,7 @@ function hmrDownload(asset) {
   }
 }
 
-async function hmrApplyUpdates(assets) {
+async function hmrApplyUpdates(assets /*: Array<HMRAsset> */) {
   global.parcelHotUpdate = Object.create(null);
 
   let scriptsToRemove;
@@ -463,7 +474,7 @@ function hmrApply(bundle /*: ParcelRequire */, asset /*:  HMRAsset */) {
   }
 }
 
-function hmrDelete(bundle, id) {
+function hmrDelete(bundle /* : ParcelRequire */, id /* : string */) {
   let modules = bundle.modules;
   if (!modules) {
     return;

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -210,7 +210,7 @@ function removeErrorOverlay() {
 }
 
 function createErrorOverlay(
-  diagnostics /*: Array<$Rest<AnsiDiagnosticResult, {codeframe: string, ...}>> */,
+  diagnostics /*: $ReadOnlyArray<$Diff<AnsiDiagnosticResult, {codeframe: string, ...}>> */,
 ) {
   var overlay = document.createElement('div');
   overlay.id = OVERLAY_ID;

--- a/packages/transformers/babel/src/config.js
+++ b/packages/transformers/babel/src/config.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type {Config, PluginOptions, PluginLogger} from '@parcel/types';
+import type {
+  Config,
+  PluginOptions,
+  PluginLogger,
+  FilePath,
+} from '@parcel/types';
+import type {FileSystem} from '@parcel/fs';
 import typeof * as BabelCore from '@babel/core';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {BabelConfig} from './types';
@@ -102,7 +108,7 @@ export async function load(
     [string]: any,
   |} = await babelCore.loadPartialConfigAsync(babelOptions);
 
-  let addIncludedFile = file => {
+  let addIncludedFile = (file: FilePath) => {
     if (JS_EXTNAME_RE.test(path.extname(file))) {
       // We need to invalidate on startup in case the config is non-static,
       // e.g. uses unknown environment variables, reads from the filesystem, etc.
@@ -239,12 +245,16 @@ async function buildDefaultBabelConfig(
   };
 }
 
-function hasRequire(options) {
+function hasRequire(options: any) {
   let configItems = [...options.presets, ...options.plugins];
   return configItems.some(item => !item.file);
 }
 
-function definePluginDependencies(config, babelConfig: ?BabelConfig, options) {
+function definePluginDependencies(
+  config: Config,
+  babelConfig: ?BabelConfig,
+  options: PluginOptions,
+) {
   if (babelConfig == null) {
     return;
   }
@@ -280,7 +290,11 @@ const redundantPresets = new Set([
   '@parcel/babel-preset-env',
 ]);
 
-async function warnOnRedundantPlugins(fs, babelConfig, logger) {
+async function warnOnRedundantPlugins(
+  fs: FileSystem,
+  babelConfig: {[string]: any},
+  logger: PluginLogger,
+) {
   if (babelConfig == null) {
     return;
   }
@@ -377,7 +391,11 @@ async function warnOnRedundantPlugins(fs, babelConfig, logger) {
   }
 }
 
-async function getCodeHighlights(fs, filePath, redundantPresets) {
+async function getCodeHighlights(
+  fs: FileSystem,
+  filePath: FilePath,
+  redundantPresets: Set<string>,
+) {
   let ext = path.extname(filePath);
   if (ext !== '.js' && ext !== '.cjs' && ext !== '.mjs') {
     let contents = await fs.readFile(filePath, 'utf8');

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -193,7 +193,7 @@ export default (new Transformer({
       }
 
       let seen = new Set();
-      let add = key => {
+      let add = (key: string) => {
         if (seen.has(key)) {
           return;
         }
@@ -285,7 +285,7 @@ export default (new Transformer({
 
 let cache = new Map();
 
-function getTargets(browsers) {
+function getTargets(browsers: void | string | Array<string>) {
   if (browsers == null) {
     return undefined;
   }

--- a/packages/transformers/elm/src/ElmTransformer.js
+++ b/packages/transformers/elm/src/ElmTransformer.js
@@ -1,4 +1,5 @@
 // @flow strict-local
+import type {FilePath, PluginLogger, MutableAsset} from '@parcel/types';
 
 import {Transformer} from '@parcel/plugin';
 import spawn from 'cross-spawn';
@@ -55,7 +56,7 @@ export default (new Transformer({
     // this can be removed after https://github.com/isaacs/node-graceful-fs/pull/200 was mergend and used in parcel
     // $FlowFixMe[method-unbinding]
     process.chdir.disabled = isWorker;
-    let code;
+    let code: ?string;
     try {
       code = await compileToString(elm, elmBinary, sources, compilerConfig);
     } catch (e) {
@@ -89,7 +90,13 @@ export default (new Transformer({
 }): Transformer);
 
 // gather extra modules that should be added to the compilation process
-function resolveExtraSources({asset, logger}) {
+function resolveExtraSources({
+  asset,
+  logger,
+}: {|
+  asset: MutableAsset,
+  logger: PluginLogger,
+|}) {
   const dirname = path.dirname(asset.filePath);
   const relativePaths = asset.query.getAll('with');
 
@@ -104,7 +111,14 @@ function resolveExtraSources({asset, logger}) {
   return relativePaths.map(relPath => path.join(dirname, relPath));
 }
 
-function compileToString(elm, elmBinary, sources, config) {
+function compileToString(
+  //$FlowFixMe[unclear-type]
+  elm: any,
+  elmBinary: ?string,
+  sources: Array<FilePath>,
+  //$FlowFixMe[unclear-type]
+  config: any,
+) {
   return elm.compileToString(sources, {
     pathToElm: elmBinary,
     ...config,
@@ -130,7 +144,7 @@ let elmPureFuncs = [
   'A9',
 ];
 
-async function minifyElmOutput(source) {
+async function minifyElmOutput(source: string) {
   // Recommended minification
   // Based on: http://elm-lang.org/0.19.0/optimize
   let result = await minify(source, {
@@ -151,7 +165,8 @@ async function minifyElmOutput(source) {
   throw result.error;
 }
 
-function formatMessagePiece(piece) {
+//$FlowFixMe[unclear-type]
+function formatMessagePiece(piece: any) {
   if (piece.string) {
     if (piece.underline) {
       return md`${md.underline(piece.string)}`;
@@ -161,12 +176,14 @@ function formatMessagePiece(piece) {
   return md`${piece}`;
 }
 
-function elmCompileErrorToParcelDiagnostics(error) {
+//$FlowFixMe[unclear-type]
+function elmCompileErrorToParcelDiagnostics(error: any) {
   const relativePath = path.relative(process.cwd(), error.path);
   return error.problems.map(problem => formatElmError(problem, relativePath));
 }
 
-function formatElmError(problem, relativePath) {
+//$FlowFixMe[unclear-type]
+function formatElmError(problem: any, relativePath: string) {
   const padLength = 80 - 5 - problem.title.length - relativePath.length;
   const dashes = '-'.repeat(padLength);
   const message = [

--- a/packages/transformers/glsl/src/GLSLTransformer.js
+++ b/packages/transformers/glsl/src/GLSLTransformer.js
@@ -1,4 +1,6 @@
 // @flow
+import type {MutableAsset} from '@parcel/types';
+
 import path from 'path';
 import {promisify} from 'util';
 import {Transformer} from '@parcel/plugin';
@@ -42,7 +44,7 @@ export default (new Transformer({
   },
 }): Transformer);
 
-function collectDependencies(asset, ast) {
+function collectDependencies(asset: MutableAsset, ast: any) {
   for (let dep of ast) {
     if (!dep.entry) {
       asset.invalidateOnFileChange(dep.file);

--- a/packages/transformers/graphql/src/GraphQLTransformer.js
+++ b/packages/transformers/graphql/src/GraphQLTransformer.js
@@ -1,4 +1,6 @@
 // @flow
+import type {FilePath} from '@parcel/types';
+
 import {Transformer} from '@parcel/plugin';
 import {parse, print, Source, stripIgnoredCharacters} from 'graphql';
 import {processDocumentImports} from 'graphql-import-macro';
@@ -8,7 +10,7 @@ export default (new Transformer({
     const document = parse(new Source(await asset.getCode(), asset.filePath));
     const expandedDocument = await processDocumentImports(document, loadImport);
 
-    async function loadImport(to, from) {
+    async function loadImport(to: FilePath, from: FilePath) {
       const filePath = await resolve(to, from);
 
       asset.invalidateOnFileChange(filePath);

--- a/packages/transformers/html/src/dependencies.js
+++ b/packages/transformers/html/src/dependencies.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {AST, MutableAsset} from '@parcel/types';
+import type {AST, DependencyOptions, MutableAsset} from '@parcel/types';
 import type {PostHTMLNode} from 'posthtml';
 import PostHTML from 'posthtml';
 // A list of all attributes that may produce a dependency
@@ -74,7 +74,7 @@ const OPTIONS = {
   iframe: {
     src: {needsStableName: true},
   },
-  link(attrs) {
+  link(attrs: any) {
     if (attrs.rel === 'stylesheet') {
       return {
         // Keep in the same bundle group as the HTML.
@@ -84,7 +84,11 @@ const OPTIONS = {
   },
 };
 
-function collectSrcSetDependencies(asset, srcset, opts) {
+function collectSrcSetDependencies(
+  asset: MutableAsset,
+  srcset: string,
+  opts: $Shape<DependencyOptions>,
+) {
   let newSources = [];
   for (const source of srcset.split(',')) {
     let pair = source.trim().split(' ');
@@ -105,12 +109,13 @@ function collectSrcSetDependencies(asset, srcset, opts) {
   return newSources.join(', ');
 }
 
-function getAttrDepHandler(attr) {
+function getAttrDepHandler(attr: string) {
   if (attr === 'srcset' || attr === 'imagesrcset') {
     return collectSrcSetDependencies;
   }
 
-  return (asset, src, opts) => asset.addURLDependency(src, opts);
+  return (asset: MutableAsset, src: string, opts: $Shape<DependencyOptions>) =>
+    asset.addURLDependency(src, opts);
 }
 
 export default function collectDependencies(

--- a/packages/transformers/jsonld/src/JSONLDTransformer.js
+++ b/packages/transformers/jsonld/src/JSONLDTransformer.js
@@ -1,4 +1,5 @@
 // @flow
+import type {JSONObject, MutableAsset} from '@parcel/types';
 
 import {Transformer} from '@parcel/plugin';
 import json5 from 'json5';
@@ -36,7 +37,7 @@ export default (new Transformer({
   },
 }): Transformer);
 
-function extractUrlsFrom(data, asset) {
+function extractUrlsFrom(data: any, asset: MutableAsset) {
   if (!data) return null;
 
   if (typeof data === 'string') {
@@ -49,7 +50,7 @@ function extractUrlsFrom(data, asset) {
   return iterateThroughObject(data, asset);
 }
 
-function iterateThroughObject(jsonObject, asset) {
+function iterateThroughObject(jsonObject: JSONObject, asset: MutableAsset) {
   Object.keys(jsonObject)
     .filter(k => SCHEMA_ATTRS.includes(k))
     .forEach(k => {
@@ -60,7 +61,7 @@ function iterateThroughObject(jsonObject, asset) {
   return jsonObject;
 }
 
-function iterateThroughArray(jsonArray, asset) {
+function iterateThroughArray(jsonArray: any, asset: MutableAsset) {
   Object.keys(jsonArray).forEach(i => {
     let value = jsonArray[i];
     jsonArray[i] = extractUrlsFrom(value, asset);

--- a/packages/transformers/less/src/LessTransformer.js
+++ b/packages/transformers/less/src/LessTransformer.js
@@ -1,4 +1,6 @@
 // @flow
+import type {FilePath, MutableAsset, ResolveFn} from '@parcel/types';
+
 import {typeof default as Less} from 'less';
 import path from 'path';
 import {Transformer} from '@parcel/plugin';
@@ -69,9 +71,9 @@ export default (new Transformer({
   },
 }): Transformer);
 
-function urlPlugin({asset}) {
+function urlPlugin({asset}: {|asset: MutableAsset|}) {
   return {
-    install(less: Less, pluginManager) {
+    install(less: Less, pluginManager: any) {
       // This is a hack; no such interface exists, even conceptually, in Less.
       type LessNodeWithValue = less.tree.Node & {value: any, ...};
 
@@ -95,19 +97,30 @@ function urlPlugin({asset}) {
   };
 }
 
-function resolvePathPlugin({asset, resolve}) {
+function resolvePathPlugin({
+  asset,
+  resolve,
+}: {|
+  asset: MutableAsset,
+  resolve: ResolveFn,
+|}) {
   return {
-    install(less, pluginManager) {
+    install(less: Less, pluginManager: any) {
+      // $FlowFixMe[prop-missing]
       class LessFileManager extends less.FileManager {
-        supports() {
+        supports(): boolean {
           return true;
         }
 
-        supportsSync() {
+        supportsSync(): boolean {
           return false;
         }
 
-        async loadFile(rawFilename, currentDirectory, options) {
+        async loadFile(
+          rawFilename: string,
+          currentDirectory: string,
+          options: any,
+        ): Promise<{|contents: string, filename: ?FilePath|}> {
           let filename = rawFilename;
 
           if (WEBPACK_ALIAS_RE.test(filename)) {

--- a/packages/transformers/postcss/src/PostCSSTransformer.js
+++ b/packages/transformers/postcss/src/PostCSSTransformer.js
@@ -239,7 +239,7 @@ export default (new Transformer({
         code = `
           module.exports = Object.assign({}, ${deps
             .map(dep => `require(${JSON.stringify(dep.specifier)})`)
-            .join(', ')}, ${JSON.stringify(cssModules, null, 2)});
+            .join(', ')}, ${JSON.stringify(nullthrows(cssModules), null, 2)});
         `;
       } else {
         code = cssModulesList
@@ -291,7 +291,7 @@ async function createLoader(
     asset.filePath,
   );
   return class ParcelFileSystemLoader extends FileSystemLoader {
-    async fetch(composesPath, relativeTo) {
+    async fetch(composesPath: string, relativeTo: string): any {
       let importPath = composesPath.replace(/^["']|["']$/g, '');
       let resolved = await resolve(relativeTo, importPath);
       let rootRelativePath = path.resolve(path.dirname(relativeTo), resolved);
@@ -313,7 +313,7 @@ async function createLoader(
       return exportTokens;
     }
 
-    get finalSource() {
+    get finalSource(): string {
       return '';
     }
   };

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -1,9 +1,10 @@
 // @flow
+import type {MutableAsset, PluginOptions} from '@parcel/types';
 
 import path from 'path';
 import {Transformer} from '@parcel/plugin';
 
-function shouldExclude(asset, options) {
+function shouldExclude(asset: MutableAsset, options: PluginOptions) {
   return (
     !asset.isSource ||
     !options.hmrOptions ||

--- a/packages/transformers/sass/src/SassTransformer.js
+++ b/packages/transformers/sass/src/SassTransformer.js
@@ -1,4 +1,11 @@
 // @flow
+import type {
+  FilePath,
+  MutableAsset,
+  PluginOptions,
+  ResolveFn,
+} from '@parcel/types';
+
 import {Transformer} from '@parcel/plugin';
 import path from 'path';
 import {EOL} from 'os';
@@ -101,12 +108,22 @@ export default (new Transformer({
   },
 }): Transformer);
 
-function resolvePathImporter({asset, resolve, includePaths, options}) {
+function resolvePathImporter({
+  asset,
+  resolve,
+  includePaths,
+  options,
+}: {|
+  asset: MutableAsset,
+  resolve: ResolveFn,
+  includePaths: any,
+  options: PluginOptions,
+|}) {
   // This is a reimplementation of the Sass resolution algorithm that uses Parcel's
   // FS and tracks all tried files so they are watched for creation.
   async function resolvePath(
-    url,
-    prev,
+    url: string,
+    prev: FilePath,
   ): Promise<{filePath: string, contents: string, ...} | void> {
     /*
       Imports are resolved by trying, in order:
@@ -174,7 +191,11 @@ function resolvePathImporter({asset, resolve, includePaths, options}) {
     }
   }
 
-  return function (rawUrl, prev, done) {
+  return function (
+    rawUrl: string,
+    prev: FilePath,
+    done: (?{|file: FilePath, contents: string|}) => void,
+  ) {
     const url = rawUrl.replace(/^file:\/\//, '');
     resolvePath(url, prev)
       .then(resolved => {

--- a/packages/transformers/stylus/src/StylusTransformer.js
+++ b/packages/transformers/stylus/src/StylusTransformer.js
@@ -1,4 +1,11 @@
 // @flow
+import type {FileSystem} from '@parcel/fs';
+import type {
+  FilePath,
+  MutableAsset,
+  PluginOptions,
+  ResolveFn,
+} from '@parcel/types';
 
 import {Transformer} from '@parcel/plugin';
 import {createDependencyLocation, isGlob, glob, globSync} from '@parcel/utils';
@@ -81,7 +88,13 @@ export default (new Transformer({
   },
 }): Transformer);
 
-function attemptResolve(importedPath, filepath, asset, resolve, deps) {
+function attemptResolve(
+  importedPath: any,
+  filepath: FilePath,
+  asset: MutableAsset,
+  resolve: ResolveFn,
+  deps: Map<any, any>,
+) {
   if (deps.has(importedPath)) {
     return;
   }
@@ -112,15 +125,15 @@ function attemptResolve(importedPath, filepath, asset, resolve, deps) {
 }
 
 async function getDependencies(
-  code,
-  filepath,
-  asset,
-  resolve,
-  options,
-  parcelOptions,
-  nativeGlob,
-  seen = new Set(),
-  includeImports = true,
+  code: string,
+  filepath: FilePath,
+  asset: MutableAsset,
+  resolve: ResolveFn,
+  options: any,
+  parcelOptions: PluginOptions,
+  nativeGlob: any,
+  seen: Set<FilePath> = new Set(),
+  includeImports: boolean = true,
 ) {
   seen.add(filepath);
 
@@ -137,7 +150,7 @@ async function getDependencies(
   }
 
   class ImportVisitor extends DepsResolver {
-    visitImport(imported) {
+    visitImport(imported: any) {
       let importedPath = imported.path.first.string;
       attemptResolve(importedPath, filepath, asset, resolve, deps);
     }
@@ -220,12 +233,12 @@ async function getDependencies(
 }
 
 async function createEvaluator(
-  code,
-  asset,
-  resolve,
-  options,
-  parcelOptions,
-  nativeGlob,
+  code: string,
+  asset: MutableAsset,
+  resolve: ResolveFn,
+  options: any,
+  parcelOptions: PluginOptions,
+  nativeGlob: any,
 ) {
   const deps = await getDependencies(
     code,
@@ -241,7 +254,7 @@ async function createEvaluator(
   // require resolution algorithm. It also adds all dependencies to the parcel asset
   // tree so the file watcher works correctly, etc.
   class CustomEvaluator extends Evaluator {
-    visitImport(imported) {
+    visitImport(imported: any): any {
       let node = this.visit(imported.path).first;
       let path = node.string;
       if (node.name !== 'url' && path && !URL_RE.test(path)) {
@@ -283,7 +296,7 @@ async function createEvaluator(
   return CustomEvaluator;
 }
 
-function patchNativeFS(fs, nativeGlob) {
+function patchNativeFS(fs: FileSystem, nativeGlob: any) {
   let invalidations = [];
   let readFileSync = nativeFS.readFileSync;
   let statSync = nativeFS.statSync;
@@ -335,7 +348,7 @@ function patchNativeFS(fs, nativeGlob) {
 /**
  * Puts the content of all given node blocks into the first one, essentially merging them.
  */
-function mergeBlocks(blocks) {
+function mergeBlocks(blocks: Array<any>) {
   let finalBlock;
   for (const block of blocks) {
     if (finalBlock) {

--- a/packages/transformers/svg-react/src/SvgReactTransformer.js
+++ b/packages/transformers/svg-react/src/SvgReactTransformer.js
@@ -1,5 +1,6 @@
 // @flow
 
+import type {FilePath} from '@parcel/types';
 import {Transformer} from '@parcel/plugin';
 
 import path from 'path';
@@ -8,7 +9,7 @@ import svgoPlugin from '@svgr/plugin-svgo';
 import jsxPlugin from '@svgr/plugin-jsx';
 import {transform} from '@svgr/core';
 
-function getComponentName(filePath) {
+function getComponentName(filePath: FilePath) {
   let validCharacters = /[^a-zA-Z0-9_-]/g;
   let name = path.parse(filePath).name.replace(validCharacters, '');
   return camelcase(name, {

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -1,5 +1,11 @@
 // @flow strict-local
-import type {TransformerResult} from '@parcel/types';
+import type {
+  FilePath,
+  MutableAsset,
+  PluginOptions,
+  ResolveFn,
+  TransformerResult,
+} from '@parcel/types';
 
 import {Transformer} from '@parcel/plugin';
 import nullthrows from 'nullthrows';
@@ -170,7 +176,8 @@ export default script;`,
   },
 }): Transformer);
 
-function createDiagnostic(err, filePath) {
+// $FlowFixMe[unclear-type]
+function createDiagnostic(err: any, filePath: FilePath) {
   if (typeof err === 'string') {
     return {
       message: err,
@@ -219,7 +226,29 @@ async function processPipeline({
   resolve,
   id,
   hmrId,
-}) {
+}: {|
+  asset: MutableAsset,
+  // $FlowFixMe[unclear-type]
+  template: any,
+  // $FlowFixMe[unclear-type]
+  script: any,
+  // $FlowFixMe[unclear-type]
+  styles: any,
+  // $FlowFixMe[unclear-type]
+  customBlocks: any,
+  config: {|
+    // $FlowFixMe[unclear-type]
+    compilerOptions: any,
+    // $FlowFixMe[unclear-type]
+    customBlocks: any,
+    filePath: ?FilePath,
+  |},
+  basePath: string,
+  options: PluginOptions,
+  resolve: ResolveFn,
+  id: string,
+  hmrId: string,
+|}) {
   switch (asset.pipeline) {
     case 'template': {
       let isFunctional = template.functional;
@@ -498,7 +527,8 @@ export default script => {
   }
 }
 
-function createMap(rawMap, projectRoot: string) {
+// $FlowFixMe[unclear-type]
+function createMap(rawMap: any, projectRoot: string) {
   let newMap = new SourceMap(projectRoot);
   newMap.addVLQMap(rawMap);
   return newMap;

--- a/packages/transformers/webmanifest/src/WebManifestTransformer.js
+++ b/packages/transformers/webmanifest/src/WebManifestTransformer.js
@@ -15,7 +15,7 @@ const RESOURCES_SCHEMA = {
     properties: {
       src: {
         type: 'string',
-        __validate: s => {
+        __validate: (s: string) => {
           if (s.length === 0) {
             return 'Must not be empty';
           }

--- a/packages/transformers/xml/src/XMLTransformer.js
+++ b/packages/transformers/xml/src/XMLTransformer.js
@@ -44,7 +44,7 @@ export default (new Transformer({
   },
 }): Transformer);
 
-function walk(element, visit) {
+function walk(element: any, visit: any) {
   visit(element);
 
   element = element.firstChild;

--- a/packages/utils/events/src/ValueEmitter.js
+++ b/packages/utils/events/src/ValueEmitter.js
@@ -29,7 +29,7 @@ export default class ValueEmitter<TValue> implements IDisposable {
     // slicing out the listener.
     // This prevents anyone holding onto the disposable after disposal from
     // unintentionally retaining a reference to this emitter.
-    let emitter = this;
+    let emitter: ?ValueEmitter<TValue> = this;
     return {
       dispose() {
         if (emitter == null) {

--- a/packages/utils/hash/browser.js
+++ b/packages/utils/hash/browser.js
@@ -32,7 +32,7 @@ class Hash {
 }
 module.exports.Hash = Hash;
 
-function concatUint8Arrays(arrays) {
+function concatUint8Arrays(arrays /*: Array<Uint8Array> */) {
   let totalLength = 0;
   for (let a of arrays) {
     totalLength += a.byteLength;
@@ -46,7 +46,7 @@ function concatUint8Arrays(arrays) {
   return result;
 }
 
-function toHex(arr) {
+function toHex(arr /*: Uint8Array */) {
   let dataView = new DataView(arr.buffer);
   return (
     dataView.getUint32(0, true).toString(16).padStart(8, '0') +

--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -482,7 +482,7 @@ export default class NodeResolver {
     sourceFile: FilePath,
     name: string,
     ctx: ResolverContext,
-  ) {
+  ): Promise<void> {
     let [moduleName] = getModuleParts(name);
     let pkg = await this.findPackage(sourceFile, ctx);
     if (!pkg) {

--- a/packages/validators/typescript/src/TypeScriptValidator.js
+++ b/packages/validators/typescript/src/TypeScriptValidator.js
@@ -3,6 +3,7 @@ import type {
   Asset,
   ConfigResult,
   PluginOptions,
+  ResolveConfigWithPathFn,
   ValidateResult,
 } from '@parcel/types';
 import type {LanguageService, Diagnostic} from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
@@ -79,9 +80,9 @@ export default (new Validator({
 }): Validator);
 
 async function getConfig(
-  asset,
-  options,
-  resolveConfigWithPath,
+  asset: Asset,
+  options: PluginOptions,
+  resolveConfigWithPath: ResolveConfigWithPathFn,
 ): Promise<TSValidatorConfig> {
   let configNames = ['tsconfig.json'];
   let tsconfig = await loadConfig(


### PR DESCRIPTION
This fixes some, but not all errors (yet) coming from trying to upgrade to Flow 0.190

Notably (and unfortunately), Flow became more similar to TS in that there is less type inference (so all functions parameters have to be declared, and a local variable is inferred to have the value of the first assigned as opposed to a type that covers all usages)
