### PR TITLE
Publish flow types for `@parcel/plugin`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,16 @@ const paths = {
     ...IGNORED_PACKAGES,
   ],
   packageOther: ['packages/*/*/src/**/dev-prelude.js'],
-  packageFlow: ['packages/core/plugin/src/PluginAPI.js'],
+  packageFlow: [
+    'packages/core/cache/src/**/*.js',
+    'packages/core/core/src/**/*.js',
+    'packages/core/diagnostic/src/diagnostic.js',
+    'packages/core/fs/src/**/*.js',
+    'packages/core/package-manager/src/**/*.js',
+    'packages/core/plugin/src/PluginAPI.js',
+    'packages/core/utils/src/**/*.js',
+    'packages/core/workers/src/**/*.js',
+  ],
   packageJson: [
     'packages/core/parcel/package.json',
     'packages/utils/create-react-app/package.json',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,7 @@ const paths = {
     ...IGNORED_PACKAGES,
   ],
   packageOther: ['packages/*/*/src/**/dev-prelude.js'],
+  packageFlow: ['packages/core/plugin/src/PluginAPI.js'],
   packageJson: [
     'packages/core/parcel/package.json',
     'packages/utils/create-react-app/package.json',
@@ -61,7 +62,7 @@ exports.clean = function clean(cb) {
 };
 
 exports.default = exports.build = gulp.series(
-  gulp.parallel(buildBabel, copyOthers),
+  gulp.parallel(buildBabel, copyOthers, copyFlow),
   // Babel reads from package.json so update these after babel has run
   paths.packageJson.map(
     packageJsonPath =>
@@ -83,6 +84,13 @@ function copyOthers() {
   return gulp
     .src(paths.packageOther)
     .pipe(renameStream(relative => relative.replace('src', 'lib')))
+    .pipe(gulp.dest(paths.packages));
+}
+
+function copyFlow() {
+  return gulp
+    .src(paths.packageFlow, {base: paths.packages})
+    .pipe(renameStream(relative => relative.replace('src', 'lib') + '.flow'))
     .pipe(gulp.dest(paths.packages));
 }
 


### PR DESCRIPTION
Currently, importing `@parcel/plugin` from npm doesn't include type information for Flow.

This copies `packages/core/plugin/src/PluginAPI.js` to `packages/core/plugin/lib/PluginAPI.js.flow` in the build step.

And as it turns out, this was missing for many more packages. I added a copy step for all user-facing ones (for plugin authors and JS API consumers)