### PR TITLE
Serve folder's index when requesting folder without slash

### DIFF
--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -176,7 +176,7 @@ describe('server', function () {
     assert.equal(await get('/', port), rootIndex);
     assert.equal(await get('/something', port), rootIndex);
     assert.equal(await get('/other', port), other);
-    assert.equal(await get('/foo', port), rootIndex);
+    assert.equal(await get('/foo', port), fooIndex);
     assert.equal(await get('/foo/', port), fooIndex);
     assert.equal(await get('/foo/bar', port), fooIndex);
     assert.equal(await get('/foo/other', port), fooOther);

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -210,8 +210,11 @@ export default class Server {
           let isIndex = withoutExtension === 'index';
 
           let matchesIsIndex = null;
-          if (isIndex && req.url.startsWith(bundleDirSubdir)) {
-            // bundle is /bar/index.html and something inside of /bar/** was requested
+          if (
+            isIndex &&
+            (req.url.startsWith(bundleDirSubdir) || req.url === bundleDir)
+          ) {
+            // bundle is /bar/index.html and (/bar or something inside of /bar/** was requested was requested)
             matchesIsIndex = true;
           } else if (req.url == path.posix.join(bundleDir, withoutExtension)) {
             // bundle is /bar/foo.html and /bar/foo was requested


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/9061

Before https://github.com/parcel-bundler/parcel/pull/8957, `GET /foo` could return `/foo/index.html`. But after my change at didn't happen anymore. So this line from that PR wasn't really thought through:

> - `/foo` doesn't match `/foo/index.html`, you need `/foo/` for that (this would otherwise break relative URLs)

Change that case back again