### PR TITLE
[webextension] Add support for `chrome_style`

### DIFF
--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -25,6 +25,7 @@ const icons: SchemaEntity = {
 const actionProps = {
   // FF only
   browser_style: boolean,
+  chrome_style: boolean,
   // You can also have a raw string, but not in Edge, apparently...
   default_icon: {
     oneOf: [icons, string],
@@ -276,6 +277,7 @@ const commonProps = {
     type: 'object',
     properties: {
       browser_style: boolean,
+      chrome_style: boolean,
       open_in_tab: boolean,
       page: string,
     },


### PR DESCRIPTION

# ↪️ Pull Request

- Closes https://github.com/parcel-bundler/parcel/issues/8866

## 🚨 Test instructions

Add this to your Chrome extension manifest:

```json
{
	"options_ui": {
		"chrome_style": true,
		"page": "options.html"
	}
}
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
