### PR TITLE
Sort CSS module exports

### DIFF
--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -242,7 +242,9 @@ export default (new Transformer({
         js += s;
       };
 
-      for (let key in exports) {
+      // It's possible that the exports can be ordered differently between builds.
+      // Sorting by key is safe as the order is irrelevant but needs to be deterministic.
+      for (let key of Object.keys(exports).sort()) {
         asset.symbols.set(key, exports[key].name);
         add(key);
       }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
It's possible that CSS module exports are ordered differently between builds which then causes unnecessary cache invalidation. As the export order is not significant I've added a simple sort of the keys to ensure all builds are deterministic. 

## 🚨 Test instructions

Existing tests should be sufficient. 
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
