### PR TITLE
Updated SWC crate for JS Transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,15 +76,15 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c704e2f6ee1a98223f5a7629a6ef0f3decb3b552ed282889dc957edff98ce1e6"
+checksum = "c09c69dffe06d222d072c878c3afe86eee2179806f20503faec97250268b4c24"
 dependencies = [
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -566,14 +566,14 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d449976075322384507443937df2f1d5577afbf4282f12a5a66ef29fa3e6307"
+checksum = "03ec5dc38ee19078d84a692b1c41181ff9f94331c76cee66ff0208c770b5e54f"
 dependencies = [
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "swc_macros_common",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c068d4c6b922cd6284c609cfa6dec0e41615c9c5a1a4ba729a970d8daba05fb"
 dependencies = [
  "Inflector",
- "pmutil",
+ "pmutil 0.5.3",
  "proc-macro2",
  "quote",
  "syn 1.0.105",
@@ -1458,6 +1458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pmutil"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "png"
 version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,7 +1901,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b862d598fbc9f7085b017890e2e61433f501e7467f2c585323e1aa3c07ef8599"
 dependencies = [
- "pmutil",
+ "pmutil 0.5.3",
  "proc-macro2",
  "quote",
  "syn 1.0.105",
@@ -1942,15 +1953,15 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0090512bdfee4b56d82480d66c0fd8a6f53f0fe0f97e075e949b252acdd482e0"
+checksum = "8fa4d4f81d7c05b9161f8de839975d3326328b8ba2831164b465524cc2f55252"
 dependencies = [
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1989,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.31.10"
+version = "0.31.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6e3021cd5a356db738aebb678a571615cb70d3dac4e4179401dbdca66fa5f7"
+checksum = "19c774005489d2907fb67909cf42af926e72edee1366512777c605ba2ef19c94"
 dependencies = [
  "ahash",
  "ast_node",
@@ -2031,22 +2042,22 @@ dependencies = [
 
 [[package]]
 name = "swc_config_macro"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dadb9998d4f5fc36ef558ed5a092579441579ee8c6fcce84a5228cca9df4004"
+checksum = "e5b5aaca9a0082be4515f0fbbecc191bf5829cd25b5b9c0a2810f6a2bb0d6829"
 dependencies = [
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.104.3"
+version = "0.104.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee855d082369cbc8acaf367d7e53bcb88bdc3fb10fca4ee6b426969291db2a3"
+checksum = "b5cf9dd351d0c285dcd36535267953a18995d4dda0cbe34ac9d1df61aa415b26"
 dependencies = [
  "bitflags 2.1.0",
  "is-macro",
@@ -2060,9 +2071,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.139.9"
+version = "0.139.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aceee845609805c012698c9487176f7c9388a1526168cbfafa83797753a04c6"
+checksum = "968d1fa52dac53706497afaa4a78b67aca6172b71f9425882164eaa951651099"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -2079,22 +2090,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen_macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ee0caee1018808d94ecd09490cb7affd3d504b19aa11c49238f5fc4b54901"
+checksum = "dcdff076dccca6cc6a0e0b2a2c8acfb066014382bc6df98ec99e755484814384"
 dependencies = [
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.43.12"
+version = "0.43.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d34c082764316fb7ff24fa13bf4952c6577a1c7d04a01761c247a26b7b306d"
+checksum = "fe45f1e5dcc1b005544ff78253b787dea5dfd5e2f712b133964cdc3545c954a4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2111,9 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.134.7"
+version = "0.134.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b9e770f5dcae13145c4e14fd32805b5f89d19c3531c67307b2f83340605eac"
+checksum = "5fb3a64f2991fa798453ae10c6f501fa64cc4c3ab7161df501c3bea9c62941f5"
 dependencies = [
  "either",
  "lexical",
@@ -2131,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.195.14"
+version = "0.195.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7f10d025b5973dd3637fe7fead5e1061aae24e9ac9430eab52f2e5ef71d3c5"
+checksum = "7970ebc5766ab24e6a3204afa9520dd55c6951692e9d424c0373a6ed10d04ab1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2156,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.218.13"
+version = "0.218.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d55649ddc29981080f7498d662e463c5c4021ab39c5d69288c57f17e4bb5f2"
+checksum = "23b675702cbd9b2335529c15e6fff04139955fc4ad7a21d00255e0c247a9bf2c"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2176,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.127.10"
+version = "0.127.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238bade06742aff91b9e50551bd12c64c46e5601e0569c2c5c4b04297cc8d06"
+checksum = "8762bf3a518e6cdfaf38f54a2aef93c30b5d90a8deb9134ff50aeccee5338320"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.1.0",
@@ -2199,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.116.10"
+version = "0.116.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c5ff9c6a76622ea4a0aa84f4222e6518c4631f818880a0a984a838f3ea1a71"
+checksum = "fb09fbf4bea65a4ef0d099d2b6db3b29a1703c3d896d8bea6613ad9775d65474"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -2213,9 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.153.11"
+version = "0.153.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3144c9a294c9fc169dee487bc2b7d15738942933b74077fe1f18543a3800768b"
+checksum = "74c0ab56173084aaae93c5e3d58a015cbfe89fb82021ff6eceaef88125f77a7d"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -2243,7 +2254,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "984d5ac69b681fc5438f9abf82b0fda34fe04e119bc75f8213b7e01128c7c9a2"
 dependencies = [
- "pmutil",
+ "pmutil 0.5.3",
  "proc-macro2",
  "quote",
  "swc_macros_common",
@@ -2252,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.170.11"
+version = "0.170.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c097e12218825f7a289b31efe872fffcf5264eef7040f7db3f17451e7f42f0c2"
+checksum = "218b43d0a43c7493526e4a096560be0c807c17f7c5432b8973735e1f57819dc0"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2280,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.187.13"
+version = "0.187.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b66e53728cf3e89c97e2bee927b267f8bd7ef8b0adc8fa2fdd24bf32d2afdab"
+checksum = "73e2259a7a3d6e76e6253d15cd5bb508f4db8867092ebfbc0bdc4218f5e27027"
 dependencies = [
  "ahash",
  "dashmap",
@@ -2305,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.161.13"
+version = "0.161.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdca0d64cc2195e996609da8eb30da0795f9e56ff4b8ac979f61a10c7957ad81"
+checksum = "3666b1f29ee049486368687922101ca74a05f2eb78624a8a9cccf0d4c084e341"
 dependencies = [
  "either",
  "rustc-hash",
@@ -2325,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.173.11"
+version = "0.173.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b6eeb8dfbb3f3d65eab60426e4e104580689c27fd189551a57404be4140d7a"
+checksum = "809026654ac6731a38a985333247d0a1c9bcf8d921e3bbff14d53a502ec4c4fd"
 dependencies = [
  "ahash",
  "base64",
@@ -2350,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.177.13"
+version = "0.177.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f4bb8a0dd2d7a41ce8a90db5d6741d66b8548e1f05cf720a8d3a62ce7bdda4"
+checksum = "9bdcb2f483daee81757509006e956283f24ea9cbd0ab06dcb85976633d86c03b"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -2366,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.117.8"
+version = "0.117.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc2a22dacab6d563df26b908c18e7714f69e0434594274bebda221903c40a1c"
+checksum = "5d4147c9ff4aec66ea551e790c654028d64cf0643c52599b50eb4b946049f375"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -2384,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.90.3"
+version = "0.90.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f728b2441b27bb7910e28e78d945b1bd69fb53c017edb6ff58b22ea8480908a7"
+checksum = "6ce3ac941ae1d6c7e683aa375fc71fbf58df58b441f614d757fbb10554936ca2"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -2398,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.228.16"
+version = "0.228.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3aa14fe114238c88537388820800dae9dbd46ec31d69e522856ab5d09283c9"
+checksum = "da336b49c72303b777ffc7d8ae495a18a07a386ce3c5a073d5c88ed5eed4a053"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_codegen",
@@ -2417,7 +2428,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c20468634668c2bbab581947bb8c75c97158d5a6959f4ba33df20983b20b4f6"
 dependencies = [
- "pmutil",
+ "pmutil 0.5.3",
  "proc-macro2",
  "quote",
  "syn 1.0.105",
@@ -2425,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.19.10"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c075775b193075f3dbe2fa3575736cf7e9d233e4a88b6ca6350d897eeeaeec9"
+checksum = "6291149aec4ba55076fd54a12ceb84cac1f703b2f571c3b2f19aa66ab9ec3009"
 dependencies = [
  "indexmap",
  "petgraph",
@@ -2437,14 +2448,14 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e582c3e3c2269238524923781df5be49e011dbe29cf7683a2215d600a562ea6"
+checksum = "7a273205ccb09b51fabe88c49f3b34c5a4631c4c00a16ae20e03111d6a42e832"
 dependencies = [
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "quote",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2460,9 +2471,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.5.5"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d5999f23421c8e21a0f2bc53a0b9e8244f3b421de89471561af2fbe40b9cca"
+checksum = "e87c337fbb2d191bf371173dea6a957f01899adb8f189c6c31b122a6cfc98fc3"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -2470,16 +2481,16 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeed7eb0f545f48ad30f5aab314e5208b735bcea1d1464f26e20f06db904989"
+checksum = "0f322730fb82f3930a450ac24de8c98523af7d34ab8cb2f46bcb405839891a99"
 dependencies = [
  "Inflector",
- "pmutil",
+ "pmutil 0.6.1",
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 1.0.105",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
-swc_ecmascript = { version = "0.228.16", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
+swc_ecmascript = { version = "0.228.35", features = ["parser", "transforms", "module", "optimization", "react", "typescript", "utils", "visit", "codegen", "utils", "preset_env"] }
 swc_common = { version = "0.31.10", features = ["tty-emitter", "sourcemap"] }
 swc_atoms = "0.5.6"
 indoc = "1.0.3"

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1968,7 +1968,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    const { foo: $abc$var$foo , ...$abc$var$bar } = $abc$import$70a00e0a8474f72a;
+    const { foo: $abc$var$foo, ...$abc$var$bar } = $abc$import$70a00e0a8474f72a;
     console.log($abc$var$foo, $abc$var$bar);
     "#}
     );
@@ -1984,7 +1984,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:x";
-    const { x: { y: $abc$var$z  }  } = $abc$import$d141bba7fdc215a3;
+    const { x: { y: $abc$var$z } } = $abc$import$d141bba7fdc215a3;
     console.log($abc$var$z);
     "#}
     );
@@ -2073,7 +2073,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    const { foo: $abc$var$foo  } = $abc$import$70a00e0a8474f72a$6a5cdcad01c973fa;
+    const { foo: $abc$var$foo } = $abc$import$70a00e0a8474f72a$6a5cdcad01c973fa;
     console.log($abc$var$foo);
     "#}
     );
@@ -2205,7 +2205,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     function $abc$var$x() {
-        const { foo: foo  } = $abc$import$70a00e0a8474f72a;
+        const { foo: foo } = $abc$import$70a00e0a8474f72a;
         console.log(foo);
     }
     "#}
@@ -2462,9 +2462,9 @@ mod tests {
     assert_eq!(
       code,
       indoc! {r#"
-    var { x: $abc$export$d141bba7fdc215a3 , ...$abc$export$4a5767248b18ef41 } = something;
+    var { x: $abc$export$d141bba7fdc215a3, ...$abc$export$4a5767248b18ef41 } = something;
     var [$abc$export$ffb5f4729a158638, ...$abc$export$9e5f44173e64f162] = something;
-    var { x: $abc$export$d141bba7fdc215a3 = 3  } = something;
+    var { x: $abc$export$d141bba7fdc215a3 = 3 } = something;
     "#}
     );
 
@@ -2952,7 +2952,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     async function $abc$var$test() {
-        const { foo: foo  } = await $abc$importAsync$70a00e0a8474f72a;
+        const { foo: foo } = await $abc$importAsync$70a00e0a8474f72a;
         console.log(foo);
     }
     "#}
@@ -2983,7 +2983,7 @@ mod tests {
       indoc! {r#"
     import "abc:other";
     async function $abc$var$test() {
-        const { foo: bar  } = await $abc$importAsync$70a00e0a8474f72a;
+        const { foo: bar } = await $abc$importAsync$70a00e0a8474f72a;
         console.log(bar);
     }
     "#}
@@ -3060,7 +3060,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$70a00e0a8474f72a.then(({ foo: foo  })=>foo);
+    $abc$importAsync$70a00e0a8474f72a.then(({ foo: foo })=>foo);
     "#}
     );
 
@@ -3085,7 +3085,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$70a00e0a8474f72a.then(({ foo: bar  })=>bar);
+    $abc$importAsync$70a00e0a8474f72a.then(({ foo: bar })=>bar);
     "#}
     );
 
@@ -3164,7 +3164,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$70a00e0a8474f72a.then(function({ foo: foo  }) {});
+    $abc$importAsync$70a00e0a8474f72a.then(function({ foo: foo }) {});
     "#}
     );
 
@@ -3189,7 +3189,7 @@ mod tests {
       code,
       indoc! {r#"
     import "abc:other";
-    $abc$importAsync$70a00e0a8474f72a.then(function({ foo: bar  }) {});
+    $abc$importAsync$70a00e0a8474f72a.then(function({ foo: bar }) {});
     "#}
     );
   }


### PR DESCRIPTION
# ↪️ Pull Request

Updated version of `swc_ecmascript` in the JS transformer to correct generics inside jsx elements

```typescript
const Foo = () => <Component<any>></Component>
```

[SWC playground](https://play.swc.rs/?version=1.3.59&code=H4sIAAAAAAAAA9PQVLC1U7Bxzs8tyM9LzSuxScyrtLOz0YcL2HEBABELyhojAAAA&config=H4sIAAAAAAAAA02OvQ6DMAyEd54i8tyhytChbxOlpgoiEPmM1Ajx7nWgPyyW7zv7dGvnHA2IdHerrSZKELD8tBHUScPLCGktjCipKF2%2BrqJZKgvvZDsM0iBP1vbE8FfvPw%2BU05T6eo6Pcy7CgLE%2BjDjF7IPy%2FFhG%2FhdsJY7cG7WjbnsDOkAxqsUAAAA%3D)

## 🚨 Test instructions

Build Parcel and try to compile something

```bash
#!/bin/bash
export NODE_ENV=production 
export PARCEL_BUILD_ENV=production
export PARCEL_SELF_BUILD=true
export PARCEL_WORKER_BACKEND=process

node scripts/build-native.js | tee

rm -rf packages/*/*/lib

npx parcel build \
  packages/core/{fs,codeframe,package-manager,utils} \
  packages/reporters/{cli,dev-server} \
  packages/utils/{parcel-lsp,parcel-lsp-protocol} \
  | tee

npx gulp | tee

```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
