### PR TITLE
Small changes helpful when developing Parcel

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -274,7 +274,7 @@ export default class Parcel {
 
       this.#requestedAssetIds.clear();
 
-      dumpGraphToGraphViz(
+      await dumpGraphToGraphViz(
         // $FlowFixMe
         this.#requestTracker.graph,
         'RequestGraph',

--- a/packages/core/core/src/dumpGraphToGraphViz.js
+++ b/packages/core/core/src/dumpGraphToGraphViz.js
@@ -191,7 +191,7 @@ export default async function dumpGraphToGraphViz(
       gEdge.set('color', color);
     }
   }
-  let tmp = tempy.file({name: `${name}.png`});
+  let tmp = tempy.file({name: `parcel-${name}.png`});
   await g.output('png', tmp);
   // eslint-disable-next-line no-console
   console.log('Dumped', tmp);

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -144,7 +144,7 @@ export default function createBundleGraphRequest(
         res.changedAssets.set(id, asset);
       }
 
-      dumpGraphToGraphViz(
+      await dumpGraphToGraphViz(
         // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381 (Windows only)
         res.bundleGraph._graph,
         'BundleGraph',


### PR DESCRIPTION
- `await` all GraphViz calls
- prefix GraphViz PNGs with `parcel-`, to make finding them easier