### PR TITLE
Add core as peerdep to image optimizer

### DIFF
--- a/packages/optimizers/image/package.json
+++ b/packages/optimizers/image/package.json
@@ -37,6 +37,9 @@
     "@parcel/utils": "2.9.1",
     "@parcel/workers": "2.9.1"
   },
+  "peerDependencies": {
+    "@parcel/core": "^2.9.1"
+  },
   "devDependencies": {
     "@napi-rs/cli": "^2.15.2",
     "tiny-benchy": "^1.0.2"


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/7880 

Forward the peerdep of `@parcel/workers` to `@parcel/core`

https://github.com/parcel-bundler/parcel/pull/7977 did this for `@parcel/transformer-js` and `@parcel/transformer-image` already