### PR TITLE
Make polyfill version validation a warning

### DIFF
--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -27,9 +27,10 @@ import {
   isGlobMatch,
 } from '@parcel/utils';
 import ThrowableDiagnostic, {
+  encodeJSONKeyComponent,
+  errorToDiagnostic,
   generateJSONCodeHighlights,
   md,
-  encodeJSONKeyComponent,
 } from '@parcel/diagnostic';
 import builtins, {empty} from './builtins';
 import nullthrows from 'nullthrows';
@@ -377,18 +378,21 @@ export default class NodeResolver {
         }
       } else if (builtin.range != null) {
         // Assert correct version
-
-        // TODO packageManager can be null for backwards compatibility, but that could cause invalid
-        // resolutions in monorepos
-        await packageManager?.resolve(
-          packageName,
-          this.projectRoot + '/index',
-          {
-            saveDev: true,
-            shouldAutoInstall: this.shouldAutoInstall,
-            range: builtin.range,
-          },
-        );
+        try {
+          // TODO packageManager can be null for backwards compatibility, but that could cause invalid
+          // resolutions in monorepos
+          await packageManager?.resolve(
+            packageName,
+            this.projectRoot + '/index',
+            {
+              saveDev: true,
+              shouldAutoInstall: this.shouldAutoInstall,
+              range: builtin.range,
+            },
+          );
+        } catch (e) {
+          this.logger?.warn(errorToDiagnostic(e));
+        }
       }
     }
 


### PR DESCRIPTION
Change code from https://github.com/parcel-bundler/parcel/pull/8387 to a warning instead, as I'm not really confident that there are no false-negatives (cases where the user wants to override themselves)

```
$ parcel build index.js

@parcel/resolver-default: Could not find module "buffer" satisfying ^5.5.0.

  /.../parcel/tests/builtins-monorepo/package.json:7:3
    6 |   "devDependencies": {
  > 7 |     "buffer": "^4.0.0"
  >   |     ^^^^^^^^ Found this conflicting local requirement.
    8 |   }
    9 | }

✨ Built in 1.50s

dist/index.js    63.74 KB    42ms
```