### PR TITLE
Fix lazy compilation

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -353,10 +353,12 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
         nodeId !== traversedNodeId
       ) {
         if (!ctx?.hasDeferred) {
+          this.safeToIncrementallyBundle = false;
           delete traversedNode.hasDeferred;
         }
         actions.skipChildren();
       } else if (traversedNode.type === 'dependency') {
+        this.safeToIncrementallyBundle = false;
         traversedNode.hasDeferred = false;
       } else if (nodeId !== traversedNodeId) {
         actions.skipChildren();

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1936,6 +1936,10 @@ export default class BundleGraph {
       bundle.id + bundle.target.publicUrl + this.getContentHash(bundle),
     );
 
+    if (bundle.isPlaceholder) {
+      hash.writeString('placeholder');
+    }
+
     let inlineBundles = this.getInlineBundles(bundle);
     for (let inlineBundle of inlineBundles) {
       hash.writeString(this.getContentHash(inlineBundle));

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -321,6 +321,10 @@ export default class Parcel {
             };
           }
 
+          // If this bundle was previously a placeholder, it now no longer is as it has
+          // been requested.
+          bundleNode.value.isPlaceholder = false;
+
           for (let assetId of bundleNode.value.entryAssetIds) {
             this.#requestedAssetIds.add(assetId);
           }

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -321,10 +321,6 @@ export default class Parcel {
             };
           }
 
-          // If this bundle was previously a placeholder, it now no longer is as it has
-          // been requested.
-          bundleNode.value.isPlaceholder = false;
-
           for (let assetId of bundleNode.value.entryAssetIds) {
             this.#requestedAssetIds.add(assetId);
           }

--- a/packages/core/integration-tests/test/integration/lazy-compile/index-sync-async.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/index-sync-async.js
@@ -1,0 +1,11 @@
+export default () => {
+    return Promise.all([
+import('./uses-static-component').then(c => {
+    return c.default()();
+}),
+import('./uses-static-component-async').then(c => {
+    return c.default();
+}).then(s => {
+    return s();
+})]);
+}

--- a/packages/core/integration-tests/test/integration/lazy-compile/index.html
+++ b/packages/core/integration-tests/test/integration/lazy-compile/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    <script src="./index.js" type="module"></script>
+</body>
+</html>

--- a/packages/core/integration-tests/test/integration/lazy-compile/index.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/index.js
@@ -1,0 +1,7 @@
+async function main() {
+    const m = await import('./lazy-1');
+    await import('./parallel-lazy-1');
+    return m.default();
+}
+
+main();

--- a/packages/core/integration-tests/test/integration/lazy-compile/lazy-1.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/lazy-1.js
@@ -1,0 +1,4 @@
+export default async () => {
+    const { world } = await import('./lazy-2');
+    return `Hello ${world}`;
+}

--- a/packages/core/integration-tests/test/integration/lazy-compile/lazy-2.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/lazy-2.js
@@ -1,0 +1,1 @@
+export const world = 'world';

--- a/packages/core/integration-tests/test/integration/lazy-compile/package.json
+++ b/packages/core/integration-tests/test/integration/lazy-compile/package.json
@@ -1,0 +1,3 @@
+{
+    "private": true
+}

--- a/packages/core/integration-tests/test/integration/lazy-compile/parallel-lazy-1.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/parallel-lazy-1.js
@@ -1,0 +1,4 @@
+export default async () => {
+    const m = await import('./parallel-lazy-2');
+    return m.default;
+};

--- a/packages/core/integration-tests/test/integration/lazy-compile/parallel-lazy-2.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/parallel-lazy-2.js
@@ -1,0 +1,1 @@
+export default 'parallel lazy 2';

--- a/packages/core/integration-tests/test/integration/lazy-compile/static-component.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/static-component.js
@@ -1,0 +1,1 @@
+export default () => "static component";

--- a/packages/core/integration-tests/test/integration/lazy-compile/uses-static-component-async.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/uses-static-component-async.js
@@ -1,0 +1,4 @@
+export default async () => {
+    const m = await import('./static-component');
+    return m.default;
+}

--- a/packages/core/integration-tests/test/integration/lazy-compile/uses-static-component.js
+++ b/packages/core/integration-tests/test/integration/lazy-compile/uses-static-component.js
@@ -1,0 +1,4 @@
+import staticComponent  from "./static-component"
+export default () => {
+    return staticComponent;
+}

