### PR TITLE
Avoid leaking local types by the generated declarations

### DIFF
--- a/packages/transformers/typescript-types/src/TSTypesTransformer.js
+++ b/packages/transformers/typescript-types/src/TSTypesTransformer.js
@@ -165,6 +165,7 @@ export default (new Transformer({
 
     let code = nullthrows(host.outputCode);
     code = code.substring(0, code.lastIndexOf('//# sourceMappingURL'));
+    code += `\nexport {};\n`;
 
     let map = JSON.parse(nullthrows(host.outputMap));
     map.sources = map.sources.map(source =>


### PR DESCRIPTION
# ↪️ Pull Request

When working on a PR [here](https://github.com/bvaughn/react-resizable-panels/pull/148), I noticed that some type **stopped** being exported. This seemed quite odd because they were never exported in the first place.

We can verify this both by checking `src/index.ts` [here](https://github.com/bvaughn/react-resizable-panels/blob/5aafa03f30778b896e5bc9b61ad5fca2ad542251/packages/react-resizable-panels/src/index.ts) and by checking the generated `.d.ts` [here](https://unpkg.com/browse/react-resizable-panels@0.0.45/dist/react-resizable-panels.d.ts). 

## 🚨 Test instructions

`git clone git@github.com:bvaughn/react-resizable-panels.git && corepack pnpm i && pnpm run prerelease && pnpm run typescript`

With this script, I'd expect the typechecking to trip over [this import](https://github.com/bvaughn/react-resizable-panels/blob/5aafa03f30778b896e5bc9b61ad5fca2ad542251/packages/react-resizable-panels-website/src/utils/UrlData.ts#L20) (and some others as well). If we apply my patch then we will witness the expected behavior.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change 
- [x] Included links to related issues/PRs

Note: I could use some pointers as to where I should put some tests for this and how they should look like (unit, integration, etc).