### PR TITLE
Fix `inlineEnvironment` perf

### DIFF
--- a/packages/core/utils/src/glob.js
+++ b/packages/core/utils/src/glob.js
@@ -5,7 +5,7 @@ import type {FileSystem} from '@parcel/fs';
 
 import _isGlob from 'is-glob';
 import fastGlob, {type FastGlobOptions} from 'fast-glob';
-import {isMatch, makeRe, type Options} from 'micromatch';
+import micromatch, {isMatch, makeRe, type Options} from 'micromatch';
 import {normalizeSeparators} from './path';
 
 export function isGlob(p: FilePath): any {
@@ -21,6 +21,18 @@ export function isGlobMatch(
     ? glob.map(normalizeSeparators)
     : normalizeSeparators(glob);
   return isMatch(filePath, glob, opts);
+}
+
+export function globMatch(
+  values: Array<string>,
+  glob: Glob | Array<Glob>,
+  opts?: Options,
+): Array<string> {
+  glob = Array.isArray(glob)
+    ? glob.map(normalizeSeparators)
+    : normalizeSeparators(glob);
+
+  return micromatch(values, glob, opts);
 }
 
 export function globToRegex(glob: Glob, opts?: Options): RegExp {

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -49,7 +49,14 @@ export {
 export {DefaultMap, DefaultWeakMap} from './DefaultMap';
 export {makeDeferredWithPromise} from './Deferred';
 export {getProgressMessage} from './progress-message.js';
-export {isGlob, isGlobMatch, globSync, glob, globToRegex} from './glob';
+export {
+  isGlob,
+  isGlobMatch,
+  globMatch,
+  globSync,
+  glob,
+  globToRegex,
+} from './glob';
 export {hashStream, hashObject, hashFile} from './hash';
 export {SharedBuffer} from './shared-buffer';
 export {fuzzySearch} from './schema';

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -10,7 +10,7 @@ import browserslist from 'browserslist';
 import semver from 'semver';
 import nullthrows from 'nullthrows';
 import ThrowableDiagnostic, {encodeJSONKeyComponent} from '@parcel/diagnostic';
-import {validateSchema, remapSourceLocation, isGlobMatch} from '@parcel/utils';
+import {validateSchema, remapSourceLocation, matchGlobs} from '@parcel/utils';
 import WorkerFarm from '@parcel/workers';
 import pkg from '../package.json';
 
@@ -365,10 +365,11 @@ export default (new Transformer({
         env.PARCEL_BUILD_ENV = 'test';
       }
     } else if (Array.isArray(config?.inlineEnvironment)) {
-      for (let key in options.env) {
-        if (isGlobMatch(key, config.inlineEnvironment)) {
-          env[key] = String(options.env[key]);
-        }
+      for (let match of matchGlobs(
+        Object.keys(options.env),
+        config.inlineEnvironment,
+      )) {
+        env[match] = String(options.env[match]);
       }
     } else {
       for (let key in options.env) {

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -10,7 +10,7 @@ import browserslist from 'browserslist';
 import semver from 'semver';
 import nullthrows from 'nullthrows';
 import ThrowableDiagnostic, {encodeJSONKeyComponent} from '@parcel/diagnostic';
-import {validateSchema, remapSourceLocation, matchGlobs} from '@parcel/utils';
+import {validateSchema, remapSourceLocation, globMatch} from '@parcel/utils';
 import WorkerFarm from '@parcel/workers';
 import pkg from '../package.json';
 
@@ -365,7 +365,7 @@ export default (new Transformer({
         env.PARCEL_BUILD_ENV = 'test';
       }
     } else if (Array.isArray(config?.inlineEnvironment)) {
-      for (let match of matchGlobs(
+      for (let match of globMatch(
         Object.keys(options.env),
         config.inlineEnvironment,
       )) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Currently, when the `inlineEnvironment` config in the JS transformer is used with an array value, it does a glob match against every environment variable in the process. This leads to a large drop in performance as it is performed for every JS file in the build. 

`micromatch`, which is used for our glob matching, actually supports many to many matching which is much more performant for this type of case. This PR exposes a new glob API (`globMatch`) which is now used in the JS transformer. 

Just change took a local build completion time from `~140s` to  `~70s`. 

While this is good, I do wonder if there's a way to optimize this further as this work should only be done once per build? It is currently done once per file.

## 🚨 Test instructions

No new tests as functionality hasn't changed. 

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
