### PR TITLE
fix: read config files from ESM projects, changes `require` to dynamic import

### DIFF
--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -72,9 +72,10 @@ export async function loadConfig(
     try {
       let extname = path.extname(configFile).slice(1);
       if (extname === 'js' || extname === 'cjs') {
+        let importedConfig = clone(await import(configFile));
         let output = {
           // $FlowFixMe
-          config: clone(require(configFile)),
+          config: importedConfig?.default || importedConfig,
           files: [{filePath: configFile}],
         };
 

--- a/packages/core/utils/test/config.test.js
+++ b/packages/core/utils/test/config.test.js
@@ -80,6 +80,38 @@ describe('loadConfig', () => {
     );
   });
 
+  it('should load with js when inside an ESM project', async () => {
+    assert.deepEqual(
+      (
+        await loadConfig(
+          fs,
+          path.join(__dirname, './input/config/esm/config.js'),
+          ['config.js'],
+          path.join(__dirname, './input/config/esm/'),
+        )
+      )?.config,
+      {
+        hoge: 'fuga',
+      },
+    );
+  });
+
+  it('should load with cjs when inside an ESM project', async () => {
+    assert.deepEqual(
+      (
+        await loadConfig(
+          fs,
+          path.join(__dirname, './input/config/esm/config.cjs'),
+          ['config.js'],
+          path.join(__dirname, './input/config/esm/'),
+        )
+      )?.config,
+      {
+        hoge: 'fuga',
+      },
+    );
+  });
+
   it('should load without an extension as json', async () => {
     assert.deepEqual(
       (

--- a/packages/core/utils/test/input/config/esm/config.cjs
+++ b/packages/core/utils/test/input/config/esm/config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  hoge: 'fuga',
+};

--- a/packages/core/utils/test/input/config/esm/config.js
+++ b/packages/core/utils/test/input/config/esm/config.js
@@ -1,0 +1,3 @@
+export default {
+  hoge: 'fuga',
+};

--- a/packages/core/utils/test/input/config/esm/package.json
+++ b/packages/core/utils/test/input/config/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Migrates usage of dynamic `require` to dynamic `import` in order to resolve [issue](https://github.com/PlasmoHQ/plasmo/issues/364)s reading config files from ESM projects (i.e. projects with `"type": "module"` in the root `package.json`)

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

(from the linked issue)

1. `pnpm create plasmo --with-svelte`
2. add `"type": "module"` to project root's `package.json`
3. rewrite `svelte.config.js` to ESM (i.e. `... export default {}`
4. run `pnpm build`
5. observe error

```
➜  pnpm build

> ban-maniacal-falcon@0.0.0 build /Users/josef/Documents/playground/plasmo-svelte/ban-maniacal-falcon
> plasmo build

🟣 Plasmo v0.60.2
🔴 The Browser Extension Framework
🔵 INFO   | Prepare to bundle the extension...
🔴 ERROR  | require() of ES Module /Users/josef/Documents/playground/plasmo-svelte/ban-maniacal-falcon/svelte.config.js from /Users/josef/Documents/playground/plasmo-svelte/ban-maniacal-falcon/plasmo/node\_modules/.pnpm/@parcel+utils@2.8.2/node\_modules/@parcel/utils/lib/index.js not supported.
Instead change the require of svelte.config.js in /Users/josef/Documents/playground/plasmo-svelte/ban-maniacal-falcon/plasmo/node\_modules/.pnpm/@parcel+utils@2.8.2/node\_modules/@parcel/utils/lib/index.js to a dynamic import() which is available in all CommonJS modules.
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

I created a few tests with proper inputs and ran the tests directly with mocha (`yarn test` didn't work for me)

```
yarn mocha packages/core/utils/test/config.test.js
```

Happy to change the test descriptions and input setup

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
