### PR TITLE
Ignore port warning when runing parcel watch

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -420,7 +420,7 @@ async function normalizeOptions(
       });
     }
 
-    if (port !== originalPort) {
+    if (port !== originalPort && command.name() !== 'watch') {
       let errorMessage = `Port "${originalPort}" could not be used`;
       if (command.port != null) {
         // Throw the error if the user defined a custom port


### PR DESCRIPTION


# ↪️ Pull Request

FIX: https://github.com/parcel-bundler/parcel/issues/8812

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
