### PR TITLE
Fix self references in CSS module JS assets

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -455,6 +455,10 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
         let dependentAsset = assetsByKey.get(dep.specifier);
         if (dependentAsset) {
           dependentAssets.push(dependentAsset);
+          if (dependentAsset.id === asset.id) {
+            // Don't orphan circular dependencies.
+            isDirect = true;
+          }
         }
       }
       let id = this.addNode(nodeFromAsset(asset));

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -271,6 +271,14 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
     this.#asset.value.sideEffects = sideEffects;
   }
 
+  get uniqueKey(): ?string {
+    return this.#asset.value.uniqueKey;
+  }
+
+  set uniqueKey(uniqueKey: ?string): void {
+    this.#asset.value.uniqueKey = uniqueKey;
+  }
+
   get symbols(): IMutableAssetSymbols {
     return new MutableAssetSymbols(this.#asset.options, this.#asset.value);
   }

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -276,6 +276,11 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
   }
 
   set uniqueKey(uniqueKey: ?string): void {
+    if (this.#asset.value.uniqueKey != null) {
+      throw new Error(
+        "Cannot change an asset's uniqueKey after it has been set.",
+      );
+    }
     this.#asset.value.uniqueKey = uniqueKey;
   }
 

--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -715,4 +715,38 @@ describe('css modules', () => {
     assert.deepEqual(res[0][0], 'mainJs');
     assert(res[0][1].includes('container') && res[0][1].includes('expand'));
   });
+
+  it('should allow css modules to be shared between targets', async function () {
+    let b = await bundle([
+      path.join(__dirname, '/integration/css-module-self-references/a'),
+      path.join(__dirname, '/integration/css-module-self-references/b'),
+    ]);
+
+    assertBundles(b, [
+      {
+        name: 'main.css',
+        assets: ['bar.module.css'],
+      },
+      {
+        name: 'main.css',
+        assets: ['bar.module.css'],
+      },
+      {
+        name: 'main.js',
+        assets: ['index.js', 'bar.module.css'],
+      },
+      {
+        name: 'main.js',
+        assets: ['index.js', 'bar.module.css'],
+      },
+      {
+        name: 'module.js',
+        assets: ['index.js', 'bar.module.css'],
+      },
+      {
+        name: 'module.js',
+        assets: ['index.js', 'bar.module.css'],
+      },
+    ]);
+  });
 });

--- a/packages/core/integration-tests/test/integration/css-module-self-references/a/index.js
+++ b/packages/core/integration-tests/test/integration/css-module-self-references/a/index.js
@@ -1,0 +1,3 @@
+import foo from '../bar.module.css';
+
+console.log('a', foo);

--- a/packages/core/integration-tests/test/integration/css-module-self-references/a/package.json
+++ b/packages/core/integration-tests/test/integration/css-module-self-references/a/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "source": "index.js"
+}

--- a/packages/core/integration-tests/test/integration/css-module-self-references/b/index.js
+++ b/packages/core/integration-tests/test/integration/css-module-self-references/b/index.js
@@ -1,0 +1,3 @@
+import foo from '../bar.module.css';
+
+console.log('b', foo);

--- a/packages/core/integration-tests/test/integration/css-module-self-references/b/package.json
+++ b/packages/core/integration-tests/test/integration/css-module-self-references/b/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "source": "index.js"
+}

