### PR TITLE
Mark import-export combinations as weak in dev

### DIFF
--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1077,17 +1077,22 @@ describe('scope hoisting', function () {
       assert.deepEqual(output, ['b', true]);
     });
 
-    it("unused and missing pseudo re-exports doen't fail the build", async function () {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/scope-hoisting/es6/re-export-pseudo/a.js',
-        ),
-      );
+    for (let shouldScopeHoist of [false, true]) {
+      it(`unused and missing pseudo re-exports doesn't fail the build with${
+        shouldScopeHoist ? '' : 'out'
+      } scope-hoisting`, async function () {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/es6/re-export-pseudo/a.js',
+          ),
+          {defaultTargetOptions: {shouldScopeHoist}},
+        );
 
-      let output = await run(b);
-      assert.deepEqual(output, 'foo');
-    });
+        let {output} = await run(b, null, {require: false});
+        assert.deepEqual(output, 'foo');
+      });
+    }
 
     it('supports requiring a re-exported and renamed ES6 import', async function () {
       let b = await bundle(

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1298,8 +1298,8 @@ mod tests {
       collect.exports,
       map! {
         w!("test") => Export {
-          source: None,
-          specifier: "bar".into(),
+          source: Some("other".into()),
+          specifier: "foo".into(),
           loc: SourceLocation {
             start_line: 3,
             start_col: 20,


### PR DESCRIPTION
**Depends on https://github.com/parcel-bundler/parcel/pull/8927**

Detect these exports as weak reexport, so that reexporting of unused (non-existing) TS type symbols doesn't fail the build
```js
import {foo} from "xyz";
export {foo};
```