### PR TITLE
Fix requires of external CommonJS SWC helpers

### DIFF
--- a/packages/core/integration-tests/test/fs.js
+++ b/packages/core/integration-tests/test/fs.js
@@ -198,7 +198,6 @@ describe('fs', function () {
         path.join(distDir, 'index.js'),
         'utf8',
       );
-      assert(contents.includes(`require("fs")`));
       assert(contents.includes('readFileSync'));
 
       await outputFS.writeFile(

--- a/packages/core/integration-tests/test/integration/formats/commonjs-helpers/index.js
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-helpers/index.js
@@ -1,0 +1,5 @@
+class X {
+  x = new Map()
+}
+
+output(new X());

--- a/packages/core/integration-tests/test/integration/formats/commonjs-helpers/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-helpers/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "dist/main.js",
+  "browserslist": "Chrome 70",
+  "dependencies": {
+    "@swc/helpers": "^0.4.14"
+  }
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2694,27 +2694,27 @@ describe('javascript', function () {
     let dist = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(
       dist.includes(
-        'require("path").resolve(__dirname, "../test/integration/env-node-replacements")',
+        'resolve(__dirname, "../test/integration/env-node-replacements")',
       ),
     );
     assert(
       dist.includes(
-        'require("path").resolve(__dirname, "../test/integration/env-node-replacements/other")',
+        'resolve(__dirname, "../test/integration/env-node-replacements/other")',
       ),
     );
     assert(
       dist.includes(
-        'require("path").resolve(__dirname, "../test/integration/env-node-replacements", "index.js")',
+        'resolve(__dirname, "../test/integration/env-node-replacements", "index.js")',
       ),
     );
     assert(
       dist.includes(
-        'require("path").resolve(__dirname, "../test/integration/env-node-replacements/sub")',
+        'resolve(__dirname, "../test/integration/env-node-replacements/sub")',
       ),
     );
     assert(
       dist.includes(
-        'require("path").resolve(__dirname, "../test/integration/env-node-replacements/sub", "index.js")',
+        'resolve(__dirname, "../test/integration/env-node-replacements/sub", "index.js")',
       ),
     );
     let f = await run(b);

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -560,6 +560,22 @@ describe('output formats', function () {
 
       assert.deepEqual(out, [1, 2]);
     });
+
+    it('should work with SWC helpers', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/formats/commonjs-helpers/index.js'),
+      );
+
+      let out = [];
+      await run(b, {
+        require,
+        output(o) {
+          out.push(o);
+        },
+      });
+
+      assert.deepEqual(out[0].x, new Map());
+    });
   });
 
   describe('esmodule', function () {

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -639,6 +639,5 @@ describe('server', function () {
     invariant(localCSS);
 
     assert(data.includes(path.basename(localCSS.filePath)));
-    assert(data.includes('css-loader'));
   });
 });

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -445,7 +445,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'const local',
-      generatedStr: 'const t',
+      generatedStr: 'const r',
       sourcePath: 'index.js',
     });
 
@@ -454,7 +454,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'local.a',
-      generatedStr: 't.a',
+      generatedStr: 'r.a',
       sourcePath: 'index.js',
     });
 

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -106,6 +106,9 @@ export class DevPackager {
           } else if (resolved) {
             deps[getSpecifier(dep)] =
               this.bundleGraph.getAssetPublicId(resolved);
+          } else {
+            // An external module - map placeholder to original specifier.
+            deps[getSpecifier(dep)] = dep.specifier;
           }
         }
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -115,12 +115,12 @@ impl<'a> DependencyCollector<'a> {
       }
     }
 
