### PR TITLE
Clippy

### DIFF
--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -665,16 +665,14 @@ impl Visit for Collect {
           self.static_cjs_exports = false;
           self.should_wrap = true;
           self.add_bailout(node.span, BailoutReason::FreeModule);
-        } else {
-          if match_property_name(node).is_none() {
-            self
-              .non_static_access
-              .entry(id!(ident))
-              .or_default()
-              .push(node.span);
-          } else if self.imports.contains_key(&id!(ident)) {
-            self.used_imports.insert(id!(ident));
-          }
+        } else if match_property_name(node).is_none() {
+          self
+            .non_static_access
+            .entry(id!(ident))
+            .or_default()
+            .push(node.span);
+        } else if self.imports.contains_key(&id!(ident)) {
+          self.used_imports.insert(id!(ident));
         }
         return;
       }

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1053,10 +1053,10 @@ impl<'a> Hoist<'a> {
       format!("${}$export${:x}", self.module_id, hash!(exported)).into()
     };
 
-    let is_esm = match self.collect.exports.get(exported) {
-      Some(Export { is_esm: true, .. }) => true,
-      _ => false,
-    };
+    let is_esm = matches!(
+      self.collect.exports.get(exported),
+      Some(Export { is_esm: true, .. })
+    );
 
     self.exported_symbols.push(ExportedSymbol {
       local: new_name.clone(),

--- a/packages/utils/fs-search/src/lib.rs
+++ b/packages/utils/fs-search/src/lib.rs
@@ -15,7 +15,7 @@ pub fn find_ancestor_file(filenames: Vec<String>, from: String, root: String) ->
     }
 
     for name in &filenames {
-      let fullpath = dir.join(&name);
+      let fullpath = dir.join(name);
       if fullpath.is_file() {
         return Some(fullpath.to_string_lossy().into_owned());
       }

--- a/packages/utils/hash/src/lib.rs
+++ b/packages/utils/hash/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::new_without_default)]
+
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use std::hash::Hasher;

--- a/packages/utils/node-resolver-core/src/lib.rs
+++ b/packages/utils/node-resolver-core/src/lib.rs
@@ -114,10 +114,7 @@ impl FileSystem for JsFileSystem {
       res.get_value()
     };
 
-    match is_file() {
-      Ok(res) => res,
-      Err(_) => false,
-    }
+    is_file().unwrap_or(false)
   }
 
   fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
@@ -128,10 +125,7 @@ impl FileSystem for JsFileSystem {
       res.get_value()
     };
 
-    match is_dir() {
-      Ok(res) => res,
-      Err(_) => false,
-    }
+    is_dir().unwrap_or(false)
   }
 }
 

--- a/packages/utils/node-resolver-core/src/lib.rs
+++ b/packages/utils/node-resolver-core/src/lib.rs
@@ -19,21 +19,21 @@ use parcel_resolver::{
   IncludeNodeModules, Invalidations, ModuleType, Resolution, ResolverError, SpecifierType,
 };
 
