### PR TITLE
Don't send HMR updates before packaging in watch mode

### DIFF
--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -91,7 +91,13 @@ export default (new Reporter({
         }
         break;
       case 'buildProgress':
-        if (event.phase === 'bundled' && hmrServer) {
+        if (
+          event.phase === 'bundled' &&
+          hmrServer &&
+          // Only send HMR updates before packaging if the built in dev server is used to ensure that
+          // no stale bundles are served. Otherwise emit it for 'buildSuccess'.
+          options.serveOptions !== false
+        ) {
           await hmrServer.emitUpdate(event);
         }
         break;
@@ -105,6 +111,9 @@ export default (new Reporter({
           }
 
           server.buildSuccess(event.bundleGraph, event.requestBundle);
+        }
+        if (hmrServer && options.serveOptions === false) {
+          await hmrServer.emitUpdate(event);
         }
         break;
       case 'buildFailure':


### PR DESCRIPTION
Since https://github.com/parcel-bundler/parcel/pull/8582, HMR updates are sent before bundles are written to disk because the dev server stalls any potential requests until the build is finished (and it never serves outdated bundles from the previous build).

But when not using the builtin dev server, outdated bundles will be served (non-deterministically depending on how quickly the browser triggers the page reload and how long Parcel takes to write all bundles).

Now, the optimization from that PR is only used when the builtin dev server is used (so not for `parcel watch`). I don't think there's anything else we can here

Closes https://github.com/parcel-bundler/parcel/issues/8940