### PR TITLE
Query glibc version only once to speed up JSTransformer on Linux

### DIFF
--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -940,23 +940,23 @@ export default (new Transformer({
 // See https://github.com/rust-lang/rust/issues/91979.
 let isLoadedOnMainThread = false;
 
-// $FlowFixMe
-let {glibcVersionRuntime} = process.report.getReport().header;
-
 async function loadOnMainThreadIfNeeded() {
   if (
     !isLoadedOnMainThread &&
     process.platform === 'linux' &&
     WorkerFarm.isWorker()
   ) {
+    // $FlowFixMe
+    let {glibcVersionRuntime} = process.report.getReport().header;
+
     if (glibcVersionRuntime && parseFloat(glibcVersionRuntime) <= 2.17) {
       let api = WorkerFarm.getWorkerApi();
       await api.callMaster({
         location: __dirname + '/loadNative.js',
         args: [],
       });
-
-      isLoadedOnMainThread = true;
     }
+
+    isLoadedOnMainThread = true;
   }
 }

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -939,14 +939,16 @@ export default (new Transformer({
 // also load the native module on the main thread, so that it is not unloaded until process exit.
 // See https://github.com/rust-lang/rust/issues/91979.
 let isLoadedOnMainThread = false;
+
+// $FlowFixMe
+let {glibcVersionRuntime} = process.report.getReport().header;
+
 async function loadOnMainThreadIfNeeded() {
   if (
     !isLoadedOnMainThread &&
     process.platform === 'linux' &&
     WorkerFarm.isWorker()
   ) {
-    // $FlowFixMe
-    let {glibcVersionRuntime} = process.report.getReport().header;
     if (glibcVersionRuntime && parseFloat(glibcVersionRuntime) <= 2.17) {
       let api = WorkerFarm.getWorkerApi();
       await api.callMaster({


### PR DESCRIPTION
# ↪️ Pull Request

While profiling Parcel as it ran on a large app at Atlassian, I noticed that calls to `process.report.getReport()` stood out in the trace —

<img width="1569" alt="Screenshot 2023-07-02 at 1 28 48 AM" src="https://github.com/parcel-bundler/parcel/assets/8946207/c6335a6c-a222-471e-a3b1-9f4a036668e4">

This function is in fact called once per transformation, to get the glibc version on linux and on an average takes 10ms per call. However, the version of glibc on a system isn't likely to change during a parcel run. Moving the call out so it is queried only once led to up to a ~35% improvement in overall build times on Linux.

This was tested on a 15 Core `c6i` AWS box, on Node `16.15.0`, with both the SWC and Babel transformers enabled. The % improvement might vary based on individual setups, however, it is still likely to be significant.