### PR TITLE
Upgrade to svgo 3

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -2910,7 +2910,11 @@ describe('html', function () {
 
     let output = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(output.includes('<x-custom stddeviation="0.5"'));
-    assert(output.includes('<svg role="img" viewBox='));
+    assert(
+      output.includes(
+        '<svg role="img" viewBox="1.8 2.4 2 2" preserveAspectRatio="xMinYMin meet">',
+      ),
+    );
     assert(output.includes('<filter'));
     assert(output.includes('<feGaussianBlur in="SourceGraphic" stdDeviation='));
   });

--- a/packages/core/integration-tests/test/integration/svgo-config/svgo.config.js
+++ b/packages/core/integration-tests/test/integration/svgo-config/svgo.config.js
@@ -1,10 +1,12 @@
-const { extendDefaultPlugins } = require('svgo');
-
 module.exports = {
-  plugins: extendDefaultPlugins([
+  plugins: [
     {
-      name: 'removeComments',
-      active: false
-    }
-  ])
-}
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeComments: false,
+        },
+      },
+    },
+  ],
+};

--- a/packages/optimizers/htmlnano/package.json
+++ b/packages/optimizers/htmlnano/package.json
@@ -24,6 +24,6 @@
     "htmlnano": "^2.0.0",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.16.5",
-    "svgo": "^2.4.0"
+    "svgo": "^3.0.2"
   }
 }

--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -73,7 +73,7 @@ export default (new Optimizer({
                 // Do not minify ids or remove unreferenced elements in
                 // inline SVGs because they could actually be referenced
                 // by a separate inline SVG.
-                cleanupIDs: false,
+                cleanupIds: false,
               },
             },
           },

--- a/packages/optimizers/svgo/package.json
+++ b/packages/optimizers/svgo/package.json
@@ -23,6 +23,6 @@
     "@parcel/diagnostic": "2.9.0",
     "@parcel/plugin": "2.9.0",
     "@parcel/utils": "2.9.0",
-    "svgo": "^2.4.0"
+    "svgo": "^3.0.0"
   }
 }

--- a/packages/optimizers/svgo/src/SVGOOptimizer.js
+++ b/packages/optimizers/svgo/src/SVGOOptimizer.js
@@ -24,28 +24,42 @@ export default (new Optimizer({
     }
 
     let code = await blobToString(contents);
-    let result = svgo.optimize(code, {
-      plugins: [
-        {
-          name: 'preset-default',
-          params: {
-            overrides: {
-              // Removing ids could break SVG sprites.
-              cleanupIDs: false,
-              // <style> elements and attributes are already minified before they
-              // are re-inserted by the packager.
-              minifyStyles: false,
+    let result;
+    try {
+      result = svgo.optimize(code, {
+        plugins: [
+          {
+            name: 'preset-default',
+            params: {
+              overrides: {
+                // Removing ids could break SVG sprites.
+                cleanupIds: false,
+                // <style> elements and attributes are already minified before they
+                // are re-inserted by the packager.
+                minifyStyles: false,
+              },
             },
           },
-        },
-      ],
-      ...config,
-    });
-
-    if (result.error != null) {
+        ],
+        ...config,
+      });
+    } catch (e) {
+      let {message, line, column} = e;
       throw new ThrowableDiagnostic({
         diagnostic: {
-          message: result.error,
+          message,
+          codeFrames: [
+            {
+              code,
+              language: 'svg',
+              codeHighlights: [
+                {
+                  start: {line, column},
+                  end: {line, column},
+                },
+              ],
+            },
+          ],
         },
       });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4640,6 +4640,22 @@ css-tree@^1.1.2, css-tree@^1.1.3:
     mdn-data "2.0.14"
     source-map "^0.6.1"
 
+css-tree@^2.2.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.3.1.tgz#10264ce1e5442e8572fc82fbe490644ff54b5c20"
+  integrity sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==
+  dependencies:
+    mdn-data "2.0.30"
+    source-map-js "^1.0.1"
+
+css-tree@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.2.1.tgz#36115d382d60afd271e377f9c5f67d02bd48c032"
+  integrity sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==
+  dependencies:
+    mdn-data "2.0.28"
+    source-map-js "^1.0.1"
+
 css-what@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
@@ -4719,6 +4735,13 @@ csso@^4.2.0:
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
+
+csso@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-5.0.5.tgz#f9b7fe6cc6ac0b7d90781bb16d5e9874303e2ca6"
+  integrity sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==
+  dependencies:
+    css-tree "~2.2.0"
 
 cssom@^0.5.0:
   version "0.5.0"
@@ -9001,6 +9024,16 @@ mdn-data@2.0.14:
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
   integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
+mdn-data@2.0.28:
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
+  integrity sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==
+
+mdn-data@2.0.30:
+  version "2.0.30"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.30.tgz#ce4df6f80af6cfbe218ecd5c552ba13c4dfa08cc"
+  integrity sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==
+
 mdurl@^1.0.0, mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
@@ -12709,7 +12742,7 @@ svg-parser@^2.0.2:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svgo@^2.4.0, svgo@^2.5.0, svgo@^2.7.0:
+svgo@^2.5.0, svgo@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
   integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==
@@ -12721,6 +12754,18 @@ svgo@^2.4.0, svgo@^2.5.0, svgo@^2.7.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+svgo@^3.0.0, svgo@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-3.0.2.tgz#5e99eeea42c68ee0dc46aa16da093838c262fe0a"
+  integrity sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==
+  dependencies:
+    "@trysound/sax" "0.2.0"
+    commander "^7.2.0"
+    css-select "^5.1.0"
+    css-tree "^2.2.1"
+    csso "^5.0.5"
+    picocolors "^1.0.0"
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/8948

The breaking changes: https://github.com/svg/svgo/releases/tag/v3.0.0

- The plugin `cleanupIDs` was renamed to `cleanupIds`
- Some custom/third-party plugins might break as the API changed
- You need to use `overrides` instead of `extendDefaultPlugins` to change preset default settings

I'm still not entirely sure if this is safe to do...