### PR TITLE
createWriteStream: Ignore error in fs.unlinkSync

### DIFF
--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -112,7 +112,11 @@ export class NodeFS implements FileSystem {
 
     writeStream.once('error', () => {
       failed = true;
-      fs.unlinkSync(tmpFilePath);
+      try {
+        fs.unlinkSync(tmpFilePath);
+      } catch (e) {
+        // ignore error
+      }
     });
 
     return writeStream;


### PR DESCRIPTION
Looks like Node's `fs.createWriteStream` sometimes fails to create a file at all, which would mean that `unlinkSync()` tries to delete a file that doesn't exist resulting in the error. (Or maybe there's a writestream error after the file was renamed?)

I don't know though why it happens only rarely on Windows and apparently nowhere else.

Closes https://github.com/parcel-bundler/parcel/issues/8571
Closes https://github.com/parcel-bundler/parcel/issues/8615