### PR TITLE
fix: check for source map flag instead of always emitting source map

### DIFF
--- a/packages/transformers/sass/src/SassTransformer.js
+++ b/packages/transformers/sass/src/SassTransformer.js
@@ -38,11 +38,13 @@ export default (new Transformer({
     }
 
     // Always emit sourcemap
-    configResult.sourceMap = true;
-    // sources are created relative to the directory of outFile
-    configResult.outFile = path.join(options.projectRoot, 'style.css.map');
-    configResult.omitSourceMapUrl = true;
-    configResult.sourceMapContents = false;
+    configResult.sourceMap = configResult.sourceMap ?? true;
+    if (configResult.sourceMap) {
+      // sources are created relative to the directory of outFile
+      configResult.outFile = path.join(options.projectRoot, 'style.css.map');
+      configResult.omitSourceMapUrl = true;
+      configResult.sourceMapContents = false;
+    }
 
     return configResult;
   },


### PR DESCRIPTION
# ↪️ Pull Request

This pull request should fix an issue I had where I needed to build Sass files with `@parcel/transformer-sass` and disable the source map generation. 

## 💻 Examples

When you create a `.sassrc` file to build Sass files with `@parcel/transformer-sass` and add the following content
```
{
   "sourceMap": false
}
``` 
The flag will be ignored as the sourceMap is being always emitted for some reason. 
