### PR TITLE
Don't retarget dependencies if a symbol is imported multiple times with different local names

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/index.js
@@ -1,0 +1,3 @@
+import * as ns from "./library/a";
+
+output = [ns, ns.value1, ns.value2];

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/a.js
@@ -1,0 +1,1 @@
+export { value1, value2 } from './b.js';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/b.js
@@ -1,0 +1,1 @@
+export { value1, value1 as value2 } from "./c";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/c.js
@@ -1,0 +1,1 @@
+export const value1 = 123;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/library/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -7079,19 +7079,6 @@ describe('javascript', function () {
         assert.deepEqual(res.output, 'bar');
       });
 
-      it('supports reexports via variable declaration (unused)', async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            '/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/index.js',
-          ),
-          options,
-        );
-
-        let res = await run(b, {}, {require: false});
-        assert.deepEqual((await res.output).foo, 'foo');
-      });
-
       it('supports named and renamed reexports of the same asset (named used)', async function () {
         let b = await bundle(
           path.join(
@@ -7124,6 +7111,32 @@ describe('javascript', function () {
           shouldScopeHoist ? ['other'] : ['other', 'index'],
         );
         assert.deepEqual(res.output, 'bar');
+      });
+
+      it('supports named and renamed reexports of the same asset (namespace used)', async function () {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/side-effects-re-exports-rename-same/index.js',
+          ),
+          options,
+        );
+
+        let res = await run(b, null, {require: false});
+        assert.deepEqual(res.output, [{value1: 123, value2: 123}, 123, 123]);
+      });
+
+      it('supports reexports via variable declaration (unused)', async function () {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/side-effects-re-exports-rename-var-unused/index.js',
+          ),
+          options,
+        );
+
+        let res = await run(b, {}, {require: false});
+        assert.deepEqual((await res.output).foo, 'foo');
       });
 
       it('supports named and namespace exports of the same asset (named used)', async function () {


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/8705

```js
export {x, x as y} from "./c";
```

can cause a situation where it tried to rewrite a dependency to have these symbols (so saying that in the parent asset, import `x` and make it available as `$id$re_export$x` and also import `x` and make it available as `$id$re_export$y`:
```js
new Map([
	[ "x", { local: "$id$re_export$x" } ],
	[ "x", { local: "$id$re_export$y" } ]
])
```
This seems fine but the way this is achieved in the symbols is that the transformer detects and uses the same local identifier for both. When retargeting dependencies however, the asset symbols cannot be changed so it just has to deopt out of retargeting here.
