### PR TITLE
Use traverseAssets in packager

### DIFF
--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -39,16 +39,14 @@ export class DevPackager {
   async package(): Promise<{|contents: string, map: ?SourceMap|}> {
     // Load assets
     let queue = new PromiseQueue({maxConcurrent: 32});
-    this.bundle.traverse(node => {
-      if (node.type === 'asset') {
-        queue.add(async () => {
-          let [code, mapBuffer] = await Promise.all([
-            node.value.getCode(),
-            this.bundle.env.sourceMap && node.value.getMapBuffer(),
-          ]);
-          return {code, mapBuffer};
-        });
-      }
+    this.bundle.traverseAssets(asset => {
+      queue.add(async () => {
+        let [code, mapBuffer] = await Promise.all([
+          asset.getCode(),
+          this.bundle.env.sourceMap && asset.getMapBuffer(),
+        ]);
+        return {code, mapBuffer};
+      });
     });
 
     let results = await queue.run();


### PR DESCRIPTION
This is more idiomatic and slightly faster in some special cases as it prevents the creation of thousands of public Dependency wrapper objects.