--- a/packages/core/integration-tests/test/integration/css-module-self-references/bar.module.css
+++ b/packages/core/integration-tests/test/integration/css-module-self-references/bar.module.css
@@ -1,0 +1,8 @@
+.foo {
+  composes: composed;
+  color: white;
+}
+
+.composed {
+  background: pink;
+}

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -749,6 +749,12 @@ export interface MutableAsset extends BaseAsset {
    * This is initially set by the resolver, but can be overridden by transformers.
    */
   sideEffects: boolean;
+  /**
+   * When a transformer returns multiple assets, it can give them unique keys to identify them.
+   * This can be used to find assets during packaging, or to create dependencies between multiple
+   * assets returned by a transformer by using the unique key as the dependency specifier.
+   */
+  uniqueKey: ?string;
   /** The symbols that the asset exports. */
   +symbols: MutableAssetSymbols;
 

--- a/packages/packagers/css/src/CSSPackager.js
+++ b/packages/packagers/css/src/CSSPackager.js
@@ -36,6 +36,7 @@ export default (new Packager({
           // Hoist unresolved external dependencies (i.e. http: imports)
           if (
             node.value.priority === 'sync' &&
+            !bundleGraph.isDependencySkipped(node.value) &&
             !bundleGraph.getResolvedAsset(node.value, bundle)
           ) {
             hoistedImports.push(node.value.specifier);

--- a/packages/transformers/css/src/CSSTransformer.js
+++ b/packages/transformers/css/src/CSSTransformer.js
@@ -196,7 +196,7 @@ export default (new Transformer({
         locals.set(exports[key].name, key);
       }
 
-      asset.uniqueKey ||= asset.id;
+      asset.uniqueKey ??= asset.id;
 
       let seen = new Set();
       let add = key => {
@@ -213,16 +213,13 @@ export default (new Transformer({
           if (ref.type === 'local') {
             let exported = nullthrows(locals.get(ref.name));
             add(exported);
-            s +=
-              '${' +
-              `module.exports[${JSON.stringify(exported)}]` +
-              '}';
+            s += '${' + `module.exports[${JSON.stringify(exported)}]` + '}';
             asset.addDependency({
-              specifier: asset.uniqueKey,
+              specifier: nullthrows(asset.uniqueKey),
               specifierType: 'esm',
               symbols: new Map([
-                [exported, {local: ref.name, isWeak: false, loc: null}]
-              ])
+                [exported, {local: ref.name, isWeak: false, loc: null}],
+              ]),
             });
           } else if (ref.type === 'global') {
             s += ref.name;
@@ -251,11 +248,11 @@ export default (new Transformer({
         if (e.isReferenced) {
           s += `module.exports[${JSON.stringify(key)}];\n`;
           asset.addDependency({
-            specifier: asset.uniqueKey,
+            specifier: nullthrows(asset.uniqueKey),
             specifierType: 'esm',
             symbols: new Map([
-              [key, {local: exports[key].name, isWeak: false, loc: null}]
-            ])
+              [key, {local: exports[key].name, isWeak: false, loc: null}],
+            ]),
           });
         }
 

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -806,8 +806,14 @@ export default (new Transformer({
           });
         }
 
+        // Use the asset id as a unique key if one has not already been set.
+        // This lets us create a dependency on the asset itself by using it as a specifier.
+        // Using the unique key ensures that the dependency always resolves to the correct asset,
+        // even if it came from a transformer that produced multiple assets (e.g. css modules).
+        // Also avoids needing a resolution request.
+        asset.uniqueKey ||= asset.id;
         asset.addDependency({
-          specifier: `./${path.basename(asset.filePath)}`,
+          specifier: asset.uniqueKey,
           specifierType: 'esm',
           symbols,
         });


### PR DESCRIPTION
If a CSS module with `composes` is referenced in multiple different targets, a "Bundle group cannot have more than one entry bundle of the same type" error can occur. This is caused by the self reference dependency that is created in the JS transformer for a `module.exports[...]` reference, which ensures the symbols are preserved. Because a CSS module creates two different assets, the resolution of the dependency in the JS asset back to itself is unclear and may resolve back to the CSS part, messing things up downstream.

This changes the self reference dependency to use the asset's `uniqueKey` as the specifier rather than the file name. This means the dependency is resolved directly to the JS asset rather than going through the resolver and maybe going back to the CSS part. If no `uniqueKey` has been set, the JS transformer will create one.