### PR TITLE
Bump swc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.138.2"
+version = "0.138.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5c325a3419d87e053a81684f3899b8424d1b1a9134243aa83641e338b0e7b8"
+checksum = "ff2d9e992e56a5358580ebe17e030ec99356644866dbdc9bbd980cfb4a11495d"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2087,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8431dfd477895a4cfad09687cd38139c7d87ad27d086ba23dbc1c34e3112f19d"
+checksum = "bd0cdc931d46441b75064f435459fe05e95c58eef56ee9ae3e3dc5ce927dbbbb"
 dependencies = [
  "either",
  "lexical",
@@ -2107,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.194.2"
+version = "0.194.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5d4854400d0689c727e7389e078165c938f7189f69d9d65c5e6bb8052c8719"
+checksum = "2f43dbb8c1899a66f4281e5229c4a5c83ec05b36b3625d21129ce38f4724c006"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2132,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.217.2"
+version = "0.217.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c4c9483d9a349c44d59093de4c0625a8df81b79151f84e516377db201ae76b"
+checksum = "ef75761df5073a469491fa4d2376b0baed85566e0edb14425d1c6f2718f198b7"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.126.2"
+version = "0.126.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7debd7bec2c25bec733f2be7d0c5a7eed035f0f8e27d6f7bb74fe79d6b50118"
+checksum = "96fdd0ddb81bd98fdbfd71aeaeef5b18a681fd60e429059d5e3a3c754cbadfec"
 dependencies = [
  "better_scoped_tls",
  "bitflags 1.3.2",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.115.2"
+version = "0.115.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a73fab9dc42d17d83b067034e14f9f2623d6839e51b100f5eb885ac5d71fa4"
+checksum = "4aff266704415fa47047d74ef742f704c6193d1b8dbf8ea65d9bbfdce93db299"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2189,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.152.2"
+version = "0.152.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d194c5283e8f0caf30950879c06019b649fe3b2ccff2628a687cfd356468127"
+checksum = "1fc8b5e02f953d16a80de80d8d93d0405e80940706fcade08454e70475d847f6"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -2228,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.169.2"
+version = "0.169.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c62af7a749dea8daa32f5aa2f607ef94552b9dacd158c3c35251607591fd4d6"
+checksum = "21cea3511dc1a1a9c9ccb00db233720721781cdba8bc959a1229b32e4cac5a99"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2256,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.186.2"
+version = "0.186.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65327cb40ae5b5271fd2322ab4339cf552813748f65bb07582eff84bc6da6d8b"
+checksum = "b3eadf98b5a956932aee802b0d8c479036fc18672aff117ab64e015537ed846c"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2281,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.160.2"
+version = "0.160.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff3f155a98e7cda8cd21f929f7166af500b73a6124ffa1785389fa2f43da7e10"
+checksum = "68d30d4c17ae9365a229c3b56a33ac47bef171269372ffe0998604ef43fe3679"
 dependencies = [
  "either",
  "rustc-hash",
@@ -2301,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.172.2"
+version = "0.172.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b971c1d639e37b604438cb7a2abb060f213f7c044815868339c967882e8dce8"
+checksum = "d641212f49398010bfff91c937d045b6d58588efa0c145742a7fd6d231288758"
 dependencies = [
  "ahash",
  "base64",
@@ -2327,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.176.2"
+version = "0.176.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de06509e0367a200b52394791d34bdc6cff67935bf3a240684cee669b45e4650"
+checksum = "e068ed02a740863a8e589a51d6da0bffd205e6e23eeb05dfa036b31346536a96"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2343,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.116.2"
+version = "0.116.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf293b158abc463fe2079c9060f50db3aba0facbfb9465267e4db9dd4c6c345"
+checksum = "dfd00ae68c2bf5b223ecc479d70e84c9182624f848321b5d76366206898b49ec"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.227.2"
+version = "0.227.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff2428dbe0a45525f0cdd10097b86540feef554d6177be49f7f1c40b414e2c"
+checksum = "95490512fa2a7c6cd80536ac0f1d5dfaa99ada2a0be13709531939e92905f831"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,9 +1969,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.43"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64593af3e0fbacd1b7147a0188f1fd77a2fc8ae3c2425bdb9528de255b9f452b"
+checksum = "4fa61e1bb77e5c179a2cd36afe8acf43670c6db098ff7d470fdf3de1a451970f"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -1997,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.30.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e95bf36e3e217431c50eab784c5601bf5f0ed3657aac6bda57748fa4d6103b"
+checksum = "1f2d1928695fcff9616aabda4817850d52247d6895f8c8c262e6546340b06eb3"
 dependencies = [
  "ahash",
  "ast_node",
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.102.5"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc96ac4740ddd7e09baaa153b6cf74e62ed7436d674606c060ea01fd7c20cd0"
+checksum = "1f2db4599c1f926b71be9ef198f67090264781ba74af19d04b0a3c1b886c496d"
 dependencies = [
  "bitflags 1.3.2",
  "is-macro",
@@ -2068,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.137.6"
+version = "0.138.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b1fc2f9d9a83e15ea27df387279c9f79c12eedeb58af29da663fda952600b1"
+checksum = "5d5c325a3419d87e053a81684f3899b8424d1b1a9134243aa83641e338b0e7b8"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.42.5"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07db9ffa757d71893e265c716307c3c9568ab85645c126e80e0d0ba7528aef5"
+checksum = "f07623afab3082fef89e68295208268d25f7a8d12729865cd021a4aa14efe9f0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2119,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.132.6"
+version = "0.133.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b8409efcb3c70fe31fb3203406ab73b3c3cd279aa2005887d1918049b2a38e"
+checksum = "8431dfd477895a4cfad09687cd38139c7d87ad27d086ba23dbc1c34e3112f19d"
 dependencies = [
  "either",
  "lexical",
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.193.2"
+version = "0.194.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f609e1d200021ac11faa4deedf1aeec21c8cea5a1ea229994f3a8872e59aa5"
+checksum = "3c5d4854400d0689c727e7389e078165c938f7189f69d9d65c5e6bb8052c8719"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.216.2"
+version = "0.217.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8127761772f4c1032a2a6fbd3127764f40f2e226bd1c562827ca872c41062469"
+checksum = "47c4c9483d9a349c44d59093de4c0625a8df81b79151f84e516377db201ae76b"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2184,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.125.1"
+version = "0.126.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b87668640fe6d63ecabaae1805534d1445ff63382ab8961cd623ccdeb1bfbc"
+checksum = "a7debd7bec2c25bec733f2be7d0c5a7eed035f0f8e27d6f7bb74fe79d6b50118"
 dependencies = [
  "better_scoped_tls",
  "bitflags 1.3.2",
@@ -2207,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.114.1"
+version = "0.115.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910df98b5306c191dc7165447493f0ed199283fb1e1395b0691c1ab533979092"
+checksum = "d8a73fab9dc42d17d83b067034e14f9f2623d6839e51b100f5eb885ac5d71fa4"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.151.1"
+version = "0.152.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd73d21a66a9a938a913ceea755cc90f1a5030664750150c5798315e94349e6a"
+checksum = "0d194c5283e8f0caf30950879c06019b649fe3b2ccff2628a687cfd356468127"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -2260,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.168.1"
+version = "0.169.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882b764db19159b48a386b1f27b0c24b96a879c16831f8e75becc3275040989a"
+checksum = "8c62af7a749dea8daa32f5aa2f607ef94552b9dacd158c3c35251607591fd4d6"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2288,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.185.2"
+version = "0.186.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4bc094edc9ee090aa8fe321bf966b656fdd7f50318e323b9ab71c75b6660cb"
+checksum = "65327cb40ae5b5271fd2322ab4339cf552813748f65bb07582eff84bc6da6d8b"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.159.1"
+version = "0.160.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0dc1c39cca530b358db9829c9aea75d7f018ee450c09dd0e84853b974bce762"
+checksum = "ff3f155a98e7cda8cd21f929f7166af500b73a6124ffa1785389fa2f43da7e10"
 dependencies = [
  "either",
  "rustc-hash",
@@ -2333,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.171.1"
+version = "0.172.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25d6c7135e487a3dc99019beb5ed16190dfa570d556bb019ae3ac8dcda60852e"
+checksum = "5b971c1d639e37b604438cb7a2abb060f213f7c044815868339c967882e8dce8"
 dependencies = [
  "ahash",
  "base64",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.175.2"
+version = "0.176.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11b5564e6b9a77fcc772032e3b1cff4d90ad33ffbb38c9822eb4a36e977502c"
+checksum = "de06509e0367a200b52394791d34bdc6cff67935bf3a240684cee669b45e4650"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2375,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.115.8"
+version = "0.116.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077231ec8a3423b1b5dea4e6e220f7681315acca80494624b71717cf39d3ae64"
+checksum = "2cf293b158abc463fe2079c9060f50db3aba0facbfb9465267e4db9dd4c6c345"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -2393,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.88.5"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67210c9d3bc4cdf6a1b2c69cb4ec77660a37e55e883c5ed9f8bc0e801758334b"
+checksum = "93c328ddcc8dbe58434c36a09119675b6ec115aedc99a6618d74cd69cf4fab97"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.226.3"
+version = "0.227.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a33a84c3ad62ea6209a136d98b16c9fa4b87a75ae13bd2edfcf4b785c6fbcc"
+checksum = "05ff2428dbe0a45525f0cdd10097b86540feef554d6177be49f7f1c40b414e2c"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2434,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.18.5"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c9081b942cd9760525ef23f4c932cb2b314c5f06f3d8b25f7bb8a1449ff7ec"
+checksum = "c21d29d548fae063af7e7802074f5ee39969de655ee4a14f24dea048c18898cd"
 dependencies = [
  "indexmap",
  "petgraph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.193.1"
+version = "0.193.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10633106b2a8cca1c1af33dd6bbd5df1a6ce43de0146b212d615fdb462a47742"
+checksum = "b1f609e1d200021ac11faa4deedf1aeec21c8cea5a1ea229994f3a8872e59aa5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.216.1"
+version = "0.216.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac3efc4e9791c4b697ea7a4c6c6a7f462d4b0abe0617aebde10c955149941c5"
+checksum = "8127761772f4c1032a2a6fbd3127764f40f2e226bd1c562827ca872c41062469"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2288,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.185.1"
+version = "0.185.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024918b39b40aaf468cb6c176ce6d8ee22057ed3df788dc60cbd9dae45868b2"
+checksum = "0f4bc094edc9ee090aa8fe321bf966b656fdd7f50318e323b9ab71c75b6660cb"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.175.1"
+version = "0.175.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3b740ee15031e8a70f3b75c09b022dafbb43c607d3bb3bdb70d63d361d2161"
+checksum = "c11b5564e6b9a77fcc772032e3b1cff4d90ad33ffbb38c9822eb4a36e977502c"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2407,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.226.2"
+version = "0.226.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecce16c528dcb7491527f0e151ab492b1bb860fb102b51673e8ca0d2f91a5904"
+checksum = "46a33a84c3ad62ea6209a136d98b16c9fa4b87a75ae13bd2edfcf4b785c6fbcc"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,12 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,15 +46,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -196,12 +181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,17 +230,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags 1.3.2",
+ "clap_lex",
+ "indexmap",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -324,27 +312,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "1.8.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
-
-[[package]]
-name = "crc"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "1.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crc32fast"
@@ -482,16 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +529,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -725,14 +704,13 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.14"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+checksum = "527909aa81e20ac3a44803521443a765550f09b5130c2c2fa1ea59c2f8f50a3a"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "num-iter",
  "num-rational",
  "num-traits",
  "png",
@@ -933,18 +911,18 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libdeflate-sys"
-version = "0.7.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cceaf6e335d658ec0602685bfe50d0f35248d6d8848b194058bfda37a9eb728"
+checksum = "43afa5b192ff058426ba20a4f35c290ef402478d6045ac934ac15aa947a3898d"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "libdeflater"
-version = "0.7.5"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f0c115fd181333eb7a82cf42e2ce2d9fac0ad06babd3ab79a9ec5bd66352fe"
+checksum = "e656b7960ec49e864badc7ad1b810427a7ac8b78511a699ce5cdc3ead0b32e5b"
 dependencies = [
  "libdeflate-sys",
 ]
@@ -1029,18 +1007,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1172,21 +1141,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-rational"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1219,16 +1177,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
-name = "oxipng"
-version = "5.0.1"
+name = "os_str_bytes"
+version = "6.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc96b13363b50f7c3f1e105fb7fe3e231a41ad1434fa1b055ed94b09b97ac786"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+
+[[package]]
+name = "oxipng"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40d437cd5308cba163907008d4c91a0280fc3b1ec1265dd20820e739002f4d9"
 dependencies = [
  "bit-vec",
- "byteorder",
  "clap",
  "cloudflare-zlib",
- "crc 2.1.0",
+ "crc",
  "crossbeam-channel",
  "filetime",
  "image",
@@ -1236,7 +1199,7 @@ dependencies = [
  "itertools",
  "libdeflater",
  "log",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
  "rayon",
  "rgb",
  "rustc_version 0.4.0",
@@ -1335,7 +1298,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "typed-arena 2.0.2",
+ "typed-arena",
  "url",
  "xxhash-rust",
 ]
@@ -1471,14 +1434,14 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.8"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
- "deflate",
- "miniz_oxide 0.3.7",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1824,6 +1787,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1916,7 +1885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69a26bbf6de627d389164afa9783739b56746c6c72c4ed16539f4ff54170327b"
 dependencies = [
  "atty",
- "chrono",
  "log",
  "termcolor",
  "thread_local",
@@ -1963,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
@@ -2134,7 +2102,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "tracing",
- "typed-arena 2.0.2",
+ "typed-arena",
 ]
 
 [[package]]
@@ -2533,12 +2501,9 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -2639,12 +2604,6 @@ dependencies = [
 
 [[package]]
 name = "typed-arena"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
-
-[[package]]
-name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
@@ -2704,12 +2663,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2899,12 +2852,13 @@ checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zopfli"
-version = "0.4.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4079b79464426ade2a1b0177fb0ce8396ba6b4084267407e333573c666073964"
+checksum = "a5b2bed49d3f0af28729a2338ee8c3a48eba2133a78ebc560779be161ebaaad8"
 dependencies = [
- "adler32",
  "byteorder",
- "crc 1.8.1",
- "typed-arena 1.7.0",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+ "typed-arena",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,11 +91,10 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7976b3a3e10d7f95891b780534b92f00d914962ab31884b0bde25762b03a0b73"
+checksum = "93f26ba4b3f1c2776bdacf6d0b96fce173155f2da6ace0202e39e7041ae33083"
 dependencies = [
- "darling",
  "pmutil",
  "proc-macro2",
  "quote",
@@ -259,7 +258,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -459,41 +458,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
  "quote",
  "syn",
 ]
@@ -725,12 +689,6 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2010,12 +1968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "swc_atoms"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.30.4"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4fd05c66a904a106351d5af7b3c42a3feb50f66b94e9fa0b815e7b6d12bdd2"
+checksum = "53e95bf36e3e217431c50eab784c5601bf5f0ed3657aac6bda57748fa4d6103b"
 dependencies = [
  "ahash",
  "ast_node",
@@ -2100,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f666110fd9cce6396101d6377b3e9e487e2d91a59974d75114140834027c068"
+checksum = "6bc96ac4740ddd7e09baaa153b6cf74e62ed7436d674606c060ea01fd7c20cd0"
 dependencies = [
  "bitflags 1.3.2",
  "is-macro",
@@ -2116,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.137.5"
+version = "0.137.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafb2dba963661305e0ead0fbbf0a2fb0d32e91c5ce32cc3099ded036950587e"
+checksum = "75b1fc2f9d9a83e15ea27df387279c9f79c12eedeb58af29da663fda952600b1"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2148,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.42.4"
+version = "0.42.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20f1950d56acba10ca48327e550f56902b6ae2b6b12969df97f40cf3491a3a3"
+checksum = "f07db9ffa757d71893e265c716307c3c9568ab85645c126e80e0d0ba7528aef5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2167,9 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.132.5"
+version = "0.132.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1188624165e3596220b81ccd0b3b7aff074ef18bb256ef8f743310793dfcb557"
+checksum = "b9b8409efcb3c70fe31fb3203406ab73b3c3cd279aa2005887d1918049b2a38e"
 dependencies = [
  "either",
  "lexical",
@@ -2187,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.193.0"
+version = "0.193.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9da5d7649129d52ed8703e6485602b0bafe99921279e21677053257531936"
+checksum = "10633106b2a8cca1c1af33dd6bbd5df1a6ce43de0146b212d615fdb462a47742"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2212,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.216.0"
+version = "0.216.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ff9aacd82603556a1e441ab2c4032079989307b9a261501104ef9070eb86aa"
+checksum = "dac3efc4e9791c4b697ea7a4c6c6a7f462d4b0abe0617aebde10c955149941c5"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2232,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.125.0"
+version = "0.125.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81a9bf9cca7352a27da030d400e8760d882332dc096fb4e98fe327b256b937c"
+checksum = "72b87668640fe6d63ecabaae1805534d1445ff63382ab8961cd623ccdeb1bfbc"
 dependencies = [
  "better_scoped_tls",
  "bitflags 1.3.2",
@@ -2255,9 +2207,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.114.0"
+version = "0.114.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3957c36731c4a733b8ffb244cada53d82f1ffb16b9d54af4ea123f14ed21f710"
+checksum = "910df98b5306c191dc7165447493f0ed199283fb1e1395b0691c1ab533979092"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2269,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.151.0"
+version = "0.151.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17200df962da6193b823216cf51b19154c116e193dbb08290b215eec4d6e849"
+checksum = "cd73d21a66a9a938a913ceea755cc90f1a5030664750150c5798315e94349e6a"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -2308,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.168.0"
+version = "0.168.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc25542b42195ead4b536a0c676b1bec0b9dc672c2809f3826b53000a8b90d7c"
+checksum = "882b764db19159b48a386b1f27b0c24b96a879c16831f8e75becc3275040989a"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2336,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.185.0"
+version = "0.185.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c08d781e6b0c305b0671da63a2dd188c9bc1c66f0b5088d2ed5263ef7aa377"
+checksum = "5024918b39b40aaf468cb6c176ce6d8ee22057ed3df788dc60cbd9dae45868b2"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2361,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.159.0"
+version = "0.159.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ca8b506d2bf37c453417a663b51789a4019aadb10869293087cf4a30041b0c"
+checksum = "c0dc1c39cca530b358db9829c9aea75d7f018ee450c09dd0e84853b974bce762"
 dependencies = [
  "either",
  "rustc-hash",
@@ -2381,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.171.0"
+version = "0.171.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f14f63086cc117d849d4b286698602213af7a5b929ecb2345585719e6c0b98"
+checksum = "25d6c7135e487a3dc99019beb5ed16190dfa570d556bb019ae3ac8dcda60852e"
 dependencies = [
  "ahash",
  "base64",
@@ -2407,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.175.0"
+version = "0.175.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fde2e3a8949388fb477d42b4519de0fe70d38749d1127f8d0ed5a8d99ca860f"
+checksum = "ec3b740ee15031e8a70f3b75c09b022dafbb43c607d3bb3bdb70d63d361d2161"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2423,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.115.7"
+version = "0.115.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834d19bff8c74e54755d72ff18020a2741bac053d8f42b3f0ba85d26c678d813"
+checksum = "077231ec8a3423b1b5dea4e6e220f7681315acca80494624b71717cf39d3ae64"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -2441,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.88.4"
+version = "0.88.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcb460985eb13a48a6c951b903a3c8a5338d21aa7a91bc3cdf7284449b54174"
+checksum = "67210c9d3bc4cdf6a1b2c69cb4ec77660a37e55e883c5ed9f8bc0e801758334b"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2455,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.226.0"
+version = "0.226.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3663bfc909b188a6ad5964749f60a3a9ae687292c73e44514070b5301e233612"
+checksum = "ecce16c528dcb7491527f0e151ab492b1bb860fb102b51673e8ca0d2f91a5904"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2482,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24c5fa6f4248fb83dae139b450489affe6e219502692122f3025ded635f4cff"
+checksum = "29c9081b942cd9760525ef23f4c932cb2b314c5f06f3d8b25f7bb8a1449ff7ec"
 dependencies = [
  "indexmap",
  "petgraph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e351bf9f01438f9479f39ed9d2c26dab615f9887d8ba50d50addd0c6536d51"
+checksum = "7976b3a3e10d7f95891b780534b92f00d914962ab31884b0bde25762b03a0b73"
 dependencies = [
  "darling",
  "pmutil",
@@ -2017,9 +2017,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.39"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebef84c2948cd0d1ba25acbf1b4bd9d80ab6f057efdbe35d8449b8d54699401"
+checksum = "64593af3e0fbacd1b7147a0188f1fd77a2fc8ae3c2425bdb9528de255b9f452b"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.30.0"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2625cf59127d2ccef0e3cbff5b2c0e370415ef274c03a49d733d0a6a03be53db"
+checksum = "3f4fd05c66a904a106351d5af7b3c42a3feb50f66b94e9fa0b815e7b6d12bdd2"
 dependencies = [
  "ahash",
  "ast_node",
@@ -2100,9 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.102.0"
+version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665dc78d58a6d2fe7fdccac27aab0084263af6f2281c4b3b8ad5b1499d334939"
+checksum = "8f666110fd9cce6396101d6377b3e9e487e2d91a59974d75114140834027c068"
 dependencies = [
  "bitflags 1.3.2",
  "is-macro",
@@ -2116,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.137.0"
+version = "0.137.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae98ea91459a603ce9c47a53f45051db9b0b27c0d418b9b72b62e21a9c342c3"
+checksum = "cafb2dba963661305e0ead0fbbf0a2fb0d32e91c5ce32cc3099ded036950587e"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2148,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.42.0"
+version = "0.42.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668223e740d85e242388bcc586cc9d2eb7f398933fd86592ff56c3099ee705bc"
+checksum = "e20f1950d56acba10ca48327e550f56902b6ae2b6b12969df97f40cf3491a3a3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.132.0"
+version = "0.132.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e18a7dc53b4c26bf35197610356aeda8025971667228c52d27aca124077ab0"
+checksum = "1188624165e3596220b81ccd0b3b7aff074ef18bb256ef8f743310793dfcb557"
 dependencies = [
  "either",
  "lexical",
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.192.0"
+version = "0.193.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cedf7ab6136f6cbcb551890293c0ce001ccc44f4efcfc30db61c5dc1741ba17e"
+checksum = "25f9da5d7649129d52ed8703e6485602b0bafe99921279e21677053257531936"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2212,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55931ed9f3d5e8b8134076685e04ae66e916fd94413b27476811d24eaecf5584"
+checksum = "08ff9aacd82603556a1e441ab2c4032079989307b9a261501104ef9070eb86aa"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2232,9 +2232,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.124.0"
+version = "0.125.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c75dcdb2354e19002b2af8d6bc9f069aa32114d39c2c83735617acc8261a8db"
+checksum = "d81a9bf9cca7352a27da030d400e8760d882332dc096fb4e98fe327b256b937c"
 dependencies = [
  "better_scoped_tls",
  "bitflags 1.3.2",
@@ -2255,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.113.0"
+version = "0.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a492f5d419319cdc30efcff9d468bd0d25f572237322ba6edc6353c9d783e3"
+checksum = "3957c36731c4a733b8ffb244cada53d82f1ffb16b9d54af4ea123f14ed21f710"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2269,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.150.0"
+version = "0.151.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ac609994fba93cc3bb6bda16233d179eea075dbf753a372af36eb05b8fd754"
+checksum = "f17200df962da6193b823216cf51b19154c116e193dbb08290b215eec4d6e849"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -2308,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.167.0"
+version = "0.168.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee56186f6d2b68aa39786557481523bd26ed5852f7517b8590249a35a4b5de90"
+checksum = "cc25542b42195ead4b536a0c676b1bec0b9dc672c2809f3826b53000a8b90d7c"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2336,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.184.0"
+version = "0.185.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed2f4b8c5ac9d935682ba4ee395ed6d650972ab250f394d3abd932989675979"
+checksum = "b7c08d781e6b0c305b0671da63a2dd188c9bc1c66f0b5088d2ed5263ef7aa377"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2361,11 +2361,12 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.158.0"
+version = "0.159.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc5bca04f0475701cc9bba4721781696b4048a0382702e677a178bcbc05a969"
+checksum = "e8ca8b506d2bf37c453417a663b51789a4019aadb10869293087cf4a30041b0c"
 dependencies = [
  "either",
+ "rustc-hash",
  "serde",
  "smallvec",
  "swc_atoms",
@@ -2380,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.170.0"
+version = "0.171.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26dc6b7a7139b818323c83814516c45a92f54a1747ca4e706b92296848c474c"
+checksum = "01f14f63086cc117d849d4b286698602213af7a5b929ecb2345585719e6c0b98"
 dependencies = [
  "ahash",
  "base64",
@@ -2406,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.174.0"
+version = "0.175.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da5625decc95363354162e3f64ee3ccc5086895692187d411e4cd29586cb9a7"
+checksum = "3fde2e3a8949388fb477d42b4519de0fe70d38749d1127f8d0ed5a8d99ca860f"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2422,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.115.0"
+version = "0.115.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807dc291b5fc3911b4da04d4002260ed369e43dbd9e70a69353329de888643c2"
+checksum = "834d19bff8c74e54755d72ff18020a2741bac053d8f42b3f0ba85d26c678d813"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -2440,9 +2441,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.88.0"
+version = "0.88.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfde1d1b73164ca87511c90cd539d49ba29d21a03b124b378dc013800c76d262"
+checksum = "dfcb460985eb13a48a6c951b903a3c8a5338d21aa7a91bc3cdf7284449b54174"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2454,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.225.0"
+version = "0.226.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11576f74c6db57590890be8bc514aa20bdd924d0512ff6fe75137d90230a474"
+checksum = "3663bfc909b188a6ad5964749f60a3a9ae687292c73e44514070b5301e233612"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2481,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.18.0"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f106eaf601212e4ff2b24c483d881327aafc66ddfb1b0072ecea02ae00fef940"
+checksum = "a24c5fa6f4248fb83dae139b450489affe6e219502692122f3025ded635f4cff"
 dependencies = [
  "indexmap",
  "petgraph",

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1478,7 +1478,7 @@ describe('html', function () {
       'utf8',
     );
     assert(!html.includes('swc/helpers'));
-    assert(html.includes('slicedToArray'));
+    assert(html.includes('sliced_to_array'));
   });
 
   it('should allow imports and requires in inline <script> tags', async function () {

--- a/packages/core/integration-tests/test/integration/formats/commonjs-helpers/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-helpers/package.json
@@ -2,6 +2,6 @@
   "main": "dist/main.js",
   "browserslist": "Chrome 70",
   "dependencies": {
-    "@swc/helpers": "^0.4.14"
+    "@swc/helpers": "^0.5.0"
   }
 }

--- a/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
+++ b/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
@@ -3,6 +3,6 @@
   "module": "dist/module.js",
   "browserslist": "IE >= 11",
   "dependencies": {
-    "@swc/helpers": "^0.4.2"
+    "@swc/helpers": "^0.5.0"
   }
 }

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5628,7 +5628,7 @@ describe('javascript', function () {
         name: 'BuildError',
         diagnostics: [
           {
-            message: md`Failed to resolve '${'@swc/helpers/cjs/_class_call_check'}' from '${normalizePath(
+            message: md`Failed to resolve '${'@swc/helpers/cjs/_class_call_check.cjs'}' from '${normalizePath(
               require.resolve('@parcel/transformer-js/src/JSTransformer.js'),
             )}'`,
             origin: '@parcel/core',
@@ -5716,7 +5716,7 @@ describe('javascript', function () {
         name: 'BuildError',
         diagnostics: [
           {
-            message: md`Failed to resolve '${'@swc/helpers/cjs/_class_call_check'}' from '${normalizePath(
+            message: md`Failed to resolve '${'@swc/helpers/cjs/_class_call_check.cjs'}' from '${normalizePath(
               require.resolve('@parcel/transformer-js/src/JSTransformer.js'),
             )}'`,
             origin: '@parcel/core',

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5628,7 +5628,7 @@ describe('javascript', function () {
         name: 'BuildError',
         diagnostics: [
           {
-            message: md`Failed to resolve '${'@swc/helpers/lib/_class_call_check.js'}' from '${normalizePath(
+            message: md`Failed to resolve '${'@swc/helpers/cjs/_class_call_check'}' from '${normalizePath(
               require.resolve('@parcel/transformer-js/src/JSTransformer.js'),
             )}'`,
             origin: '@parcel/core',
@@ -5716,7 +5716,7 @@ describe('javascript', function () {
         name: 'BuildError',
         diagnostics: [
           {
-            message: md`Failed to resolve '${'@swc/helpers/lib/_class_call_check.js'}' from '${normalizePath(
+            message: md`Failed to resolve '${'@swc/helpers/cjs/_class_call_check'}' from '${normalizePath(
               require.resolve('@parcel/transformer-js/src/JSTransformer.js'),
             )}'`,
             origin: '@parcel/core',
@@ -5741,7 +5741,7 @@ describe('javascript', function () {
           },
           {
             message:
-              'External dependency "@swc/helpers" does not satisfy required semver range "^0.4.12".',
+              'External dependency "@swc/helpers" does not satisfy required semver range "^0.5.0".',
             origin: '@parcel/resolver-default',
             codeFrames: [
               {
@@ -5764,7 +5764,7 @@ describe('javascript', function () {
               },
             ],
             hints: [
-              'Update the dependency on "@swc/helpers" to satisfy "^0.4.12".',
+              'Update the dependency on "@swc/helpers" to satisfy "^0.5.0".',
             ],
           },
         ],

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -366,7 +366,7 @@ describe('transpilation', function () {
         .filePath,
       'utf8',
     );
-    assert(file.includes('@swc/helpers/cjs/_class_call_check'));
+    assert(file.includes('@swc/helpers/cjs/_class_call_check.cjs'));
 
     file = await outputFS.readFile(
       nullthrows(b.getBundles().find(b => b.env.outputFormat === 'esmodule'))
@@ -391,7 +391,7 @@ describe('transpilation', function () {
     );
 
     let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('@swc/helpers/cjs/_class_call_check'));
+    assert(file.includes('@swc/helpers/cjs/_class_call_check.cjs'));
     await run(b);
   });
 

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -366,14 +366,14 @@ describe('transpilation', function () {
         .filePath,
       'utf8',
     );
-    assert(file.includes('@swc/helpers/lib/_class_call_check.js'));
+    assert(file.includes('@swc/helpers/cjs/_class_call_check'));
 
     file = await outputFS.readFile(
       nullthrows(b.getBundles().find(b => b.env.outputFormat === 'esmodule'))
         .filePath,
       'utf8',
     );
-    assert(file.includes('@swc/helpers/src/_class_call_check.mjs'));
+    assert(file.includes('@swc/helpers/_/_class_call_check'));
   });
 
   it('should support commonjs versions of @swc/helpers without scope hoisting', async function () {
@@ -391,7 +391,7 @@ describe('transpilation', function () {
     );
 
     let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('@swc/helpers/lib/_class_call_check.js'));
+    assert(file.includes('@swc/helpers/cjs/_class_call_check'));
     await run(b);
   });
 

--- a/packages/optimizers/image/Cargo.toml
+++ b/packages/optimizers/image/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = {version = "2.10.6", features = ["napi4", "compat-mode"]}
 napi-derive = "2.9.4"
-oxipng = "5.0.0"
+oxipng = "6.0.0"
 mozjpeg-sys = "1.0.0"
 libc = "0.2"
 

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.227.2", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_ecmascript = { version = "0.227.5", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
 swc_common = { version = "0.31.0", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.5.0"
 indoc = "1.0.3"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.226.3", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.30.5", features = ["tty-emitter", "sourcemap"] }
-swc_atoms = "0.4.43"
+swc_ecmascript = { version = "0.227.2", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.31.0", features = ["tty-emitter", "sourcemap"] }
+swc_atoms = "0.5.0"
 indoc = "1.0.3"
 serde = "1.0.123"
 serde_bytes = "0.11.5"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.225.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.30.0", features = ["tty-emitter", "sourcemap"] }
-swc_atoms = "0.4.39"
+swc_ecmascript = { version = "0.226.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.30.4", features = ["tty-emitter", "sourcemap"] }
+swc_atoms = "0.4.43"
 indoc = "1.0.3"
 serde = "1.0.123"
 serde_bytes = "0.11.5"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.226.0", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
-swc_common = { version = "0.30.4", features = ["tty-emitter", "sourcemap"] }
+swc_ecmascript = { version = "0.226.2", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_common = { version = "0.30.5", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.4.43"
 indoc = "1.0.3"
 serde = "1.0.123"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.226.2", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_ecmascript = { version = "0.226.3", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
 swc_common = { version = "0.30.5", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.4.43"
 indoc = "1.0.3"

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -107,11 +107,9 @@ impl<'a> DependencyCollector<'a> {
     // Rewrite SWC helpers from ESM to CJS for library output.
     let mut is_specifier_rewritten = false;
     if self.config.is_library && !self.config.is_esm_output {
-      if let Some(suffix) = specifier.strip_prefix("@swc/helpers/src/") {
-        if let Some(prefix) = suffix.strip_suffix(".mjs") {
-          specifier = format!("@swc/helpers/lib/{}.js", prefix).into();
-          is_specifier_rewritten = true;
-        }
+      if let Some(rest) = specifier.strip_prefix("@swc/helpers/_/") {
+        specifier = format!("@swc/helpers/cjs/{}", rest).into();
+        is_specifier_rewritten = true;
       }
     }
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -108,7 +108,7 @@ impl<'a> DependencyCollector<'a> {
     let mut is_specifier_rewritten = false;
     if self.config.is_library && !self.config.is_esm_output {
       if let Some(rest) = specifier.strip_prefix("@swc/helpers/_/") {
-        specifier = format!("@swc/helpers/cjs/{}", rest).into();
+        specifier = format!("@swc/helpers/cjs/{}.cjs", rest).into();
         is_specifier_rewritten = true;
       }
     }

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -35,7 +35,7 @@
     "@parcel/source-map": "^2.1.1",
     "@parcel/utils": "2.8.3",
     "@parcel/workers": "2.8.3",
-    "@swc/helpers": "^0.4.12",
+    "@swc/helpers": "^0.5.0",
     "browserslist": "^4.6.6",
     "nullthrows": "^1.1.1",
     "regenerator-runtime": "^0.13.7",

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -8,7 +8,7 @@ let release = process.argv.includes('--release');
 build();
 
 async function build() {
-  if (process.platform === 'darwin') {
+  if (process.env.CI && process.platform === 'darwin') {
     setupMacBuild();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,10 +2399,10 @@
     "@swc/core-win32-ia32-msvc" "1.3.36"
     "@swc/core-win32-x64-msvc" "1.3.36"
 
-"@swc/helpers@^0.4.12":
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.4.12.tgz#203243e78cff3c87c081c97ae548ab33e2503573"
-  integrity sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==
+"@swc/helpers@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.0.tgz#bf1d807b60f7290d0ec763feea7ccdeda06e85f1"
+  integrity sha512-SjY/p4MmECVVEWspzSRpQEM3sjR17sP8PbGxELWrT+YZMBfiUyt1MRUNjMV23zohwlG2HYtCQOsCwsTHguXkyg==
   dependencies:
     tslib "^2.4.0"
 


### PR DESCRIPTION
The helper package was restructured (now using [`exports`](https://unpkg.com/browse/@swc/helpers@0.5.0/package.json) or [subpackages](https://unpkg.com/browse/@swc/helpers@0.5.0/_/_array_like_to_array/) for mjs/cjs selection)

I disabled the Mac compiler adjustment function on non-CI builds because this somehow causes Cargo to always recompile some crates (which have a build script) for me locally even when not changing any code