### PR TITLE
Fix Best key logic truncating package names

### DIFF
--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -123,10 +123,9 @@ impl<'a> TsConfig<'a> {
         if let Specifier::Package(module, subpath) = key {
           let path = concat_specifier(module.as_ref(), subpath.as_ref());
           if let Some((prefix, suffix)) = path.split_once('*') {
-            if best_key.is_none()
-              || prefix.len() > longest_prefix_length
-                && full_specifier.starts_with(prefix)
-                && full_specifier.ends_with(suffix)
+            if (best_key.is_none() || prefix.len() > longest_prefix_length)
+              && full_specifier.starts_with(prefix)
+              && full_specifier.ends_with(suffix)
             {
               longest_prefix_length = prefix.len();
               longest_suffix_length = suffix.len();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Logic below allowed for incorrect matching of `path` to `specifier` when resolving.

Context: Encountered an issue with the resolver in an app where package names were split as a result of variable `bestKey` always passing the first loop condition for altering `longest_suffix` , resulting in path splitting a specifier that did not include the path, or worse, and out of bounds error on a later splitting.

## 💻 Examples

Not sure exactly how to test this, but this is the situation I ran into / highlights the logic issue

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=26d018c121654e1beb80a45c77bfd991


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
