### PR TITLE
Fix overriding single export of a `export *`

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/a.js
@@ -1,0 +1,3 @@
+import { foo, c } from "./b.js";
+
+export default foo() + c;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/b.js
@@ -1,0 +1,8 @@
+import { foo as old } from "./c";
+export * from "./c";
+
+function foo() {
+	return "fooB" + old();
+}
+
+export { foo };

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/c.js
@@ -1,0 +1,5 @@
+export function foo() {
+	return "fooC";
+}
+
+export const c = "C";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-override/index.js
@@ -1,0 +1,3 @@
+if (Date.now() > 0) {
+	output = require("./a.js").default;
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -397,6 +397,18 @@ describe('scope hoisting', function () {
       assert.equal(output, 15);
     });
 
+    it('supports re-exporting all exports and overriding individual exports', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-all-override/index.js',
+        ),
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, 'fooBfooCC');
+    });
+
     it('can import from a different bundle via a re-export (1)', async function () {
       let b = await bundle(
         path.join(


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/8652

Right now, the order of `$parcel$export` is wrong. The exports coming from `export *` should always be first and get overridden by the explicit exports of the asset
```js
// this was `export {foo}`
$parcel$export(module.exports, "foo", () => $e6ba20bd13e7c6a6$export$6a5cdcad01c973fa); 

// this is `export * from "./c";`
$parcel$export(module.exports, "foo", () => (parcelRequire("1mXMP")).foo);

var $1mXMP = parcelRequire("1mXMP");

var $1mXMP = parcelRequire("1mXMP");
function $e6ba20bd13e7c6a6$export$6a5cdcad01c973fa() {
    return "fooB" + (0, $1mXMP.foo)();
}
```

### TODO

- [x] Implement Fix