### PR TITLE
Deduplicate imports in hoist transformer

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-multiple-wrapped/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-multiple-wrapped/a.js
@@ -1,0 +1,14 @@
+import "./b.js";
+import "./b.js";
+import "./b.js";
+import "./b.js";
+import "./b.js";
+import "./b.js";
+import "./b.js";
+import { v1 } from "./b.js";
+import { v2 } from "./b.js";
+import { v3 } from "./b.js";
+import { v4 } from "./b.js";
+import { v5 } from "./b.js";
+
+export const result = v1 + v2 + v3 + v4 + v5;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-multiple-wrapped/b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-multiple-wrapped/b.js
@@ -1,0 +1,5 @@
+export const v1 = 1;
+export const v2 = 2;
+export const v3 = 3;
+export const v4 = 4;
+export const v5 = 5;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-multiple-wrapped/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/import-multiple-wrapped/index.js
@@ -1,0 +1,1 @@
+output = require("./a.js").result;

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -457,6 +457,49 @@ describe('scope hoisting', function () {
       assert.equal(foo + bar + baz + a + bb, 15);
     });
 
+    it('deduplicates imports when wrapped', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/import-multiple-wrapped/index.js',
+        ),
+      );
+
+      let contents = await outputFS.readFile(
+        b.getBundles()[0].filePath,
+        'utf8',
+      );
+
+      let assetB = nullthrows(
+        b.getBundles()[0]?.traverseAssets((a, _, actions) => {
+          if (
+            a.filePath ===
+            path.join(
+              __dirname,
+              '/integration/scope-hoisting/es6/import-multiple-wrapped/b.js',
+            )
+          ) {
+            actions.stop();
+            return a;
+          }
+        }),
+      );
+      assert.equal(
+        [
+          ...contents.matchAll(
+            new RegExp(
+              'parcelRequires*\\(s*"' + b.getAssetPublicId(assetB) + '"s*\\)',
+              'g',
+            ),
+          ),
+        ].length,
+        1,
+      );
+
+      let output = await run(b);
+      assert.equal(output, 15);
+    });
+
     it('supports re-exporting all exports from multiple modules deep', async function () {
       let b = await bundle(
         path.join(
@@ -546,6 +589,8 @@ describe('scope hoisting', function () {
         'integration/scope-hoisting/es6/re-export-exclude-default/b.js',
         false,
       )} does not export 'default'`;
+
+      // $FlowFixMe[prop-missing]
       await assert.rejects(() => bundle(path.join(__dirname, source)), {
         name: 'BuildError',
         message,
@@ -584,6 +629,7 @@ describe('scope hoisting', function () {
         'integration/scope-hoisting/es6/re-export-missing/c.js',
         false,
       )} does not export 'foo'`;
+      // $FlowFixMe[prop-missing]
       await assert.rejects(() => bundle(path.join(__dirname, source)), {
         name: 'BuildError',
         message,
@@ -653,6 +699,7 @@ describe('scope hoisting', function () {
       };
 
       let source = path.join(__dirname, entry);
+      // $FlowFixMe[prop-missing]
       await assert.rejects(
         () =>
           bundle(source, {
@@ -662,6 +709,7 @@ describe('scope hoisting', function () {
           }),
         error,
       );
+      // $FlowFixMe[prop-missing]
       await assert.rejects(
         () =>
           bundle(source, {


### PR DESCRIPTION
Previously,
```js
import "./b.js";
import "./b.js";
import "./b.js";
import { v1 } from "./b.js";
import { v2 } from "./b.js";
import { v3 } from "./b.js";

export var result = v1 + v2 + v3;
```
would be transformed to
```js
import "05d3ea58fa452475:./b.js:esm";
import "05d3ea58fa452475:./b.js:esm"; // unneeded
import "05d3ea58fa452475:./b.js:esm"; // unneeded
import "05d3ea58fa452475:./b.js:esm"; // unneeded
import "05d3ea58fa452475:./b.js:esm"; // unneeded
import "05d3ea58fa452475:./b.js:esm"; // unneeded
var $05d3ea58fa452475$export$aaf36426b5008f7a = (0, $05d3ea58fa452475$import$3e6e1c8e3d0d0b77$11cb33cb3c138832) + (0,
$05d3ea58fa452475$import$3e6e1c8e3d0d0b77$8815aa1d021a7d50) + (0, $05d3ea58fa452475$import$3e6e1c8e3d0d0b77$815b03eba529a08e);
```
which got packaged into
```js
parcelRequire.register("v1jxS", function(module, exports) {
$parcel$export(module.exports, "result", () => $05d3ea58fa452475$export$aaf36426b5008f7a);

var $hiPYL = parcelRequire("hiPYL");
var $hiPYL = parcelRequire("hiPYL");
var $hiPYL = parcelRequire("hiPYL");
var $hiPYL = parcelRequire("hiPYL");
var $hiPYL = parcelRequire("hiPYL");
var $hiPYL = parcelRequire("hiPYL");
var $05d3ea58fa452475$export$aaf36426b5008f7a = (0, $hiPYL.v1) + (0, $hiPYL.v2) + (0, $hiPYL.v3);
});
```

Now the transformer doesn't insert these hoisted `import "05d3ea58fa452475:./b.js:esm";` declarations multiple times anymore.