### PR TITLE
Ignore duplicate slashes at the start of relative path specifiers

### DIFF
--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -1228,6 +1228,14 @@ mod tests {
     );
     assert_eq!(
       test_resolver()
+        .resolve(".///bar.js", &root().join("foo.js"), SpecifierType::Esm)
+        .result
+        .unwrap()
+        .0,
+      Resolution::Path(root().join("bar.js"))
+    );
+    assert_eq!(
+      test_resolver()
         .resolve("./bar", &root().join("foo.js"), SpecifierType::Esm)
         .result
         .unwrap()

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -59,7 +59,11 @@ impl<'a> Specifier<'a> {
 
     Ok(match specifier.as_bytes()[0] {
       b'.' => {
-        let specifier = specifier.strip_prefix("./").unwrap_or(specifier);
+        let specifier = if let Some(specifier) = specifier.strip_prefix("./") {
+          specifier.trim_start_matches('/')
+        } else {
+          specifier
+        };
         let (path, query) = decode_path(specifier, specifier_type);
         (Specifier::Relative(path), query)
       }


### PR DESCRIPTION
Fixes #9042

Rust already ignores duplicate separators in paths, but we were stripping the leading "./"` from relative separators, and if there were another "/" it would be interpreted as an absolute path instead.