### PR TITLE
Add mjs and cjs to resolver extensions

### DIFF
--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -22,7 +22,7 @@ export default (new Resolver({
       extensions:
         dependency.specifierType === 'commonjs' ||
         dependency.specifierType === 'esm'
-          ? ['ts', 'tsx', 'js', 'jsx', 'json']
+          ? ['ts', 'tsx', 'mjs', 'js', 'jsx', 'cjs', 'json']
           : [],
       mainFields: ['source', 'browser', 'module', 'main'],
       packageManager: options.packageManager,


### PR DESCRIPTION
Not totally sure about the order we should use, but seems good to prioritize mjs.