### PR TITLE
Fix pnpm autoinstall

### DIFF
--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -2,6 +2,8 @@
 
 import type {PackageInstaller, InstallerOptions} from './types';
 
+import path from 'path';
+import fs from 'fs';
 import commandExists from 'command-exists';
 import spawn from 'cross-spawn';
 import logger from '@parcel/logger';
@@ -84,7 +86,10 @@ export class Pnpm implements PackageInstaller {
   }: InstallerOptions): Promise<void> {
     let args = ['add', '--reporter', 'ndjson'];
     if (saveDev) {
-      args.push('-D', '-W');
+      args.push('-D');
+    }
+    if (fs.existsSync(path.join(cwd, '.pnpm_workspaces'))) {
+      args.push('-w');
     }
     args = args.concat(modules.map(npmSpecifierFromModuleRequest));
 
@@ -148,9 +153,9 @@ export class Pnpm implements PackageInstaller {
       if (addedCount > 0 || removedCount > 0) {
         logger.log({
           origin: '@parcel/package-manager',
-          message: `Added ${addedCount} and ${
-            removedCount > 0 ? `removed ${removedCount}` : ''
-          } packages via pnpm`,
+          message: `Added ${addedCount} ${
+            removedCount > 0 ? `and removed ${removedCount} ` : ''
+          }packages via pnpm`,
         });
       }
 

--- a/packages/core/package-manager/src/Yarn.js
+++ b/packages/core/package-manager/src/Yarn.js
@@ -4,20 +4,17 @@ import type {PackageInstaller, InstallerOptions} from './types';
 
 import commandExists from 'command-exists';
 import spawn from 'cross-spawn';
-import {exec as _exec} from 'child_process';
-import {promisify} from 'util';
 import logger from '@parcel/logger';
 import split from 'split2';
 import JSONParseStream from './JSONParseStream';
 import promiseFromProcess from './promiseFromProcess';
 import {registerSerializableClass} from '@parcel/core';
-import {npmSpecifierFromModuleRequest} from './utils';
+import {exec, npmSpecifierFromModuleRequest} from './utils';
 
 // $FlowFixMe
 import pkg from '../package.json';
 
 const YARN_CMD = 'yarn';
-const exec = promisify(_exec);
 
 type YarnStdOutMessage =
   | {|

--- a/packages/core/package-manager/src/utils.js
+++ b/packages/core/package-manager/src/utils.js
@@ -7,6 +7,14 @@ import type {FileSystem} from '@parcel/fs';
 import invariant from 'assert';
 import ThrowableDiagnostic from '@parcel/diagnostic';
 import {resolveConfig} from '@parcel/utils';
+import {exec as _exec} from 'child_process';
+import {promisify} from 'util';
+
+export const exec: (
+  command: string,
+  options?: child_process$execOpts,
+) => Promise<{|stdout: string | Buffer, stderr: string | Buffer|}> =
+  promisify(_exec);
 
 export function npmSpecifierFromModuleRequest(
   moduleRequest: ModuleRequest,

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -281,6 +281,9 @@ export default class NodeResolver {
             },
           );
 
+          // Need to clear the resolver caches after installing the package
+          this.resolversByEnv.clear();
+
           // Re-resolve
           return this.resolve({
             ...options,


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/8304
Closes https://github.com/parcel-bundler/parcel/issues/8782

[pnpm 7](https://github.com/pnpm/pnpm/releases/tag/v7.0.0) (release May 2022) removed the `-W` flag and instead added `-w` which always installs in the workspace root (regardless of cwd).

https://pnpm.io/workspaces:

> A workspace must have a pnpm-workspace.yaml file in its root

So I've used that to determine if `-w` should be added.

~This does break backwards compatibility of autoinstall with pnpm <7 in monorepos, though there are probably not many people on older versions?~ Similar to our Yarn handling, check the major version of pnpm and add the correct flag based on that