### PR TITLE
Fix EntryResolver.resolveEntry infinite loop when entries look like globs

### DIFF
--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -153,7 +153,7 @@ export class EntryResolver {
     this.options = options;
   }
 
-  isTrulyGlob(entry: FilePath): Promise<boolean> {
+  isTrulyGlob(entry: FilePath): Promise<Boolean> {
     if (!isGlob(entry)) {
       return false;
     }

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -153,9 +153,9 @@ export class EntryResolver {
     this.options = options;
   }
 
-  isTrulyGlob(entry: FilePath): Promise<Boolean> {
+  isTrulyGlob(entry: FilePath): Promise<boolean> {
     if (!isGlob(entry)) {
-      return false;
+      return Promise.resolve(false);
     }
 
     return this.options.inputFS

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -153,8 +153,19 @@ export class EntryResolver {
     this.options = options;
   }
 
+  isTrulyGlob(entry: FilePath): Promise<boolean> {
+    if (!isGlob(entry)) {
+      return false;
+    }
+
+    return this.options.inputFS
+      .stat(entry)
+      .then(() => false)
+      .catch(() => true);
+  }
+
   async resolveEntry(entry: FilePath): Promise<EntryResult> {
-    if (isGlob(entry)) {
+    if (await this.isTrulyGlob(entry)) {
       let files = await glob(entry, this.options.inputFS, {
         absolute: true,
         onlyFiles: false,

--- a/packages/core/core/test/EntryRequest.test.js
+++ b/packages/core/core/test/EntryRequest.test.js
@@ -34,6 +34,11 @@ const INVALID_TARGET_SOURCE_NOT_FILE_FIXTURE_PATH = path.join(
   'fixtures/invalid-target-source-not-file',
 );
 
+const GLOB_LIKE_FIXTURE_PATH = path.join(
+  __dirname,
+  'fixtures/glob-like/[entry].js',
+);
+
 describe('EntryResolver', function () {
   let entryResolver = new EntryResolver({...DEFAULT_OPTIONS});
 
@@ -202,5 +207,9 @@ describe('EntryResolver', function () {
         ],
       },
     );
+  });
+  it('does not time out on glob-like entry', async function () {
+    this.timeout(10000);
+    await entryResolver.resolveEntry(GLOB_LIKE_FIXTURE_PATH);
   });
 });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
https://github.com/parcel-bundler/parcel/issues/8519

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

if you try to build any file whose path looks like a glob, like `/blog/[id].html` it will cause a infinite loop

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

~~I wasn't able to run test locally, I am having this error:~~

> ```
> /parcel/packages/core/core/src/AssetGraph.js: Cannot find module '@parcel/hash'
> ```

~~Even with v2 branch.~~

~~I couldn't find any solution. Maybe I need some guidance.~~

Also with the linter, It was erroring, but it was not showing any specific reason.

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
