### PR TITLE
Fix missing asset errors in runtime manifest bundles

### DIFF
--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -66,10 +66,15 @@ export default async function applyRuntimes<TResult>({
   let runtimes = await config.getRuntimes();
   let connections: Array<RuntimeConnection> = [];
 
-  // As manifest bundles may be added during runtimes we process them in reverse order.
-  // This allows bundles to be added to their bundle groups before they are referenced
+  // As manifest bundles may be added during runtimes we process them in reverse topological
+  // sort order. This allows bundles to be added to their bundle groups before they are referenced
   // by other bundle groups by loader runtimes
-  let bundles = bundleGraph.getBundles({includeInline: true}).reverse();
+  let bundles = [];
+  bundleGraph.traverseBundles({
+    exit(bundle) {
+      bundles.push(bundle);
+    },
+  });
 
   for (let bundle of bundles) {
     for (let runtime of runtimes) {

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -258,38 +258,82 @@ describe('bundler', function () {
 
   it('should split manifest bundle', async function () {
     let b = await bundle(
-      path.join(__dirname, 'integration/split-manifest-bundle/index.html'),
+      [
+        path.join(__dirname, 'integration/split-manifest-bundle/a.html'),
+        path.join(__dirname, 'integration/split-manifest-bundle/b.html'),
+      ],
       {
         mode: 'production',
         defaultTargetOptions: {
           shouldScopeHoist: false,
+          shouldOptimize: false,
         },
       },
     );
 
+    // There should be two manifest bunldes added, one for a.js, one for b.js
     assertBundles(b, [
       {
-        name: 'index.html',
-        assets: ['index.html'],
+        assets: ['a.html'],
       },
       {
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: ['b.html'],
       },
       {
-        assets: ['bundle-manifest.js'],
+        assets: ['a.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
       },
       {
-        assets: ['a.js', 'esmodule-helpers.js'],
+        assets: ['bundle-manifest.js'], // manifest bundle
       },
       {
-        assets: ['b.js', 'esmodule-helpers.js'],
+        assets: [
+          'b.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'esmodule-helpers.js',
+          'bundle-manifest.js',
+        ],
+      },
+      {
+        assets: ['bundle-manifest.js'], // manifest bundle
+      },
+      {
+        assets: ['c.js'],
       },
     ]);
+
+    let aManifestBundle = b
+      .getBundles()
+      .find(
+        bundle => !bundle.getMainEntry() && /a\.HASH_REF/.test(bundle.name),
+      );
+
+    let bBundles = b
+      .getBundles()
+      .filter(bundle => /b\.HASH_REF/.test(bundle.name));
+
+    let aBundleManifestAsset;
+    aManifestBundle.traverseAssets((asset, _, {stop}) => {
+      if (/runtime-[a-z0-9]{16}\.js/.test(asset.filePath)) {
+        aBundleManifestAsset = asset;
+        stop();
+      }
+    });
+    let aBundleManifestAssetCode = await aBundleManifestAsset.getCode();
+
+    // Assert the a.js manifest bundle is aware of all the b.js bundles
+    for (let bundle of bBundles) {
+      assert(
+        aBundleManifestAssetCode.includes(bundle.name),
+        `Bundle should contain reference to: "${bundle.name}"`,
+      );
+    }
   });
 
   it('should not split manifest bundle for stable entries', async function () {
     let b = await bundle(
-      path.join(__dirname, 'integration/split-manifest-bundle/index.js'),
+      path.join(__dirname, 'integration/split-manifest-bundle/a.js'),
       {
         mode: 'production',
         defaultTargetOptions: {
@@ -301,18 +345,17 @@ describe('bundler', function () {
     assertBundles(b, [
       {
         assets: [
-          'index.js',
+          'a.js',
+          'b.js',
           'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
+          'esmodule-helpers.js',
           'bundle-manifest.js',
         ],
       },
       {
-        assets: ['a.js', 'esmodule-helpers.js'],
-      },
-      {
-        assets: ['b.js', 'esmodule-helpers.js'],
+        assets: ['c.js'],
       },
     ]);
   });

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -271,7 +271,7 @@ describe('bundler', function () {
       },
     );
 
-    // There should be two manifest bunldes added, one for a.js, one for b.js
+    // There should be two manifest bundles added, one for a.js, one for b.js
     assertBundles(b, [
       {
         assets: ['a.html'],

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -292,7 +292,6 @@ describe('bundler', function () {
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
-          'bundle-manifest.js',
         ],
       },
       {

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/a.html
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/a.html
@@ -1,0 +1,1 @@
+<script type="module" src="a.js"></script>

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/a.js
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/a.js
@@ -1,1 +1,4 @@
-export const a = 'a'
+
+import {c} from './b';
+
+const ignore = () => import('./c');

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/b.html
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/b.html
@@ -1,0 +1,1 @@
+<script type="module" src="b.js"></script>

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/b.js
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/b.js
@@ -1,1 +1,1 @@
-export const b = 'b'
+export const c = () => import('./c');

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/c.js
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/index.html
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <title>External bundle manifest</title>
-</head>
-<body>
-  <script type="module" src="./index.js"></script>
-</body>
-</html>

--- a/packages/core/integration-tests/test/integration/split-manifest-bundle/index.js
+++ b/packages/core/integration-tests/test/integration/split-manifest-bundle/index.js
@@ -1,4 +1,0 @@
-const a = import('./a');
-const b = import('./b');
-
-console.log(a.a, b.b)


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR fixes an issue where runtime manifest bundles could cause bundles to be missing from the register code, causing a runtime error (`Error: Could not resolve bundle with id abKQ5`).

This issue would occur when a runtime manifest bundle was split out from the bundle group entry but one (or more) of it's parents runtimes had already been processed, causing the new bundle to be missing from the register code. 

Previously we were processing the bundles in reverse order to handle this issue, but that only minimised the issue and didn't eliminate it completely. The fix here is to process the bundles in reverse topological order which means all child bundles will be processed before their parents. 

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 🚨 Test instructions

As this is just a slight modification of the existing code I haven't added more tests scenarios.

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
