### PR TITLE
Fixup collect.used_imports and dev symbol translation

### DIFF
--- a/packages/core/integration-tests/test/integration/js-require-import-different/addons.js
+++ b/packages/core/integration-tests/test/integration/js-require-import-different/addons.js
@@ -1,0 +1,1 @@
+export * from "./hooks";

--- a/packages/core/integration-tests/test/integration/js-require-import-different/hooks.js
+++ b/packages/core/integration-tests/test/integration/js-require-import-different/hooks.js
@@ -1,0 +1,1 @@
+export var HooksContext = 123;

--- a/packages/core/integration-tests/test/integration/js-require-import-different/index.js
+++ b/packages/core/integration-tests/test/integration/js-require-import-different/index.js
@@ -1,0 +1,3 @@
+import { StoryStore } from './store';
+
+output = [StoryStore, require('./addons')];

--- a/packages/core/integration-tests/test/integration/js-require-import-different/package.json
+++ b/packages/core/integration-tests/test/integration/js-require-import-different/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": [
+    "index.js"
+  ]
+}

--- a/packages/core/integration-tests/test/integration/js-require-import-different/store.js
+++ b/packages/core/integration-tests/test/integration/js-require-import-different/store.js
@@ -1,0 +1,2 @@
+import { HooksContext } from "./addons";
+export var StoryStore = HooksContext;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5376,6 +5376,25 @@ describe('javascript', function () {
     assert.strictEqual(output, 'a');
   });
 
