### PR TITLE
Minor - added missing import to @parcel/cache types

### DIFF
--- a/packages/core/cache/index.d.ts
+++ b/packages/core/cache/index.d.ts
@@ -1,6 +1,8 @@
 import type {FilePath} from '@parcel/types';
 
 export type {Cache} from './lib/types';
+import type {Cache} from './lib/types';
+
 export const FSCache: {
   new (cacheDir: FilePath): Cache
 };

--- a/packages/core/cache/index.d.ts
+++ b/packages/core/cache/index.d.ts
@@ -1,8 +1,7 @@
 import type {FilePath} from '@parcel/types';
-
-export type {Cache} from './lib/types';
 import type {Cache} from './lib/types';
 
+export type {Cache} from './lib/types';
 export const FSCache: {
   new (cacheDir: FilePath): Cache
 };


### PR DESCRIPTION
# ↪️ Pull Request

When creating a Parcel plugin using TypeScript and the `@parcel/types` package, it would fail to compile because of an invalid type export in `@parcel/cache`

```typescript
import { Transformer } from '@parcel/plugin';
import type { Transformer as TransformerOpts } from '@parcel/types';

export type TransformerConfigType = {};

export type TransformerOptions = Parameters<TransformerOpts<TransformerConfigType>['transform']>[0];
export type TransformerResult = ReturnType<TransformerOpts<TransformerConfigType>['transform']>;
export type TransformerFunc = (options: TransformerOptions) => TransformerResult

// Transformer function and its types are extracted so it can be independently unit tested
// It would be in a seperate file to the default export below to avoid instantiation during testing
export const transform: TransformerFunc = ({ asset }) => [asset]

export default new Transformer<TransformerConfigType>({ transform });
```

```
$ npx tsc

../../node_modules/.pnpm/@parcel+cache@2.8.3_@parcel+core@2.8.3/node_modules/@parcel/cache/index.d.ts:5:29 - error TS2304: Cannot find name 'Cache'.

5   new (cacheDir: FilePath): Cache
                              ~~~~~

../../node_modules/.pnpm/@parcel+cache@2.8.3_@parcel+core@2.8.3/node_modules/@parcel/cache/index.d.ts:9:29 - error TS2304: Cannot find name 'Cache'.

9   new (cacheDir: FilePath): Cache
                              ~~~~~
Found 2 errors in the same file, starting at: ../../node_modules/.pnpm/@parcel+cache@2.8.3_@parcel+core@2.8.3/node_modules/@parcel/cache/index.d.ts:5
```

Looking at the type signature, sure enough we are exporting a type but not importing the type for consumption.
![image](https://github.com/parcel-bundler/parcel/assets/12656294/cca72797-832c-4f68-b91a-e8b394c4f1cf)

This PR just imports `Cache` into the file that uses it. Making this change locally fixes the build.
