### PR TITLE
Fix resolving of builtins with tsconfig + baseUrl

### DIFF
--- a/packages/utils/node-resolver-core/test/fixture/tsconfig/builtins/tsconfig.json
+++ b/packages/utils/node-resolver-core/test/fixture/tsconfig/builtins/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "."
+  }
+}

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -2318,6 +2318,18 @@ mod tests {
         module: "ts-path".into()
       },
     );
+    assert_eq!(
+      test_resolver()
+        .resolve(
+          "zlib",
+          &root().join("tsconfig/builtins/thing.js"),
+          SpecifierType::Cjs
+        )
+        .result
+        .unwrap()
+        .0,
+      Resolution::Builtin("zlib".into())
+    );
 
     let invalidations = test_resolver()
       .resolve("ts-path", &root().join("foo.js"), SpecifierType::Esm)

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -142,6 +142,11 @@ impl<'a> TsConfig<'a> {
       }
     }
 
+    if matches!(specifier, Specifier::Builtin(..)) {
+      // If specifier is a builtin then there's no match
+      return Either::Right(Either::Right(std::iter::empty()));
+    }
+
     // If no paths were found, try relative to the base url.
     Either::Right(base_url_iter)
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR fixes an issue where builtins would get resolved to the tsconfig baseUrl location. 

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 🚨 Test instructions

Unit test added

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Included links to related issues/PRs
