### PR TITLE
Resolver fixes

### DIFF
--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-exports/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-exports/package.json
@@ -8,7 +8,8 @@
     "./invalid": "../foo/index.js",
     "./space": "./with%20space.mjs",
     "./with%20space": "./with space.mjs",
-    "./missing": "./missing.mjs"
+    "./missing": "./missing.mjs",
+    "./extensionless-features/*": "./features/*"
   },
   "imports": {
     "#internal": "./internal.mjs",

--- a/packages/utils/node-resolver-core/test/fixture/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/package.json
@@ -9,7 +9,8 @@
     "aliasedabsolute": "/nested",
     "foo/bar": "./bar.js",
     "glob/*/*": "./nested/$2",
-    "./baz": "./bar.js"
+    "./baz": "./bar.js",
+    "url": false
   },
   "imports": {
     "#test": "./bar.js"

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -2651,7 +2651,7 @@ describe('resolver', function () {
                     column: 14,
                   },
                   end: {
-                    line: 12,
+                    line: 13,
                     column: 3,
                   },
                 },
@@ -2697,11 +2697,11 @@ describe('resolver', function () {
                 {
                   message: undefined,
                   start: {
-                    line: 14,
+                    line: 15,
                     column: 14,
                   },
                   end: {
-                    line: 16,
+                    line: 17,
                     column: 3,
                   },
                 },

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -53,13 +53,15 @@ bitflags! {
     const TYPESCRIPT_EXTENSIONS = 1 << 8;
     /// Whether to allow omitting the extension when resolving the same file type.
     const PARENT_EXTENSION = 1 << 9;
+    /// Whether to allow optional extensions in the "exports" field.
+    const EXPORTS_OPTIONAL_EXTENSIONS = 1 << 10;
 
     /// Default Node settings for CommonJS.
     const NODE_CJS = Self::EXPORTS.bits | Self::DIR_INDEX.bits | Self::OPTIONAL_EXTENSIONS.bits;
     /// Default Node settings for ESM.
     const NODE_ESM = Self::EXPORTS.bits;
     /// Default TypeScript settings.
-    const TYPESCRIPT = Self::TSCONFIG.bits | Self::EXPORTS.bits | Self::DIR_INDEX.bits | Self::OPTIONAL_EXTENSIONS.bits | Self::TYPESCRIPT_EXTENSIONS.bits;
+    const TYPESCRIPT = Self::TSCONFIG.bits | Self::EXPORTS.bits | Self::DIR_INDEX.bits | Self::OPTIONAL_EXTENSIONS.bits | Self::TYPESCRIPT_EXTENSIONS.bits | Self::EXPORTS_OPTIONAL_EXTENSIONS.bits;
   }
 }
 
@@ -638,8 +640,18 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
           error: e,
         })?;
 