--- a/packages/core/integration-tests/test/lazy-compile.js
+++ b/packages/core/integration-tests/test/lazy-compile.js
@@ -1,0 +1,87 @@
+import assert from 'assert';
+import path from 'path';
+import {
+  bundler,
+  outputFS,
+  distDir,
+  getNextBuild,
+  assertBundles,
+  removeDistDirectory,
+} from '@parcel/test-utils';
+
+const findBundle = (bundleGraph, nameRegex) => {
+  return bundleGraph.getBundles().find(b => nameRegex.test(b.name));
+};
+
+const distDirIncludes = async matches => {
+  const files = await outputFS.readdir(distDir);
+  for (const match of matches) {
+    if (typeof match === 'string') {
+      if (!files.some(file => file === match)) {
+        throw new Error(
+          `No file matching ${match} was found in ${files.join(', ')}`,
+        );
+      }
+    } else {
+      if (!files.some(file => match.test(file))) {
+        throw new Error(
+          `No file matching ${match} was found in ${files.join(', ')}`,
+        );
+      }
+    }
+  }
+  return true;
+};
+
+describe('lazy compile', function () {
+  it('should lazy compile', async function () {
+    const b = await bundler(
+      path.join(__dirname, '/integration/lazy-compile/index.js'),
+      {
+        shouldBuildLazily: true,
+        mode: 'development',
+        shouldContentHash: false,
+      },
+    );
+
+    await removeDistDirectory();
+
+    const subscription = await b.watch();
+    let result = await getNextBuild(b);
+
+    // This simulates what happens if index.js is loaded as well as lazy-1 which loads lazy-2.
+    // While parallel-lazy-1 is also async imported by index.js, we pretend it wasn't requested (i.e. like
+    // if it was behind a different trigger).
+    result = await result.requestBundle(
+      findBundle(result.bundleGraph, /index.js/),
+    );
+    result = await result.requestBundle(
+      findBundle(result.bundleGraph, /^lazy-1/),
+    );
+    result = await result.requestBundle(
+      findBundle(result.bundleGraph, /^lazy-2/),
+    );
+
+    // Expect the bundle graph to contain the whole nest of lazy from `lazy-1`, but not
+    // `parallel-lazy-1` which wasn't requested.
+    assertBundles(result.bundleGraph, [
+      {
+        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+      },
+      {
+        assets: ['lazy-1.js', 'esmodule-helpers.js'],
+      },
+      {
+        assets: ['lazy-2.js'],
+      },
+      {
+        assets: ['parallel-lazy-1.js'],
+      },
+    ]);
+
+    subscription.unsubscribe();
+
+    // Ensure the files match the bundle graph - lazy-2 should've been produced as it was requested
+    assert(await distDirIncludes(['index.js', /^lazy-1\./, /^lazy-2\./]));
+  });
+});

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -360,11 +360,7 @@ function getLoaderRuntime({
   // Also do this when building lazily or the runtime itself could get deduplicated and only
   // exist in the parent. This causes errors if an old version of the parent without the runtime
   // is already loaded.
-  if (
-    bundle.env.outputFormat === 'commonjs' ||
-    bundle.env.isLibrary ||
-    options.shouldBuildLazily
-  ) {
+  if (bundle.env.outputFormat === 'commonjs' || bundle.env.isLibrary) {
     externalBundles = [mainBundle];
   } else {
     // Otherwise, load the bundle group entry after the others.
@@ -443,7 +439,7 @@ function getLoaderRuntime({
     loaderModules.push(code);
   }
 
-  if (bundle.env.context === 'browser' && !options.shouldBuildLazily) {
+  if (bundle.env.context === 'browser') {
     loaderModules.push(
       ...externalBundles
         // TODO: Allow css to preload resources as well

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -357,9 +357,12 @@ function getLoaderRuntime({
   // Importing of the other bundles will be handled by the bundle group entry.
   // Do the same thing in library mode for ES modules, as we are building for another bundler
   // and the imports for sibling bundles will be in the target bundle.
-  // Also do this when building lazily or the runtime itself could get deduplicated and only
-  // exist in the parent. This causes errors if an old version of the parent without the runtime
-  // is already loaded.
+
+  // Previously we also did this when building lazily, however it seemed to cause issues in some cases.
+  // The original comment as to why is left here, in case a future traveller is trying to fix that issue:
+  // > [...] the runtime itself could get deduplicated and only exist in the parent. This causes errors if an
+  // > old version of the parent without the runtime
+  // > is already loaded.
   if (bundle.env.outputFormat === 'commonjs' || bundle.env.isLibrary) {
     externalBundles = [mainBundle];
   } else {
@@ -439,6 +442,8 @@ function getLoaderRuntime({
     loaderModules.push(code);
   }
 
+  // Similar to the comment above, this also used to be skipped when shouldBuildLazily was true,
+  // however it caused issues where a bundle group contained multiple bundles.
   if (bundle.env.context === 'browser') {
     loaderModules.push(
       ...externalBundles


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This fixes the reproduction provided in #8816 (Thanks @rayinaway), as well as a separate reproduction I created at https://github.com/marcins/lazy-testbed.

There were a couple of issues I found when trying to create a basic lazy compilation example:
* The decision as to whether a bundle is a placeholder isn't revisited after the bundle is created. A change has been made to set the placeholder value to false when a bundle is requested.
* Whether a bundle is a placeholder has been added to it's hash so that the bundle graph hash is invalidated when a bundle is no longer a placeholder.
* When a previously deferred dependency was no longer deferred, the asset graph was updated correctly, but this didn't re-trigger bundling with incremental bundling. A change has been made to skip incremental bundling when a dependency is "un-deferred".

A new integration test based on my testbed reproduction has been added that I first verified was failing on current `v2` branch, and verified that it now passes with these changes. In addition I tested the reproduction from #8816 and verified that Parcel with these fixes now loads those bundles correctly.

Note that due to my lack of deep knowledge in the areas touched the testing is possibly not exhaustive, I possibly haven't tested some scenarios that may still fail with these changes. I did manually test adding / removing dependencies and confirming that things re-compiled correctly.

Given the scope of the changes, they shouldn't affect anything outside of `--lazy` mode, so at least they're unlikely to break other functionality.

## 🚨 Test instructions

See repro repos above - these fail with current v2, but succeed when using Parcel linked with these changes.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
