### PR TITLE
fix: remove @parcel/utils dep in @parcel/graph

### DIFF
--- a/packages/core/graph/package.json
+++ b/packages/core/graph/package.json
@@ -20,7 +20,6 @@
     "node": ">= 12.0.0"
   },
   "dependencies": {
-    "@parcel/utils": "2.8.0",
     "nullthrows": "^1.1.1"
   }
 }

--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -1,7 +1,7 @@
 // @flow
 import assert from 'assert';
 import nullthrows from 'nullthrows';
-import {SharedBuffer} from '@parcel/utils';
+import {SharedBuffer} from './shared-buffer';
 import {fromNodeId, toNodeId} from './types';
 import {ALL_EDGE_TYPES, type NullEdgeType, type AllEdgeTypes} from './Graph';
 import type {NodeId} from './types';

--- a/packages/core/graph/src/shared-buffer.js
+++ b/packages/core/graph/src/shared-buffer.js
@@ -1,0 +1,24 @@
+// @flow
+/* global MessageChannel:readonly */
+// Copy from @parcel/utils to fix: https://github.com/stackblitz/core/issues/1855
+export let SharedBuffer: Class<ArrayBuffer> | Class<SharedArrayBuffer>;
+
+// $FlowFixMe[prop-missing]
+if (process.browser) {
+  SharedBuffer = ArrayBuffer;
+  // Safari has removed the constructor
+  if (typeof SharedArrayBuffer !== 'undefined') {
+    let channel = new MessageChannel();
+    try {
+      // Firefox might throw when sending the Buffer over a MessagePort
+      channel.port1.postMessage(new SharedArrayBuffer(0));
+      SharedBuffer = SharedArrayBuffer;
+    } catch (_) {
+      // NOOP
+    }
+    channel.port1.close();
+    channel.port2.close();
+  }
+} else {
+  SharedBuffer = SharedArrayBuffer;
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
This fixes https://github.com/stackblitz/core/issues/1855
Remove the @parcel/utils dependency so that can be used on  [stackblitz](https://stackblitz.com/edit/github-jn7xvb?file=index.js)


https://github.com/parcel-bundler/parcel/issues/8621#issuecomment-1312468108
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples
 [stackblitz](https://stackblitz.com/edit/github-jn7xvb?file=index.js)
<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions
None
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
