### PR TITLE
Catch uncaught promise build abort race

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -150,7 +150,7 @@ export type RunAPI = {|
   runRequest: <TInput, TResult>(
     subRequest: Request<TInput, TResult>,
     opts?: RunRequestOpts,
-  ) => Async<TResult>,
+  ) => Promise<TResult>,
 |};
 
 type RunRequestOpts = {|
@@ -885,7 +885,7 @@ export default class RequestTracker {
   async getRequestResult<T>(
     contentKey: ContentKey,
     ifMatch?: string,
-  ): Async<?T> {
+  ): Promise<?T> {
     let node = nullthrows(this.graph.getNodeByContentKey(contentKey));
     invariant(node.type === 'request');
 
@@ -958,7 +958,7 @@ export default class RequestTracker {
   async runRequest<TInput, TResult>(
     request: Request<TInput, TResult>,
     opts?: ?RunRequestOpts,
-  ): Async<TResult> {
+  ): Promise<TResult> {
     let requestId = this.graph.hasContentKey(request.id)
       ? this.graph.getNodeIdByContentKey(request.id)
       : undefined;
@@ -1068,7 +1068,7 @@ export default class RequestTracker {
       runRequest: <TInput, TResult>(
         subRequest: Request<TInput, TResult>,
         opts?: RunRequestOpts,
-      ): Async<TResult> => {
+      ): Promise<TResult> => {
         subRequestContentKeys.add(subRequest.id);
         return this.runRequest<TInput, TResult>(subRequest, opts);
       },

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -113,7 +113,10 @@ async function run({input, api, farm, options}: RunInput) {
             hashRefToNameHash,
             bundleGraph,
           });
-          writeEarlyPromises[bundle.id] = api.runRequest(writeBundleRequest);
+          let promise = api.runRequest(writeBundleRequest);
+          // If the promise rejects before we await it (below), we don't want to crash the build.
+          promise.catch(() => {});
+          writeEarlyPromises[bundle.id] = promise;
         }
       }),
     );


### PR DESCRIPTION
If a build is aborted while writing bundles, the process could crash. This happened because we didn't immediately await a promise, so if the build was aborted between when the promise was created and when it was awaited, node would trigger an unhandled promise rejection. This adds an empty `.catch` to prevent that. The error should still be picked up when the promise is awaited later.

Closes https://github.com/parcel-bundler/parcel/issues/8548