### PR TITLE
Remove v8-compile-cache

### DIFF
--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -33,8 +33,7 @@
     "@parcel/utils": "2.8.3",
     "chalk": "^4.1.0",
     "commander": "^7.0.0",
-    "get-port": "^4.2.0",
-    "v8-compile-cache": "^2.0.0"
+    "get-port": "^4.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -13,8 +13,6 @@ import path from 'path';
 import getPort from 'get-port';
 import {version} from '../package.json';
 
-require('v8-compile-cache');
-
 const program = new commander.Command();
 
 // Exit codes in response to signals are traditionally

--- a/packages/core/utils/src/prettyDiagnostic.js
+++ b/packages/core/utils/src/prettyDiagnostic.js
@@ -77,10 +77,14 @@ export default async function prettyDiagnostic(
         });
       }
 
-      let location =
-        typeof filePath !== 'string'
-          ? ''
-          : `${filePath}:${highlights[0].start.line}:${highlights[0].start.column}`;
+      let location;
+      if (typeof filePath !== 'string') {
+        location = '';
+      } else if (highlights.length === 0) {
+        location = filePath;
+      } else {
+        location = `${filePath}:${highlights[0].start.line}:${highlights[0].start.column}`;
+      }
       result.codeframe += location ? chalk.gray.underline(location) + '\n' : '';
       result.codeframe += formattedCodeFrame;
       if (codeFrame !== codeFrames[codeFrames.length - 1]) {


### PR DESCRIPTION
Because of https://github.com/zertosh/v8-compile-cache/issues/30

Closes https://github.com/parcel-bundler/parcel/issues/8987

The diagnostics change fixes an error caused by https://github.com/parcel-bundler/parcel/blob/2facd5df904b3888774a965a6be0e16248006449/packages/core/package-manager/src/NodePackageManager.js#L130-L139
because `codeHighlights[0]` was undefined