### PR TITLE
Set max concurrent calls to 1 when tracing

### DIFF
--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -60,6 +60,8 @@ export type WorkerApi = {|
 
 export {Handle};
 
+const DEFAULT_MAX_CONCURRENT_CALLS: number = 30;
+
 /**
  * workerPath should always be defined inside farmOptions
  */
@@ -83,7 +85,9 @@ export default class WorkerFarm extends EventEmitter {
     super();
     this.options = {
       maxConcurrentWorkers: WorkerFarm.getNumWorkers(),
-      maxConcurrentCallsPerWorker: WorkerFarm.getConcurrentCallsPerWorker(),
+      maxConcurrentCallsPerWorker: WorkerFarm.getConcurrentCallsPerWorker(
+        farmOptions.shouldTrace ? 1 : DEFAULT_MAX_CONCURRENT_CALLS,
+      ),
       forcedKillTime: 500,
       warmWorkers: false,
       useLocalWorker: true, // TODO: setting this to false makes some tests fail, figure out why
@@ -648,8 +652,12 @@ export default class WorkerFarm extends EventEmitter {
     return child.workerApi;
   }
 
-  static getConcurrentCallsPerWorker(): number {
-    return parseInt(process.env.PARCEL_MAX_CONCURRENT_CALLS, 10) || 30;
+  static getConcurrentCallsPerWorker(
+    defaultValue?: number = DEFAULT_MAX_CONCURRENT_CALLS,
+  ): number {
+    return (
+      parseInt(process.env.PARCEL_MAX_CONCURRENT_CALLS, 10) || defaultValue
+    );
   }
 }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

When generating a trace with `--trace`, it is possible to get inaccurate results on the timings not because of anything in particular that the tracing setup is doing, but because of the work queue used by workers. By default Parcel will have a "max concurrent call" size of 30 for workers. With this, it is possible for plugins that are `await`ing the results of an async call in their internal logic can get blocked by a large piece of unrelated work on the event loop. This is exacerbated because in a worker there could be 30 plugin calls waiting, so any delay in completion of the plugin call has a multiplicative effect for plugins that otherwise complete very quickly.

This results in the timing for that plugin call not accurately reflecting the relative time spent in the plugin.

This change will set the max concurrent calls for a worker farm to 1 when tracing is enabled, this only has a minor difference on build performance in practice, and the intention of tracing is to provide _relative_ costs of different operations rather than absolute.  

It is still possible to override the max concurrent calls with `PARCEL_MAX_CONCURRENT_CALLS` even when tracing is enabled.

## 🚨 Test instructions

Run Parcel with `--trace`, observe that things still work correctly and the numbers when analysed in Perfetto look reasonable.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
