### PR TITLE
Fix * re-exports from empty files

### DIFF
--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -108,6 +108,7 @@ pub struct TransformResult {
   needs_esm_helpers: bool,
   used_env: HashSet<swc_atoms::JsWord>,
   has_node_replacements: bool,
+  is_empty_file: bool,
 }
 
 fn targets_to_versions(targets: &Option<HashMap<String, String>>) -> Option<Versions> {
@@ -446,6 +447,13 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
               if let Some(bailouts) = &collect.bailouts {
                 diagnostics.extend(bailouts.iter().map(|bailout| bailout.to_diagnostic()));
               }
+
+              result.is_empty_file = collect.decls.len() == 0
+                && collect.exports.len() == 0
+                && collect.exports_all.len() == 0
+                && collect.exports_locals.len() == 0
+                && collect.imports.len() == 0
+                && !collect.has_cjs_exports;
 
               let module = if config.scope_hoist {
                 let res = hoist(module, config.module_id.as_str(), unresolved_mark, &collect);

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -386,6 +386,7 @@ export default (new Transformer({
       diagnostics,
       used_env,
       has_node_replacements,
+      is_empty_file,
     } = transform({
       filename: asset.filePath,
       code,

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -814,7 +814,8 @@ export default (new Transformer({
       // This allows accessing symbols that don't exist without errors in symbol propagation.
       if (
         hoist_result.has_cjs_exports ||
-        (!hoist_result.is_esm &&
+        (!is_empty_file &&
+          !hoist_result.is_esm &&
           deps.size === 0 &&
           Object.keys(hoist_result.exported_symbols).length === 0) ||
         (hoist_result.should_wrap && !asset.symbols.hasExportSymbol('*'))


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

In some cases where a `*` export points to an empty file e.g. `export * from './file-with-no-contents'` Parcel incorrectly assign symbols to the file. This seems to be due to a [default `*` symbol assigned to these types of files](https://github.com/parcel-bundler/parcel/blob/711ae183f7b61be36128e9da0e424d874d836015/packages/transformers/js/src/JSTransformer.js#L821). While it's strange to export from an empty file, it can often occur in packages that don't remove their type exports from the runtime code. 

My fix is to pass a new `is_empty_file` value back from the native Js transformer which is set to true when a file has no exports, imports or declarations. 

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

I have replicated this issue but it doesn't seem to fail in the integration test suite. 

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
