### PR TITLE
Resolve `publicUrl` and `distDir` from environment variables (.env)

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -97,12 +97,6 @@ export default async function resolveOptions(
     initialOptions?.defaultTargetOptions?.shouldOptimize ??
     mode === 'production';
 
-  let publicUrl = initialOptions?.defaultTargetOptions?.publicUrl ?? '/';
-  let distDir =
-    initialOptions?.defaultTargetOptions?.distDir != null
-      ? path.resolve(inputCwd, initialOptions?.defaultTargetOptions?.distDir)
-      : undefined;
-
   let shouldBuildLazily = initialOptions.shouldBuildLazily ?? false;
   let shouldContentHash =
     initialOptions.shouldContentHash ?? initialOptions.mode === 'production';
@@ -122,6 +116,17 @@ export default async function resolveOptions(
   };
 
   let port = determinePort(initialOptions.serveOptions, env.PORT);
+  let publicUrl =
+    initialOptions?.defaultTargetOptions?.publicUrl ??
+    env.PARCEL_PUBLIC_URL ??
+    '/';
+  let distDir =
+    initialOptions?.defaultTargetOptions?.distDir ??
+    env.PARCEL_DIST_DIR ??
+    undefined;
+  if (distDir != null) {
+    distDir = path.resolve(inputCwd, distDir);
+  }
 
   return {
     config: getRelativeConfigSpecifier(


### PR DESCRIPTION
(I couldn't find any open or closed PRs & issues related to this functionality.)

# ↪️ Pull Request

It's very difficult to provide the desired `publicUrl` or `distDir` arguments to parcel when they are sourced from environment variables. It's near-impossible (to my knowledge) to do so in a cross-platform compatible way from either the CLI or package.json. The environment variables are injected by Parcel and can be used in the build pipeline just fine, but Parcel itself will not be able to pick them up. So while your code might know the correct public URL based on the environment, you will still have to specify it manually to the build command.

This PR proposes a solution similar to how you can specify `PORT` as a fallback environment variable.

## 💻 Examples

```bash
// .env
PARCEL_PUBLIC_URL=/path
PARCEL_DIST_DIR=public
```

Running `parcel build` or `parcel serve` will default to a public URL of "/path" when not specified otherwise (via CLI or targets).

## 🚨 Test instructions

I was unable to test this behavior in practice yet. That will require me to dive a bit deeper into how this repository works,, but I'll be happy to do so once I know whether this is a welcome change or not.

## ✔️ PR Todo

- [ ] Test and add automatic testing.
