### PR TITLE
Fix resolution of absolute paths inside project root

### DIFF
--- a/packages/utils/node-resolver-core/src/NodeResolver.js
+++ b/packages/utils/node-resolver-core/src/NodeResolver.js
@@ -583,7 +583,9 @@ export default class NodeResolver {
 
         // Absolute path. Resolve relative to project root.
         dir = this.projectRoot;
-        filename = '.' + filename;
+        filename = filename.startsWith(dir)
+          ? path.relative(dir, filename)
+          : '.' + filename;
         break;
       }
 

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -102,7 +102,7 @@ describe('resolver', function () {
       assert.equal(nullthrows(resolved).filePath, path.join(rootDir, 'bar.js'));
     });
 
-    it('should resolve an absolute path from the root module', async function () {
+    it('should resolve an absolute path outside root module from the root module', async function () {
       let resolved = await resolver.resolve({
         env: BROWSER_ENV,
         filename: '/bar',
@@ -110,6 +110,19 @@ describe('resolver', function () {
         parent: path.join(rootDir, 'nested', 'test.js'),
       });
       assert.equal(nullthrows(resolved).filePath, path.join(rootDir, 'bar.js'));
+    });
+
+    it('should resolve an absolute path inside root module from the root module', async function () {
+      let resolved = await resolver.resolve({
+        env: BROWSER_ENV,
+        filename: path.join(rootDir, 'node_modules', 'foo', 'index.js'),
+        specifierType: 'esm',
+        parent: path.join(rootDir, 'nested', 'test.js'),
+      });
+      assert.equal(
+        nullthrows(resolved).filePath,
+        path.join(rootDir, 'node_modules', 'foo', 'index.js'),
+      );
     });
 
     it('should resolve an absolute path from a node_modules folder', async function () {


### PR DESCRIPTION
# ↪️ Pull Request

When `NodeResolver` is trying to resolve an absolute path inside the parcel's project directory, it incorrectly resolves the path.

## 💻 Examples

For example, resolving `/projectDir/someFolder/index.js` when the project dir is `/projectDir`,
 `NodeResolver` will resolve the file to — `/projectDir/projectDir/someFolder/index.js` which is incorrect.

Instead, it should treat absolute paths inside the project directory differently, and perhaps resolve them without duplicating the project directory.

## 🚨 Test instructions

See test case added for an example.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
