### PR TITLE
Update GitHub Actions CI to get rid of warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
       - uses: actions-rs/toolchain@v1
@@ -25,8 +25,8 @@ jobs:
     name: Flow
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
       - run: yarn --frozen-lockfile
@@ -49,8 +49,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
           node-version: ${{matrix.node}}
@@ -74,8 +74,8 @@ jobs:
       fail-fast: false
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           cache: yarn
           node-version: ${{matrix.node}}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -14,7 +14,7 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     container:
       image: docker.io/adrienv1520/nodejs-16-centos7
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install yarn
         run: npm install --global yarn@1
       - name: Install Rust
@@ -81,7 +81,7 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -136,7 +136,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_TOKEN }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install build tools
         run: apk add --no-cache python3 make gcc g++ musl-dev curl
       - name: Install Rust
@@ -169,7 +169,7 @@ jobs:
     name: aarch64-apple-darwin
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -204,7 +204,7 @@ jobs:
       - build-linux-gnu-arm
       - build-apple-silicon
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: bahmutov/npm-install@v1.1.0
       - name: Build native packages
         run: yarn build-native-release

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -14,7 +14,7 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     container:
       image: docker.io/adrienv1520/nodejs-16-centos7
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install yarn
         run: npm install --global yarn@1
       - name: Install Rust
@@ -81,7 +81,7 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -136,7 +136,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_TOKEN }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install build tools
         run: apk add --no-cache python3 make gcc g++ musl-dev curl
       - name: Install Rust
@@ -169,7 +169,7 @@ jobs:
     name: aarch64-apple-darwin
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -204,7 +204,7 @@ jobs:
       - build-linux-gnu-arm
       - build-apple-silicon
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: bahmutov/npm-install@v1.1.0
       - name: Download artifacts
         uses: actions/download-artifact@v2


### PR DESCRIPTION
The following updates are performed:
* update [`actions/checkout`](https://github.com/actions/checkout) to v3
* update [`actions/setup-node`](https://github.com/actions/setup-node) to v3

Still using outdated versions of this actions will generate several warnings in CI runs, for example in https://github.com/parcel-bundler/parcel/actions/runs/3559400956:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2

The PR will get rid of those warnings.