### PR TITLE
Preserve error formatting in browser overlay and make it scrollable

### DIFF
--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -212,7 +212,7 @@ function createErrorOverlay(diagnostics) {
   overlay.id = OVERLAY_ID;
 
   let errorHTML =
-    '<div style="background: black; opacity: 0.85; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; font-family: Menlo, Consolas, monospace; z-index: 9999;">';
+    '<div style="background: black; opacity: 0.85; font-size: 16px; color: white; position: fixed; height: 100%; width: 100%; top: 0px; left: 0px; padding: 30px; font-family: Menlo, Consolas, monospace; z-index: 9999; white-space: pre; overflow: scroll;">';
 
   for (let diagnostic of diagnostics) {
     let stack = diagnostic.frames.length


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

At least when using Elm (i.e. `@parcel/elm-transformer`), the error messages in the browser do not appear properly formatted. New lines seem to be ignored and only the first screen of messages is visible, i.e. the message overlay is not scrollable. Of course, it would be very handy to be able to see the error messages properly formatted and scrollable in the browser, like in the terminal, where the error messages are printed as expected. The change suggested in this PR is a small (inline) CSS fix to preserve the original empty and new lines and to allow scrolling past the first screen.

⚠️ Please note that I have not tested how messages are displayed using other languages or frameworks, so I don't know if this is a problem at all or even if this fix will break something in other cases than with the errors reported by `@parcel/elm-transformer`.

Please note also that this is my first PR in this project. I have read the contributing guidelines and have also reviewed issues and PRs searching for this topic, but please bear with me if I missed something. One issue that seems related is https://github.com/parcel-bundler/parcel/issues/3188, but it might not be relevant since it is quite old and this behavior seems to be a regression that happened between parcel versions 2.5.0 and 2.7.0.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

Since this is just a small UI change via two added inline CSS properties, it is easier to show the change with a couple of screenshots:

### Before the change

<img width="718" alt="Screenshot 2022-11-07 at 09 51 49" src="https://user-images.githubusercontent.com/807084/200330717-509e74b1-ab7e-40f1-b971-9b483bd4da05.png">

### After the change proposed in this PR

<img width="718" alt="Screenshot 2022-11-07 at 09 53 05" src="https://user-images.githubusercontent.com/807084/200330774-33d0119a-d080-4d9b-ad28-9a37a53811e5.png">


## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

To reproduce this behavior, start serving an Elm project that compiles *without* errors, and apply a small modification in the Elm code that breaks the compilation. The error should appear in the browser overlay and in the terminal output.

## ✔️ PR Todo

- ~Added/updated unit tests for this change~
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