+  it('should support import and non-top-level require of same asset from different assets', async () => {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-require-import-different/index.js'),
+    );
+    let {output} = await run(b, null, {require: false});
+    assert.deepEqual(output, [123, {HooksContext: 123}]);
+  });
+
+  it('should support import and non-top-level require of same asset from different assets with scope hoisting', async () => {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-require-import-different/index.js'),
+      {
+        mode: 'production',
+      },
+    );
+    let {output} = await run(b, null, {require: false});
+    assert.deepEqual(output, [123, {HooksContext: 123}]);
+  });
+
   it('should support runtime module deduplication', async function () {
     let b = await bundle(
       path.join(__dirname, 'integration/js-runtime-dedup/index.js'),

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -66,8 +66,6 @@ pub struct Collect {
   pub exports_all: HashMap<JsWord, SourceLocation>,
   /// the keys in `imports` that are actually used (referenced), except namespace imports
   pub used_imports: HashSet<Id>,
-  /// the keys in `imports` that are actually used (referenced), only namespace imports that hoist optimizes away
-  pub used_import_namespaces: HashSet<Id>,
   pub non_static_access: HashMap<Id, Vec<Span>>,
   pub non_const_bindings: HashMap<Id, Vec<Span>>,
   pub non_static_requires: HashSet<JsWord>,
@@ -135,7 +133,6 @@ impl Collect {
       exports_locals: HashMap::new(),
       exports_all: HashMap::new(),
       used_imports: HashSet::new(),
-      used_import_namespaces: HashSet::new(),
       non_static_access: HashMap::new(),
       non_const_bindings: HashMap::new(),
       non_static_requires: HashSet::new(),
@@ -156,9 +153,7 @@ impl From<Collect> for CollectResult {
       .imports
       .into_iter()
       .filter(|(local, _)| {
-        collect.used_imports.contains(local)
-          || collect.used_import_namespaces.contains(local)
-          || collect.exports_locals.contains_key(local)
+        collect.used_imports.contains(local) || collect.exports_locals.contains_key(local)
       })
       .map(
         |(
@@ -667,7 +662,7 @@ impl Visit for Collect {
               .or_default()
               .push(node.span);
           } else if self.imports.contains_key(&id!(ident)) {
-            self.used_import_namespaces.insert(id!(ident));
+            self.used_imports.insert(id!(ident));
           }
         }
         return;

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1314,20 +1314,27 @@ mod tests {
     let (collect, _code, _hoist) = parse(
       r#"
     import { a, b, c, d } from "other";
+    import * as x from "other";
+    import * as y from "other";
 
     log(a);
     b.x();
     c();
+    log(x);
+    y.foo();
     "#,
     );
-    assert_eq_set!(collect.used_imports, set! { w!("a"), w!("b"), w!("c") });
+    assert_eq_set!(collect.used_imports, set! { w!("a"), w!("c"), w!("x") });
+    assert_eq_set!(collect.used_import_namespaces, set! { w!("b"), w!("y") });
     assert_eq_imports!(
       collect.imports,
       map! {
         w!("a") => (w!("other"), w!("a"), false),
         w!("b") => (w!("other"), w!("b"), false),
         w!("c") => (w!("other"), w!("c"), false),
-        w!("d") => (w!("other"), w!("d"), false)
+        w!("d") => (w!("other"), w!("d"), false),
+        w!("x") => (w!("other"), w!("*"), false),
+        w!("y") => (w!("other"), w!("*"), false)
       }
     );
   }

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1324,8 +1324,10 @@ mod tests {
     y.foo();
     "#,
     );
-    assert_eq_set!(collect.used_imports, set! { w!("a"), w!("c"), w!("x") });
-    assert_eq_set!(collect.used_import_namespaces, set! { w!("b"), w!("y") });
+    assert_eq_set!(
+      collect.used_imports,
+      set! { w!("a"), w!("b"), w!("c"), w!("x"), w!("y") }
+    );
     assert_eq_imports!(
       collect.imports,
       map! {

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1283,7 +1283,7 @@ mod tests {
   }
 
   #[test]
-  fn esm() {
+  fn collect_esm() {
     let (collect, _code, _hoist) = parse(
       r#"
     import {foo as bar} from 'other';
@@ -1294,10 +1294,46 @@ mod tests {
       collect.imports,
       map! { w!("bar") => (w!("other"), w!("foo"), false) }
     );
+    assert_eq!(
+      collect.exports,
+      map! {
+        w!("test") => Export {
+          source: None,
+          specifier: "bar".into(),
+          loc: SourceLocation {
+            start_line: 3,
+            start_col: 20,
+            end_line: 3,
+            end_col: 23
+          },
+          is_esm: true
+        }
+      }
+    );
+
+    let (collect, _code, _hoist) = parse(
+      r#"
+    import { a, b, c, d } from "other";
+
+    log(a);
+    b.x();
+    c();
+    "#,
+    );
+    assert_eq_set!(collect.used_imports, set! { w!("a"), w!("b"), w!("c") });
+    assert_eq_imports!(
+      collect.imports,
+      map! {
+        w!("a") => (w!("other"), w!("a"), false),
+        w!("b") => (w!("other"), w!("b"), false),
+        w!("c") => (w!("other"), w!("c"), false),
+        w!("d") => (w!("other"), w!("d"), false)
+      }
+    );
   }
 
   #[test]
-  fn cjs_namespace() {
+  fn collect_cjs_namespace() {
     let (collect, _code, _hoist) = parse(
       r#"
     const x = require('other');
@@ -1319,7 +1355,7 @@ mod tests {
   }
 
   #[test]
-  fn cjs_namespace_non_static() {
+  fn collect_cjs_namespace_non_static() {
     let (collect, _code, _hoist) = parse(
       r#"
     const x = require('other');
@@ -1346,7 +1382,7 @@ mod tests {
   }
 
   #[test]
-  fn cjs_destructure() {
+  fn collect_cjs_destructure() {
     let (collect, _code, _hoist) = parse(
       r#"
     const {foo: bar} = require('other');
@@ -1361,7 +1397,7 @@ mod tests {
   }
 
   #[test]
-  fn cjs_reassign() {
+  fn collect_cjs_reassign() {
     let (collect, _code, _hoist) = parse(
       r#"
     exports = 2;
@@ -1378,7 +1414,7 @@ mod tests {
   }
 
   #[test]
-  fn should_wrap() {
+  fn collect_should_wrap() {
     let (collect, _code, _hoist) = parse(
       r#"
     eval('');
@@ -1437,7 +1473,7 @@ mod tests {
   }
 
   #[test]
-  fn cjs_non_static_exports() {
+  fn collect_cjs_non_static_exports() {
     let (collect, _code, _hoist) = parse(
       r#"
     exports[test] = 2;
@@ -1540,7 +1576,7 @@ mod tests {
   }
 
   #[test]
-  fn dynamic_import() {
+  fn collect_dynamic_import() {
     let (collect, _code, _hoist) = parse(
       r#"
     async function test() {

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -874,6 +874,15 @@ export default (new Transformer({
           dep.symbols.set('*', '*', convertLoc(loc), true);
         }
 
+        // For all other imports and requires, mark everything as imported (this covers both dynamic
+        // imports and non-top-level requires.)
+        for (let dep of deps.values()) {
+          if (dep.symbols.isCleared) {
+            dep.symbols.ensure();
+            dep.symbols.set('*', '$');
+          }
+        }
+
         // Add * symbol if there are CJS exports, no imports/exports at all, or the asset is wrapped.
         // This allows accessing symbols that don't exist without errors in symbol propagation.
         if (
@@ -884,15 +893,6 @@ export default (new Transformer({
           (symbol_result.should_wrap && !asset.symbols.hasExportSymbol('*'))
         ) {
           asset.symbols.set('*', `$`);
-        }
-
-        // For dynamic imports, mark everything as imported (a more detailed analysis similar to
-        // what scope hoisting does with `const {foo} = await import(...);` isn't hook up yet.)
-        for (let d of deps.values()) {
-          if (d.priority === 'lazy') {
-            d.symbols.ensure();
-            d.symbols.set('*', '$');
-          }
         }
       }
 


### PR DESCRIPTION
Instead of cleared symbols on the (currently) non-analyzed imports/requires, add `*` instead. This is what scopehoisting does as a fallback as well. (Because cleared dependencies are slightly broken: https://github.com/parcel-bundler/parcel/pull/8928)

Also fix a bug where `symbol_result.imports` didn't list a named import when it was used in a member expression:
```js
import { b } from "foo";
b.run();
```