### PR TITLE
Refresh cache before writing contents to bundle

### DIFF
--- a/packages/core/cache/src/FSCache.js
+++ b/packages/core/cache/src/FSCache.js
@@ -116,6 +116,10 @@ export class FSCache implements Cache {
       logger.error(err, '@parcel/cache');
     }
   }
+
+  refresh(): void {
+    // NOOP
+  }
 }
 
 registerSerializableClass(`${packageJson.version}:FSCache`, FSCache);

--- a/packages/core/cache/src/IDBCache.browser.js
+++ b/packages/core/cache/src/IDBCache.browser.js
@@ -117,6 +117,10 @@ export class IDBCache implements Cache {
   setLargeBlob(key: string, contents: Buffer | string): Promise<void> {
     return this.setBlob(key, contents);
   }
+
+  refresh(): void {
+    // NOOP
+  }
 }
 
 registerSerializableClass(`${packageJson.version}:IDBCache`, IDBCache);

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -102,6 +102,7 @@ export class LMDBCache implements Cache {
   async setLargeBlob(key: string, contents: Buffer | string): Promise<void> {
     await this.fs.writeFile(path.join(this.dir, key), contents);
   }
+
   refresh(): void {
     // Reset the read transaction for the store. This guarantees that
     // the next read will see the latest changes to the store.

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -102,6 +102,13 @@ export class LMDBCache implements Cache {
   async setLargeBlob(key: string, contents: Buffer | string): Promise<void> {
     await this.fs.writeFile(path.join(this.dir, key), contents);
   }
+  refresh(): void {
+    // Reset the read transaction for the store. This guarantees that
+    // the next read will see the latest changes to the store.
+    // Useful in scenarios where reads and writes are multi-threaded.
+    // See https://github.com/kriszyp/lmdb-js#resetreadtxn-void
+    this.store.resetReadTxn();
+  }
 }
 
 registerSerializableClass(`${packageJson.version}:LMDBCache`, LMDBCache);

--- a/packages/core/cache/src/types.js
+++ b/packages/core/cache/src/types.js
@@ -14,5 +14,10 @@ export interface Cache {
   getLargeBlob(key: string): Promise<Buffer>;
   setLargeBlob(key: string, contents: Buffer | string): Promise<void>;
   getBuffer(key: string): Promise<?Buffer>;
+  /**
+   * In a multi-threaded environment, where there are potentially multiple Cache
+   * instances writing to the cache, ensure that this instance has the latest view
+   * of the changes that may have been written to the cache in other threads.
+   */
   refresh(): void;
 }

--- a/packages/core/cache/src/types.js
+++ b/packages/core/cache/src/types.js
@@ -14,4 +14,5 @@ export interface Cache {
   getLargeBlob(key: string): Promise<Buffer>;
   setLargeBlob(key: string, contents: Buffer | string): Promise<void>;
   getBuffer(key: string): Promise<?Buffer>;
+  refresh(): void;
 }

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -129,16 +129,6 @@ async function run({input, options, api}) {
   if (info.isLargeBlob) {
     contentStream = options.cache.getStream(cacheKeys.content);
   } else {
-    // Force a refresh of the cache to avoid a race condition
-    // between threaded reads and writes that can result in an LMDB cache miss:
-    //   1. Thread A has read some value from cache, necessitating a read transaction.
-    //   2. Concurrently, Thread B finishes a packaging request.
-    //   3. Subsequently, Thread A is tasked with this request, but fails because the read transaction is stale.
-    // This only occurs if the reading thread has a transaction that was created before the writing thread committed,
-    // and the transaction is still live when the reading thread attempts to get the written value.
-    // See https://github.com/parcel-bundler/parcel/issues/9121
-    options.cache.refresh();
-
     contentStream = blobToStream(
       await options.cache.getBlob(cacheKeys.content),
     );

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -129,6 +129,16 @@ async function run({input, options, api}) {
   if (info.isLargeBlob) {
     contentStream = options.cache.getStream(cacheKeys.content);
   } else {
+    // Force a refresh of the cache to avoid a race condition
+    // between threaded reads and writes that can result in an LMDB cache miss:
+    //   1. Thread A has read some value from cache, necessitating a read transaction.
+    //   2. Concurrently, Thread B finishes a packaging request.
+    //   3. Subsequently, Thread A is tasked with this request, but fails because the read transaction is stale.
+    // This only occurs if the reading thread has a transaction that was created before the writing thread committed,
+    // and the transaction is still live when the reading thread attempts to get the written value.
+    // See https://github.com/parcel-bundler/parcel/issues/9121
+    options.cache.refresh();
+
     contentStream = blobToStream(
       await options.cache.getBlob(cacheKeys.content),
     );


### PR DESCRIPTION
Fixes #9121 

## Background

As described in #9121 and comments, a race condition exists for our LMDB cache backend when used in a multi threaded way. The condition is:

1. Thread A performs some task that necessitates an LMDB read transaction
2. Concurrently, Thread B performs a packaging request and caches the result
3. Subsequently, Thread A is tasked with using the packaging result, but fails because it has a live read transaction with a stale snapshot that does not include the write from Thread B.

The fix is to manually reset the read transaction in Thread A so that the next read sees a fresh snapshot of the db.

Note that this is not a bug in LMDB, and there is a [documented API](https://github.com/kriszyp/lmdb-js#resetreadtxn-void) for dealing with this scenario.

## Implementation

Because requests deal with a `Cache` abstraction rather than dealing directly with the cache backend, this PR opts to add a `Cache.refresh()` method to the interface. It is a no-op for all of the existing backends _except_ for `LMDBCache`, which simply calls `resetReadTxn()` on the backing store.

The `cache.refresh()` method is currently called right before running a `WriteBundleRequest` (and only when the preceeding `PackageRequest` was not run in the main thread), which is the only place we've seen this type of failure so far, but there may be other places where we should add it.

## 🚨 Test instructions

Still trying to work out if we can add a test for this, as it is not easy to replicate in the wild. 

