### PR TITLE
Doc: update wrong help option

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -111,7 +111,7 @@ var hmrOptions = {
     process.env.PORT,
   ],
   '--host <host>':
-    'set the host to listen on, defaults to listening on all interfaces',
+    'set the host to listen on, defaults to listening on localhost',
   '--https': 'serves files over HTTPS',
   '--cert <path>': 'path to certificate to use with HTTPS',
   '--key <path>': 'path to private key to use with HTTPS',


### PR DESCRIPTION
$ parcel --version
2.8.3

$ parcel serve 
Server running at http://localhost:1234

$ parcel serve --help | grep -A1 "\-\-host"
  --host <host>              set the host to listen on, defaults to listening
                             on all interfaces

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
