### PR TITLE
Bump some dependencies with "breaking" changes in patch versions

### DIFF
--- a/flow-libs/fastest-levenshtein.js.flow
+++ b/flow-libs/fastest-levenshtein.js.flow
@@ -1,7 +1,5 @@
 // @flow strict-local
 
 declare module 'fastest-levenshtein' {
-  declare module.exports: {|
-   distance(a: string, b: string): number;
-  |};
+  declare export function distance(a: string, b: string): number;
 }

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -47,7 +47,7 @@
     "ansi-html-community": "0.0.8",
     "clone": "^2.1.1",
     "fast-glob": "^3.2.12",
-    "fastest-levenshtein": "^1.0.8",
+    "fastest-levenshtein": "^1.0.16",
     "is-glob": "^4.0.0",
     "is-url": "^1.2.2",
     "json5": "^2.2.0",

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -6,8 +6,7 @@ import ThrowableDiagnostic, {
 } from '@parcel/diagnostic';
 import type {Mapping} from '@mischnic/json-sourcemap';
 import nullthrows from 'nullthrows';
-// flowlint-next-line untyped-import:off
-import levenshtein from 'fastest-levenshtein';
+import * as levenshtein from 'fastest-levenshtein';
 
 export type SchemaEntity =
   | SchemaObject

--- a/packages/packagers/xml/package.json
+++ b/packages/packagers/xml/package.json
@@ -23,6 +23,6 @@
     "@parcel/plugin": "2.8.3",
     "@parcel/types": "2.8.3",
     "@parcel/utils": "2.8.3",
-    "@xmldom/xmldom": "^0.7.5"
+    "@xmldom/xmldom": "^0.7.9"
   }
 }

--- a/packages/packagers/xml/src/XMLPackager.js
+++ b/packages/packagers/xml/src/XMLPackager.js
@@ -53,8 +53,11 @@ export default (new Packager({
             contents,
             'application/xml',
           );
-          element.parentNode.removeChild(element);
-          element.parentNode.appendChild(parsed.documentElement);
+          if (parsed.documentElement != null) {
+            let parent = element.parentNode;
+            parent.removeChild(element);
+            parent.appendChild(parsed.documentElement);
+          }
         } else {
           element.parentNode.textContent = contents;
         }

--- a/packages/transformers/xml/package.json
+++ b/packages/transformers/xml/package.json
@@ -21,6 +21,6 @@
   },
   "dependencies": {
     "@parcel/plugin": "2.8.3",
-    "@xmldom/xmldom": "^0.7.5"
+    "@xmldom/xmldom": "^0.7.9"
   }
 }

--- a/packages/transformers/xml/src/atom.js
+++ b/packages/transformers/xml/src/atom.js
@@ -34,11 +34,10 @@ export function content(
       break;
     case 'xhtml': {
       let fragment = element.ownerDocument.createDocumentFragment();
-      let child = element.firstChild;
-      while (child) {
+      let child;
+      while ((child = element.firstChild)) {
         element.removeChild(child);
         fragment.appendChild(child.cloneNode(true));
-        child = child.nextSibling;
       }
       contents = new XMLSerializer().serializeToString(fragment);
       break;

--- a/packages/transformers/xml/src/rss.js
+++ b/packages/transformers/xml/src/rss.js
@@ -37,10 +37,9 @@ export function description(
     bundleBehavior: 'inline',
   });
 
-  let child = element.firstChild;
-  while (child) {
+  let child;
+  while ((child = element.firstChild)) {
     element.removeChild(child);
-    child = child.nextSibling;
   }
 
   let el = element.ownerDocument.createElementNS(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6101,10 +6101,10 @@ fast-url-parser@1.1.3:
   dependencies:
     punycode "^1.3.2"
 
-fastest-levenshtein@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.8.tgz#96684719abfc533c2d0b47bbdad0eb60ec0edbe4"
-  integrity sha512-SRj7muXzcgIvuq8wYyANmMRwuCWhE6e+HIKlLAUNICRaxNRc0ZAhpayNVKefoscbP5mGBorLy0RTdrkH7l5IIA==
+fastest-levenshtein@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
+  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
 fastq@^1.6.0:
   version "1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2689,10 +2689,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.27.tgz#d5c6e574ee1afd55043470bf70b15772da4e19a2"
   integrity sha512-rpAn9k6O08Lvo7ekBIAnkOukX/4EsEQLPrRJBKhIEasMsOI5eX0f6mq1sDUSY7cgAqWw2d7QtP74CWxdXoyKxA==
 
-"@xmldom/xmldom@^0.7.5":
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.6.tgz#6f55073fa73e65776bd85826958b98c8cd1457b5"
-  integrity sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==
+"@xmldom/xmldom@^0.7.9":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.9.tgz#7f9278a50e737920e21b297b8a35286e9942c056"
+  integrity sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==
 
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
@@ -3950,14 +3950,7 @@ chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.4:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
-chrome-trace-event@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
-  integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
-  dependencies:
-    tslib "^1.9.0"
-
-chrome-trace-event@^1.0.3:
+chrome-trace-event@^1.0.2, chrome-trace-event@^1.0.3:
   version "1.0.3"
   resolved "https://packages.atlassian.com/api/npm/npm-remote/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==
@@ -5880,12 +5873,7 @@ estraverse@^4.1.1:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
-  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
-
-estraverse@^5.3.0:
+estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==


### PR DESCRIPTION
I copied some changes from #8631 that aren't related to undeclared dependencies (and caused the tests to fail once some deps were bumped in the lockfile)

Both of these happened in a patch version (that is covered by our dependency ranges):
- `fastest-levenshtein` added `__esModule: true`, so `import levenshtein from "..."` didn't work anymore.
- `xmldom` now correctly updates `element.parentNode` after removing the element:
```js
element.parentNode.removeChild(element);
element.parentNode.appendChild(...); // parentNode is null now
```
And for empty documents, `parsed.documentElement` is null