### PR TITLE
Fix the development and production package conditions

### DIFF
--- a/packages/core/integration-tests/test/integration/resolve-mode-condition/default.js
+++ b/packages/core/integration-tests/test/integration/resolve-mode-condition/default.js
@@ -1,0 +1,1 @@
+throw new Error('Should never resolve');

--- a/packages/core/integration-tests/test/integration/resolve-mode-condition/dev.js
+++ b/packages/core/integration-tests/test/integration/resolve-mode-condition/dev.js
@@ -1,0 +1,1 @@
+export const isDevelopment = true;

--- a/packages/core/integration-tests/test/integration/resolve-mode-condition/index.js
+++ b/packages/core/integration-tests/test/integration/resolve-mode-condition/index.js
@@ -1,0 +1,2 @@
+import {isDevelopment} from '#is-development';
+export default isDevelopment ? 'development' : 'production';

--- a/packages/core/integration-tests/test/integration/resolve-mode-condition/package.json
+++ b/packages/core/integration-tests/test/integration/resolve-mode-condition/package.json
@@ -1,0 +1,13 @@
+{
+  "module": "dist/module.js",
+  "imports": {
+    "#is-development": {
+      "development": "./dev.js",
+      "production": "./prod.js",
+      "default": "./default.js"
+    }
+  },
+  "@parcel/resolver-default": {
+    "packageExports": true
+  }
+}

--- a/packages/core/integration-tests/test/integration/resolve-mode-condition/prod.js
+++ b/packages/core/integration-tests/test/integration/resolve-mode-condition/prod.js
@@ -1,0 +1,1 @@
+export const isDevelopment = false;

--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -426,4 +426,22 @@ describe('resolver', function () {
     let output = await run(b);
     assert.strictEqual(output.default, 'hello bar');
   });
+
+  it('should support the development and production import conditions', async () => {
+    let b = await bundle(
+      path.join(__dirname, '/integration/resolve-mode-condition/index.js'),
+      {mode: 'development'},
+    );
+
+    let output = await run(b);
+    assert.strictEqual(output.default, 'development');
+
+    b = await bundle(
+      path.join(__dirname, '/integration/resolve-mode-condition/index.js'),
+      {mode: 'production'},
+    );
+
+    output = await run(b);
+    assert.strictEqual(output.default, 'production');
+  });
 });

--- a/packages/resolvers/default/src/DefaultResolver.js
+++ b/packages/resolvers/default/src/DefaultResolver.js
@@ -18,6 +18,7 @@ export default (new Resolver({
       projectRoot: options.projectRoot,
       packageManager: options.packageManager,
       shouldAutoInstall: options.shouldAutoInstall,
+      mode: options.mode,
       logger,
       packageExports: conf?.contents?.packageExports ?? false,
     });

--- a/packages/resolvers/glob/src/GlobResolver.js
+++ b/packages/resolvers/glob/src/GlobResolver.js
@@ -83,6 +83,7 @@ export default (new Resolver({
         packageManager: options.shouldAutoInstall
           ? options.packageManager
           : undefined,
+        mode: options.mode,
         logger,
       });
 

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -47,7 +47,7 @@ type Options = {|
   packageManager?: PackageManager,
   logger?: PluginLogger,
   shouldAutoInstall?: boolean,
-  mode?: BuildMode,
+  mode: BuildMode,
   mainFields?: Array<string>,
   extensions?: Array<string>,
   packageExports?: boolean,


### PR DESCRIPTION
The "development" and "production" package exports/imports conditions were not working because we forgot to pass the `mode` through from the DefaultResolver to the underlying NodeResolver. Originally reported on twitter: https://twitter.com/brian_d_vaughn/status/1672662358546677765