### PR TITLE
Treat re-exports of '*' from empty files as ESM

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/index.js
@@ -1,0 +1,3 @@
+import {bar} from 'lib';
+
+output = `foo ${bar}`;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/bar.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/bar.js
@@ -1,0 +1,1 @@
+export default 'bar';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/index.js
@@ -1,0 +1,2 @@
+export * from './other';
+export * from './empty';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/other.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/other.js
@@ -1,0 +1,1 @@
+export {default as bar} from './bar';

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "lib",
+  "module": "./index.js",
+  "sideEffects": false
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -360,6 +360,28 @@ describe('scope hoisting', function () {
       assert.strictEqual(output, '2 4');
     });
 
+    it('supports re-exporting all from an empty module without side effects', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-all-empty-no-side-effects/index.js',
+        ),
+        {
+          mode: 'production',
+        },
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, 'foo bar');
+
+      let contents = await outputFS.readFile(
+        b.getBundles().find(b => b.getMainEntry().filePath.endsWith('index.js'))
+          .filePath,
+        'utf8',
+      );
+      assert.match(contents, /output="foo bar"/);
+    });
+
     it('supports re-exporting all exports from an external module', async function () {
       let b = await bundle(
         path.join(

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -813,11 +813,13 @@ export default (new Transformer({
         });
       }
 
-      // Add * symbol if there are CJS exports, no imports/exports at all, or the asset is wrapped.
+      // Add * symbol if there are CJS exports, no imports/exports at all
+      // (and the asset has side effects), or the asset is wrapped.
       // This allows accessing symbols that don't exist without errors in symbol propagation.
       if (
         hoist_result.has_cjs_exports ||
         (!hoist_result.is_esm &&
+          asset.sideEffects &&
           deps.size === 0 &&
           Object.keys(hoist_result.exported_symbols).length === 0) ||
         (hoist_result.should_wrap && !asset.symbols.hasExportSymbol('*'))


### PR DESCRIPTION
# ↪️ Pull Request

## Background

Many packages written in e.g., TypeScript are built for publishing to NPM by stripping types from the source files. This can lead to situations where ‘types-only’ files are stripped of all of their type definitions, leaving completely empty files behind. If there are imports from these ‘types-only’ files that are not also stripped (e.g., they re-export `*` from the module without the `type` keyword), then the resulting package ships with a dependency on a completely empty file.

## Current Behavior

This is a conundrum for Parcel, as it’s not clear what to do about the empty file when resolving. The current behavior is to treat these files as ‘dynamic CJS’ (to account for scenarios where `module.exports` might be modified outside of the module itself).

## The Problem

However, this is suboptimal for what is probably the most common case (as described in the first paragraph); ideally Parcel would treat these empty files as ESM with empty exports, and thus avoid the deopt to dynamic resolution altogether.

## Suggested Change

The compromise solution here is to treat these empty files as ESM **only if the asset is known to have no side effects** (e.g., the package defines `sideEffects: false`), and keep the 'dynamic CJS' behavior as the fallback.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