-      // Extensionless specifiers are not supported in the exports field.
-      if let Some(res) = self.try_file_without_aliases(&path)? {
+      // Extensionless specifiers are not supported in the exports field
+      // according to the Node spec (for both ESM and CJS). However, webpack
+      // didn't follow this, so there are many packages that rely on it (e.g. underscore).
+      if self
+        .resolver
+        .flags
+        .contains(Flags::EXPORTS_OPTIONAL_EXTENSIONS)
+      {
+        if let Some(res) = self.load_file(&path, Some(package))? {
+          return Ok(res);
+        }
+      } else if let Some(res) = self.try_file_without_aliases(&path)? {
         return Ok(res);
       }
 
@@ -1961,6 +1973,72 @@ mod tests {
       test_resolver()
         .resolve(
           "package-exports/features/test",
+          &root().join("foo.js"),
+          SpecifierType::Esm
+        )
+        .result
+        .unwrap()
+        .0,
+      Resolution::Path(root().join("node_modules/package-exports/features/test.mjs"))
+    );
+    assert_eq!(
+      test_resolver()
+        .resolve(
+          "package-exports/extensionless-features/test",
+          &root().join("foo.js"),
+          SpecifierType::Esm
+        )
+        .result
+        .unwrap()
+        .0,
+      Resolution::Path(root().join("node_modules/package-exports/features/test.mjs"))
+    );
+    assert_eq!(
+      test_resolver()
+        .resolve(
+          "package-exports/extensionless-features/test.mjs",
+          &root().join("foo.js"),
+          SpecifierType::Esm
+        )
+        .result
+        .unwrap()
+        .0,
+      Resolution::Path(root().join("node_modules/package-exports/features/test.mjs"))
+    );
+    assert_eq!(
+      node_resolver()
+        .resolve(
+          "package-exports/extensionless-features/test",
+          &root().join("foo.js"),
+          SpecifierType::Esm
+        )
+        .result
+        .unwrap_err(),
+      ResolverError::ModuleSubpathNotFound {
+        module: "package-exports".into(),
+        package_path: root().join("node_modules/package-exports/package.json"),
+        path: root().join("node_modules/package-exports/features/test"),
+      },
+    );
+    assert_eq!(
+      node_resolver()
+        .resolve(
+          "package-exports/extensionless-features/test",
+          &root().join("foo.js"),
+          SpecifierType::Cjs
+        )
+        .result
+        .unwrap_err(),
+      ResolverError::ModuleSubpathNotFound {
+        module: "package-exports".into(),
+        package_path: root().join("node_modules/package-exports/package.json"),
+        path: root().join("node_modules/package-exports/features/test"),
+      },
+    );
+    assert_eq!(
+      node_resolver()
+        .resolve(
+          "package-exports/extensionless-features/test.mjs",
           &root().join("foo.js"),
           SpecifierType::Esm
         )

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -1481,6 +1481,7 @@ mod tests {
         "./foo/src/**".into() => AliasValue::Specifier("./foo/lib/$1".into()),
         "/foo/src/**".into() => AliasValue::Specifier("/foo/lib/$1".into()),
         "~/foo/src/**".into() => AliasValue::Specifier("~/foo/lib/$1".into()),
+        "url".into() => AliasValue::Bool(false),
       },
       ..PackageJson::default()
     };
@@ -1528,6 +1529,10 @@ mod tests {
     assert_eq!(
       pkg.resolve_aliases(&"~/foo/src/a/b".into(), Fields::ALIAS),
       Some(Cow::Owned(AliasValue::Specifier("~/foo/lib/a/b".into())))
+    );
+    assert_eq!(
+      pkg.resolve_aliases(&"url".into(), Fields::ALIAS),
+      Some(Cow::Owned(AliasValue::Bool(false)))
     );
   }
 

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -612,9 +612,10 @@ impl<'a> PackageJson<'a> {
       let (glob, path) = match (key, specifier) {
         (Specifier::Relative(glob), Specifier::Relative(path))
         | (Specifier::Absolute(glob), Specifier::Absolute(path))
-        | (Specifier::Tilde(glob), Specifier::Tilde(path)) => {
-          (glob.as_os_str().to_string_lossy(), path.as_os_str().to_string_lossy())
-        }
+        | (Specifier::Tilde(glob), Specifier::Tilde(path)) => (
+          glob.as_os_str().to_string_lossy(),
+          path.as_os_str().to_string_lossy(),
+        ),
         (Specifier::Package(module_a, glob), Specifier::Package(module_b, path))
           if module_a == module_b =>
         {
@@ -1546,7 +1547,9 @@ mod tests {
     );
     assert_eq!(
       pkg.resolve_aliases(&"@internal/foo/bar".into(), Fields::ALIAS),
-      Some(Cow::Owned(AliasValue::Specifier("./internal/foo/bar".into())))
+      Some(Cow::Owned(AliasValue::Specifier(
+        "./internal/foo/bar".into()
+      )))
     );
     assert_eq!(
       pkg.resolve_aliases(&"@foo/a/bar/b".into(), Fields::ALIAS),

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -163,6 +163,24 @@ impl<'a> Specifier<'a> {
       }
     })
   }
+
+  pub fn to_string(&'a self) -> Cow<'a, str> {
+    match self {
+      Specifier::Relative(path) |
+      Specifier::Absolute(path) |
+      Specifier::Tilde(path) => path.as_os_str().to_string_lossy(),
+      Specifier::Hash(path) => path.clone(),
+      Specifier::Package(module, subpath) => {
+        if subpath.is_empty() {
+          Cow::Borrowed(module)
+        } else {
+          Cow::Owned(format!("{}/{}", module, subpath))
+        }
+      }
+      Specifier::Builtin(builtin) => Cow::Borrowed(&builtin),
+      Specifier::Url(url) => Cow::Borrowed(url)
+    }
+  }
 }
 
 // https://url.spec.whatwg.org/#scheme-state

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -166,9 +166,9 @@ impl<'a> Specifier<'a> {
 
   pub fn to_string(&'a self) -> Cow<'a, str> {
     match self {
-      Specifier::Relative(path) |
-      Specifier::Absolute(path) |
-      Specifier::Tilde(path) => path.as_os_str().to_string_lossy(),
+      Specifier::Relative(path) | Specifier::Absolute(path) | Specifier::Tilde(path) => {
+        path.as_os_str().to_string_lossy()
+      }
       Specifier::Hash(path) => path.clone(),
       Specifier::Package(module, subpath) => {
         if subpath.is_empty() {
@@ -178,7 +178,7 @@ impl<'a> Specifier<'a> {
         }
       }
       Specifier::Builtin(builtin) => Cow::Borrowed(&builtin),
-      Specifier::Url(url) => Cow::Borrowed(url)
+      Specifier::Url(url) => Cow::Borrowed(url),
     }
   }
 }

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -113,10 +113,10 @@ impl<'a> TsConfig<'a> {
       let mut longest_prefix_length = 0;
       let mut longest_suffix_length = 0;
       let mut best_key = None;
-      let full_specifier = concat_specifier(specifier);
+      let full_specifier = specifier.to_string();
 
       for key in paths.keys() {
-        let path = concat_specifier(key);
+        let path = key.to_string();
         if let Some((prefix, suffix)) = path.split_once('*') {
           if (best_key.is_none() || prefix.len() > longest_prefix_length)
             && full_specifier.starts_with(prefix)
@@ -144,20 +144,6 @@ impl<'a> TsConfig<'a> {
 
     // If no paths were found, try relative to the base url.
     Either::Right(base_url_iter)
-  }
-}
-
-fn concat_specifier<'a>(specifier: &'a Specifier) -> Cow<'a, str> {
-  match specifier {
-    Specifier::Package(module, subpath) => {
-      if subpath.is_empty() {
-        Cow::Borrowed(module)
-      } else {
-        Cow::Owned(format!("{}/{}", module, subpath))
-      }
-    }
-    Specifier::Builtin(builtin) => Cow::Borrowed(&builtin),
-    _ => unreachable!(),
   }
 }
 


### PR DESCRIPTION
Some compatibility fixes for the new resolver:

* Support using the "alias" field in package.json and "paths" in tsconfig.json to change the resolution of node builtins (matching prior parcel behavior for aliases).
* Allow optional extensions in the "exports" field. This does not match Node or the spec, but it is implemented this way by webpack and typescript and several large packages depend on it (e.g. underscore). This is implemented behind a flag which can be disabled when matching node behavior.
* Support globs in aliased package names, e.g. `@internal/*`, rather than only package subpaths.