### PR TITLE
Persist non-error diagnostics

### DIFF
--- a/packages/core/codeframe/src/codeframe.js
+++ b/packages/core/codeframe/src/codeframe.js
@@ -1,5 +1,6 @@
 // @flow
 import type {DiagnosticCodeHighlight} from '@parcel/diagnostic';
+import type {Color} from 'chalk';
 
 import chalk from 'chalk';
 import emphasize from 'emphasize';
@@ -20,6 +21,7 @@ type CodeFrameOptions = {|
   padding: CodeFramePadding,
   terminalWidth: number,
   language?: string,
+  baseColor?: Color,
 |};
 
 const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
@@ -56,13 +58,15 @@ export default function codeFrame(
       before: 1,
       after: 2,
     },
+    baseColor: inputOpts.baseColor ?? 'red',
   };
 
   // Highlights messages and prefixes when colors are enabled
   const highlighter = (s: string, bold?: boolean) => {
     if (opts.useColor) {
-      let redString = chalk.red(s);
-      return bold ? chalk.bold(redString) : redString;
+      // $FlowFixMe[incompatible-use]
+      let colorString = chalk[opts.baseColor](s);
+      return bold ? chalk.bold(colorString) : colorString;
     }
 
     return s;

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -10,10 +10,12 @@ import type {
   Async,
 } from '@parcel/types';
 import type SourceMap from '@parcel/source-map';
+
 import type {
   Bundle as InternalBundle,
   Config,
   DevDepRequest,
+  InternalDiagnosticWithLevel,
   ParcelOptions,
   ReportFn,
   RequestInvalidation,
@@ -59,7 +61,7 @@ import {
 } from './requests/DevDepRequest';
 import {createBuildCache} from './buildCache';
 import {getInvalidationId, getInvalidationHash} from './assetUtils';
-import {optionsProxy} from './utils';
+import {optionsProxy, toInternalDiagnosticWithLevel} from './utils';
 import {invalidateDevDeps} from './requests/DevDepRequest';
 
 type Opts = {|
@@ -85,6 +87,7 @@ export type BundleInfo = {|
   +time?: number,
   +cacheKeys: CacheKeyMap,
   +isLargeBlob: boolean,
+  +diagnostics: Array<InternalDiagnosticWithLevel>,
 |};
 
 type CacheKeyMap = {|
@@ -307,7 +310,7 @@ export default class PackagerRunner {
     configs: Map<string, Config>,
     bundleConfigs: Map<string, Config>,
   ): Promise<BundleInfo> {
-    let {type, contents, map} = await this.getBundleResult(
+    let {type, contents, map, diagnostics} = await this.getBundleResult(
       bundle,
       bundleGraph,
       configs,
@@ -328,7 +331,7 @@ export default class PackagerRunner {
       info: PackagerRunner.getInfoKey(cacheKey),
     };
 
-    return this.writeToCache(cacheKeys, type, contents, map);
+    return this.writeToCache(cacheKeys, type, contents, map, diagnostics);
   }
 
   async getBundleResult(
@@ -340,15 +343,16 @@ export default class PackagerRunner {
     type: string,
     contents: Blob,
     map: ?string,
+    diagnostics: Array<InternalDiagnosticWithLevel>,
   |}> {
-    let packaged = await this.package(
+    let packaged: BundleResult = await this.package(
       bundle,
       bundleGraph,
       configs,
       bundleConfigs,
     );
     let type = packaged.type ?? bundle.type;
-    let res = await this.optimize(
+    let res: BundleResult = await this.optimize(
       bundle,
       bundleGraph,
       type,
@@ -358,12 +362,21 @@ export default class PackagerRunner {
       bundleConfigs,
     );
 
+    let diagnostics = packaged.diagnostics ?? [];
+    if (res.diagnostics) {
+      diagnostics.push(...res.diagnostics);
+    }
+    diagnostics = diagnostics.map(d =>
+      toInternalDiagnosticWithLevel(this.options.projectRoot, d),
+    );
+
     let map =
       res.map != null ? await this.generateSourceMap(bundle, res.map) : null;
     return {
       type: res.type ?? type,
       contents: res.contents,
       map,
+      diagnostics,
     };
   }
 
@@ -395,7 +408,7 @@ export default class PackagerRunner {
     let packager = await this.config.getPackager(bundle.name);
     let {name, resolveFrom, plugin} = packager;
     try {
-      return await plugin.package({
+      let result = await plugin.package({
         config: configs.get(name)?.result,
         bundleConfig: bundleConfigs.get(name)?.result,
         bundle,
@@ -430,6 +443,13 @@ export default class PackagerRunner {
           return {contents: res.contents};
         },
       });
+      return {
+        ...result,
+        diagnostics: result.diagnostics?.map(d => ({
+          ...d,
+          origin: d.origin ?? name,
+        })),
+      };
     } catch (e) {
       throw new ThrowableDiagnostic({
         diagnostic: errorToDiagnostic(e, {
@@ -492,6 +512,7 @@ export default class PackagerRunner {
       type,
       contents,
       map,
+      diagnostics: [],
     };
 
     for (let optimizer of optimizers) {
@@ -513,6 +534,14 @@ export default class PackagerRunner {
         optimized.type = next.type ?? optimized.type;
         optimized.contents = next.contents;
         optimized.map = next.map;
+        if (next.diagnostics) {
+          optimized.diagnostics.push(
+            ...next.diagnostics?.map(d => ({
+              ...d,
+              origin: d.origin ?? optimizer.name,
+            })),
+          );
+        }
       } catch (e) {
         throw new ThrowableDiagnostic({
           diagnostic: errorToDiagnostic(e, {
@@ -702,6 +731,7 @@ export default class PackagerRunner {
     type: string,
     contents: Blob,
     map: ?string,
+    diagnostics: Array<InternalDiagnosticWithLevel>,
   ): Promise<BundleInfo> {
     let size = 0;
     let hash;
@@ -751,6 +781,7 @@ export default class PackagerRunner {
       hashReferences,
       cacheKeys,
       isLargeBlob,
+      diagnostics,
     };
     await this.options.cache.set(cacheKeys.info, info);
     return info;

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -154,7 +154,15 @@ export default class Parcel {
     await this._end();
 
     if (result.type === 'buildFailure') {
-      throw new BuildError(result.diagnostics);
+      // TODO
+      /* eslint-disable no-unused-vars */
+      throw new BuildError(
+        // $FlowFixMe[prop-missing]
+        result.diagnostics.map(({level, ...d}) => ({
+          ...d,
+        })),
+        /* eslint-enable no-unused-vars */
+      );
     }
 
     return result;
@@ -338,7 +346,15 @@ export default class Parcel {
           let results = await this.#watchQueue.run();
           let result = results.filter(Boolean).pop();
           if (result.type === 'buildFailure') {
-            throw new BuildError(result.diagnostics);
+            throw new BuildError(
+              // TODO?
+              /* eslint-disable no-unused-vars */
+              // $FlowFixMe[prop-missing]
+              result.diagnostics.map(({level, ...d}) => ({
+                ...d,
+              })),
+              /* eslint-enable no-unused-vars */
+            );
           }
 
           return result;

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -21,6 +21,7 @@ import type {
   AssetSymbols as IAssetSymbols,
   BundleBehavior,
 } from '@parcel/types';
+import type {DiagnosticWithLevel} from '@parcel/diagnostic';
 import type {Asset as AssetValue, ParcelOptions} from '../types';
 
 import nullthrows from 'nullthrows';
@@ -35,7 +36,10 @@ import {
   BundleBehavior as BundleBehaviorMap,
   BundleBehaviorNames,
 } from '../types';
-import {toInternalSourceLocation} from '../utils';
+import {
+  toInternalSourceLocation,
+  toInternalDiagnosticWithLevel,
+} from '../utils';
 
 const inspect = Symbol.for('nodejs.util.inspect.custom');
 
@@ -277,6 +281,25 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
 
   addDependency(dep: DependencyOptions): string {
     return this.#asset.addDependency(dep);
+  }
+
+  addDiagnostic(
+    diagnostic: DiagnosticWithLevel | Array<DiagnosticWithLevel>,
+  ): void {
+    if (Array.isArray(diagnostic)) {
+      this.#asset.diagnostics.push(
+        ...diagnostic.map(d =>
+          toInternalDiagnosticWithLevel(this.#asset.options.projectRoot, d),
+        ),
+      );
+    } else {
+      this.#asset.diagnostics.push(
+        toInternalDiagnosticWithLevel(
+          this.#asset.options.projectRoot,
+          diagnostic,
+        ),
+      );
+    }
   }
 
   invalidateOnFileChange(filePath: FilePath): void {

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -53,6 +53,7 @@ type AssetGraphRequestResult = {|
   assetGroupsWithRemovedParents: ?Set<NodeId>,
   previousSymbolPropagationErrors: ?Map<NodeId, Array<Diagnostic>>,
   assetRequests: Array<AssetGroup>,
+  targetDiagnostics: Array<InternalDiagnosticWithLevel>,
   diagnostics: Map<ContentKey, Array<InternalDiagnosticWithLevel>>,
 |};
 
@@ -118,6 +119,7 @@ export class AssetGraphBuilder {
   isSingleChangeRebuild: boolean;
   assetGroupsWithRemovedParents: Set<NodeId>;
   previousSymbolPropagationErrors: Map<NodeId, Array<Diagnostic>>;
+  targetDiagnostics: Array<InternalDiagnosticWithLevel> = [];
   diagnostics: Map<ContentKey, Array<InternalDiagnosticWithLevel>>;
 
   constructor(
@@ -236,6 +238,7 @@ export class AssetGraphBuilder {
           previousSymbolPropagationErrors: undefined,
           assetRequests: [],
           diagnostics: this.diagnostics,
+          targetDiagnostics: this.targetDiagnostics,
         },
         this.cacheKey,
       );
@@ -270,6 +273,7 @@ export class AssetGraphBuilder {
               previousSymbolPropagationErrors: errors,
               assetRequests: [],
               diagnostics: this.diagnostics,
+              targetDiagnostics: this.targetDiagnostics,
             },
             this.cacheKey,
           );
@@ -299,6 +303,7 @@ export class AssetGraphBuilder {
         previousSymbolPropagationErrors: undefined,
         assetRequests: [],
         diagnostics: this.diagnostics,
+        targetDiagnostics: this.targetDiagnostics,
       },
       this.cacheKey,
     );
@@ -310,6 +315,7 @@ export class AssetGraphBuilder {
       assetGroupsWithRemovedParents: undefined,
       previousSymbolPropagationErrors: undefined,
       assetRequests: this.assetRequests,
+      targetDiagnostics: this.targetDiagnostics,
       diagnostics: this.diagnostics,
     };
   }
@@ -421,9 +427,17 @@ export class AssetGraphBuilder {
 
   async runTargetRequest(input: Entry) {
     let request = createTargetRequest(input);
-    let targets = await this.api.runRequest<Entry, Array<Target>>(request, {
+    let {targets /* , diagnostics */} = await this.api.runRequest<
+      Entry,
+      {|
+        targets: Array<Target>,
+        diagnostics: Array<InternalDiagnosticWithLevel>,
+      |},
+    >(request, {
       force: true,
     });
+    // TODO this can run multiple times
+    // this.targetDiagnostics = diagnostics;
     this.assetGraph.resolveTargets(request.input, targets, request.id);
   }
 

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -63,7 +63,13 @@ function getId(input: AssetRequestInput) {
   );
 }
 
-async function run({input, api, farm, invalidateReason, options}) {
+async function run({
+  input,
+  api,
+  farm,
+  invalidateReason,
+  options,
+}): Promise<AssetRequestResult> {
   report({
     type: 'buildProgress',
     phase: 'transforming',
@@ -133,6 +139,7 @@ async function run({input, api, farm, invalidateReason, options}) {
     invalidations,
     invalidateOnFileCreate,
     devDepRequests,
+    diagnostics,
   } = (await farm.createHandle(
     'runTransform',
     input.isSingleChangeRebuild,
@@ -181,6 +188,6 @@ async function run({input, api, farm, invalidateReason, options}) {
   if (error != null) {
     throw new ThrowableDiagnostic({diagnostic: error});
   } else {
-    return nullthrows(assets);
+    return {assets: nullthrows(assets), diagnostics};
   }
 }

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -29,8 +29,33 @@ import type {
 import type {SharedReference} from '@parcel/workers';
 import type {FileSystem} from '@parcel/fs';
 import type {Cache} from '@parcel/cache';
+import type {
+  DiagnosticLevel,
+  DiagnosticCodeHighlight,
+} from '@parcel/diagnostic';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ProjectPath} from './projectPath';
+
+export type InternalDiagnosticCodeFrame = {|
+  code?: string,
+  filePath?: ?ProjectPath,
+  language?: string,
+  codeHighlights: Array<DiagnosticCodeHighlight>,
+|};
+export type InternalDiagnostic = {|
+  message: string,
+  origin?: string,
+  stack?: string,
+  name?: string,
+  codeFrames?: ?Array<InternalDiagnosticCodeFrame>,
+  hints?: Array<string>,
+  skipFormatting?: boolean,
+  documentationURL?: string,
+|};
+export type InternalDiagnosticWithLevel = {|
+  ...InternalDiagnostic,
+  level: DiagnosticLevel,
+|};
 
 export type ParcelPluginNode = {|
   packageName: PackageName,
@@ -367,7 +392,10 @@ export type AssetRequestInput = {|
   isSingleChangeRebuild?: boolean,
 |};
 
-export type AssetRequestResult = Array<Asset>;
+export type AssetRequestResult = {|
+  assets: Array<Asset>,
+  diagnostics: ?Map<string, Array<InternalDiagnosticWithLevel>>,
+|};
 // Asset group nodes are essentially used as placeholders for the results of an asset request
 export type AssetGroup = $Rest<
   AssetRequestInput,
@@ -537,6 +565,7 @@ export type PackagedBundleInfo = {|
   filePath: ProjectPath,
   type: string,
   stats: Stats,
+  diagnostics: Array<InternalDiagnosticWithLevel>,
 |};
 
 export type TransformationOpts = {|

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -12,8 +12,10 @@ import type {
   InternalFileCreateInvalidation,
   InternalSourceLocation,
   InternalDevDepOptions,
+  InternalDiagnosticWithLevel,
 } from './types';
 import type {PackageManager} from '@parcel/package-manager';
+import type {DiagnosticWithLevel} from '@parcel/diagnostic';
 
 import invariant from 'assert';
 import baseX from 'base-x';
@@ -233,4 +235,47 @@ export function toInternalSymbols<T: {|loc: ?SourceLocation|}>(
       },
     ]),
   );
+}
+
+export function toInternalDiagnosticWithLevel(
+  projectRoot: FilePath,
+  diagnostic: DiagnosticWithLevel,
+): InternalDiagnosticWithLevel {
+  if (diagnostic.codeFrames) {
+    return {
+      ...diagnostic,
+      codeFrames: diagnostic.codeFrames.map(f => {
+        return {
+          ...f,
+          filePath: toProjectPath(projectRoot, f.filePath),
+        };
+      }),
+    };
+  } else
+    return {
+      ...diagnostic,
+      codeFrames: diagnostic.codeFrames,
+    };
+}
+
+export function fromInternalDiagnosticWithLevel(
+  projectRoot: FilePath,
+  diagnostic: InternalDiagnosticWithLevel,
+): DiagnosticWithLevel {
+  if (diagnostic.codeFrames) {
+    return {
+      ...diagnostic,
+      codeFrames: diagnostic.codeFrames.map(({filePath, ...f}) => {
+        if (filePath == null) return {...f};
+        return {
+          ...f,
+          filePath: fromProjectPath(projectRoot, filePath),
+        };
+      }),
+    };
+  } else
+    return {
+      ...diagnostic,
+      codeFrames: diagnostic.codeFrames,
+    };
 }

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -93,6 +93,13 @@ export type DiagnosticWithoutOrigin = {|
   origin?: string,
 |};
 
+export type DiagnosticLevel = 'error' | 'warn' | 'info' | 'verbose';
+
+export type DiagnosticWithLevel = {|
+  ...Diagnostic,
+  level: DiagnosticLevel,
+|};
+
 /** Something that can be turned into a diagnostic. */
 export type Diagnostifiable =
   | Diagnostic

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -7,6 +7,7 @@ import type WorkerFarm from '@parcel/workers';
 import type {PackageManager} from '@parcel/package-manager';
 import type {
   Diagnostic,
+  DiagnosticWithLevel,
   Diagnostifiable,
   DiagnosticWithoutOrigin,
 } from '@parcel/diagnostic';
@@ -757,6 +758,10 @@ export interface MutableAsset extends BaseAsset {
    * This is a shortcut for addDependency that sets the specifierType to 'url' and priority to 'lazy'.
    */
   addURLDependency(url: string, opts: $Shape<DependencyOptions>): string;
+  /** Non-fatal messages to emit for this asset. */
+  addDiagnostic(
+    diagnostic: DiagnosticWithLevel | Array<DiagnosticWithLevel>,
+  ): void;
   /** Invalidates the transformation when the given file is modified or deleted. */
   invalidateOnFileChange(FilePath): void;
   /** Invalidates the transformation when matched files are created. */
@@ -936,6 +941,8 @@ export type TransformerResult = {|
    * assets returned by a transformer by using the unique key as the dependency specifier.
    */
   +uniqueKey?: ?string,
+  /** Non-fatal messages to emit for this asset. */
+  +diagnostics?: Array<DiagnosticWithLevel>,
 |};
 
 export type Async<T> = T | Promise<T>;
@@ -1506,13 +1513,14 @@ export interface BundleGraph<TBundle: Bundle> {
 }
 
 /**
- * @section bundler
+ * @section packager
  */
 export type BundleResult = {|
   +contents: Blob,
   +ast?: AST,
   +map?: ?SourceMap,
   +type?: string,
+  +diagnostics?: Array<DiagnosticWithLevel>,
 |};
 
 export type GlobInvalidation = {|
@@ -1714,6 +1722,7 @@ export type Compressor = {|
   |}): Async<?{|
     stream: Readable,
     type?: string,
+    diagnostics?: Array<DiagnosticWithLevel>,
   |}>,
 |};
 
@@ -1869,7 +1878,8 @@ export type BuildSuccessEvent = {|
   +type: 'buildSuccess',
   +bundleGraph: BundleGraph<PackagedBundle>,
   +buildTime: number,
-  +changedAssets: Map<string, Asset>,
+  +diagnostics: Array<DiagnosticWithLevel>,
+  +changedAssets: $ReadOnlyMap<string, Asset>,
   +requestBundle: (bundle: NamedBundle) => Promise<BuildSuccessEvent>,
 |};
 

--- a/packages/core/utils/src/prettyDiagnostic.js
+++ b/packages/core/utils/src/prettyDiagnostic.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import type {Diagnostic} from '@parcel/diagnostic';
+import type {Diagnostic, DiagnosticWithLevel} from '@parcel/diagnostic';
 import type {PluginOptions} from '@parcel/types';
 
 import formatCodeFrame from '@parcel/codeframe';
@@ -26,7 +26,7 @@ export type AnsiDiagnosticResult = {|
 |};
 
 export default async function prettyDiagnostic(
-  diagnostic: Diagnostic,
+  diagnostic: Diagnostic | DiagnosticWithLevel,
   options?: PluginOptions,
   terminalWidth?: number,
 ): Promise<AnsiDiagnosticResult> {

--- a/packages/optimizers/css/src/CSSOptimizer.js
+++ b/packages/optimizers/css/src/CSSOptimizer.js
@@ -66,7 +66,6 @@ Parcel\'s default CSS minifer changed from cssnano to lightningcss, but a "cssna
   async optimize({
     bundle,
     bundleGraph,
-    logger,
     contents: prevContents,
     getSourceMapReference,
     map: prevMap,
@@ -79,6 +78,8 @@ Parcel\'s default CSS minifer changed from cssnano to lightningcss, but a "cssna
     let targets = getTargets(bundle.env.engines.browsers);
     let code = await blobToBuffer(prevContents);
 
+    // TODO these warnings will only show in prod
+    let diagnostics = [];
     let unusedSymbols;
     if (bundle.env.shouldScopeHoist) {
       unusedSymbols = [];
@@ -103,7 +104,7 @@ Parcel\'s default CSS minifer changed from cssnano to lightningcss, but a "cssna
           );
           if (defaultImport) {
             let loc = defaultImport.symbols.get('default')?.loc;
-            logger.warn({
+            diagnostics.push({
               message:
                 'CSS modules cannot be tree shaken when imported with a default specifier',
               ...(loc && {
@@ -121,6 +122,7 @@ Parcel\'s default CSS minifer changed from cssnano to lightningcss, but a "cssna
               ],
               documentationURL:
                 'https://parceljs.org/languages/css/#tree-shaking',
+              level: 'warn',
             });
           }
         }
@@ -186,6 +188,7 @@ Parcel\'s default CSS minifer changed from cssnano to lightningcss, but a "cssna
     return {
       contents,
       map,
+      diagnostics,
     };
   },
 }): Optimizer);

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -76,17 +76,39 @@ export default (new Packager({
       }));
     }
 
-    return replaceInlineReferences({
-      bundle,
-      bundleGraph,
-      contents,
-      getInlineReplacement: (dependency, inlineType, content) => ({
-        from: `"${dependency.id}"`,
-        to: inlineType === 'string' ? JSON.stringify(content) : content,
-      }),
-      getInlineBundleContents,
-      map,
-    });
+    return {
+      ...(await replaceInlineReferences({
+        bundle,
+        bundleGraph,
+        contents,
+        getInlineReplacement: (dependency, inlineType, content) => ({
+          from: `"${dependency.id}"`,
+          to: inlineType === 'string' ? JSON.stringify(content) : content,
+        }),
+        getInlineBundleContents,
+        map,
+      })),
+      diagnostics: contents.includes('warning2')
+        ? [
+            {
+              message: 'From the packager',
+              level: 'verbose',
+              codeFrames: [
+                {
+                  filePath: '/Users/niklas/Desktop/y/a.js',
+                  codeHighlights: [
+                    {
+                      start: {line: 1, column: 2},
+                      end: {line: 1, column: 5},
+                      message: 'here',
+                    },
+                  ],
+                },
+              ],
+            },
+          ]
+        : [],
+    };
   },
 }): Packager);
 

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -1,7 +1,10 @@
 // @flow
 import type {ReporterEvent, PluginOptions} from '@parcel/types';
-import type {Diagnostic, DiagnosticWithLevel} from '@parcel/diagnostic';
-import type {Color} from 'chalk';
+import type {
+  Diagnostic,
+  DiagnosticWithLevel,
+  DiagnosticLevel,
+} from '@parcel/diagnostic';
 
 import {Reporter} from '@parcel/plugin';
 import {
@@ -29,13 +32,6 @@ import wrapAnsi from 'wrap-ansi';
 const THROTTLE_DELAY = 100;
 const seenWarnings = new Set();
 const seenPhases = new Set();
-
-const LEVEL_TO_COLOR = {
-  info: 'blue',
-  verbose: 'blue',
-  warn: 'yellow',
-  error: 'red',
-};
 
 let statusThrottle = throttle((message: string) => {
   updateSpinner(message);
@@ -106,21 +102,23 @@ export async function _report(
       break;
     }
     case 'buildSuccess':
-      if (logLevelFilter < logLevels.info) {
-        break;
+      if (logLevelFilter >= logLevels.info) {
+        persistSpinner(
+          'buildProgress',
+          'success',
+          chalk.green.bold(`Built in ${prettifyTime(event.buildTime)}`),
+        );
       }
-
-      persistSpinner(
-        'buildProgress',
-        'success',
-        chalk.green.bold(`Built in ${prettifyTime(event.buildTime)}`),
-      );
 
       if (event.diagnostics.length > 0) {
-        await writeDiagnostic(options, event.diagnostics, 'yellow', true);
+        await writeDiagnostic(
+          options,
+          event.diagnostics.filter(d => logLevels[d.level] <= logLevelFilter),
+          'info',
+        );
       }
 
-      if (options.mode === 'production') {
+      if (logLevelFilter >= logLevels.info && options.mode === 'production') {
         await bundleReport(
           event.bundleGraph,
           options.outputFS,
@@ -138,7 +136,7 @@ export async function _report(
 
       persistSpinner('buildProgress', 'error', chalk.red.bold('Build failed.'));
 
-      await writeDiagnostic(options, event.diagnostics, 'red', true);
+      await writeDiagnostic(options, event.diagnostics, 'error', true);
       break;
     case 'log': {
       if (logLevelFilter < logLevels[event.level]) {
@@ -154,7 +152,7 @@ export async function _report(
           break;
         case 'verbose':
         case 'info':
-          await writeDiagnostic(options, event.diagnostics, 'blue');
+          await writeDiagnostic(options, event.diagnostics, 'info');
           break;
         case 'warn':
           if (
@@ -162,14 +160,14 @@ export async function _report(
               diagnostic => !seenWarnings.has(diagnostic.message),
             )
           ) {
-            await writeDiagnostic(options, event.diagnostics, 'yellow', true);
+            await writeDiagnostic(options, event.diagnostics, 'warn', true);
             for (let diagnostic of event.diagnostics) {
               seenWarnings.add(diagnostic.message);
             }
           }
           break;
         case 'error':
-          await writeDiagnostic(options, event.diagnostics, 'red', true);
+          await writeDiagnostic(options, event.diagnostics, 'error', true);
           break;
         default:
           throw new Error('Unknown log level ' + event.level);
@@ -181,7 +179,7 @@ export async function _report(
 async function writeDiagnostic(
   options: PluginOptions,
   diagnostics: $ReadOnlyArray<Diagnostic | DiagnosticWithLevel>,
-  color: Color,
+  fallbackLevel: DiagnosticLevel,
   isError: boolean = false,
 ) {
   let columns = getTerminalWidth().columns;
@@ -189,10 +187,12 @@ async function writeDiagnostic(
   let spaceAfter = isError;
   for (let diagnostic of diagnostics) {
     let {message, stack, codeframe, hints, documentation} =
-      await prettyDiagnostic(diagnostic, options, columns - indent);
-    let c = diagnostic.level ? LEVEL_TO_COLOR[diagnostic.level] : color;
-    // $FlowFixMe[incompatible-use]
-    message = chalk[c](message);
+      await prettyDiagnostic(
+        diagnostic,
+        options,
+        columns - indent,
+        fallbackLevel,
+      );
 
     if (spaceAfter) {
       writeOut('');

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -20,7 +20,7 @@ export default (new Transformer({
     });
     return conf?.contents;
   },
-  async transform({asset, config, options, logger}) {
+  async transform({asset, config, options}) {
     // Normalize the asset's environment so that properties that only affect JS don't cause CSS to be duplicated.
     // For example, with ESModule and CommonJS targets, only a single shared CSS bundle should be produced.
     let env = asset.env;
@@ -106,8 +106,8 @@ export default (new Transformer({
     }
 
     if (res.warnings) {
-      for (let warning of res.warnings) {
-        logger.warn({
+      asset.addDiagnostic(
+        res.warnings.map(warning => ({
           message: warning.message,
           codeFrames: [
             {
@@ -126,8 +126,9 @@ export default (new Transformer({
               ],
             },
           ],
-        });
-      }
+          level: 'warn',
+        })),
+      );
     }
 
     asset.setBuffer(res.code);

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -262,6 +262,8 @@ pub enum DiagnosticSeverity {
   Warning,
   /// An error if this is source code in the project, or a warning if in node_modules.
   SourceError,
+  /// Logs a verbose diagnostic
+  Verbose,
 }
 
 #[derive(Serialize, Debug, Deserialize, Eq, PartialEq, Clone, Copy)]
@@ -287,7 +289,7 @@ impl Bailout {
         message: None,
       }]),
       show_environment: false,
-      severity: DiagnosticSeverity::Warning,
+      severity: DiagnosticSeverity::Verbose,
       hints: None,
     }
   }

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -436,7 +436,7 @@ export default (new Transformer({
       supports_module_workers: supportsModuleWorkers,
       is_library: asset.env.isLibrary,
       is_esm_output: asset.env.outputFormat === 'esmodule',
-      trace_bailouts: options.logLevel === 'verbose',
+      trace_bailouts: true, //options.logLevel === 'verbose',
       is_swc_helpers: /@swc[/\\]helpers/.test(asset.filePath),
     });
 

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -1,7 +1,7 @@
 // @flow
 import type {JSONObject, EnvMap} from '@parcel/types';
 import type {SchemaEntity} from '@parcel/utils';
-import type {Diagnostic} from '@parcel/diagnostic';
+import type {DiagnosticWithLevel, DiagnosticLevel} from '@parcel/diagnostic';
 import SourceMap from '@parcel/source-map';
 import {Transformer} from '@parcel/plugin';
 import {init, transform} from '../native';
@@ -302,7 +302,7 @@ export default (new Transformer({
       useDefineForClassFields,
     };
   },
-  async transform({asset, config, options, logger}) {
+  async transform({asset, config, options}) {
     let [code, originalMap] = await Promise.all([
       asset.getBuffer(),
       asset.getMap(),
@@ -469,9 +469,12 @@ export default (new Transformer({
       );
       let warnings = diagnostics.filter(
         d =>
-          d.severity === 'Warning' ||
-          (d.severity === 'SourceError' && !asset.isSource),
+          !(
+            d.severity === 'Error' ||
+            (d.severity === 'SourceError' && asset.isSource)
+          ),
       );
+
       let convertDiagnostic = diagnostic => {
         let message = diagnostic.message;
         if (message === 'SCRIPT_ERROR') {
@@ -479,7 +482,7 @@ export default (new Transformer({
           message = err?.message || SCRIPT_ERRORS.browser.message;
         }
 
-        let res: Diagnostic = {
+        let res: DiagnosticWithLevel = {
           message,
           codeFrames: [
             {
@@ -495,6 +498,7 @@ export default (new Transformer({
             },
           ],
           hints: diagnostic.hints,
+          level: convertSeverity(asset.isSource, diagnostic.severity),
         };
 
         if (diagnostic.documentation_url) {
@@ -534,7 +538,7 @@ export default (new Transformer({
         });
       }
 
-      logger.warn(warnings.map(convertDiagnostic));
+      asset.addDiagnostic(warnings.map(convertDiagnostic));
     }
 
     if (shebang) {
@@ -918,6 +922,34 @@ export default (new Transformer({
     asset.type = 'js';
     asset.setBuffer(compiledCode);
 
+    if (code.toString().includes('warning1')) {
+      let s = code.toString();
+      let pos = s.indexOf('warning1');
+      let before = s.slice(0, pos);
+      let beforeLines = before.split('\n');
+      let startLine = beforeLines.length;
+      let startCol = beforeLines[beforeLines.length - 1].length + 1;
+      asset.addDiagnostic({
+        message: 'Some problem',
+        codeFrames: [
+          {
+            filePath: asset.filePath,
+            codeHighlights: [
+              {
+                start: {line: startLine, column: startCol},
+                end: {
+                  line: startLine,
+                  column: startCol + 'warning1'.length - 1,
+                },
+                message: 'here',
+              },
+            ],
+          },
+        ],
+        level: 'warn',
+      });
+    }
+
     if (map) {
       let sourceMap = new SourceMap(options.projectRoot);
       sourceMap.addVLQMap(JSON.parse(map));
@@ -930,6 +962,19 @@ export default (new Transformer({
     return [asset];
   },
 }): Transformer);
+
+function convertSeverity(
+  isSource: boolean,
+  severity: 'Error' | 'Warning' | 'SourceError' | 'Verbose',
+): DiagnosticLevel {
+  if (severity === 'Error' || (severity === 'SourceError' && isSource)) {
+    return 'error';
+  } else if (severity === 'Warning' || severity === 'SourceError') {
+    return 'warn';
+  } else {
+    return 'verbose';
+  }
+}
 
 // On linux with older versions of glibc (e.g. CentOS 7), we encounter a segmentation fault
 // when worker threads exit due to thread local variables used by SWC. A workaround is to

--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -159,7 +159,7 @@ export default (new Transformer({
       throw new ThrowableDiagnostic({diagnostic: parcelDiagnostics});
     } else {
       for (let d of parcelDiagnostics) {
-        logger.warn(d);
+        asset.addDiagnostic({...d, level: 'warn'});
       }
     }
 


### PR DESCRIPTION
Store diagnostics (that were previously passed to the logger). This means that cached builds will still show the same warnings (e.g. like Rust/cargo does). This is especially important for the LSP reporter.

As a consequence, this changes most calls from `if(logLevel === "verbose") { logger.warn() }` to `diagnostics.push({..., level: "verbose"})` meaning there will be much more diagnostics generated than before. Especially for the JS transformer (tree shaking optimization bailouts which are now always being generated but just potentially not shown).
Log level was never part of the cache key, so now `--log-level` behaves as one expects: nothing is rebuild when changing it but still every diagnostic is shown correctly. 

Also improves the styling a bit to also use the log level color for the code highlights as well:

<img width="700" alt="Bildschirm­foto 2023-03-18 um 14 09 44" src="https://user-images.githubusercontent.com/4586894/226108310-ddcaf818-7292-4f5e-bc46-f835e7b126a9.png">



Todo/Future improvements
- [x] The absolute path is stored in the cache, switch to project path
- [ ] The deduplication logic in Transformation.js is kind of sketchy
- [ ] Does this slow things down?
- [ ] Be able to add diagnostics from `Transformer#loadConfig`
- [ ] Be able to add diagnostics from resolvers
- [ ] Be able to add diagnostics from validators
- [x] Store the diagnostics from the target resolver (which are currently on verbose mode)
- [ ] Store "Could not load existing source map for" in Transformation.js
- [ ] Should the various "you're missing out on caching due to a JS config" warnings be stored or just logged once?

Future improvements
- Show CSS module tree shaking warnings from optimizer also in dev
- We could modernize our codeframe rendering a bit, similar to [miette](https://github.com/zkat/miette). [example](https://twitter.com/rvcas/status/1636856756629372930), [example](https://twitter.com/kdy1dev/status/1502876252159766528), [example](https://twitter.com/jntrnr/status/1467025246674849793), [example](https://twitter.com/zkat__/status/1435820136326328326)
