### PR TITLE
Don't retarget dependencies with `*`

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -215,6 +215,10 @@ export default class BundleGraph {
           node.usedSymbolsUp.size > 0 &&
           // Only perform rewriting if the dependency only points to a single asset (e.g. CSS modules)
           !hasAmbiguousSymbols &&
+          // It doesn't make sense to retarget dependencies where `*` is used, because the
+          // retargeting won't enable any benefits in that case (apart from potentially even more
+          // code being generated).
+          !node.usedSymbolsUp.has('*') &&
           // TODO We currently can't rename imports in async imports, e.g. from
           //      (parcelRequire("...")).then(({ a }) => a);
           // to

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/index.js
@@ -1,0 +1,5 @@
+import { v } from "./library/a.js";
+
+import * as y from "./library/a.js";
+
+output = [v, sideEffectNoop(y).v];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/a.js
@@ -1,0 +1,1 @@
+export * from "./b.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/b.js
@@ -1,0 +1,1 @@
+export {v} from "./c.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/c.js
@@ -1,0 +1,1 @@
+export const v = 123;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/retarget-namespace-single/library/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2224,6 +2224,17 @@ describe('scope hoisting', function () {
       ]);
     });
 
+    it('should correctly retarget dependencies when both namespace and indvidual export are used', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/retarget-namespace-single/index.js',
+        ),
+      );
+      let output = await run(b);
+      assert.deepEqual(output, [123, 123]);
+    });
+
     it('should correctly handle circular dependencies', async function () {
       let b = await bundle(
         path.join(__dirname, '/integration/scope-hoisting/es6/circular/a.mjs'),

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -338,7 +338,7 @@ export async function runBundles(
 
   // A utility to prevent optimizers from removing side-effect-free code needed for testing
   // $FlowFixMe[prop-missing]
-  ctx.sideEffectNoop = () => {};
+  ctx.sideEffectNoop = v => v;
 
   vm.createContext(ctx);
   let esmOutput;


### PR DESCRIPTION
Fixes #8624

 It doesn't really make sense to do retargeting if the dependency has a used `*` symbols, because the retargeting won't enable any benefits in that case (apart from potentially even more code being generated).

Furthermore, that fixes a bug where a dependency with symbols `* -> *` was split into two (one for the used `*` and one for a specific symbol itself) which really confused this code: https://github.com/parcel-bundler/parcel/blob/fbe9fde8f233cbf526fe945c8937f48bf10cfc4a/packages/packagers/js/src/ScopeHoistingPackager.js#L1063-L1080