-    // For normal imports/requires, the specifier will remain unchanged.
+    // For ESM imports, the specifier will remain unchanged.
     // For other types of dependencies, the specifier will be changed to a hash
     // that also contains the dependency kind. This way, multiple kinds of dependencies
     // to the same specifier can be used within the same file.
     let placeholder = match kind {
-      DependencyKind::Import | DependencyKind::Export | DependencyKind::Require => {
+      DependencyKind::Import | DependencyKind::Export => {
         if is_specifier_rewritten {
           Some(specifier.as_ref().to_owned())
         } else {


### PR DESCRIPTION
Fixes a regression introduced by #8555. [Reproduction](https://parcel2-repl-mischnic.vercel.app/#JTdCJTIyZmlsZXMlMjIlM0ElNUIlNUIlMjIlMkZzcmMlMkZpbmRleC5qcyUyMiUyQyU3QiUyMnZhbHVlJTIyJTNBJTIyY2xhc3MlMjBYJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHglMjAlM0QlMjBuZXclMjBNYXAoKSU1Q24lN0QlMjIlMkMlMjJpc0VudHJ5JTIyJTNBdHJ1ZSU3RCU1RCUyQyU1QiUyMiUyRnNyYyUyRm90aGVyLmpzJTIyJTJDJTdCJTIydmFsdWUlMjIlM0ElMjIlMjIlN0QlNUQlMkMlNUIlMjIlMkZwYWNrYWdlLmpzb24lMjIlMkMlN0IlMjJ2YWx1ZSUyMiUzQSUyMiU3QiU1Q24lMjAlMjAlNUMlMjJtYWluJTVDJTIyJTNBJTIwJTVDJTIyZGlzdCUyRm1haW4uanMlNUMlMjIlMkMlNUNuJTIwJTIwJTVDJTIyYnJvd3NlcnNsaXN0JTVDJTIyJTNBJTIwJTVDJTIyQ2hyb21lJTIwNzAlNUMlMjIlMkMlNUNuJTIwJTIwJTVDJTIyZGVwZW5kZW5jaWVzJTVDJTIyJTNBJTIwJTdCJTVDbiUyMCUyMCUyMCUyMCU1QyUyMiU0MHN3YyUyRmhlbHBlcnMlNUMlMjIlM0ElMjAlNUMlMjIlNUUwLjQuMTQlNUMlMjIlNUNuJTIwJTIwJTdEJTVDbiU3RCUyMiU3RCU1RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJlbnRyaWVzJTIyJTNBJTVCJTVEJTJDJTIybWluaWZ5JTIyJTNBZmFsc2UlMkMlMjJzY29wZUhvaXN0JTIyJTNBdHJ1ZSUyQyUyMnNvdXJjZU1hcHMlMjIlM0FmYWxzZSUyQyUyMnB1YmxpY1VybCUyMiUzQSUyMiUyRl9fcmVwbF9kaXN0JTIyJTJDJTIydGFyZ2V0VHlwZSUyMiUzQSUyMmJyb3dzZXJzJTIyJTJDJTIydGFyZ2V0RW52JTIyJTNBbnVsbCUyQyUyMm91dHB1dEZvcm1hdCUyMiUzQW51bGwlMkMlMjJobXIlMjIlM0FmYWxzZSUyQyUyMm1vZGUlMjIlM0ElMjJwcm9kdWN0aW9uJTIyJTJDJTIycmVuZGVyR3JhcGhzJTIyJTNBZmFsc2UlMkMlMjJ2aWV3U291cmNlbWFwcyUyMiUzQWZhbHNlJTJDJTIyZGVwZW5kZW5jaWVzJTIyJTNBJTVCJTVEJTJDJTIybnVtV29ya2VycyUyMiUzQTAlN0QlMkMlMjJ1c2VUYWJzJTIyJTNBZmFsc2UlMkMlMjJicm93c2VyQ29sbGFwc2VkJTIyJTNBJTVCJTVEJTJDJTIydmlld3MlMjIlM0ElNUIlMjIlMkZzcmMlMkZpbmRleC5qcyUyMiUyQyUyMiUyRnBhY2thZ2UuanNvbiUyMiU1RCUyQyUyMmN1cnJlbnRWaWV3JTIyJTNBMiU3RA==)

The root cause was that due to library mode rewriting SWC helpers for CJS libraries, the dep had a `placeholder`: https://github.com/parcel-bundler/parcel/blob/v2/packages/transformers/js/core/src/dependency_collector.rs#L124-L125

Then, when we build our dep map, we use the placeholder rather than the original specifier + "esm": https://github.com/parcel-bundler/parcel/blob/426852f01f009f875142b14b03646a82d3878ea2/packages/transformers/js/src/JSTransformer.js#L734-L736

But when looking up the dep, we would still append "esm", leading no dep to be found and therefore no symbols replaced later on: https://github.com/parcel-bundler/parcel/blob/426852f01f009f875142b14b03646a82d3878ea2/packages/transformers/js/src/JSTransformer.js#L751-L755

To fix this, I've changed the way this works so we don't append "esm" but instead use a placeholder for CJS deps on the rust side. This fixes the original issue where CJS and ESM imports for the same specifier wouldn't work, without needing additional metadata. To get that to work, I had to add specifiers for external modules to the dev packager so we remap from the placeholder to the original specifier when requiring them.