### PR TITLE
filter out title execArgv to workers

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -53,11 +53,11 @@ export default class Worker extends EventEmitter {
 
     for (let i = 0; i < filteredArgs.length; i++) {
       let arg = filteredArgs[i];
-      let hasArgWithParam =
+      let isArgWithParam =
         ((arg === '-r' || arg === '--require') &&
           filteredArgs[i + 1] === '@parcel/register') ||
         arg === '--title';
-      if (hasArgWithParam) {
+      if (isArgWithParam) {
         filteredArgs.splice(i, 2);
         i--;
       }

--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -53,10 +53,11 @@ export default class Worker extends EventEmitter {
 
     for (let i = 0; i < filteredArgs.length; i++) {
       let arg = filteredArgs[i];
-      if (
-        (arg === '-r' || arg === '--require') &&
-        filteredArgs[i + 1] === '@parcel/register'
-      ) {
+      let hasArgWithParam =
+        ((arg === '-r' || arg === '--require') &&
+          filteredArgs[i + 1] === '@parcel/register') ||
+        arg === '--title';
+      if (hasArgWithParam) {
         filteredArgs.splice(i, 2);
         i--;
       }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

As I reported in #8673 parcel will crash when a `--title [process name]` is passed to node and worker threads are being used. This PR filters that arg out so that parcel will not crash. 

## 💻 Examples

`--title [process name]` sets the name of the process (so it makes sense why threads can't take this arg). It can be set by some tools. I noticed it while using [moon](https://moonrepo.dev/).

## 🚨 Test instructions

There don't seem to be unit tests for the other filtered args, so I didn't add any here, but it's easy to test manually, just run `node --title test /path/to/parcel index.html`

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
