### PR TITLE
Fix absolute `file:` URL imports on Windows

### DIFF
--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -2872,11 +2872,6 @@ describe('resolver', function () {
     });
 
     it('should treat file: urls as absolute paths', async function () {
-      // TODO fixme
-      if (process.platform === 'win32') {
-        return;
-      }
-
       let resolved = await resolver.resolve({
         env: BROWSER_ENV,
         filename: 'file:///bar.js',


### PR DESCRIPTION
I found this in https://github.com/parcel-bundler/parcel/pull/8889 and added a test, but it turns out this was already broken before:

```rust
let url = URL::parse("file:///foo.js")?;
let path = url.to_file_path()?; // fails on Windows because `/foo.js` is not a valid Windows filepath
```

https://github.com/parcel-bundler/parcel/blob/99f46635710785eb1e79e4f3c6bfe8c7b2062993/packages/utils/node-resolver-rs/src/url_to_path.rs#L20-L21

https://github.com/servo/rust-url/blob/74b8694568d8eb936e339a7d726bda46881dcd9d/url/src/lib.rs#L2554

Not yet sure what to do about this 