+type NapiSideEffectsVariants = napi::Either<bool, napi::Either<Vec<String>, HashMap<String, bool>>>;
+
 #[napi(object)]
 pub struct JsFileSystemOptions {
   pub canonicalize: JsFunction,
   pub read: JsFunction,
   pub is_file: JsFunction,
   pub is_dir: JsFunction,
-  pub include_node_modules:
-    Option<napi::Either<bool, napi::Either<Vec<String>, HashMap<String, bool>>>>,
+  pub include_node_modules: Option<NapiSideEffectsVariants>,
 }
 
 #[napi(object, js_name = "FileSystem")]
 pub struct JsResolverOptions {
   pub fs: Option<JsFileSystemOptions>,
-  pub include_node_modules:
-    Option<napi::Either<bool, napi::Either<Vec<String>, HashMap<String, bool>>>>,
+  pub include_node_modules: Option<NapiSideEffectsVariants>,
   pub conditions: Option<u16>,
   pub module_dir_resolver: Option<JsFunction>,
   pub mode: u8,

--- a/packages/utils/node-resolver-core/src/lib.rs
+++ b/packages/utils/node-resolver-core/src/lib.rs
@@ -345,7 +345,7 @@ impl Resolver {
     );
 
     let side_effects = if let Ok((Resolution::Path(p), _)) = &res.result {
-      match self.resolver.resolve_side_effects(&p, &res.invalidations) {
+      match self.resolver.resolve_side_effects(p, &res.invalidations) {
         Ok(side_effects) => side_effects,
         Err(err) => {
           res.result = Err(err);

--- a/packages/utils/node-resolver-rs/src/builtins.rs
+++ b/packages/utils/node-resolver-rs/src/builtins.rs
@@ -1,5 +1,5 @@
 // node -p "[...require('module').builtinModules].map(b => JSON.stringify(b)).join(',\n')"
-pub const BUILTINS: &'static [&'static str] = &[
+pub const BUILTINS: &[&str] = &[
   "_http_agent",
   "_http_client",
   "_http_common",

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -41,7 +41,7 @@ impl<'a, Fs> Deref for CacheCow<'a, Fs> {
 
   fn deref(&self) -> &Self::Target {
     match self {
-      CacheCow::Borrowed(c) => *c,
+      CacheCow::Borrowed(c) => c,
       CacheCow::Owned(c) => c,
     }
   }

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -169,7 +169,7 @@ impl<Fs: FileSystem> Cache<Fs> {
       path: &Path,
       process: F,
     ) -> Result<TsConfigWrapper<'static>, ResolverError> {
-      let data = read(fs, arena, &path)?;
+      let data = read(fs, arena, path)?;
       let mut tsconfig =
         TsConfig::parse(path.to_owned(), data).map_err(|e| JsonError::new(path.to_owned(), e))?;
       // Convice the borrow checker that 'a will live as long as self and not 'static.

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -215,7 +215,7 @@ impl<'a, Fs: FileSystem> Resolver<'a, Fs> {
       Ok(s) => s,
       Err(e) => return Err(e.into()),
     };
-    let mut request = ResolveRequest::new(self, &specifier, specifier_type, from, &invalidations);
+    let mut request = ResolveRequest::new(self, &specifier, specifier_type, from, invalidations);
     if !options.conditions.is_empty() || !options.custom_conditions.is_empty() {
       // If custom conditions are defined, these override the default conditions inferred from the specifier type.
       request.conditions = self.conditions | options.conditions;

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -2637,58 +2637,46 @@ mod tests {
 
   #[test]
   fn test_side_effects() {
-    assert_eq!(
-      resolve_side_effects("side-effects-false/src/index.js", &root().join("foo.js")),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects("side-effects-false/src/index", &root().join("foo.js")),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects("side-effects-false/src/", &root().join("foo.js")),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects("side-effects-false", &root().join("foo.js")),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects(
-        "side-effects-package-redirect-up/foo/bar",
-        &root().join("foo.js")
-      ),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects(
-        "side-effects-package-redirect-down/foo/bar",
-        &root().join("foo.js")
-      ),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects("side-effects-false-glob/a/index", &root().join("foo.js")),
-      true,
-    );
-    assert_eq!(
-      resolve_side_effects("side-effects-false-glob/b/index.js", &root().join("foo.js")),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects(
-        "side-effects-false-glob/sub/a/index.js",
-        &root().join("foo.js")
-      ),
-      false,
-    );
-    assert_eq!(
-      resolve_side_effects(
-        "side-effects-false-glob/sub/index.json",
-        &root().join("foo.js")
-      ),
-      true,
-    );
+    assert!(!resolve_side_effects(
+      "side-effects-false/src/index.js",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-false/src/index",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-false/src/",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-false",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-package-redirect-up/foo/bar",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-package-redirect-down/foo/bar",
+      &root().join("foo.js")
+    ));
+    assert!(resolve_side_effects(
+      "side-effects-false-glob/a/index",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-false-glob/b/index.js",
+      &root().join("foo.js")
+    ));
+    assert!(!resolve_side_effects(
+      "side-effects-false-glob/sub/a/index.js",
+      &root().join("foo.js")
+    ));
+    assert!(resolve_side_effects(
+      "side-effects-false-glob/sub/index.json",
+      &root().join("foo.js")
+    ));
   }
 
   #[test]

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -747,9 +747,7 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
         }
       }
 
-      if let Err(e) = res {
-        return Err(e);
-      }
+      res?;
 
       return Err(ResolverError::ModuleSubpathNotFound {
         module: module.to_owned(),

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -937,13 +937,13 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
       .map_or([""].as_slice(), |v| v.as_slice());
 
     for suffix in module_suffixes {
-      let mut p = if *suffix != "" {
+      let mut p = if !suffix.is_empty() {
         // The suffix is placed before the _last_ extension. If we will be appending
         // another extension later, then we only need to append the suffix first.
         // Otherwise, we need to remove the original extension so we can add the suffix.
         // TODO: TypeScript only removes certain extensions here...
         let original_ext = path.extension();
-        let mut s = if ext == "" && original_ext.is_some() {
+        let mut s = if ext.is_empty() && original_ext.is_some() {
           path.with_extension("").into_os_string()
         } else {
           path.into()
@@ -953,7 +953,7 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
         s.push(suffix);
 
         // Re-add the original extension if we removed it earlier.
-        if ext == "" {
+        if ext.is_empty() {
           if let Some(original_ext) = original_ext {
             s.push(".");
             s.push(original_ext);
@@ -965,7 +965,7 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
         Cow::Borrowed(path)
       };
 
-      if ext != "" {
+      if !ext.is_empty() {
         // Append the extension.
         let mut s = p.into_owned().into_os_string();
         s.push(".");

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -177,18 +177,18 @@ impl<'a, Fs: FileSystem> Resolver<'a, Fs> {
     }
   }
 
-  pub fn resolve<'s>(
+  pub fn resolve(
     &self,
-    specifier: &'s str,
+    specifier: &str,
     from: &Path,
     specifier_type: SpecifierType,
   ) -> ResolveResult {
     self.resolve_with_options(specifier, from, specifier_type, Default::default())
   }
 
-  pub fn resolve_with_options<'s>(
+  pub fn resolve_with_options(
     &self,
-    specifier: &'s str,
+    specifier: &str,
     from: &Path,
     specifier_type: SpecifierType,
     options: ResolveOptions,

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -102,7 +102,7 @@ pub enum Extensions<'a> {
 impl<'a> Extensions<'a> {
   fn iter(&self) -> impl Iterator<Item = &str> {
     match self {
-      Extensions::Borrowed(v) => itertools::Either::Left(v.iter().map(|s| *s)),
+      Extensions::Borrowed(v) => itertools::Either::Left(v.iter().copied()),
       Extensions::Owned(v) => itertools::Either::Right(v.iter().map(|s| s.as_str())),
     }
   }

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -203,9 +203,9 @@ impl<'a, Fs: FileSystem> Resolver<'a, Fs> {
     }
   }
 
-  pub fn resolve_with_invalidations<'s>(
+  pub fn resolve_with_invalidations(
     &self,
-    specifier: &'s str,
+    specifier: &str,
     from: &Path,
     specifier_type: SpecifierType,
     invalidations: &Invalidations,

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -716,22 +716,22 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
       }
 
       // TODO: track location of resolved field
-      return Err(ResolverError::ModuleSubpathNotFound {
+      Err(ResolverError::ModuleSubpathNotFound {
         module: module.to_owned(),
         path,
         package_path: package.path.clone(),
-      });
+      })
     } else if !subpath.is_empty() {
       package_dir.push(subpath);
       if let Some(res) = self.load_path(&package_dir, Some(package))? {
         return Ok(res);
       }
 
-      return Err(ResolverError::ModuleSubpathNotFound {
+      Err(ResolverError::ModuleSubpathNotFound {
         module: module.to_owned(),
         path: package_dir,
         package_path: package.path.clone(),
-      });
+      })
     } else {
       let res = self.try_package_entries(package);
       if let Ok(Some(res)) = res {
@@ -749,11 +749,11 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
 
       res?;
 
-      return Err(ResolverError::ModuleSubpathNotFound {
+      Err(ResolverError::ModuleSubpathNotFound {
         module: module.to_owned(),
         path: package_dir.join(self.resolver.index_file),
         package_path: package.path.clone(),
-      });
+      })
     }
   }
 

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -400,7 +400,7 @@ impl<'a> PackageJson<'a> {
             return Err(PackageJsonError::InvalidPackageTarget);
           }
 
-          if pattern_match != "" {
+          if !pattern_match.is_empty() {
             let target = target.replace('*', pattern_match);
             return Ok(ExportsResolution::Package(Cow::Owned(target)));
           }
@@ -408,7 +408,7 @@ impl<'a> PackageJson<'a> {
           return Ok(ExportsResolution::Package(Cow::Borrowed(target)));
         }
 
-        let target = if pattern_match == "" {
+        let target = if pattern_match.is_empty() {
           Cow::Borrowed(*target)
         } else {
           Cow::Owned(target.replace('*', pattern_match))

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -777,11 +777,11 @@ fn pattern_key_compare(a: &str, b: &str) -> Ordering {
     return cmp;
   }
 
-  if a_pos == None {
+  if a_pos.is_none() {
     return Ordering::Greater;
   }
 
-  if b_pos == None {
+  if b_pos.is_none() {
     return Ordering::Less;
   }
 

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -161,10 +161,10 @@ impl<'a> From<&'a str> for ExportsKey<'a> {
   fn from(key: &'a str) -> Self {
     if key == "." {
       ExportsKey::Main
-    } else if key.starts_with("./") {
-      ExportsKey::Pattern(&key[2..])
-    } else if key.starts_with('#') {
-      ExportsKey::Pattern(&key[1..])
+    } else if let Some(key) = key.strip_prefix("./") {
+      ExportsKey::Pattern(key)
+    } else if let Some(key) = key.strip_prefix('#') {
+      ExportsKey::Pattern(key)
     } else if let Ok(c) = ExportsCondition::try_from(key) {
       ExportsKey::Condition(c)
     } else {
@@ -649,11 +649,7 @@ impl<'a> PackageJson<'a> {
 
     fn side_effects_glob_matches(glob: &str, path: &str) -> bool {
       // Trim leading "./"
-      let glob = if glob.starts_with("./") {
-        &glob[2..]
-      } else {
-        glob
-      };
+      let glob = glob.strip_prefix("./").unwrap_or(glob);
 
       // If the glob does not contain any '/' characters, prefix with "**/" to match webpack.
       let glob = if !glob.contains('/') {

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -348,7 +348,7 @@ impl<'a> PackageJson<'a> {
       // All exports must start with "." at this point.
       match self.resolve_package_imports_exports(
         subpath,
-        &exports,
+        exports,
         false,
         conditions,
         custom_conditions,
@@ -705,7 +705,7 @@ impl<'a> PackageJson<'a> {
       let glob = if glob.starts_with("./") {
         &glob[2..]
       } else {
-        &glob
+        glob
       };
 
       // If the glob does not contain any '/' characters, prefix with "**/" to match webpack.
@@ -735,7 +735,7 @@ fn replace_path_captures<'a>(
   captures: &Vec<Range<usize>>,
 ) -> Option<Cow<'a, Path>> {
   Some(
-    match replace_captures(s.as_os_str().to_str()?, path, &captures) {
+    match replace_captures(s.as_os_str().to_str()?, path, captures) {
       Cow::Borrowed(b) => Cow::Borrowed(Path::new(b)),
       Cow::Owned(b) => Cow::Owned(PathBuf::from(b)),
     },

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -242,10 +242,7 @@ impl<'a> PackageJson<'a> {
         Cow::Borrowed(self.name),
         Cow::Borrowed(""),
       )) {
-        Some(AliasValue::Specifier(s)) => match s {
-          Specifier::Relative(s) => Some(resolve_path(&self.path, s)),
-          _ => None,
-        },
+        Some(AliasValue::Specifier(Specifier::Relative(s))) => Some(resolve_path(&self.path, s)),
         _ => None,
       },
     }
@@ -769,13 +766,11 @@ impl<'a> Iterator for EntryIter<'a> {
           return Some((resolve_path(&self.package.path, browser), "browser"))
         }
         BrowserField::Map(map) => {
-          if let Some(AliasValue::Specifier(s)) = map.get(&Specifier::Package(
+          if let Some(AliasValue::Specifier(Specifier::Relative(s))) = map.get(&Specifier::Package(
             Cow::Borrowed(self.package.name),
             Cow::Borrowed(""),
           )) {
-            if let Specifier::Relative(s) = s {
-              return Some((resolve_path(&self.package.path, s), "browser"));
-            }
+            return Some((resolve_path(&self.package.path, s), "browser"));
           }
         }
       }

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -28,7 +28,7 @@ bitflags! {
   }
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageJson<'a> {
   #[serde(skip)]
@@ -55,58 +55,29 @@ pub struct PackageJson<'a> {
   side_effects: SideEffects<'a>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ModuleType {
+  #[default]
   CommonJs,
   Module,
   Json,
 }
 
-impl Default for ModuleType {
-  fn default() -> Self {
-    ModuleType::CommonJs
-  }
-}
-
-impl<'a> Default for PackageJson<'a> {
-  fn default() -> Self {
-    PackageJson {
-      path: Default::default(),
-      name: "",
-      module_type: Default::default(),
-      main: None,
-      module: None,
-      tsconfig: None,
-      types: None,
-      source: Default::default(),
-      browser: Default::default(),
-      alias: Default::default(),
-      exports: Default::default(),
-      imports: Default::default(),
-      side_effects: Default::default(),
-    }
-  }
-}
-
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
 #[serde(untagged)]
 pub enum BrowserField<'a> {
+  #[default]
   None,
   #[serde(borrow)]
   String(&'a str),
   Map(IndexMap<Specifier<'a>, AliasValue<'a>>),
 }
 
-impl<'a> Default for BrowserField<'a> {
-  fn default() -> Self {
-    BrowserField::None
-  }
-}
-
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Default)]
 #[serde(untagged)]
 pub enum SourceField<'a> {
+  #[default]
   None,
   #[serde(borrow)]
   String(&'a str),
@@ -115,26 +86,15 @@ pub enum SourceField<'a> {
   Bool(bool),
 }
 
-impl<'a> Default for SourceField<'a> {
-  fn default() -> Self {
-    SourceField::None
-  }
-}
-
-#[derive(serde::Deserialize, Debug, PartialEq)]
+#[derive(serde::Deserialize, Debug, Default, PartialEq)]
 #[serde(untagged)]
 pub enum ExportsField<'a> {
+  #[default]
   None,
   #[serde(borrow)]
   String(&'a str),
   Array(Vec<ExportsField<'a>>),
   Map(IndexMap<ExportsKey<'a>, ExportsField<'a>>),
-}
-
-impl<'a> Default for ExportsField<'a> {
-  fn default() -> Self {
-    ExportsField::None
-  }
 }
 
 bitflags! {
@@ -234,20 +194,15 @@ pub enum AliasValue<'a> {
   },
 }
 
-#[derive(serde::Deserialize, Clone, PartialEq, Debug)]
+#[derive(serde::Deserialize, Clone, Default, PartialEq, Debug)]
 #[serde(untagged)]
 pub enum SideEffects<'a> {
+  #[default]
   None,
   Boolean(bool),
   #[serde(borrow)]
   String(&'a str),
   Array(Vec<&'a str>),
-}
-
-impl<'a> Default for SideEffects<'a> {
-  fn default() -> Self {
-    SideEffects::None
-  }
 }
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -228,10 +228,10 @@ impl<'a> PackageJson<'a> {
   }
 
   pub fn entries(&self, fields: Fields) -> EntryIter {
-    return EntryIter {
+    EntryIter {
       package: self,
       fields,
-    };
+    }
   }
 
   pub fn source(&self) -> Option<PathBuf> {

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -176,7 +176,7 @@ impl<'a> Specifier<'a> {
 
 // https://url.spec.whatwg.org/#scheme-state
 // https://github.com/servo/rust-url/blob/1c1e406874b3d2aa6f36c5d2f3a5c2ea74af9efb/url/src/parser.rs#L387
-pub fn parse_scheme<'a>(input: &'a str) -> Result<(Cow<'a, str>, &'a str), ()> {
+pub fn parse_scheme(input: &str) -> Result<(Cow<'_, str>, &str), ()> {
   if input.is_empty() || !input.starts_with(ascii_alpha) {
     return Err(());
   }
@@ -209,7 +209,7 @@ pub fn parse_scheme<'a>(input: &'a str) -> Result<(Cow<'a, str>, &'a str), ()> {
 }
 
 // https://url.spec.whatwg.org/#path-state
-fn parse_path<'a>(input: &'a str) -> (&'a str, &'a str) {
+fn parse_path(input: &str) -> (&str, &str) {
   // We don't really want to normalize the path (e.g. replacing ".." and "." segments).
   // That is done later. For now, we just need to find the end of the path.
   if let Some(pos) = input.chars().position(|c| c == '?' || c == '#') {
@@ -220,7 +220,7 @@ fn parse_path<'a>(input: &'a str) -> (&'a str, &'a str) {
 }
 
 // https://url.spec.whatwg.org/#query-state
-fn parse_query<'a>(input: &'a str) -> (Option<&'a str>, &'a str) {
+fn parse_query(input: &str) -> (Option<&str>, &str) {
   if !input.is_empty() && input.as_bytes()[0] == b'?' {
     if let Some(pos) = input.chars().position(|c| c == '#') {
       (Some(&input[0..pos]), &input[pos..])
@@ -238,7 +238,7 @@ fn ascii_alpha(ch: char) -> bool {
   matches!(ch, 'a'..='z' | 'A'..='Z')
 }
 
-fn parse_package<'a>(specifier: Cow<'a, str>) -> Result<Specifier, SpecifierError> {
+fn parse_package(specifier: Cow<'_, str>) -> Result<Specifier, SpecifierError> {
   match specifier {
     Cow::Borrowed(specifier) => {
       let (module, subpath) = parse_package_specifier(specifier)?;
@@ -276,10 +276,10 @@ pub fn parse_package_specifier(specifier: &str) -> Result<(&str, &str), Specifie
   }
 }
 
-pub fn decode_path<'a>(
-  specifier: &'a str,
+pub fn decode_path(
+  specifier: &str,
   specifier_type: SpecifierType,
-) -> (Cow<'a, Path>, Option<&'a str>) {
+) -> (Cow<'_, Path>, Option<&str>) {
   match specifier_type {
     SpecifierType::Url | SpecifierType::Esm => {
       let (path, rest) = parse_path(specifier);

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -168,7 +168,7 @@ impl<'a> Specifier<'a> {
           Cow::Owned(format!("{}/{}", module, subpath))
         }
       }
-      Specifier::Builtin(builtin) => Cow::Borrowed(&builtin),
+      Specifier::Builtin(builtin) => Cow::Borrowed(builtin),
       Specifier::Url(url) => Cow::Borrowed(url),
     }
   }

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -267,12 +267,12 @@ pub fn parse_package_specifier(specifier: &str) -> Result<(&str, &str), Specifie
         &specifier[idx + *next + 2..],
       ))
     } else {
-      Ok((&specifier, ""))
+      Ok((specifier, ""))
     }
   } else if let Some(idx) = idx {
     Ok((&specifier[0..idx], &specifier[idx + 1..]))
   } else {
-    Ok((&specifier, ""))
+    Ok((specifier, ""))
   }
 }
 

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -180,9 +180,8 @@ pub fn parse_scheme(input: &str) -> Result<(Cow<'_, str>, &str), ()> {
   if input.is_empty() || !input.starts_with(ascii_alpha) {
     return Err(());
   }
-  let mut i = 0;
   let mut is_lowercase = true;
-  for c in input.chars() {
+  for (i, c) in input.chars().enumerate() {
     match c {
       'A'..='Z' => {
         is_lowercase = false;
@@ -201,7 +200,6 @@ pub fn parse_scheme(input: &str) -> Result<(Cow<'_, str>, &str), ()> {
         return Err(());
       }
     }
-    i += 1;
   }
 
   // EOF before ':'

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -235,7 +235,7 @@ fn parse_query(input: &str) -> (Option<&str>, &str) {
 /// https://url.spec.whatwg.org/#ascii-alpha
 #[inline]
 fn ascii_alpha(ch: char) -> bool {
-  matches!(ch, 'a'..='z' | 'A'..='Z')
+  ch.is_ascii_alphabetic()
 }
 
 fn parse_package(specifier: Cow<'_, str>) -> Result<Specifier, SpecifierError> {

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -95,7 +95,7 @@ impl<'a> Specifier<'a> {
               let (query, _) = parse_query(rest);
               match scheme.as_ref() {
                 "npm" if flags.contains(Flags::NPM_SCHEME) => {
-                  if BUILTINS.contains(&path.as_ref()) {
+                  if BUILTINS.contains(&path) {
                     return Ok((Specifier::Builtin(Cow::Borrowed(path)), None));
                   }
 
@@ -120,7 +120,7 @@ impl<'a> Specifier<'a> {
               // otherwise treat this as a relative path.
               let (path, rest) = parse_path(specifier);
               if specifier_type == SpecifierType::Esm {
-                if BUILTINS.contains(&path.as_ref()) {
+                if BUILTINS.contains(&path) {
                   return Ok((Specifier::Builtin(Cow::Borrowed(path)), None));
                 }
 
@@ -136,7 +136,7 @@ impl<'a> Specifier<'a> {
             }
           }
           SpecifierType::Cjs => {
-            if BUILTINS.contains(&specifier.as_ref()) {
+            if BUILTINS.contains(&specifier) {
               (Specifier::Builtin(Cow::Borrowed(specifier)), None)
             } else {
               #[cfg(windows)]

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -267,12 +267,12 @@ pub fn parse_package_specifier(specifier: &str) -> Result<(&str, &str), Specifie
         &specifier[idx + *next + 2..],
       ))
     } else {
-      Ok((&specifier[..], ""))
+      Ok((&specifier, ""))
     }
   } else if let Some(idx) = idx {
     Ok((&specifier[0..idx], &specifier[idx + 1..]))
   } else {
-    Ok((&specifier[..], ""))
+    Ok((&specifier, ""))
   }
 }
 

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -59,11 +59,7 @@ impl<'a> Specifier<'a> {
 
     Ok(match specifier.as_bytes()[0] {
       b'.' => {
-        let specifier = if specifier.starts_with("./") {
-          &specifier[2..]
-        } else {
-          specifier
-        };
+        let specifier = specifier.strip_prefix("./").unwrap_or(specifier);
         let (path, query) = decode_path(specifier, specifier_type);
         (Specifier::Relative(path), query)
       }

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -194,12 +194,12 @@ mod tests {
     let mut tsconfig = TsConfig {
       path: "/foo/tsconfig.json".into(),
       paths: Some(indexmap! {
-        "jquery".into() => vec!["node_modules/jquery/dist/jquery".into()],
-        "*".into() => vec!["generated/*".into()],
-        "bar/*".into() => vec!["test/*".into()],
-        "bar/baz/*".into() => vec!["baz/*".into(), "yo/*".into()],
-        "@/components/*".into() => vec!["components/*".into()],
-        "url".into() => vec!["node_modules/my-url".into()],
+        "jquery".into() => vec!["node_modules/jquery/dist/jquery"],
+        "*".into() => vec!["generated/*"],
+        "bar/*".into() => vec!["test/*"],
+        "bar/baz/*".into() => vec!["baz/*", "yo/*"],
+        "@/components/*".into() => vec!["components/*"],
+        "url".into() => vec!["node_modules/my-url"],
       }),
       ..Default::default()
     };
@@ -254,10 +254,10 @@ mod tests {
       path: "/foo/tsconfig.json".into(),
       base_url: Some(Path::new("src").into()),
       paths: Some(indexmap! {
-        "*".into() => vec!["generated/*".into()],
-        "bar/*".into() => vec!["test/*".into()],
-        "bar/baz/*".into() => vec!["baz/*".into(), "yo/*".into()],
-        "@/components/*".into() => vec!["components/*".into()],
+        "*".into() => vec!["generated/*"],
+        "bar/*".into() => vec!["test/*"],
+        "bar/baz/*".into() => vec!["baz/*", "yo/*"],
+        "@/components/*".into() => vec!["components/*"],
       }),
       ..Default::default()
     };

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -154,7 +154,7 @@ impl<'a> TsConfig<'a> {
 
 fn join_paths<'a>(
   base_url: &'a Path,
-  paths: &'a Vec<&'a str>,
+  paths: &'a [&'a str],
   replacement: Option<(Cow<'a, str>, usize, usize)>,
 ) -> impl Iterator<Item = PathBuf> + 'a {
   paths

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -163,9 +163,9 @@ fn join_paths<'a>(
     .map(move |path| {
       if let Some((replacement, start, end)) = &replacement {
         let path = path.replace('*', &replacement[*start..replacement.len() - *end]);
-        base_url.join(&path)
+        base_url.join(path)
       } else {
-        base_url.join(&path)
+        base_url.join(path)
       }
     })
 }

--- a/packages/utils/node-resolver-rs/src/url_to_path.rs
+++ b/packages/utils/node-resolver-rs/src/url_to_path.rs
@@ -16,11 +16,9 @@ pub fn url_to_path(input: &str) -> Result<PathBuf, SpecifierError> {
 
   #[cfg(not(target_arch = "wasm32"))]
   {
-    Ok(
-      url
-        .to_file_path()
-        .map_err(|_| SpecifierError::InvalidFileUrl)?,
-    )
+    url
+      .to_file_path()
+      .map_err(|_| SpecifierError::InvalidFileUrl)
   }
 }
 

--- a/packages/utils/node-resolver-rs/src/url_to_path.rs
+++ b/packages/utils/node-resolver-rs/src/url_to_path.rs
@@ -98,6 +98,7 @@ pub fn to_file_path(this: &Url) -> Result<PathBuf, ()> {
   Err(())
 }
 
+#[allow(clippy::manual_is_ascii_check)]
 #[cfg(any(target_arch = "wasm32", test))]
 fn file_url_segments_to_pathbuf(
   host: Option<&str>,


### PR DESCRIPTION
- [ ] This loop indeed never loops. But I think the intention here is indeed "take the first declared field and fail if it doesn't exist"
https://github.com/parcel-bundler/parcel/blob/d63df810a691600d20fa91e0fdb2ea579b3f2348/packages/utils/node-resolver-rs/src/lib.rs#L723-L739
So can we replace it with this?
```rust
    if let Some((entry, field)) = package.entries(self.resolver.entries).next() {
```
- [x] Enum size, but this should probably stay as-is? There will only be a few objects of these
```
warning: large size difference between variants
  --> packages/utils/node-resolver-rs/src/cache.rs:35:1
   |
35 | / pub enum CacheCow<'a, Fs> {
36 | |   Borrowed(&'a Cache<Fs>),
   | |   ----------------------- the second-largest variant contains at least 8 bytes
37 | |   Owned(Cache<Fs>),
   | |   ---------------- the largest variant contains at least 320 bytes
38 | | }
   | |_^ the entire enum is at least 320 bytes
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
   = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields to reduce the total size of the enum
   |
37 |   Owned(Box<Cache<Fs>>),
   |         ~~~~~~~~~~~~~~
```