### PR TITLE
Add fsFixture test util

### DIFF
--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -743,6 +743,7 @@ class WriteStream extends Writable {
 const S_IFREG = 0o100000;
 const S_IFDIR = 0o040000;
 const S_IFLNK = 0o120000;
+const S_IFMT = 0o170000;
 
 class Entry {
   mode: number;
@@ -853,11 +854,11 @@ class Dirent {
   }
 
   isFile(): boolean {
-    return Boolean(this.#mode & S_IFREG);
+    return (this.#mode & S_IFMT) === S_IFREG;
   }
 
   isDirectory(): boolean {
-    return Boolean(this.#mode & S_IFDIR);
+    return (this.#mode & S_IFMT) === S_IFDIR;
   }
 
   isBlockDevice(): boolean {
@@ -869,7 +870,7 @@ class Dirent {
   }
 
   isSymbolicLink(): boolean {
-    return Boolean(this.#mode & S_IFLNK);
+    return (this.#mode & S_IFMT) === S_IFLNK;
   }
 
   isFIFO(): boolean {

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -244,10 +244,15 @@ export class MemoryFS implements FileSystem {
       throw new FSError('ENOENT', dir, 'does not exist');
     }
 
-    dir += path.sep;
+    if (!dir.endsWith(path.sep)) {
+      dir += path.sep;
+    }
 
     let res = [];
     for (let [filePath, entry] of this.dirs) {
+      if (filePath === dir) {
+        continue;
+      }
       if (
         filePath.startsWith(dir) &&
         filePath.indexOf(path.sep, dir.length) === -1

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -134,7 +134,7 @@ export class MemoryFS implements FileSystem {
   }
 
   _normalizePath(filePath: FilePath, realpath: boolean = true): FilePath {
-    filePath = path.resolve(this.cwd(), filePath);
+    filePath = path.normalize(path.join(this.cwd(), filePath));
 
     // get realpath by following symlinks
     if (realpath) {

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -59,13 +59,13 @@ export class MemoryFS implements FileSystem {
 
   constructor(workerFarm: WorkerFarm) {
     this.farm = workerFarm;
-    this.dirs = new Map([['/', new Directory()]]);
+    this._cwd = path.resolve(path.sep);
+    this.dirs = new Map([[this._cwd, new Directory()]]);
     this.files = new Map();
     this.symlinks = new Map();
     this.watchers = new Map();
     this.events = [];
     this.id = id++;
-    this._cwd = '/';
     this._workerHandles = [];
     this._eventQueue = [];
     instances.set(this.id, this);
@@ -134,7 +134,10 @@ export class MemoryFS implements FileSystem {
   }
 
   _normalizePath(filePath: FilePath, realpath: boolean = true): FilePath {
-    filePath = path.normalize(path.join(this.cwd(), filePath));
+    filePath = path.normalize(filePath);
+    if (!filePath.startsWith(this.cwd())) {
+      filePath = path.resolve(this.cwd(), filePath);
+    }
 
     // get realpath by following symlinks
     if (realpath) {

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -56,6 +56,8 @@ const DISALLOWED_FILETYPES = new Set([
   '.webp',
 ]);
 
+const MAX_FILE_SIZE = 1000;
+
 export async function toFixture(
   fs: FileSystem,
   dir: string = fs.cwd(),
@@ -91,6 +93,11 @@ export async function toFixture(
     } else if (dirent.isFile()) {
       if (DISALLOWED_FILETYPES.has(path.extname(dirent.name))) {
         throw new Error(`Disallowed file type: ${name}`);
+      }
+
+      let size = (await fs.stat(filepath)).size;
+      if (size > MAX_FILE_SIZE) {
+        throw new Error(`File too large: ${name}`);
       }
 
       let content = escapeFixtureContent(await fs.readFile(filepath, 'utf8'));

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -236,6 +236,9 @@ export class FixtureParser {
       assert(depth < this.#dirStack.length, 'Invalid nesting');
       this.#dirStack = this.#dirStack.slice(0, depth + 1);
       this.#cwd = this.#dirStack[this.#dirStack.length - 1];
+    } else {
+      assert(this.#dirStack.length > 1, 'Invalid nesting');
+      this.#dirStack.pop();
     }
   };
 

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -1,0 +1,266 @@
+// @flow strict-local
+
+import type {FileSystem} from '@parcel/fs';
+
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+type FixtureToken = {|type: string, value: string|};
+
+type Fixture = FixtureRoot | FixtureChild;
+type FixtureChild = FixtureDir | FixtureFile | FixtureLink;
+
+export function fsFixture(
+  fs: FileSystem,
+  cwd: string = fs.cwd(),
+): (
+  strings: Array<string>,
+  ...exprs: Array<
+    null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
+  >
+) => Promise<void> {
+  return async function apply(strings, ...exprs) {
+    let src = dedentRaw(strings, ...exprs);
+    let tokens = new FixtureTokenizer(src).tokenize();
+    let fixture = new FixtureParser(tokens).parse();
+    await applyFixture(fs, fixture, cwd);
+  };
+}
+
+async function applyFixture(
+  fs: FileSystem,
+  node: Fixture,
+  dir: string,
+): Promise<void> {
+  switch (node.type) {
+    case 'root': {
+      for (let child of node.children) {
+        await applyFixture(fs, child, dir);
+      }
+      break;
+    }
+    case 'dir': {
+      let filepath = path.join(dir, node.name);
+      await fs.mkdirp(filepath);
+      for (let child of node.children) {
+        await applyFixture(fs, child, filepath);
+      }
+      break;
+    }
+    case 'file': {
+      await fs.writeFile(path.join(dir, node.name), node.content);
+      break;
+    }
+    case 'link': {
+      await fs.symlink(node.target, path.join(dir, node.name));
+      break;
+    }
+    default: {
+      /*:: ((node: empty) => void 0)(node); */
+      throw new Error(`Unexpected node type "${node.type}"`);
+    }
+  }
+}
+
+const NAME = /([^:>\n\\\/]+)(?=\/|\b)/.source;
+const EOL = / *(?:\n|$)/.source;
+const CONTENT = /"(.*)"/.source; // TODO: support multiline
+const PATH = /([^:>\n]+)\b/.source;
+
+const TOKEN_TYPES = {
+  nest: /^(\/|  )/,
+  dirname: new RegExp(`^${NAME}(?:(?=\/)|${EOL})`),
+  filename: new RegExp(`^${NAME}(?= *(?::|->))`),
+  content: new RegExp(`^ *: *${CONTENT}${EOL}`),
+  link: new RegExp(`^ *-> *${PATH}${EOL}`),
+};
+
+export class FixtureTokenizer {
+  #src: string;
+  #tokens: Array<FixtureToken>;
+
+  #tokenizeNext = () => {
+    for (let type in TOKEN_TYPES) {
+      let match = this.#src.match(TOKEN_TYPES[type]);
+      if (match) {
+        let [substr, value] = match;
+        this.#src = this.#src.slice(substr.length);
+        this.#tokens.push({type, value});
+        return;
+      }
+    }
+    throw new Error(`Failed to match token on "${this.#src}"`);
+  };
+
+  constructor(src: string) {
+    this.#src = src;
+  }
+
+  tokenize(): Array<FixtureToken> {
+    if (!this.#tokens) {
+      this.#tokens = [];
+      while (this.#src.length > 0) {
+        this.#tokenizeNext();
+      }
+    }
+    return this.#tokens;
+  }
+}
+
+export class FixtureParser {
+  #tokens: Array<FixtureToken>;
+  #root: FixtureRoot;
+  #cwd: FixtureRoot | FixtureDir;
+  #dirStack: Array<FixtureRoot | FixtureDir>;
+
+  #peek = type => this.#tokens[this.#tokens.length - 1]?.type === type;
+
+  #consume = type => {
+    let token = this.#tokens.pop();
+    if (token?.type !== type) {
+      throw new Error(
+        `Expected token of type "${type}" but got "${token?.type}"`,
+      );
+    }
+    return token;
+  };
+
+  #parseNest = () => {
+    let depth = 0;
+    let isSegment = false;
+    let nest;
+    while (this.#peek('nest')) {
+      nest = this.#consume('nest');
+      if (nest.value === '/') {
+        assert(!isSegment, 'Unexpected segment nest');
+        isSegment = true;
+      } else {
+        assert(!isSegment, 'Unexpected indent nest');
+        depth++;
+      }
+    }
+
+    if (!isSegment) {
+      assert(depth <= this.#dirStack.length, 'Invalid nesting');
+      this.#dirStack = this.#dirStack.slice(0, depth + 1);
+      this.#cwd = this.#dirStack[this.#dirStack.length - 1];
+    }
+  };
+
+  #parseDir = () => {
+    let dir = new FixtureDir(this.#consume('dirname').value);
+    this.#cwd.children.push(dir);
+    this.#cwd = dir;
+    this.#dirStack.push(dir);
+  };
+
+  #parseFile = () => {
+    let name = this.#consume('filename').value;
+    if (this.#peek('content')) {
+      let content = this.#consume('content').value;
+      this.#cwd.children.push(new FixtureFile(name, content));
+    } else if (this.#peek('link')) {
+      let target = this.#consume('link').value;
+      this.#cwd.children.push(new FixtureLink(name, target));
+    } else {
+      throw new Error(
+        `Expected content or link token but got ${this.#tokens.pop()?.type}`,
+      );
+    }
+  };
+
+  constructor(tokens: Array<FixtureToken>) {
+    this.#tokens = [...tokens].reverse();
+  }
+
+  parse(): FixtureRoot {
+    if (!this.#root) {
+      this.#root = new FixtureRoot();
+      this.#cwd = this.#root;
+      this.#dirStack = [this.#root];
+
+      while (this.#tokens.length) {
+        this.#parseNest();
+        if (this.#peek('dirname')) {
+          this.#parseDir();
+        } else if (this.#peek('filename')) {
+          this.#parseFile();
+        } else {
+          throw new Error(`Unexpected ${this.#tokens.pop()?.type} token`);
+        }
+      }
+    }
+    return this.#root;
+  }
+}
+
+export class FixtureRoot {
+  type: 'root' = 'root';
+  children: Array<FixtureChild> = [];
+}
+
+export class FixtureDir {
+  type: 'dir' = 'dir';
+  name: string;
+  children: Array<FixtureChild> = [];
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+export class FixtureFile {
+  type: 'file' = 'file';
+  name: string;
+  content: string;
+  constructor(name: string, content: string) {
+    this.name = name;
+    this.content = content;
+  }
+}
+
+export class FixtureLink {
+  type: 'link' = 'link';
+  name: string;
+  target: string;
+  constructor(name: string, target: string) {
+    this.name = name;
+    this.target = target;
+  }
+}
+
+export function dedentRaw(
+  strings: Array<string>,
+  ...exprs: Array<
+    null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
+  >
+): string {
+  let src = '';
+  for (let i = 0; i < strings.length; i++) {
+    src += strings[i];
+    if (i < exprs.length) {
+      let expr = exprs[i];
+      if (typeof expr !== 'string') {
+        expr = JSON.stringify(exprs[i]).replace(/^"|"$/g, '');
+      }
+      src += expr;
+    }
+  }
+  src = src.trimRight().replace(/^ *\n?/, '');
+
+  let dedent = nullthrows(src.match(/^(?:  )*/))[0].length;
+
+  if (dedent === 0) {
+    dedent = Infinity;
+    for (let indent of nullthrows(src.match(/^(?:  )*/gm))) {
+      let len = indent.length - 2;
+      if (len >= 0 && len < dedent) dedent = len;
+    }
+  }
+
+  if (dedent < Infinity && dedent > 0) {
+    src = src.replace(new RegExp(`^ {${dedent}}`, 'gm'), '');
+  }
+
+  return src;
+}

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -173,7 +173,7 @@ const COMPOUND_TYPES = [
   // Matches are captured as `indent`,`path`, and `link` groups.
   // The `indent` and `path` groups can be matched to `TOKEN_TYPES`,
   // and then `link` can be directly tokenized as `link`.
-  /^(?<indent>(?: {2})*)(?<path>[^:>\n]+\b *->) *(?<link>[^:>\n]+\b) *(?:\n|$)/,
+  /^(?<indent>(?: {2})*)(?<path>[^:>\n]+\b *->) *(?<link>.+\b) *(?:\n|$)/,
   // Matches are captured as `indent`,`path`, and `content` groups.
   // The `indent` and `path` groups can be matched to `TOKEN_TYPES`,
   // and then `content` can be directly tokenized as `content`.

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -79,7 +79,7 @@ export async function toFixture(
       );
     } else if (dirent.isFile()) {
       // TODO: throw for binary files.
-      let content = await fs.readFile(filepath, 'utf8');
+      let content = escapeFixtureContent(await fs.readFile(filepath, 'utf8'));
       fixture.children.push(new FixtureFile(name, content));
     } else if (dirent.isDirectory()) {
       fixture.children.push(
@@ -363,6 +363,13 @@ export class FixtureLink {
   toString(): string {
     return `${this.name} -> ${this.target}`;
   }
+}
+
+export function escapeFixtureContent(content: string): string {
+  return content
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\${/g, '\\${');
 }
 
 export function dedentRaw(

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -323,6 +323,12 @@ export class FixtureParser {
       this.#cwd = this.#root;
       this.#dirStack = [this.#root];
 
+      // Consume any leading `nest` tokens.
+      // This allows a fixture path to start with '/'.
+      while (this.#peek('nest')) {
+        this.#consume('nest');
+      }
+
       while (this.#tokens.length) {
         this.#parseNest();
         if (this.#peek('dirname')) {

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -33,6 +33,12 @@ declare function toFixture(
   dir?: string,
 ): Promise<FixtureRoot | FixtureDir>;
 
+declare function toFixture(
+  fs: FileSystem,
+  dir: string,
+  includeDir?: boolean,
+): Promise<FixtureRoot | FixtureDir>;
+
 declare function toFixture<T>(
   fs: FileSystem,
   dir: string,
@@ -42,8 +48,21 @@ declare function toFixture<T>(
 export async function toFixture(
   fs: FileSystem,
   dir: string = fs.cwd(),
-  fixture?: FixtureRoot | FixtureDir = new FixtureRoot(),
+  fixtureOrIncludeDir?: FixtureRoot | FixtureDir | boolean = false,
 ) {
+  let fixture: FixtureRoot | FixtureDir;
+  if (fixtureOrIncludeDir == null || typeof fixtureOrIncludeDir === 'boolean') {
+    fixture = new FixtureRoot();
+    if (fixtureOrIncludeDir) {
+      fixture.children.push(
+        await toFixture(fs, dir, new FixtureDir(path.basename(dir))),
+      );
+      return fixture;
+    }
+  } else {
+    fixture = nullthrows(fixtureOrIncludeDir);
+  }
+
   assert(
     (await fs.stat(dir)).isDirectory(),
     `Expected ${dir} to be a directory`,

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -45,6 +45,17 @@ declare function toFixture<T>(
   parent: T,
 ): Promise<T>;
 
+const DISALLOWED_FILETYPES = new Set([
+  '.crt',
+  '.gitkeep',
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.pem',
+  '.png',
+  '.webp',
+]);
+
 export async function toFixture(
   fs: FileSystem,
   dir: string = fs.cwd(),
@@ -78,7 +89,10 @@ export async function toFixture(
         new FixtureLink(name, await fs.realpath(filepath)),
       );
     } else if (dirent.isFile()) {
-      // TODO: throw for binary files.
+      if (DISALLOWED_FILETYPES.has(path.extname(dirent.name))) {
+        throw new Error(`Disallowed file type: ${name}`);
+      }
+
       let content = escapeFixtureContent(await fs.readFile(filepath, 'utf8'));
       fixture.children.push(new FixtureFile(name, content));
     } else if (dirent.isDirectory()) {

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -33,12 +33,14 @@ declare function toFixture(
   dir?: string,
 ): Promise<FixtureRoot | FixtureDir>;
 
+// eslint-disable-next-line no-redeclare
 declare function toFixture(
   fs: FileSystem,
   dir: string,
   includeDir?: boolean,
 ): Promise<FixtureRoot | FixtureDir>;
 
+// eslint-disable-next-line no-redeclare
 declare function toFixture<T>(
   fs: FileSystem,
   dir: string,
@@ -58,6 +60,7 @@ const DISALLOWED_FILETYPES = new Set([
 
 const MAX_FILE_SIZE = 1000;
 
+// eslint-disable-next-line no-redeclare
 export async function toFixture(
   fs: FileSystem,
   dir: string = fs.cwd(),
@@ -154,11 +157,11 @@ export async function applyFixture(
 // a match for `dirname` can be tokenized as a `dirname` token, etc.
 const TOKEN_TYPES = [
   // `/` in `a/b` or `  ` in `a\n  b`
-  /^(?<nest>\/|  )/,
+  /^(?<nest>\/| {2})/,
   // e.g. `a` or `b` in `a/b/c.txt`
-  /^(?<dirname>[^:>\n\/]+\b)(?:(?=\/)| *\n| *$)/,
+  /^(?<dirname>[^:>\n/]+\b)(?:(?=\/)| *\n| *$)/,
   // e.g. `c.txt` in `a/b/c.txt:` or `a/b/c.txt ->`
-  /^(?<filename>[^:>\n\/]+\b) *(?:->|:) *(?:\n|$)/,
+  /^(?<filename>[^:>\n/]+\b) *(?:->|:) *(?:\n|$)/,
 ];
 
 // Named capture groups that can be directly tokenized,
@@ -167,15 +170,15 @@ const TOKEN_TYPES = [
 const COMPOUND_TYPES = [
   // Matches are captured as `indent` and`path` groups,
   // which can then be matched to `TOKEN_TYPES`.
-  /^(?<indent>(?:  )*)(?<path>[^:>\n]+\b) *(?:\n|$)/,
+  /^(?<indent>(?: {2})*)(?<path>[^:>\n]+\b) *(?:\n|$)/,
   // Matches are captured as `indent`,`path`, and `link` groups.
   // The `indent` and `path` groups can be matched to `TOKEN_TYPES`,
   // and then `link` can be directly tokenized as `link`.
-  /^(?<indent>(?:  )*)(?<path>[^:>\n]+\b *->) *(?<link>[^:>\n]+\b) *(?:\n|$)/,
+  /^(?<indent>(?: {2})*)(?<path>[^:>\n]+\b *->) *(?<link>[^:>\n]+\b) *(?:\n|$)/,
   // Matches are captured as `indent`,`path`, and `content` groups.
   // The `indent` and `path` groups can be matched to `TOKEN_TYPES`,
   // and then `content` can be directly tokenized as `content`.
-  /^(?<indent>(?:  )*)(?<path>[^:>\n]+\b *:)(?<content>.*(?:\n^(?:$|\k<indent>  .*))*) *(?:\n|$)/m,
+  /^(?<indent>(?: {2})*)(?<path>[^:>\n]+\b *:)(?<content>.*(?:\n^(?:$|\k<indent> {2}.*))*) *(?:\n|$)/m,
 ];
 
 const MAX_ITER = 10000;
@@ -412,11 +415,11 @@ export function dedentRaw(
   }
   src = src.trimRight().replace(/^ *\n?/, '');
 
-  let dedent = nullthrows(src.match(/^(?:  )*/))[0].length;
+  let dedent = nullthrows(src.match(/^(?: {2})*/))[0].length;
 
   if (dedent === 0) {
     dedent = Infinity;
-    for (let indent of nullthrows(src.match(/^(?:  )*/gm))) {
+    for (let indent of nullthrows(src.match(/^(?: {2})*/gm))) {
       let len = indent.length - 2;
       if (len >= 0 && len < dedent) dedent = len;
     }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -35,6 +35,8 @@ import {makeDeferredWithPromise, normalizeSeparators} from '@parcel/utils';
 import _chalk from 'chalk';
 import resolve from 'resolve';
 
+export {fsFixture} from './fsFixture';
+
 export const workerFarm = (createWorkerFarm(): WorkerFarm);
 export const inputFS: NodeFS = new NodeFS();
 export let outputFS: MemoryFS = new MemoryFS(workerFarm);

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -206,6 +206,25 @@ describe('FixtureTokenizer', () => {
       },
     ]);
   });
+
+  it('tokenizes windows paths', () => {
+    let tokens = new FixtureTokenizer(dedentRaw`
+      foo\\bar
+        bat:
+        baz -> foo\\bar\\bat
+    `).tokenize();
+    assert.deepEqual(tokens, [
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'bar'},
+      {type: 'nest', value: ''},
+      {type: 'filename', value: 'bat'},
+      {type: 'content', value: ''},
+      {type: 'nest', value: ''},
+      {type: 'filename', value: 'baz'},
+      {type: 'link', value: 'foo/bar/bat'},
+    ]);
+  });
 });
 
 describe('FixtureParser', () => {
@@ -513,6 +532,16 @@ describe('fsFixture', () => {
       fs.readFileSync('/app/bar.js', 'utf8'),
       `import foo from "foo";\n\nexport function bar() {\n  return \`\${foo()} bar\`\n}`,
     );
+  });
+
+  it('applies a fixture with windows paths', async () => {
+    await fsFixture(fs)`
+      foo\\bar
+        bat:
+        baz -> foo\\bar\\bat`;
+
+    assert(fs.existsSync('/foo/bar/bat'));
+    assert.equal(fs.realpathSync('/foo/bar/baz'), '/foo/bar/bat');
   });
 });
 

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -241,10 +241,7 @@ describe('FixtureParser', () => {
   });
 
   it('errors on invalid nesting', () => {
-    let result = new FixtureParser([{type: 'nest', value: ''}]);
-    assert.throws(() => result.parse(), /Invalid nesting/);
-
-    result = new FixtureParser([
+    let result = new FixtureParser([
       {type: 'filename', value: 'foo'},
       {type: 'content', value: ''},
       {type: 'nest', value: ''},
@@ -428,6 +425,35 @@ describe('FixtureParser', () => {
     bat.children.push(new FixtureFile('qux', 'qux'));
     expected.children.push((foo = new FixtureDir('foo')));
     foo.children.push(new FixtureLink('bar', 'foo/bat'));
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('parses a leading /', () => {
+    // /foo
+    //   bar
+    // /bat
+    //   /baz/qux
+    let result = new FixtureParser([
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: ''},
+      {type: 'dirname', value: 'bar'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'bat'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'baz'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'qux'},
+    ]).parse();
+
+    let expected = new FixtureRoot();
+    let foo, bar, bat, baz;
+    expected.children.push((foo = new FixtureDir('foo')));
+    foo.children.push((bar = new FixtureDir('bar')));
+    bar.children.push((bat = new FixtureDir('bat')));
+    bat.children.push((baz = new FixtureDir('baz')));
+    baz.children.push(new FixtureDir('qux'));
 
     assert.deepEqual(result, expected);
   });

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -1,0 +1,377 @@
+// @flow
+
+import {
+  dedentRaw,
+  fsFixture,
+  FixtureParser,
+  FixtureTokenizer,
+  FixtureRoot,
+  FixtureDir,
+  FixtureFile,
+  FixtureLink,
+} from '../src/fsFixture';
+import {MemoryFS} from '@parcel/fs';
+import WorkerFarm from '@parcel/workers';
+
+import assert from 'assert';
+import path from 'path';
+
+describe('dedentRaw', () => {
+  it('dedents a string with leading space', () => {
+    assert.equal(
+      dedentRaw`     foo
+        bar
+          baz
+    `,
+      'foo\n  bar\n    baz',
+    );
+  });
+
+  it('dedents a string with leading newline', () => {
+    assert.equal(
+      dedentRaw`
+        foo
+          bar
+            baz
+      `,
+      'foo\n  bar\n    baz',
+    );
+  });
+
+  it('dedents correctly with multiple top level entries', () => {
+    assert.equal(
+      dedentRaw`
+      foo
+        bar: "bar"
+      foo/bar -> foo/bat
+        bat
+          qux - qux
+        bat/qux: "qux"
+    `,
+      'foo\n  bar: "bar"\nfoo/bar -> foo/bat\n  bat\n    qux - qux\n  bat/qux: "qux"',
+    );
+  });
+
+  it('stringifies object expressions', () => {
+    assert.equal(
+      dedentRaw`
+        foo
+          ${{
+            bar: 'baz',
+            bat: 'qux',
+          }}
+            baz
+      `,
+      'foo\n  {"bar":"baz","bat":"qux"}\n    baz',
+    );
+  });
+
+  it('does not stringify literal expressions', () => {
+    assert.equal(
+      dedentRaw`
+        foo
+          ${JSON.stringify({
+            bar: 'baz',
+            bat: 'qux',
+          })}
+            baz
+              bat: ${false}
+              qux: ${123}
+      `,
+      'foo\n  {"bar":"baz","bat":"qux"}\n    baz\n      bat: false\n      qux: 123',
+    );
+  });
+});
+
+describe('FixtureTokenizer', () => {
+  it('errors on malformed fixture', () => {
+    assert.throws(() => {
+      new FixtureTokenizer('foo: bar').tokenize();
+    }, /Failed to match token/);
+
+    assert.throws(() => {
+      new FixtureTokenizer(': bar').tokenize();
+    }, /Failed to match token/);
+
+    assert.throws(() => {
+      new FixtureTokenizer('foo\n:\n"bar"').tokenize();
+    }, /Failed to match token/);
+  });
+
+  it('tokenizes a dirname', () => {
+    let tokens = new FixtureTokenizer('foo  \nfoo/bar\n    bat').tokenize();
+    assert.deepEqual(tokens, [
+      {type: 'dirname', value: 'foo'},
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'bar'},
+      {type: 'nest', value: '  '},
+      {type: 'nest', value: '  '},
+      {type: 'dirname', value: 'bat'},
+    ]);
+  });
+
+  it('tokenizes a file', () => {
+    let tokens = new FixtureTokenizer(
+      `foo: ""\nbar :"{"foo": "bar"}"`,
+    ).tokenize();
+    assert.deepEqual(tokens, [
+      {type: 'filename', value: 'foo'},
+      {type: 'content', value: ''},
+      {type: 'filename', value: 'bar'},
+      {type: 'content', value: '{"foo": "bar"}'},
+    ]);
+  });
+
+  it('tokenizes a link', () => {
+    let tokens = new FixtureTokenizer('foo -> bar/bat\nbat->baz').tokenize();
+    assert.deepEqual(tokens, [
+      {type: 'filename', value: 'foo'},
+      {type: 'link', value: 'bar/bat'},
+      {type: 'filename', value: 'bat'},
+      {type: 'link', value: 'baz'},
+    ]);
+  });
+
+  it('tokenizes nested files', () => {
+    let tokens = new FixtureTokenizer(
+      'foo\n  bar: ""\nfoo/baz/bat: ""\n    qux: ""',
+    ).tokenize();
+    assert.deepEqual(tokens, [
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '  '},
+      {type: 'filename', value: 'bar'},
+      {type: 'content', value: ''},
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'baz'},
+      {type: 'nest', value: '/'},
+      {type: 'filename', value: 'bat'},
+      {type: 'content', value: ''},
+      {type: 'nest', value: '  '},
+      {type: 'nest', value: '  '},
+      {type: 'filename', value: 'qux'},
+      {type: 'content', value: ''},
+    ]);
+  });
+
+  it('tokenizes nested links', () => {
+    let tokens = new FixtureTokenizer(
+      'foo\n  bar -> foo/baz\nfoo/baz -> bat\n  bat -> foo',
+    ).tokenize();
+    assert.deepEqual(tokens, [
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '  '},
+      {type: 'filename', value: 'bar'},
+      {type: 'link', value: 'foo/baz'},
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '/'},
+      {type: 'filename', value: 'baz'},
+      {type: 'link', value: 'bat'},
+      {type: 'nest', value: '  '},
+      {type: 'filename', value: 'bat'},
+      {type: 'link', value: 'foo'},
+    ]);
+  });
+});
+
+describe('FixtureParser', () => {
+  it('errors on a filename without content or link', () => {
+    let result = new FixtureParser([{type: 'filename', value: 'foo'}]);
+    assert.throws(() => result.parse(), /Expected content or link token/);
+  });
+
+  it('errors on content or link without preceeding filename', () => {
+    let result = new FixtureParser([{type: 'content', value: ''}]);
+    assert.throws(() => result.parse(), /Unexpected content token/);
+    result = new FixtureParser([{type: 'link', value: 'foo'}]);
+    assert.throws(() => result.parse(), /Unexpected link token/);
+  });
+
+  it('parses a dirname', () => {
+    let result = new FixtureParser([{type: 'dirname', value: 'foo'}]).parse();
+
+    let expected = new FixtureRoot();
+    expected.children.push(new FixtureDir('foo'));
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('parses a filename', () => {
+    // foo: "bar"
+    let result = new FixtureParser([
+      {type: 'filename', value: 'foo'},
+      {type: 'content', value: 'bar'},
+    ]).parse();
+
+    let expected = new FixtureRoot();
+    expected.children.push(new FixtureFile('foo', 'bar'));
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('parses a link', () => {
+    // foo -> bar
+    let result = new FixtureParser([
+      {type: 'filename', value: 'foo'},
+      {type: 'link', value: 'bar'},
+    ]).parse();
+
+    let expected = new FixtureRoot();
+    expected.children.push(new FixtureLink('foo', 'bar'));
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('parses nested dirs', () => {
+    // foo
+    // bar
+    //   bat
+    //   bat/baz
+    //     qux
+    let result = new FixtureParser([
+      {type: 'dirname', value: 'foo'},
+      {type: 'dirname', value: 'bar'},
+      {type: 'nest', value: '  '},
+      {type: 'dirname', value: 'bat'},
+      {type: 'nest', value: '  '},
+      {type: 'dirname', value: 'bat'},
+      {type: 'nest', value: '/'},
+      {type: 'dirname', value: 'baz'},
+      {type: 'nest', value: '  '},
+      {type: 'nest', value: '  '},
+      {type: 'dirname', value: 'qux'},
+    ]).parse();
+
+    let expected = new FixtureRoot();
+    let bar, bat;
+    expected.children.push(new FixtureDir('foo'));
+    expected.children.push((bar = new FixtureDir('bar')));
+    bar.children.push(new FixtureDir('bat'));
+    bar.children.push((bat = new FixtureDir('bat')));
+    bat.children.push(new FixtureDir('baz'));
+    bat.children.push(new FixtureDir('qux'));
+
+    assert.deepEqual(result, expected);
+  });
+
+  it('parses nested files and links', () => {
+    // foo
+    //   bar: "bar"
+    // foo/bar -> foo/bat
+    //   bat
+    //     qux -> qux
+    //   bat/qux: "qux"
+    let result = new FixtureParser([
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '  '},
+      {type: 'filename', value: 'bar'},
+      {type: 'content', value: 'bar'},
+      {type: 'dirname', value: 'foo'},
+      {type: 'nest', value: '/'},
+      {type: 'filename', value: 'bar'},
+      {type: 'link', value: 'foo/bat'},
+      {type: 'nest', value: '  '},
+      {type: 'dirname', value: 'bat'},
+      {type: 'nest', value: '  '},
+      {type: 'nest', value: '  '},
+      {type: 'filename', value: 'qux'},
+      {type: 'link', value: 'qux'},
+      {type: 'nest', value: '  '},
+      {type: 'dirname', value: 'bat'},
+      {type: 'nest', value: '/'},
+      {type: 'filename', value: 'qux'},
+      {type: 'content', value: 'qux'},
+    ]).parse();
+
+    let expected = new FixtureRoot();
+    let foo, bat;
+
+    expected.children.push((foo = new FixtureDir('foo')));
+    foo.children.push(new FixtureFile('bar', 'bar'));
+    expected.children.push((foo = new FixtureDir('foo')));
+    foo.children.push(new FixtureLink('bar', 'foo/bat'));
+    foo.children.push((bat = new FixtureDir('bat')));
+    bat.children.push(new FixtureLink('qux', 'qux'));
+    foo.children.push((bat = new FixtureDir('bat')));
+    bat.children.push(new FixtureFile('qux', 'qux'));
+
+    assert.deepEqual(result, expected);
+  });
+});
+
+describe('fsFixture', () => {
+  let fs;
+  let workerFarm;
+
+  beforeEach(() => {
+    workerFarm = new WorkerFarm({
+      workerPath: require.resolve('@parcel/core/src/worker.js'),
+    });
+    fs = new MemoryFS(workerFarm);
+  });
+
+  afterEach(async () => {
+    await workerFarm.end();
+  });
+
+  it('applies a fixture with nesting and overwriting', async () => {
+    await fsFixture(fs)`
+      foo
+        bar: "bar"
+      foo/bar -> foo/bat
+        bat
+          qux -> qux
+        bat/qux: "qux"
+    `;
+
+    assert(fs.readFileSync('foo/bat/qux', 'utf8'), 'qux');
+    assert(fs.readFileSync('foo/bar/qux', 'utf8'), 'qux');
+  });
+
+  it('applies a fixture with expressions', async () => {
+    await fsFixture(fs)`
+      app
+        yarn.lock: ""
+        node_modules
+          .bin
+            parcel -> ${path.resolve(__dirname, '../../parcel/src/bin.js')}
+          parcel -> ${path.resolve(__dirname, '../../parcel')}
+          @parcel
+            core -> ${path.resolve(__dirname, '../../core')}
+        .parcelrc: "${{
+          extends: '@parcel/config-default',
+          transforms: ['parcel-transformer-custom', '...'],
+        }}"
+    `;
+
+    assert(fs.existsSync('/app'));
+
+    assert.equal(fs.readFileSync('/app/yarn.lock'), '');
+
+    assert.equal(
+      fs.readFileSync('/app/.parcelrc', 'utf8'),
+      JSON.stringify({
+        extends: '@parcel/config-default',
+        transforms: ['parcel-transformer-custom', '...'],
+      }),
+    );
+
+    assert(fs.existsSync('/app/node_modules'));
+
+    assert.equal(
+      fs.realpathSync('/app/node_modules/.bin/parcel'),
+      path.resolve(__dirname, '../../parcel/src/bin.js'),
+    );
+
+    assert.equal(
+      fs.realpathSync('/app/node_modules/parcel'),
+      path.resolve(__dirname, '../../parcel'),
+    );
+
+    assert.equal(
+      fs.realpathSync('/app/node_modules/@parcel/core'),
+      path.resolve(__dirname, '../../core'),
+    );
+  });
+});

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -458,7 +458,7 @@ describe('fsFixture', () => {
       foo/bar -> foo/bat
     `;
 
-    assert.equal(fs.realpathSync('foo/bar'), '/foo/bat');
+    assert.equal(fs.realpathSync('foo/bar'), path.resolve('/foo/bat'));
     assert(fs.readFileSync('foo/bat/qux', 'utf8'), 'qux');
     assert(fs.readFileSync('foo/bar/qux', 'utf8'), 'qux');
   });
@@ -538,10 +538,10 @@ describe('fsFixture', () => {
     await fsFixture(fs)`
       foo\\bar
         bat:
-        baz -> foo\\bar\\bat`;
+        baz -> D:\\foo\\bar\\bat`;
 
     assert(fs.existsSync('/foo/bar/bat'));
-    assert.equal(fs.realpathSync('/foo/bar/baz'), '/foo/bar/bat');
+    assert.equal(fs.realpathSync('/foo/bar/baz'), path.resolve('/foo/bar/bat'));
   });
 });
 

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -587,4 +587,28 @@ describe('toFixture', () => {
 
     assert.equal(fixture.toString(), `bar:\n  bar\nbat -> /foo/bar`);
   });
+
+  it('includes the directory name in the fixture', async () => {
+    await fs.mkdirp('/foo');
+    await fs.writeFile('/foo/bar', 'bar');
+    await fs.symlink('/foo/bar', '/foo/bat');
+
+    let fixture = await toFixture(fs, 'foo', true);
+
+    assert.deepEqual(fixture, {
+      type: 'root',
+      children: [
+        {
+          type: 'dir',
+          name: 'foo',
+          children: [
+            {type: 'file', name: 'bar', content: 'bar'},
+            {type: 'link', name: 'bat', target: '/foo/bar'},
+          ],
+        },
+      ],
+    });
+
+    assert.equal(fixture.toString(), `foo\n  bar:\n    bar\n  bat -> /foo/bar`);
+  });
 });

--- a/scripts/to-fs-fixture.js
+++ b/scripts/to-fs-fixture.js
@@ -1,0 +1,34 @@
+#! /usr/bin/env node
+/* eslint-disable no-console */
+
+require('@parcel/babel-register');
+
+const fs = require('fs').promises;
+const path = require('path');
+
+/* eslint-disable-next-line import/no-extraneous-dependencies */
+const {toFixture} = require('@parcel/test-utils/src/fsFixture');
+
+let args = process.argv.slice(2);
+
+if (args.includes('--help')) {
+  console.log('Usage: to-fs-fixture.js <fixtureName> <outputDir>');
+  process.exit(0);
+}
+
+if (args.length < 1) {
+  console.log(
+    `Usage:
+
+    to-fs-fixture.js <path/to/dir>
+`,
+  );
+  process.exit(1);
+}
+
+main(args[0]);
+
+async function main(dir) {
+  let fixture = await toFixture(fs, path.resolve(dir));
+  console.log(fixture.toString());
+}

--- a/scripts/to-fs-fixture.js
+++ b/scripts/to-fs-fixture.js
@@ -3,32 +3,862 @@
 
 require('@parcel/babel-register');
 
-const fs = require('fs').promises;
-const path = require('path');
+const fs = require('node:fs').promises;
+const path = require('node:path');
+const {spawn, execSync} = require('node:child_process');
 
-/* eslint-disable-next-line import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies */
+const commander = require('commander');
+const inquirer = require('inquirer');
+const chalk = require('chalk');
+const diff = require('diff');
+const nullthrows = require('nullthrows');
+
 const {toFixture} = require('@parcel/test-utils/src/fsFixture');
+const {isGlobMatch} = require('@parcel/utils/src/glob');
+/* eslint-enable import/no-extraneous-dependencies */
 
-let args = process.argv.slice(2);
+/** A simple promisified exec(). */
+function execAsync(cmd) {
+  return new Promise((resolve, reject) => {
+    let child = spawn(cmd, {
+      stdio: 'inherit',
+      shell: true,
+    });
 
-if (args.includes('--help')) {
-  console.log('Usage: to-fs-fixture.js <fixtureName> <outputDir>');
-  process.exit(0);
+    child.on('close', code => {
+      if (code !== 0) {
+        reject(new Error(`Exit code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+  });
 }
 
-if (args.length < 1) {
-  console.log(
-    `Usage:
-
-    to-fs-fixture.js <path/to/dir>
-`,
+/** Pretty print a test fixture filepath. */
+function printPath(filePath) {
+  let root = path.resolve(
+    path.join(__dirname, '../packages/core/integration-tests/test'),
   );
-  process.exit(1);
+  return chalk.blue(
+    path.relative(
+      root,
+      filePath.startsWith(root) ? filePath : path.join(root, filePath),
+    ),
+  );
 }
 
-main(args[0]);
+/** Pretty print a code location. */
+function printLoc(loc) {
+  return chalk.dim(`${loc.start.line}:${loc.start.column}`);
+}
 
-async function main(dir) {
-  let fixture = await toFixture(fs, path.resolve(dir));
-  console.log(fixture.toString());
+/** Asserts that the given node is a test call expression. */
+function assertIsTest(file, test, api) {
+  let j = api.jscodeshift;
+
+  let it = test.find(j.CallExpression, {callee: {name: 'it'}});
+
+  if (it.length === 0) {
+    let loc = test.get('loc').value;
+    throw new Error(
+      `Expected an it() call at ${file.path}:${loc.start.line}:${loc.start.column}`,
+    );
+  }
+}
+
+/** Asserts that the given test is an async function declaration. */
+function assertIsAsyncTest(file, test, api) {
+  let j = api.jscodeshift;
+
+  assertIsTest(file, test, api);
+
+  let fn = test
+    .find(j.CallExpression, {callee: {name: 'it'}})
+    .get('arguments', 1).value;
+
+  if (
+    (fn.type !== 'FunctionExpression' &&
+      fn.type !== 'ArrowFunctionExpression') ||
+    !fn.async
+  ) {
+    throw new Error(
+      `Expected an async function at ${file.path}:${fn.loc.start.line}:${fn.loc.start.column}`,
+    );
+  }
+}
+
+/** Gets the test name as it might be presented by mocha. */
+function getTestName(test, api) {
+  let j = api.jscodeshift;
+  let it = test
+    .find(j.CallExpression, {callee: {name: 'it'}})
+    .get('arguments', 0).value.value;
+
+  let desc = [it];
+
+  let describe = test.closest(j.CallExpression, {callee: {name: 'describe'}});
+  while (describe.length > 0) {
+    desc.unshift(describe.get('arguments', 0).value.value);
+    describe = describe.closest(j.CallExpression, {callee: {name: 'describe'}});
+  }
+
+  return desc.join(' ');
+}
+
+/**
+ * Find tests that contain fixture paths that contain `integration/`.
+ * See `findFixturePaths` for more details.
+ */
+function findTestsWithFixturePaths(root, api, options) {
+  const j = api.jscodeshift;
+
+  let testMap = new Map();
+  root
+    .find(j.ExpressionStatement, {expression: {callee: {name: 'it'}}})
+    .forEach(p => {
+      let test = j(p);
+      let fixturePaths = findFixturePaths(test, api, options);
+      if (
+        fixturePaths.literals.length > 0 ||
+        fixturePaths.templates.length > 0
+      ) {
+        testMap.set(test, fixturePaths);
+      }
+    });
+
+  return testMap;
+}
+
+/** Checks if the given fixture path matches any of the 'keep' globs. */
+function shouldKeepFixture(fixturePath, keep) {
+  if (keep == null) return false;
+  if (!Array.isArray(keep)) keep = [keep];
+  if (keep?.length) {
+    for (let glob of keep) {
+      if (isGlobMatch(fixturePath, glob, {bash: true})) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Checks if the given test name matches any of the 'grep' patterns. */
+function shouldTransformTest(testName, grep) {
+  if (grep == null) return true;
+  if (!Array.isArray(grep)) grep = [grep];
+  if (grep?.length) {
+    for (let pattern of grep) {
+      if (new RegExp(pattern).test(testName)) {
+        return true;
+      }
+    }
+  }
+}
+
+/**
+ * Find fixture paths that contain `integration/`.
+ *
+ * Things we could find:
+ *
+ *   '/integration/...'
+ *   __dirname + '/integration/...'
+ *   path.join(__dirname, '/integration/...')
+ *   `${__dirname}/integration/...`
+ */
+function findFixturePaths(test, api, {verbose, keep}) {
+  let j = api.jscodeshift;
+  return {
+    literals: test.find(j.Literal).filter(p => {
+      let {value, loc} = p.value;
+      if (value?.includes?.('integration/')) {
+        if (shouldKeepFixture(value, keep)) {
+          if (verbose) {
+            console.log(
+              chalk.yellow(
+                `Skipping fixture path ${printPath(value)} at ${printLoc(
+                  loc,
+                )} because it matches a keep glob.`,
+              ),
+            );
+          }
+          return false;
+        }
+
+        if (verbose) {
+          console.log(
+            chalk.dim(
+              `Found fixture path ${printPath(p.value.value)} at ${printLoc(
+                loc,
+              )}`,
+            ),
+          );
+        }
+        return true;
+      }
+      return false;
+    }),
+    templates: test.find(j.TemplateElement).filter(p => {
+      let {value, loc} = p.value;
+      if (value?.cooked?.includes?.('integration/')) {
+        if (shouldKeepFixture(value.cooked, keep)) {
+          if (verbose) {
+            console.log(
+              chalk.yellow(
+                `Skipping fixture path ${printPath(value.cooked)} at ${printLoc(
+                  loc,
+                )} because it matches a keep glob.`,
+              ),
+            );
+          }
+          return false;
+        }
+
+        if (verbose) {
+          console.log(
+            chalk.dim(
+              `Found fixture path ${printPath(value.cooked)} at ${printLoc(
+                loc,
+              )}`,
+            ),
+          );
+        }
+        return true;
+      }
+      return false;
+    }),
+  };
+}
+
+/** Resolve a fixture path from a test to an absolute filepath. */
+function resolveFixturePath(value) {
+  let filePath = value;
+  let dirname = path.dirname(filePath);
+  while (path.basename(dirname) !== 'integration') {
+    if (filePath === dirname) {
+      throw new Error(`Could not find integration/ in path: ${value}`);
+    }
+    filePath = dirname;
+    dirname = path.dirname(filePath);
+  }
+
+  filePath = path.resolve(
+    path.join(__dirname, '../packages/core/integration-tests/test', filePath),
+  );
+  return filePath;
+}
+
+/**
+ * Given a set of nodes that specify fixture paths,
+ * generates a map of fixture paths to the `fsFixture`
+ * template string equivalents for the files in those paths.
+ */
+async function generateFsFixtures(fixturePaths, api, {verbose}) {
+  let toGenerate = [];
+
+  fixturePaths.literals.forEach(match => {
+    toGenerate.push(resolveFixturePath(match.get('value').value));
+  });
+
+  fixturePaths.templates.forEach(match => {
+    toGenerate.push(resolveFixturePath(match.get('value').value.cooked));
+  });
+
+  let fixtures = new Map();
+  for (let filePath of toGenerate) {
+    if (!fixtures.has(filePath)) {
+      try {
+        fixtures.set(filePath, await toFixture(fs, filePath, true));
+      } catch (e) {
+        if (e.code === 'ENOENT') {
+          if (verbose) {
+            console.log(
+              chalk.yellow(
+                `Skipping missing fixture path: ${printPath(filePath)}`,
+              ),
+            );
+          }
+          continue;
+        } else if (e.message.startsWith('Disallowed')) {
+          if (verbose) {
+            console.log(
+              chalk.yellow(
+                `Skipping fixture path with disallowed filetypes: ${printPath(
+                  filePath,
+                )}`,
+              ),
+            );
+          }
+          continue;
+        } else if (e.message.startsWith('File too large')) {
+          if (verbose) {
+            console.log(
+              chalk.yellow(
+                `Skipping fixture path with large file(s): ${printPath(
+                  filePath,
+                )}`,
+              ),
+            );
+          }
+          continue;
+        }
+        throw e;
+      }
+    }
+  }
+
+  return fixtures;
+}
+
+/** Print a diff of the test before and after the transform. */
+async function printDiff(testName, testString, api, options) {
+  let j = api.jscodeshift;
+  let test = j(testString);
+  // Suppress redundant verbose output while generating the diff.
+  let opts = {...options, verbose: false};
+  let fixturePaths = findFixturePaths(test, api, opts);
+  let fixtures = await generateFsFixtures(fixturePaths, api, opts);
+  if (fixtures.size) {
+    insertFsFixtures(test, fixtures, api, opts);
+    replaceInputFS(test, api, opts);
+    replaceFixturePaths(fixturePaths, api, opts);
+    console.log(
+      diff
+        .createTwoFilesPatch('before', 'after', testString, test.toSource())
+        .split('\n')
+        .map(line => {
+          if (/^\++ /.test(line)) {
+            return chalk.green(line);
+          } else if (/^-+ /.test(line)) {
+            return chalk.red(line);
+          } else if (/^@+ /.test(line)) {
+            return chalk.black(line);
+          }
+          return line;
+        })
+        .join('\n'),
+    );
+  }
+}
+
+/**
+ * Replaces the fixture paths in the test with the paths
+ * used in the generated `fsFixture` template string.
+ */
+function replaceFixturePaths(fixturePaths, api) {
+  let j = api.jscodeshift;
+
+  for (let match of fixturePaths.literals.paths().map(p => j(p))) {
+    match.replaceWith(p => p.value.raw.replace(/(\/)?integration\//, '$1'));
+  }
+
+  for (let match of fixturePaths.templates.paths().map(p => j(p))) {
+    // TODO: Update the path. this probably isn't the right way?
+    match.replaceWith(p =>
+      p.value.value.cooked.replace(/(\/)?integration\//, '$1'),
+    );
+  }
+}
+
+/** Where to insert the `fixtureFS` argument for various test utils. */
+const TEST_UTIL_ARITY = {
+  ncp: 3,
+  assertESMExports: 5,
+};
+
+/**
+ * Where possible, specifies `fixtureFS` as the input fs for the test.
+ *
+ * For example, in a test that uses the `bundle` test util, the options
+ * to the `bundle` call will be updated to use `fixtureFS` as the input fs,
+ * unless already specified.
+ * */
+function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
+  let shouldReplace = false;
+  test.find(j.CallExpression).forEach(node => {
+    let {loc, arguments: args, callee} = node.value;
+    let name = callee?.name;
+    switch (name) {
+      case 'bundle':
+      case 'bundler': {
+        let options = args[1];
+        if (options) {
+          if (options.type !== 'ObjectExpression') {
+            throw new Error(`Expected options to be an object`);
+          }
+          let inputFS = options.properties.find(
+            prop => prop.key.name === 'inputFS',
+          );
+          if (!inputFS) {
+            shouldReplace = true;
+            options.properties.push(
+              j.property(
+                'init',
+                j.identifier('inputFS'),
+                j.identifier('fixtureFS'),
+              ),
+            );
+            if (verbose) {
+              console.log(
+                chalk.dim(
+                  `Adding ${chalk.yellow(
+                    'inputFS: fixtureFS',
+                  )} option to ${chalk.yellow(name)} call at ${printLoc(loc)}`,
+                ),
+              );
+            }
+          } else if (verbose) {
+            console.log(
+              chalk.yellow(
+                `Skipping ${name} call at ${printLoc(
+                  loc,
+                )} because it already had an inputFS option.`,
+              ),
+            );
+          }
+        } else {
+          shouldReplace = true;
+          args[1] = j.objectExpression([
+            j.property(
+              'init',
+              j.identifier('inputFS'),
+              j.identifier('fixtureFS'),
+            ),
+          ]);
+          if (verbose) {
+            console.log(
+              chalk.dim(
+                `Adding ${chalk.yellow(
+                  'inputFS: fixtureFS',
+                )} option arg to ${chalk.yellow(name)} call at ${printLoc(
+                  loc,
+                )}`,
+              ),
+            );
+          }
+        }
+        break;
+      }
+      case 'assertESMExports':
+      case 'ncp': {
+        let arity = nullthrows(TEST_UTIL_ARITY[name]);
+        if (arity != null && args.length < arity) {
+          while (args.length < arity - 1) {
+            args.push(j.literal(null));
+          }
+          args.push(j.identifier('fixtureFS'));
+          if (verbose) {
+            console.log(
+              chalk.dim(
+                `Adding ${chalk.yellow('fixtureFS')} argument to ${chalk.yellow(
+                  name,
+                )} call at ${printLoc(loc)}`,
+              ),
+            );
+          }
+        } else if (verbose) {
+          console.log(
+            chalk.yellow(
+              `Skipping ${name} call at ${printLoc(
+                loc,
+              )} because it already has an fs argument.`,
+            ),
+          );
+        }
+        break;
+      }
+    }
+  });
+
+  if (shouldReplace) {
+    test.find(j.Identifier, {name: 'inputFS'}).forEach(path => {
+      if (path.parentPath.value.type === 'Property') return;
+      if (verbose) {
+        console.log(
+          chalk.dim(
+            `Replacing ${chalk.yellow('inputFS')} with ${chalk.yellow(
+              'fixtureFS',
+            )} at ${printLoc(path.value.loc)}`,
+          ),
+        );
+      }
+      path.value.name = 'fixtureFS';
+    });
+  }
+}
+
+/** Adds imports for `fsFixture` and `fixtureFS`. */
+function insertFsFixtureImport(root, api) {
+  let j = api.jscodeshift;
+  // Insert import for fsFixture
+  let testUtils = root.find(j.ImportDeclaration, {
+    source: {value: '@parcel/test-utils'},
+  });
+
+  if (testUtils.length === 0) {
+    root.find(j.ImportDeclaration).at(-1).insertAfter(`
+        import {fsFixture, fixtureFS} from '@parcel/test-utils';
+      `);
+  } else {
+    let specifiers = testUtils.find(j.Specifier);
+    if (!specifiers.paths().some(p => p.value.imported.name === 'fsFixture')) {
+      specifiers
+        .at(-1)
+        .insertAfter(j.importSpecifier(j.identifier('fsFixture')));
+    }
+    if (!specifiers.paths().some(p => p.value.imported.name === 'fixtureFS')) {
+      specifiers
+        .at(-1)
+        .insertAfter(j.importSpecifier(j.identifier('fixtureFS')));
+    }
+  }
+}
+
+/** Prints the `fsFixture` template string. */
+function printFsFixture(fixtures) {
+  return `await fsFixture(fixtureFS, __dirname)\`\n${[...fixtures.values()]
+    .map(fixture =>
+      fixture
+        .toString()
+        .trim()
+        .split('\n')
+        .map(l => `  ${l}`)
+        .join('\n'),
+    )
+    .join('\n')}\`;`;
+}
+
+/** Adds fsFixture declaration expressions to the test. */
+function insertFsFixtures(test, fixtures, api) {
+  let j = api.jscodeshift;
+  let firstBodyNode = test
+    .find(j.CallExpression, {callee: {name: 'it'}})
+    .find(j.BlockStatement)
+    .get('body', 0);
+  firstBodyNode.insertBefore(printFsFixture(fixtures));
+}
+
+/** Prompts the user to transform a test. Noop if `yes` is true. */
+async function promptToTransformFixtures(testName, {yes}) {
+  if (yes) return true;
+  let {result} = await inquirer.prompt({
+    type: 'expand',
+    name: 'result',
+    message: `Transform ${chalk.blue(testName)}`,
+    default: 0,
+    choices: [
+      {key: 'y', name: 'transform this test', value: true},
+      {key: 'n', name: 'do not transform this test', value: false},
+      {key: 'a', name: 'transform remaining tests in the file', value: 'all'},
+      {key: 'd', name: 'skip remaining tests in the file', value: 'none'},
+      {key: 'v', name: 'view the diff for this test', value: 'view'},
+    ],
+  });
+  return result;
+}
+
+/**
+ * Finds all tests that use fs fixtures and converts them to use fsFixture.
+ *
+ * This is the transform that jscodeshift will run on each file.
+ */
+async function transform(file, api, options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // Manage a local copy of options so we can modify it iteratively.
+  let opts = {...options, dryRun: options.dryRun ?? options.dry};
+  let hasTransformedFixtures = false;
+
+  // Manage a stack of tests so we can interactively transform them,
+  // e.g., view the diff, then decide to transform or not.
+  let tests = [...findTestsWithFixturePaths(root, api, opts)].reverse();
+
+  let printedDiff = new Set();
+  outer: while (tests.length) {
+    let [test, fixturePaths] = tests.pop();
+    let testName = getTestName(test, api);
+
+    if (!shouldTransformTest(testName, opts.grep)) {
+      if (opts.verbose) {
+        console.log(
+          chalk.yellow(
+            `Skipping ${chalk.blue(
+              testName,
+            )} because it does not match grep patterns.`,
+          ),
+        );
+      }
+      continue;
+    }
+
+    assertIsAsyncTest(file, test, api);
+
+    if (opts.verbose && (!opts.yes || opts.dryRun) && !printedDiff.has(test)) {
+      await printDiff(testName, test.toSource(), api, opts);
+    }
+    printedDiff.add(test);
+
+    switch (await promptToTransformFixtures(testName, opts)) {
+      case true: {
+        let fixtures = await generateFsFixtures(fixturePaths, api, opts);
+        if (fixtures.size) {
+          insertFsFixtures(test, fixtures, api, opts);
+          replaceInputFS(test, api, opts);
+          replaceFixturePaths(fixturePaths, api, opts);
+
+          hasTransformedFixtures = true;
+
+          // Report converted fixture filePaths for cleanup.
+          for (let fixturePath of fixtures.keys()) {
+            process.send?.({type: 'fixture', filePath: file.path, fixturePath});
+          }
+
+          // Also report the test scope so we know which tests need to be run.
+          process.send?.({type: 'test', filePath: file.path, testName});
+        }
+        break;
+      }
+      case 'all': {
+        opts.yes = true;
+        tests.push([test, fixturePaths]);
+        break;
+      }
+      case 'none': {
+        break outer;
+      }
+      case 'view': {
+        await printDiff(testName, test.toSource(), api, opts);
+        tests.push([test, fixturePaths]);
+        break;
+      }
+    }
+  }
+
+  if (hasTransformedFixtures) {
+    insertFsFixtureImport(root, api, options);
+    // Only return something if we changed something.
+    return root.toSource();
+  }
+}
+
+module.exports = transform;
+module.exports.parser = 'flow';
+
+/**
+ * Runs jscodeshift to apply `transform` to `file`.
+ * Collects the results of the transform and resolves to them when complete.
+ */
+function runJsCodeshift(file, {dryRun, verbose, yes, keep, grep}) {
+  return new Promise((resolve, reject) => {
+    let results = {
+      /** A set of fixture paths that were converted. */
+      fixturesToCleanup: new Set(),
+      /** A set of test names that were modified. */
+      testsToVerify: new Set(),
+    };
+
+    let args = ['--run-in-band', '--parser=flow'];
+    if (dryRun) args.push('--dry');
+    if (verbose) args.push('--verbose=2');
+    if (yes) args.push('--yes');
+    if (keep?.length) args = args.concat(keep.map(k => `--keep "${k}"`));
+    if (grep?.length) args = args.concat(grep.map(g => `--grep "${g}"`));
+    args.push(`--transform=${__filename}`);
+    args = args.concat(file);
+
+    if (verbose) {
+      console.log(chalk.dim(`jscodeshift ${args.join(' ')}`));
+    }
+
+    const jscodeshift = spawn('jscodeshift', args, {
+      env: {FORCE_COLOR: 'true', ...process.env},
+      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+      shell: true,
+    });
+
+    jscodeshift.on('message', event => {
+      switch (event.type) {
+        case 'fixture': {
+          results.fixturesToCleanup.add(event.fixturePath);
+          break;
+        }
+        case 'test': {
+          results.testsToVerify.add(event.testName);
+          break;
+        }
+        default: {
+          console.error(`Unknown event type: ${event.type}`);
+        }
+      }
+    });
+
+    jscodeshift.on('close', code => {
+      if (code !== 0) {
+        reject(new Error(`Exit code ${code}`));
+      } else {
+        resolve(results);
+      }
+    });
+  });
+}
+
+/** Cleans up old fixtures that were replaced by the transform. */
+async function cleanupFixtures(fixturesToCleanup, {cleanup, dryRun, verbose}) {
+  if (!cleanup || fixturesToCleanup.size === 0) {
+    return;
+  }
+
+  console.log(
+    chalk.yellow(`Cleaning up ${fixturesToCleanup.size} fixtures...`),
+  );
+
+  for (let fixture of fixturesToCleanup) {
+    if (dryRun) {
+      console.log(chalk.green(`Would remove ${printPath(fixture)}`));
+      continue;
+    }
+
+    if (verbose) {
+      console.log(chalk.red(`Removing ${printPath(fixture)}`));
+    }
+
+    try {
+      await fs.rm(fixture, {recursive: true});
+    } catch (err) {
+      console.error(err);
+    }
+  }
+}
+
+/** Reports the results of the transforms. */
+function reportResults({fixturesToCleanup, testsToVerify}, options) {
+  if (fixturesToCleanup.size && !options.cleanup) {
+    console.log(
+      chalk.yellow(
+        `\nThe following fixtures would've been removed with --cleanup:`,
+      ),
+    );
+    for (let fixture of fixturesToCleanup) {
+      console.log(chalk.yellow(`  ${printPath(fixture)}`));
+    }
+  }
+
+  if (testsToVerify.size === 0) {
+    console.log(
+      chalk.green(`\nNo tests were modified. No need to verify any tests.`),
+    );
+    return;
+  }
+
+  for (let [filename, tests] of testsToVerify) {
+    console.log(
+      chalk.green(
+        `\nPlease verify that ${chalk.blue(filename)} still passes all tests.`,
+      ),
+    );
+    if (options.verbose) {
+      if (options.dryRun) {
+        console.log(chalk.dim(`Tests that would've been modified:`));
+      } else {
+        console.log(chalk.dim(`Tests that were modified:`));
+      }
+      for (let test of tests) {
+        console.log(chalk.dim(`  ${test}`));
+      }
+    }
+  }
+}
+
+/** Bootstraps jscodeshift and runs the transform. */
+function bootstrap(files, {parent: options}) {
+  let cmd = 'npx --package jscodeshift';
+
+  let npxVersion = execSync('npx -v');
+  if (parseInt(npxVersion.toString().split('.').shift(), 10) > 6) {
+    cmd = `${cmd} --yes`;
+  }
+
+  // Bootstrap jscodeshift and rerun this script as a jscodeshift transform.
+  let args = ['run'];
+  if (options.cleanup) args.push('--cleanup');
+  if (options.dryRun) args.push('--dry-run');
+  if (options.verbose) args.push('--verbose');
+  if (options.yes) args.push('--yes');
+  if (options.keep) args = args.concat(options.keep.map(k => `--keep "${k}"`));
+  if (options.grep) args = args.concat(options.grep.map(g => `--grep "${g}"`));
+  args.push('--');
+  args = args.concat(files);
+  args = args.join(' ');
+
+  if (options.verbose) {
+    console.log(chalk.dim(`${cmd} -c '${__filename} ${args}'`));
+  }
+  return execAsync(`${cmd} -c '${__filename} ${args}'`);
+}
+
+/** Runs the transform and optionally cleans up and verifies the results. */
+async function run(files, {parent: options}) {
+  let opts = {
+    cleanup: Boolean(options.cleanup),
+    dryRun: Boolean(options.dryRun),
+    keep: options.keep,
+    grep: options.grep,
+    verbose: Boolean(options.verbose) || Boolean(options.dryRun),
+    yes: Boolean(options.yes),
+  };
+
+  let fixturesToCleanup = new Set();
+  let testsToVerify = new Map();
+
+  for (let file of files) {
+    let results = await runJsCodeshift(file, opts);
+    for (let fixture of results.fixturesToCleanup) {
+      fixturesToCleanup.add(fixture);
+    }
+    testsToVerify.set(file, results.testsToVerify);
+  }
+
+  await cleanupFixtures(fixturesToCleanup, opts);
+  reportResults({fixturesToCleanup, testsToVerify}, opts);
+}
+
+if (require.main === module) {
+  let program = new commander.Command();
+  program
+    .arguments('<files...>')
+    .usage('[options] <files...>')
+    .description('Convert test files to use fsFixture.', {
+      files: 'One or more files to be transformed in-place. Required.',
+    })
+    .option('--cleanup', 'Cleanup old fixtures after running')
+    .option('--dry-run', 'Dry run (implies --verbose)')
+    .option(
+      '--grep <pattern>',
+      'Only transform tests matching this pattern. Can be repeated.',
+      (v, a) => a.concat(v),
+      [],
+    )
+    .option(
+      '--keep <glob>',
+      'Keep fixtures matching glob. Can be repeated.',
+      (v, a) => a.concat(v),
+      [],
+    )
+    .option('--verbose', 'Verbose output')
+    .option('--yes', 'Say yes to all prompts');
+
+  program.command('bootstrap <files...>', {noHelp: true}).action(bootstrap);
+  program.command('run <files...>', {noHelp: true}).action(run);
+
+  let args = process.argv;
+  if (!args.includes('--help') && !args.includes('-h')) {
+    if (!args[2] || !program.commands.some(c => c.name() === args[2])) {
+      args.splice(2, 0, 'bootstrap');
+    }
+  }
+
+  program.parse(args);
 }

--- a/scripts/to-fs-fixture.js
+++ b/scripts/to-fs-fixture.js
@@ -362,17 +362,17 @@ function replaceFixturePaths(fixturePaths, api) {
   }
 }
 
-/** Where to insert the `fixtureFS` argument for various test utils. */
+/** Where to insert the `overlayFS` argument for various test utils. */
 const TEST_UTIL_ARITY = {
   ncp: 3,
   assertESMExports: 5,
 };
 
 /**
- * Where possible, specifies `fixtureFS` as the input fs for the test.
+ * Where possible, specifies `overlayFS` as the input fs for the test.
  *
  * For example, in a test that uses the `bundle` test util, the options
- * to the `bundle` call will be updated to use `fixtureFS` as the input fs,
+ * to the `bundle` call will be updated to use `overlayFS` as the input fs,
  * unless already specified.
  * */
 function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
@@ -397,14 +397,14 @@ function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
               j.property(
                 'init',
                 j.identifier('inputFS'),
-                j.identifier('fixtureFS'),
+                j.identifier('overlayFS'),
               ),
             );
             if (verbose) {
               console.log(
                 chalk.dim(
                   `Adding ${chalk.yellow(
-                    'inputFS: fixtureFS',
+                    'inputFS: overlayFS',
                   )} option to ${chalk.yellow(name)} call at ${printLoc(loc)}`,
                 ),
               );
@@ -424,14 +424,14 @@ function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
             j.property(
               'init',
               j.identifier('inputFS'),
-              j.identifier('fixtureFS'),
+              j.identifier('overlayFS'),
             ),
           ]);
           if (verbose) {
             console.log(
               chalk.dim(
                 `Adding ${chalk.yellow(
-                  'inputFS: fixtureFS',
+                  'inputFS: overlayFS',
                 )} option arg to ${chalk.yellow(name)} call at ${printLoc(
                   loc,
                 )}`,
@@ -448,11 +448,11 @@ function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
           while (args.length < arity - 1) {
             args.push(j.literal(null));
           }
-          args.push(j.identifier('fixtureFS'));
+          args.push(j.identifier('overlayFS'));
           if (verbose) {
             console.log(
               chalk.dim(
-                `Adding ${chalk.yellow('fixtureFS')} argument to ${chalk.yellow(
+                `Adding ${chalk.yellow('overlayFS')} argument to ${chalk.yellow(
                   name,
                 )} call at ${printLoc(loc)}`,
               ),
@@ -479,17 +479,17 @@ function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
         console.log(
           chalk.dim(
             `Replacing ${chalk.yellow('inputFS')} with ${chalk.yellow(
-              'fixtureFS',
+              'overlayFS',
             )} at ${printLoc(path.value.loc)}`,
           ),
         );
       }
-      path.value.name = 'fixtureFS';
+      path.value.name = 'overlayFS';
     });
   }
 }
 
-/** Adds imports for `fsFixture` and `fixtureFS`. */
+/** Adds imports for `fsFixture` and `overlayFS`. */
 function insertFsFixtureImport(root, api) {
   let j = api.jscodeshift;
   // Insert import for fsFixture
@@ -499,7 +499,7 @@ function insertFsFixtureImport(root, api) {
 
   if (testUtils.length === 0) {
     root.find(j.ImportDeclaration).at(-1).insertAfter(`
-        import {fsFixture, fixtureFS} from '@parcel/test-utils';
+        import {fsFixture, overlayFS} from '@parcel/test-utils';
       `);
   } else {
     let specifiers = testUtils.find(j.Specifier);
@@ -508,17 +508,17 @@ function insertFsFixtureImport(root, api) {
         .at(-1)
         .insertAfter(j.importSpecifier(j.identifier('fsFixture')));
     }
-    if (!specifiers.paths().some(p => p.value.imported.name === 'fixtureFS')) {
+    if (!specifiers.paths().some(p => p.value.imported.name === 'overlayFS')) {
       specifiers
         .at(-1)
-        .insertAfter(j.importSpecifier(j.identifier('fixtureFS')));
+        .insertAfter(j.importSpecifier(j.identifier('overlayFS')));
     }
   }
 }
 
 /** Prints the `fsFixture` template string. */
 function printFsFixture(fixtures) {
-  return `await fsFixture(fixtureFS, __dirname)\`\n${[...fixtures.values()]
+  return `await fsFixture(overlayFS, __dirname)\`\n${[...fixtures.values()]
     .map(fixture =>
       fixture
         .toString()


### PR DESCRIPTION
`fsFixture` is test utility that is meant to make writing integration test cases easier by allowing us to colocate the filesystem-bound fixtures with the tests.

## Example

A test from the javascript suite converted to `fsFixture`

```javascript
  it('should produce a basic JS bundle with CommonJS requires', async function () {
    await fsFixture(overlayFS, __dirname)`
      commonjs
        index.js:
          var local = require('./local');
          // eslint-disable-next-line no-unused-vars
          var url = require('url');

          module.exports = function () {
            return local.a + local.b;
          };

        local.js:
          exports.a = 1;
          exports.b = 2;`;
    
    // The fixture is a set of files defined by the above `fsFixture`
    let b = await bundle(path.join(__dirname, '/commonjs/index.js'), {
      inputFS: overlayFS,
    });

    let output = await run(b);
    assert.equal(typeof output, 'function');
    assert.equal(output(), 3);
  });

```
<details>
<summary>See the original</summary>

```javascript
  it('should produce a basic JS bundle with CommonJS requires', async function () {
    // The fixture is a set of files at the path `/integration/commonjs/`
    let b = await bundle(
      path.join(__dirname, '/integration/commonjs/index.js'),
    );

    let output = await run(b);
    assert.equal(typeof output, 'function');
    assert.equal(output(), 3);
  });
```
</details>

The test itself becomes a bit more verbose, but hopefully it's obvious that the fixtures themselves are now closer to the test.

While this example shows converting an existing test, `fsFixture` is probably most useful for authoring new tests, as it allows us to iterate on the fixtures themselves along with tests without switching between files and directories.

## Changes to `MemoryFS`

Use cases for `fsFixture` revealed a couple of edge cases that are addressed in this PR:
- Reading from the root dir ('/') didn't work due to a couple of assumptions about filepaths
- The bitmasks used to detect an entry type (file, directory, symlink) didn't always mask the mode correctly, which could result in it being impossible to distinguish a symlink from a file.

## Grammar
`fsFixture` defines a simple DSL with just a handful of rules:
- directories are defined on a line by themselves:
  ```javascript
  fsFixture(fs)`
    dirname
  `
  ```
- directories can be nested with two spaces:
  ```javascript
  fsFixture(fs)`
    dirname
      nested
  `
  ```
- or on one line with `/`:
  ```javascript
  fsFixture(fs)`
    dirname/nested
  `
  ```
- symlinks are defined with a `->`:
  ```javascript
  fsFixture(fs)`
    symlink -> target
  `
  ```
- files are defined with a `:`:
  ```javascript
  fsFixture(fs)`
    emptyfile:
  `
  ```
- files contents are defined as everything after the ':' until the indentation level matches the file's:
  ```javascript
  fsFixture(fs)`
    file: contents
    anotherfile:
      multiline
      contents
    emptyfile:
  `
  ```

Since `fsFixture` is a tagged template literal, it is possible to embed expressions using the `${embedded expression}` syntax.

See the tests in this PR for more examples!

## Converting existing tests

A CLI can be found at `scripts/to-fs-fixture.js` that is capable of doing some pretty thorough code modification to existing tests:
```shell
Usage: to-fs-fixture [options] <files...>

Convert test files to use fsFixture.

Arguments:

  files             One or more files to be transformed in-place. Required.

Options:
  --cleanup         Cleanup old fixtures after running
  --dry-run         Dry run (implies --verbose)
  --grep <pattern>  Only transform tests matching this pattern. Can be repeated. (default: [])
  --keep <glob>     Keep fixtures matching glob. Can be repeated. (default: [])
  --verbose         Verbose output
  --yes             Say yes to all prompts
  -h, --help        output usage information
```

By default, it will prompt for modifying each test it finds, and it can display a diff of the change it will apply, with options to skip, which makes running this tool on an existing test suite an incremental process.