### PR TITLE
Don't blow up HMR when <link />s don't have hrefs

### DIFF
--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -303,6 +303,11 @@ function getParents(bundle, id) /*: Array<[ParcelRequire, string]> */ {
 }
 
 function updateLink(link) {
+  var href = link.getAttribute('href');
+
+  if (!href) {
+    return;
+  }
   var newLink = link.cloneNode();
   newLink.onload = function () {
     if (link.parentNode !== null) {
@@ -313,7 +318,7 @@ function updateLink(link) {
   newLink.setAttribute(
     'href',
     // $FlowFixMe
-    link.getAttribute('href').split('?')[0] + '?' + Date.now(),
+    href.split('?')[0] + '?' + Date.now(),
   );
   // $FlowFixMe
   link.parentNode.insertBefore(newLink, link.nextSibling);


### PR DESCRIPTION
Many browser extensions inject `<link />` tags without `href` attributes, kinda like this one:

```html
<link type="text/css" rel="stylesheet" id="dark-mode-custom-link" />
```

When a page with a link to a stylesheet contains one of these `href`-less links, and the CSS on the page is updated, `updateLink()` tries to recreate _all_ `<link />` tags, including the ones that don't link to anything. Consequently, `getAttribute('href')` returns `null`, which blows up string operations, specifically:

```
Uncaught TypeError: Cannot read properties of null (reading 'split')
```

This PR builds a safety check into the `updateLink()` function, so that the internal API doesn't change and downstream consumers don't have to think about it.

## 🚨 Test instructions

I skimmed the tests and wasn't totally clear on how to write one for this (happy to do so if someone knowledgeable wants to point me in the right direction), but in lieu of that, here's a reliable way to reproduce the issue:

```bash
mkdir hmr-test; \
  cd hmr-test; \
  curl https://gist.githubusercontent.com/nateabele/186825281fc96772468828786f86349a/raw/cb477118db4455be04df5abb2f3c1403467efc63/parcel-test.html > index.html; \
  curl https://gist.githubusercontent.com/nateabele/186825281fc96772468828786f86349a/raw/b31f6421fd286a37431e346a60726e994946b133/parcel-test.css > index.css; \
  parcel index.html
```

Then, make changes to `index.css` and save it. You should see the error in the console.
