### PR TITLE
[WIP] Remove package cycles

### DIFF
--- a/packages/core/cache/src/FSCache.js
+++ b/packages/core/cache/src/FSCache.js
@@ -1,9 +1,8 @@
 // @flow strict-local
 
 import type {Readable, Writable} from 'stream';
-import type {FilePath} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
-import type {Cache} from './types';
+import type {FilePath, FileSystem} from '@parcel/types';
+import type {Cache} from '@parcel/types';
 
 import stream from 'stream';
 import path from 'path';

--- a/packages/core/cache/src/IDBCache.browser.js
+++ b/packages/core/cache/src/IDBCache.browser.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import type {Cache} from './types';
+import type {Cache} from '@parcel/types';
 
 import {Readable} from 'stream';
 import {serialize, deserialize, registerSerializableClass} from '@parcel/core';

--- a/packages/core/cache/src/IDBCache.js
+++ b/packages/core/cache/src/IDBCache.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import type {Cache} from './types';
+import type {Cache} from '@parcel/types';
 
 // $FlowFixMe
 export class IDBCache implements Cache {

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -1,6 +1,5 @@
 // @flow strict-local
-import type {FilePath} from '@parcel/types';
-import type {Cache} from './types';
+import type {Cache, FilePath} from '@parcel/types';
 import type {Readable, Writable} from 'stream';
 
 import stream from 'stream';

--- a/packages/core/cache/src/index.js
+++ b/packages/core/cache/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-export type {Cache} from './types';
 export * from './LMDBCache';
 export * from './FSCache';
 export * from './IDBCache';

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -6,10 +6,12 @@ import type {
   BuildSuccessEvent,
   InitialParcelOptions,
   PackagedBundle as IPackagedBundle,
+  SharedReference,
+  WorkerFarm as IWorkerFarm,
 } from '@parcel/types';
 import type {ParcelOptions} from './types';
 // eslint-disable-next-line no-unused-vars
-import type {FarmOptions, SharedReference} from '@parcel/workers';
+import type {FarmOptions} from '@parcel/workers';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 
@@ -51,7 +53,7 @@ export const INTERNAL_RESOLVE: symbol = Symbol('internal_resolve');
 export default class Parcel {
   #requestTracker /*: RequestTracker*/;
   #config /*: ParcelConfig*/;
-  #farm /*: WorkerFarm*/;
+  #farm /*: IWorkerFarm */;
   #initialized /*: boolean*/ = false;
   #disposable /*: Disposable */;
   #initialOptions /*: InitialParcelOptions*/;

--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -6,8 +6,6 @@ import type {
   BuildSuccessEvent,
   InitialParcelOptions,
   PackagedBundle as IPackagedBundle,
-  SharedReference,
-  WorkerFarm as IWorkerFarm,
 } from '@parcel/types';
 import type {ParcelOptions} from './types';
 // eslint-disable-next-line no-unused-vars

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -1,6 +1,10 @@
 // @flow strict-local
 
-import type {ReporterEvent, Reporter} from '@parcel/types';
+import type {
+  ReporterEvent,
+  Reporter,
+  WorkerFarm as IWorkerFarm,
+} from '@parcel/types';
 import type {WorkerApi} from '@parcel/workers';
 import type {Bundle as InternalBundle, ParcelOptions} from './types';
 import type {LoadedPlugin} from './ParcelConfig';
@@ -26,13 +30,13 @@ import {tracer, PluginTracer} from '@parcel/profiler';
 type Opts = {|
   config: ParcelConfig,
   options: ParcelOptions,
-  workerFarm: WorkerFarm,
+  workerFarm: IWorkerFarm,
 |};
 
 const instances: Set<ReporterRunner> = new Set();
 
 export default class ReporterRunner {
-  workerFarm: WorkerFarm;
+  workerFarm: IWorkerFarm;
   config: ParcelConfig;
   options: ParcelOptions;
   pluginOptions: PluginOptions;

--- a/packages/core/core/src/ReporterRunner.js
+++ b/packages/core/core/src/ReporterRunner.js
@@ -6,6 +6,7 @@ import type {
   WorkerFarm as IWorkerFarm,
 } from '@parcel/types';
 import type {WorkerApi} from '@parcel/workers';
+import {bus} from '@parcel/workers';
 import type {Bundle as InternalBundle, ParcelOptions} from './types';
 import type {LoadedPlugin} from './ParcelConfig';
 
@@ -15,7 +16,6 @@ import {
   bundleToInternalBundleGraph,
   NamedBundle,
 } from './public/Bundle';
-import WorkerFarm, {bus} from '@parcel/workers';
 import ParcelConfig from './ParcelConfig';
 import logger, {
   patchConsole,

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -3,7 +3,6 @@
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import type {Async, EnvMap, WorkerFarm as IWorkerFarm} from '@parcel/types';
 import type {EventType, Options as WatcherOptions} from '@parcel/watcher';
-import type WorkerFarm from '@parcel/workers';
 import type {
   ContentGraphOpts,
   ContentKey,

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
-import type {Async, EnvMap} from '@parcel/types';
+import type {Async, EnvMap, WorkerFarm as IWorkerFarm} from '@parcel/types';
 import type {EventType, Options as WatcherOptions} from '@parcel/watcher';
 import type WorkerFarm from '@parcel/workers';
 import type {
@@ -158,7 +158,7 @@ type RunRequestOpts = {|
 |};
 
 export type StaticRunOpts<TResult> = {|
-  farm: WorkerFarm,
+  farm: IWorkerFarm,
   options: ParcelOptions,
   api: RunAPI<TResult>,
   invalidateReason: InvalidateReason,
@@ -818,7 +818,7 @@ export class RequestGraph extends ContentGraph<
 
 export default class RequestTracker {
   graph: RequestGraph;
-  farm: WorkerFarm;
+  farm: IWorkerFarm;
   options: ParcelOptions;
   signal: ?AbortSignal;
 
@@ -828,7 +828,7 @@ export default class RequestTracker {
     options,
   }: {|
     graph?: RequestGraph,
-    farm: WorkerFarm,
+    farm: IWorkerFarm,
     options: ParcelOptions,
   |}) {
     this.graph = graph || new RequestGraph();
@@ -1125,7 +1125,7 @@ export default class RequestTracker {
     farm,
     options,
   }: {|
-    farm: WorkerFarm,
+    farm: IWorkerFarm,
     options: ParcelOptions,
   |}): Async<RequestTracker> {
     let graph = await loadRequestGraph(options);

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -1,8 +1,11 @@
 // @flow strict-local
 
 import type {ContentKey} from '@parcel/graph';
-import type {Dependency, NamedBundle as INamedBundle} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {
+  Dependency,
+  NamedBundle as INamedBundle,
+  SharedReference,
+} from '@parcel/types';
 import type {
   Asset,
   AssetGroup,

--- a/packages/core/core/src/loadDotEnv.js
+++ b/packages/core/core/src/loadDotEnv.js
@@ -1,7 +1,6 @@
 // @flow strict-local
 
-import type {FileSystem} from '@parcel/fs';
-import type {EnvMap, FilePath} from '@parcel/types';
+import type {EnvMap, FilePath, FileSystem} from '@parcel/types';
 
 import {resolveConfig} from '@parcel/utils';
 import dotenv from 'dotenv';

--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -2,7 +2,6 @@
 
 import type SourceMap from '@parcel/source-map';
 import type {Readable} from 'stream';
-import type {FileSystem} from '@parcel/fs';
 
 import type {
   Asset as IAsset,
@@ -14,6 +13,7 @@ import type {
   EnvironmentOptions,
   FileCreateInvalidation,
   FilePath,
+  FileSystem,
   Meta,
   MutableAsset as IMutableAsset,
   Stats,

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -3,14 +3,14 @@ import type {
   BuildMode,
   EnvMap,
   FilePath,
+  FileSystem,
   LogLevel,
+  PackageManager,
   PluginOptions as IPluginOptions,
   ServerOptions,
   HMROptions,
   DetailedReportOptions,
 } from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
-import type {PackageManager} from '@parcel/package-manager';
 import type {ParcelOptions} from '../types';
 
 let parcelOptionsToPluginOptions: WeakMap<ParcelOptions, PluginOptions> =

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -1,8 +1,7 @@
 // @flow strict-local
 
 import type {NodeId} from '@parcel/graph';
-import type {Async} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {Async, SharedReference} from '@parcel/types';
 import type {
   Asset,
   AssetGroup,

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -1,7 +1,11 @@
 // @flow strict-local
 
-import type {Async, Bundle as IBundle, Namer} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {
+  Async,
+  Bundle as IBundle,
+  Namer,
+  SharedReference,
+} from '@parcel/types';
 import type ParcelConfig, {LoadedPlugin} from '../ParcelConfig';
 import type {StaticRunOpts, RunAPI} from '../RequestTracker';
 import type {

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -1,9 +1,8 @@
 // @flow strict-local
 
-import type {Async, FilePath, PackageJSON} from '@parcel/types';
+import type {Async, FilePath, FileSystem, PackageJSON} from '@parcel/types';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {Entry, InternalFile, ParcelOptions} from '../types';
-import type {FileSystem} from '@parcel/fs';
 
 import {
   isDirectoryInside,

--- a/packages/core/core/src/requests/PackageRequest.js
+++ b/packages/core/core/src/requests/PackageRequest.js
@@ -1,8 +1,7 @@
 // @flow strict-local
 
 import type {ContentKey} from '@parcel/graph';
-import type {Async} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {Async, SharedReference} from '@parcel/types';
 
 import type {StaticRunOpts} from '../RequestTracker';
 import type {Bundle} from '../types';

--- a/packages/core/core/src/requests/ParcelBuildRequest.js
+++ b/packages/core/core/src/requests/ParcelBuildRequest.js
@@ -1,8 +1,7 @@
 // @flow strict-local
 
 import type {ContentKey} from '@parcel/graph';
-import type {Async} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {Async, SharedReference} from '@parcel/types';
 import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 
 import type {StaticRunOpts} from '../RequestTracker';

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -2,11 +2,11 @@
 import type {
   Async,
   FilePath,
+  FileSystem,
   PackageName,
   RawParcelConfig,
   ResolvedParcelConfigFile,
 } from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {
   ExtendableParcelConfigPipeline,

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -1,11 +1,11 @@
 // @flow strict-local
 
 import type {Diagnostic} from '@parcel/diagnostic';
-import type {FileSystem} from '@parcel/fs';
 import type {
   Async,
   Engines,
   FilePath,
+  FileSystem,
   PackageJSON,
   PackageTargetDescriptor,
   TargetDescriptor,

--- a/packages/core/core/src/requests/ValidationRequest.js
+++ b/packages/core/core/src/requests/ValidationRequest.js
@@ -1,6 +1,5 @@
 // @flow strict-local
-import type {Async} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {Async, SharedReference} from '@parcel/types';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {AssetGroup} from '../types';
 import type {ConfigAndCachePath} from './ParcelConfigRequest';

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -1,8 +1,12 @@
 // @flow strict-local
-
-import type {FileSystem, FileOptions} from '@parcel/fs';
 import type {ContentKey} from '@parcel/graph';
-import type {Async, FilePath, Compressor} from '@parcel/types';
+import type {
+  Async,
+  FilePath,
+  FileSystem,
+  FileOptions,
+  Compressor,
+} from '@parcel/types';
 
 import type {RunAPI, StaticRunOpts} from '../RequestTracker';
 import type {Bundle, PackagedBundleInfo, ParcelOptions} from '../types';

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -1,8 +1,7 @@
 // @flow strict-local
 
 import type {ContentKey} from '@parcel/graph';
-import type {Async} from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
+import type {Async, SharedReference} from '@parcel/types';
 import type {StaticRunOpts} from '../RequestTracker';
 import type {PackagedBundleInfo} from '../types';
 import type BundleGraph from '../BundleGraph';

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -2,11 +2,11 @@
 
 import type {
   FilePath,
+  FileSystem,
   InitialParcelOptions,
   DependencySpecifier,
   InitialServerOptions,
 } from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
 import type {ParcelOptions} from './types';
 
 import path from 'path';

--- a/packages/core/core/src/summarizeRequest.js
+++ b/packages/core/core/src/summarizeRequest.js
@@ -1,6 +1,5 @@
 // @flow strict-local
-import type {Blob, FilePath} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {Blob, FileSystem, FilePath} from '@parcel/types';
 
 import {hashStream} from '@parcel/utils';
 import path from 'path';

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -4,14 +4,17 @@ import type {ContentKey} from '@parcel/graph';
 import type {
   ASTGenerator,
   BuildMode,
+  Cache,
   Engines,
   EnvironmentContext,
   EnvMap,
   FilePath,
+  FileSystem,
   Glob,
   LogLevel,
   Meta,
   DependencySpecifier,
+  PackageManager,
   PackageName,
   ReporterEvent,
   SemverRange,
@@ -27,9 +30,6 @@ import type {
   DetailedReportOptions,
 } from '@parcel/types';
 import type {SharedReference} from '@parcel/workers';
-import type {FileSystem} from '@parcel/fs';
-import type {Cache} from '@parcel/cache';
-import type {PackageManager} from '@parcel/package-manager';
 import type {ProjectPath} from './projectPath';
 
 export type ParcelPluginNode = {|

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -19,6 +19,7 @@ import type {
   ReporterEvent,
   SemverRange,
   ServerOptions,
+  SharedReference,
   SourceType,
   Stats,
   Symbol,
@@ -29,7 +30,6 @@ import type {
   HMROptions,
   DetailedReportOptions,
 } from '@parcel/types';
-import type {SharedReference} from '@parcel/workers';
 import type {ProjectPath} from './projectPath';
 
 export type ParcelPluginNode = {|

--- a/packages/core/core/src/utils.js
+++ b/packages/core/core/src/utils.js
@@ -4,6 +4,7 @@ import type {AbortSignal} from 'abortcontroller-polyfill/dist/cjs-ponyfill';
 import type {
   FilePath,
   FileCreateInvalidation,
+  PackageManager,
   SourceLocation,
 } from '@parcel/types';
 import type {
@@ -13,7 +14,6 @@ import type {
   InternalSourceLocation,
   InternalDevDepOptions,
 } from './types';
-import type {PackageManager} from '@parcel/package-manager';
 
 import invariant from 'assert';
 import baseX from 'base-x';

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -6,7 +6,8 @@ import type {
   ProcessedParcelConfig,
   RequestInvalidation,
 } from './types';
-import type {SharedReference, WorkerApi} from '@parcel/workers';
+import type {SharedReference} from '@parcel/types';
+import type {WorkerApi} from '@parcel/workers';
 import {loadConfig as configCache} from '@parcel/utils';
 import type {DevDepSpecifier} from './requests/DevDepRequest';
 

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -1,7 +1,11 @@
 // @flow
 
 import type {FileSystem, FileOptions, ReaddirOptions, Encoding} from './types';
-import type {FilePath} from '@parcel/types';
+import type {
+  FilePath,
+  WorkerFarm as IWorkerFarm,
+  Handle as IHandle,
+} from '@parcel/types';
 import type {
   Event,
   Options as WatcherOptions,
@@ -47,8 +51,8 @@ export class MemoryFS implements FileSystem {
   watchers: Map<FilePath, Set<Watcher>>;
   events: Array<Event>;
   id: number;
-  handle: Handle;
-  farm: WorkerFarm;
+  handle: IHandle;
+  farm: IWorkerFarm;
   _cwd: FilePath;
   _eventQueue: Array<Event>;
   _watcherTimer: TimeoutID;

--- a/packages/core/fs/src/index.js
+++ b/packages/core/fs/src/index.js
@@ -1,13 +1,11 @@
 // @flow strict-local
-import type {FileSystem} from './types';
-import type {FilePath} from '@parcel/types';
+import type {FilePath, FileSystem} from '@parcel/types';
 import type {Readable, Writable} from 'stream';
 
 import path from 'path';
 import stream from 'stream';
 import {promisify} from 'util';
 
-export type * from './types';
 export * from './NodeFS';
 export * from './MemoryFS';
 export * from './OverlayFS';

--- a/packages/core/package-manager/src/MockPackageInstaller.js
+++ b/packages/core/package-manager/src/MockPackageInstaller.js
@@ -1,8 +1,7 @@
 // @flow
 
 import type {ModuleRequest, PackageInstaller, InstallerOptions} from './types';
-import type {FileSystem} from '@parcel/fs';
-import type {FilePath} from '@parcel/types';
+import type {FileSystem, FilePath} from '@parcel/types';
 
 import path from 'path';
 import {ncp} from '@parcel/fs';

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -1,14 +1,18 @@
 // @flow
-import type {FilePath, DependencySpecifier, SemverRange} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {
+  FilePath,
+  FileSystem,
+  DependencySpecifier,
+  PackageManager,
+  PackageManagerResolveResult as ResolveResult,
+  SemverRange,
+} from '@parcel/types';
 import type {
   ModuleRequest,
-  PackageManager,
   PackageInstaller,
   InstallOptions,
   Invalidations,
 } from './types';
-import type {ResolveResult} from './types';
 
 import {registerSerializableClass} from '@parcel/core';
 import ThrowableDiagnostic, {

--- a/packages/core/package-manager/src/index.js
+++ b/packages/core/package-manager/src/index.js
@@ -1,5 +1,4 @@
 // @flow
-export type * from './types';
 export * from './Npm';
 export * from './Pnpm';
 export * from './Yarn';

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -1,13 +1,12 @@
 // @flow
 
-import type {FilePath, PackageJSON} from '@parcel/types';
 import type {
-  ModuleRequest,
+  FilePath,
+  FileSystem,
   PackageManager,
-  PackageInstaller,
-  InstallOptions,
-} from './types';
-import type {FileSystem} from '@parcel/fs';
+  PackageJSON,
+} from '@parcel/types';
+import type {ModuleRequest, PackageInstaller, InstallOptions} from './types';
 
 import invariant from 'assert';
 import path from 'path';

--- a/packages/core/package-manager/src/types.js
+++ b/packages/core/package-manager/src/types.js
@@ -1,21 +1,10 @@
 // @flow
-
 import type {
   FilePath,
+  FileSystem,
   FileCreateInvalidation,
   SemverRange,
-  DependencySpecifier,
-  PackageJSON,
 } from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
-
-export type ResolveResult = {|
-  resolved: FilePath | DependencySpecifier,
-  pkg?: ?PackageJSON,
-  invalidateOnFileCreate: Array<FileCreateInvalidation>,
-  invalidateOnFileChange: Set<FilePath>,
-  type: number,
-|};
 
 export type InstallOptions = {
   installPeers?: boolean,
@@ -41,21 +30,6 @@ export type Invalidations = {|
   invalidateOnFileChange: Set<FilePath>,
   invalidateOnStartup: boolean,
 |};
-
-export interface PackageManager {
-  require(
-    id: DependencySpecifier,
-    from: FilePath,
-    ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
-  ): Promise<any>;
-  resolve(
-    id: DependencySpecifier,
-    from: FilePath,
-    ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
-  ): Promise<ResolveResult>;
-  getInvalidations(id: DependencySpecifier, from: FilePath): Invalidations;
-  invalidate(id: DependencySpecifier, from: FilePath): void;
-}
 
 export type ModuleRequest = {|
   +name: string,

--- a/packages/core/package-manager/src/utils.js
+++ b/packages/core/package-manager/src/utils.js
@@ -1,8 +1,7 @@
 // @flow strict-local
 
 import type {ModuleRequest} from './types';
-import type {FilePath} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FilePath, FileSystem} from '@parcel/types';
 
 import invariant from 'assert';
 import ThrowableDiagnostic from '@parcel/diagnostic';

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -10,7 +10,7 @@ import type {
   InitialParcelOptions,
   PackagedBundle,
 } from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem} from '@parcel/types';
 import type WorkerFarm from '@parcel/workers';
 import type {IncomingMessage} from 'http';
 

--- a/packages/core/types/cache.js
+++ b/packages/core/types/cache.js
@@ -1,0 +1,17 @@
+// @flow strict-local
+import type {Readable} from 'stream';
+
+export interface Cache {
+  ensure(): Promise<void>;
+  has(key: string): Promise<boolean>;
+  get<T>(key: string): Promise<?T>;
+  set(key: string, value: mixed): Promise<void>;
+  getStream(key: string): Readable;
+  setStream(key: string, stream: Readable): Promise<void>;
+  getBlob(key: string): Promise<Buffer>;
+  setBlob(key: string, contents: Buffer | string): Promise<void>;
+  hasLargeBlob(key: string): Promise<boolean>;
+  getLargeBlob(key: string): Promise<Buffer>;
+  setLargeBlob(key: string, contents: Buffer | string): Promise<void>;
+  getBuffer(key: string): Promise<?Buffer>;
+}

--- a/packages/core/types/fs.js
+++ b/packages/core/types/fs.js
@@ -1,0 +1,126 @@
+// @flow strict-local
+import type {FilePath} from './index';
+import type {Readable, Writable} from 'stream';
+import type {
+  Event,
+  Options as WatcherOptions,
+  AsyncSubscription,
+} from '@parcel/watcher';
+
+export type FileOptions = {mode?: number, ...};
+export type ReaddirOptions =
+  | {withFileTypes?: false, ...}
+  | {withFileTypes: true, ...};
+
+export interface Stats {
+  dev: number;
+  ino: number;
+  mode: number;
+  nlink: number;
+  uid: number;
+  gid: number;
+  rdev: number;
+  size: number;
+  blksize: number;
+  blocks: number;
+  atimeMs: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  birthtimeMs: number;
+  atime: Date;
+  mtime: Date;
+  ctime: Date;
+  birthtime: Date;
+
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isBlockDevice(): boolean;
+  isCharacterDevice(): boolean;
+  isSymbolicLink(): boolean;
+  isFIFO(): boolean;
+  isSocket(): boolean;
+}
+
+export type Encoding =
+  | 'hex'
+  | 'utf8'
+  | 'utf-8'
+  | 'ascii'
+  | 'binary'
+  | 'base64'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'utf16le'
+  | 'latin1';
+
+export interface FileSystem {
+  readFile(filePath: FilePath): Promise<Buffer>;
+  readFile(filePath: FilePath, encoding: Encoding): Promise<string>;
+  readFileSync(filePath: FilePath): Buffer;
+  readFileSync(filePath: FilePath, encoding: Encoding): string;
+  writeFile(
+    filePath: FilePath,
+    contents: Buffer | string,
+    options: ?FileOptions,
+  ): Promise<void>;
+  copyFile(
+    source: FilePath,
+    destination: FilePath,
+    flags?: number,
+  ): Promise<void>;
+  stat(filePath: FilePath): Promise<Stats>;
+  statSync(filePath: FilePath): Stats;
+  readdir(
+    path: FilePath,
+    opts?: {withFileTypes?: false, ...},
+  ): Promise<FilePath[]>;
+  readdir(path: FilePath, opts: {withFileTypes: true, ...}): Promise<Dirent[]>;
+  readdirSync(path: FilePath, opts?: {withFileTypes?: false, ...}): FilePath[];
+  readdirSync(path: FilePath, opts: {withFileTypes: true, ...}): Dirent[];
+  unlink(path: FilePath): Promise<void>;
+  realpath(path: FilePath): Promise<FilePath>;
+  realpathSync(path: FilePath): FilePath;
+  exists(path: FilePath): Promise<boolean>;
+  existsSync(path: FilePath): boolean;
+  mkdirp(path: FilePath): Promise<void>;
+  rimraf(path: FilePath): Promise<void>;
+  ncp(source: FilePath, destination: FilePath): Promise<void>;
+  createReadStream(path: FilePath, options?: ?FileOptions): Readable;
+  createWriteStream(path: FilePath, options?: ?FileOptions): Writable;
+  cwd(): FilePath;
+  chdir(dir: FilePath): void;
+  watch(
+    dir: FilePath,
+    fn: (err: ?Error, events: Array<Event>) => mixed,
+    opts: WatcherOptions,
+  ): Promise<AsyncSubscription>;
+  getEventsSince(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions,
+  ): Promise<Array<Event>>;
+  writeSnapshot(
+    dir: FilePath,
+    snapshot: FilePath,
+    opts: WatcherOptions,
+  ): Promise<void>;
+  findAncestorFile(
+    fileNames: Array<string>,
+    fromDir: FilePath,
+    root: FilePath,
+  ): ?FilePath;
+  findNodeModule(moduleName: string, fromDir: FilePath): ?FilePath;
+  findFirstFile(filePaths: Array<FilePath>): ?FilePath;
+}
+
+// https://nodejs.org/api/fs.html#fs_class_fs_dirent
+export interface Dirent {
+  +name: string;
+  isBlockDevice(): boolean;
+  isCharacterDevice(): boolean;
+  isDirectory(): boolean;
+  isFIFO(): boolean;
+  isFile(): boolean;
+  isSocket(): boolean;
+  isSymbolicLink(): boolean;
+}

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -3,7 +3,7 @@
 import type {Readable} from 'stream';
 import type SourceMap from '@parcel/source-map';
 import type {FileSystem, FileOptions} from './fs';
-import type WorkerFarm from '@parcel/workers';
+import type {WorkerFarm} from './worker-farm';
 import type {
   PackageManager,
   ResolveResult as PackageManagerResolveResult,
@@ -2018,3 +2018,21 @@ export interface PluginTracer {
 export type {FileSystem, FileOptions};
 export type {Cache};
 export type {PackageManager, PackageManagerResolveResult};
+export type {
+  CallRequest,
+  WorkerFarm,
+  SharedReference,
+  createSharedReference,
+  Handle,
+  HandleCallRequest,
+  HandleOpts,
+  HandleFunction,
+  Worker,
+  WorkerAPI,
+  WorkerCall,
+  WorkerDataResponse,
+  WorkerErrorResponse,
+  WorkerMessage,
+  WorkerResponse,
+  WorkerRequest,
+} from './worker-farm';

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -2,15 +2,18 @@
 
 import type {Readable} from 'stream';
 import type SourceMap from '@parcel/source-map';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem, FileOptions} from './fs';
 import type WorkerFarm from '@parcel/workers';
-import type {PackageManager} from '@parcel/package-manager';
+import type {
+  PackageManager,
+  ResolveResult as PackageManagerResolveResult,
+} from './package-manager';
 import type {
   Diagnostic,
   Diagnostifiable,
   DiagnosticWithoutOrigin,
 } from '@parcel/diagnostic';
-import type {Cache} from '@parcel/cache';
+import type {Cache} from './cache';
 
 import type {AST as _AST, ConfigResult as _ConfigResult} from './unsafe';
 import type {TraceMeasurement} from '@parcel/profiler';
@@ -2011,3 +2014,7 @@ export interface PluginTracer {
     otherArgs?: {[key: string]: mixed},
   ): TraceMeasurement | null;
 }
+
+export type {FileSystem, FileOptions};
+export type {Cache};
+export type {PackageManager, PackageManagerResolveResult};

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -2022,7 +2022,6 @@ export type {
   CallRequest,
   WorkerFarm,
   SharedReference,
-  createSharedReference,
   Handle,
   HandleCallRequest,
   HandleOpts,
@@ -2036,3 +2035,4 @@ export type {
   WorkerResponse,
   WorkerRequest,
 } from './worker-farm';
+export {createSharedReference} from './worker-farm';

--- a/packages/core/types/package-manager.js
+++ b/packages/core/types/package-manager.js
@@ -1,0 +1,38 @@
+//@flow
+
+import type {
+  FilePath,
+  FileCreateInvalidation,
+  SemverRange,
+  DependencySpecifier,
+  PackageJSON,
+} from './index';
+
+export type Invalidations = {|
+  invalidateOnFileCreate: Array<FileCreateInvalidation>,
+  invalidateOnFileChange: Set<FilePath>,
+  invalidateOnStartup: boolean,
+|};
+
+export type ResolveResult = {|
+  resolved: FilePath | DependencySpecifier,
+  pkg?: ?PackageJSON,
+  invalidateOnFileCreate: Array<FileCreateInvalidation>,
+  invalidateOnFileChange: Set<FilePath>,
+  type: number,
+|};
+
+export interface PackageManager {
+  require(
+    id: DependencySpecifier,
+    from: FilePath,
+    ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
+  ): Promise<any>;
+  resolve(
+    id: DependencySpecifier,
+    from: FilePath,
+    ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
+  ): Promise<ResolveResult>;
+  getInvalidations(id: DependencySpecifier, from: FilePath): Invalidations;
+  invalidate(id: DependencySpecifier, from: FilePath): void;
+}

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@parcel/diagnostic": "2.9.3",
     "@parcel/source-map": "^2.1.1",
-    "@parcel/workers": "2.9.3",
     "utility-types": "^3.10.0"
   }
 }

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -16,10 +16,7 @@
     "check-ts": "tsc --noEmit lib/index.d.ts"
   },
   "dependencies": {
-    "@parcel/cache": "2.9.3",
     "@parcel/diagnostic": "2.9.3",
-    "@parcel/fs": "2.9.3",
-    "@parcel/package-manager": "2.9.3",
     "@parcel/source-map": "^2.1.1",
     "@parcel/workers": "2.9.3",
     "utility-types": "^3.10.0"

--- a/packages/core/types/worker-farm.js
+++ b/packages/core/types/worker-farm.js
@@ -1,0 +1,136 @@
+// @flow
+import type {Diagnostic} from '@parcel/diagnostic';
+import type {ErrorWithCode, FilePath} from './index';
+
+export opaque type SharedReference = number;
+
+export function createSharedReference(id: number): SharedReference {
+  return id;
+}
+
+export type WorkerCall = {|
+  method?: string,
+  handle?: number,
+  args: $ReadOnlyArray<any>,
+  retries: number,
+  skipReadyCheck?: boolean,
+  resolve: (result: Promise<any> | any) => void,
+  reject: (error: any) => void,
+|};
+
+// $FlowFixMe
+export type HandleFunction = (...args: Array<any>) => any;
+
+export type HandleOpts = {|
+  fn?: HandleFunction,
+  childId?: ?number,
+  id?: number,
+|};
+
+export interface Handle {
+  id: number;
+  childId: ?number;
+  dispose(): void;
+  serialize(): {|childId: ?number, id: number|};
+}
+
+export type LocationCallRequest = {|
+  args: $ReadOnlyArray<mixed>,
+  location: string,
+  method?: string,
+|};
+
+export type HandleCallRequest = {|
+  args: $ReadOnlyArray<mixed>,
+  handle: number,
+|};
+
+export type CallRequest = LocationCallRequest | HandleCallRequest;
+
+export type WorkerAPI = {|
+  callChild: (childId: number, request: HandleCallRequest) => Promise<mixed>,
+  callMaster: (
+    request: CallRequest,
+    awaitResponse?: ?boolean,
+  ) => Promise<mixed>,
+  createReverseHandle: (fn: HandleFunction) => Handle,
+  getSharedReference: (ref: SharedReference) => mixed,
+  resolveSharedReference: (value: mixed) => void | SharedReference,
+  runHandle: (handle: Handle, args: Array<any>) => Promise<mixed>,
+|};
+export interface WorkerFarm {
+  ending: boolean;
+  workerApi: WorkerAPI;
+  warmupWorker(method: string, args: Array<any>): void;
+  shouldStartRemoteWorkers(): boolean;
+  createHandle(method: string, useMainThread?: boolean): HandleFunction;
+  onError(error: ErrorWithCode, worker: Worker): void | Promise<void>;
+  startChild(): void;
+  stopWorker(worker: Worker): Promise<void>;
+  processQueue(): void;
+  callWorker(worker: Worker, call: WorkerCall): Promise<void>;
+  processRequest(
+    data: {|
+      location: FilePath,
+    |} & $Shape<WorkerRequest>,
+    worker?: Worker,
+  ): Promise<?string>;
+  addCall(method: string, args: Array<any>): Promise<any>;
+  end(): Promise<void>;
+  startMaxWorkers(): void;
+  shouldUseRemoteWorkers(): boolean;
+  createReverseHandle(fn: HandleFunction): Handle;
+  createSharedReference(
+    value: mixed,
+    isCacheable?: boolean,
+  ): {|ref: SharedReference, dispose(): Promise<mixed>|};
+  getSerializedSharedReference(ref: SharedReference): ArrayBuffer;
+  startProfile(): Promise<void>;
+  endProfile(): Promise<void>;
+  callAllWorkers(method: string, args: Array<any>): Promise<void>;
+  takeHeapSnapshot(): Promise<void>;
+}
+
+export type WorkerDataResponse = {|
+  idx?: number,
+  child?: number,
+  type: 'response',
+  contentType: 'data',
+  content: string,
+|};
+
+export type WorkerErrorResponse = {|
+  idx?: number,
+  child?: number,
+  type: 'response',
+  contentType: 'error',
+  content: Diagnostic | Array<Diagnostic>,
+|};
+
+export type WorkerRequest = {|
+  args: $ReadOnlyArray<any>,
+  awaitResponse?: boolean,
+  child?: ?number,
+  idx?: number,
+  location?: FilePath,
+  method?: ?string,
+  type: 'request',
+  handle?: number,
+|};
+export type WorkerResponse = WorkerDataResponse | WorkerErrorResponse;
+export type WorkerMessage = WorkerRequest | WorkerResponse;
+
+export interface Worker {
+  id: number;
+  calls: Map<number, WorkerCall>;
+  sentSharedReferences: Set<SharedReference>;
+  ready: boolean;
+  stopped: boolean;
+  isStopping: boolean;
+  fork(forkModule: FilePath): Promise<void>;
+  sendSharedReference(ref: SharedReference, value: mixed): Promise<any>;
+  send(data: WorkerMessage): void;
+  call(call: WorkerCall): void;
+  receive(message: WorkerMessage): void;
+  stop(): Promise<void>;
+}

--- a/packages/core/utils/src/alternatives.js
+++ b/packages/core/utils/src/alternatives.js
@@ -1,6 +1,6 @@
 // @flow
 import path from 'path';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem} from '@parcel/types';
 import {fuzzySearch} from './schema';
 import {relativePath} from './path';
 import {resolveConfig} from './config';

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {ConfigResult, File, FilePath} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {ConfigResult, File, FileSystem, FilePath} from '@parcel/types';
 import ThrowableDiagnostic from '@parcel/diagnostic';
 import path from 'path';
 import clone from 'clone';

--- a/packages/core/utils/src/generateBuildMetrics.js
+++ b/packages/core/utils/src/generateBuildMetrics.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {FilePath, PackagedBundle} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FilePath, FileSystem, PackagedBundle} from '@parcel/types';
 import SourceMap from '@parcel/source-map';
 import nullthrows from 'nullthrows';
 import path from 'path';

--- a/packages/core/utils/src/generateCertificate.js
+++ b/packages/core/utils/src/generateCertificate.js
@@ -1,5 +1,5 @@
 // @flow
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem} from '@parcel/types';
 import forge from 'node-forge';
 import path from 'path';
 import logger from '@parcel/logger';

--- a/packages/core/utils/src/getCertificate.js
+++ b/packages/core/utils/src/getCertificate.js
@@ -1,6 +1,5 @@
 // @flow
-import type {HTTPSOptions} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem, HTTPSOptions} from '@parcel/types';
 
 export default async function getCertificate(
   fs: FileSystem,

--- a/packages/core/utils/src/glob.js
+++ b/packages/core/utils/src/glob.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {FilePath, Glob} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FilePath, FileSystem, Glob} from '@parcel/types';
 
 import _isGlob from 'is-glob';
 import fastGlob, {type FastGlobOptions} from 'fast-glob';

--- a/packages/core/utils/src/hash.js
+++ b/packages/core/utils/src/hash.js
@@ -1,7 +1,7 @@
 // @flow strict-local
 
 import type {Readable} from 'stream';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem} from '@parcel/types';
 
 import {objectSortedEntriesDeep} from './collection';
 import {hashString, Hash} from '@parcel/hash';

--- a/packages/core/utils/src/http-server.js
+++ b/packages/core/utils/src/http-server.js
@@ -11,8 +11,7 @@ import type {
   ServerResponse as HTTPSResponse,
 } from 'https';
 import type {Socket} from 'net';
-import type {FilePath, HTTPSOptions} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem, FilePath, HTTPSOptions} from '@parcel/types';
 
 import http from 'http';
 import https from 'https';

--- a/packages/core/utils/src/sourcemap.js
+++ b/packages/core/utils/src/sourcemap.js
@@ -1,6 +1,5 @@
 // @flow
-import type {SourceLocation} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem, SourceLocation} from '@parcel/types';
 import SourceMap from '@parcel/source-map';
 import path from 'path';
 import {normalizeSeparators, isAbsolute} from './path';

--- a/packages/core/workers/src/Handle.js
+++ b/packages/core/workers/src/Handle.js
@@ -1,21 +1,18 @@
 // @flow strict-local
 import {registerSerializableClass} from '@parcel/core';
+import type {
+  Handle as IHandle,
+  HandleOpts,
+  HandleFunction,
+} from '@parcel/types';
+
 // $FlowFixMe
 import packageJson from '../package.json';
 
 let HANDLE_ID = 0;
-// $FlowFixMe
-export type HandleFunction = (...args: Array<any>) => any;
+const handleById: Map<number, IHandle> = new Map();
 
-type HandleOpts = {|
-  fn?: HandleFunction,
-  childId?: ?number,
-  id?: number,
-|};
-
-const handleById: Map<number, Handle> = new Map();
-
-export default class Handle {
+export default class Handle implements IHandle {
   id: number;
   childId: ?number;
   fn: ?HandleFunction;

--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -1,23 +1,18 @@
 // @flow
 
-import type {FilePath} from '@parcel/types';
-import type {BackendType, WorkerImpl, WorkerMessage} from './types';
-import type {SharedReference} from './WorkerFarm';
+import type {
+  FilePath,
+  SharedReference,
+  WorkerCall,
+  Worker as IWorker,
+  WorkerMessage,
+} from '@parcel/types';
+import type {BackendType, WorkerImpl} from './types';
 
 import nullthrows from 'nullthrows';
 import EventEmitter from 'events';
 import ThrowableDiagnostic from '@parcel/diagnostic';
 import {getWorkerBackend} from './backend';
-
-export type WorkerCall = {|
-  method?: string,
-  handle?: number,
-  args: $ReadOnlyArray<any>,
-  retries: number,
-  skipReadyCheck?: boolean,
-  resolve: (result: Promise<any> | any) => void,
-  reject: (error: any) => void,
-|};
 
 type WorkerOpts = {|
   forcedKillTime: number,
@@ -28,7 +23,7 @@ type WorkerOpts = {|
 |};
 
 let WORKER_ID = 0;
-export default class Worker extends EventEmitter {
+export default class Worker extends EventEmitter implements IWorker {
   +options: WorkerOpts;
   worker: WorkerImpl;
   id: number = WORKER_ID++;

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -7,6 +7,7 @@ import type {
   ErrorWithCode,
   FilePath,
   HandleFunction,
+  SharedReference,
   WorkerFarm as IWorkerFarm,
   Worker as IWorker,
   WorkerCall,
@@ -17,7 +18,6 @@ import type {
 } from '@parcel/types';
 import {createSharedReference} from '@parcel/types';
 import type {BackendType} from './types';
-import type {} from './Handle';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -37,7 +37,6 @@ import {detectBackend} from './backend';
 import {SamplingProfiler, Trace} from '@parcel/profiler';
 import fs from 'fs';
 import logger from '@parcel/logger';
-import type {SharedReference} from '../../types/worker-farm';
 
 let referenceId = 1;
 

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -1,16 +1,18 @@
 // @flow
 
+import type {ChildImpl} from './types';
 import type {
+  Async,
   CallRequest,
+  Handle as IHandle,
+  IDisposable,
+  SharedReference,
   WorkerDataResponse,
   WorkerErrorResponse,
   WorkerMessage,
-  WorkerRequest,
   WorkerResponse,
-  ChildImpl,
-} from './types';
-import type {Async, IDisposable} from '@parcel/types';
-import type {SharedReference} from './WorkerFarm';
+  WorkerRequest,
+} from '@parcel/types';
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
@@ -68,18 +70,18 @@ export class Child {
       request: CallRequest,
       awaitResponse?: ?boolean,
     ) => Promise<mixed>,
-    createReverseHandle: (fn: (...args: Array<any>) => mixed) => Handle,
+    createReverseHandle: (fn: (...args: Array<any>) => mixed) => IHandle,
     getSharedReference: (ref: SharedReference) => mixed,
     resolveSharedReference: (value: mixed) => void | SharedReference,
-    runHandle: (handle: Handle, args: Array<any>) => Promise<mixed>,
+    runHandle: (handle: IHandle, args: Array<any>) => Promise<mixed>,
   |} = {
     callMaster: (
       request: CallRequest,
       awaitResponse: ?boolean = true,
     ): Promise<mixed> => this.addCall(request, awaitResponse),
-    createReverseHandle: (fn: (...args: Array<any>) => mixed): Handle =>
+    createReverseHandle: (fn: (...args: Array<any>) => mixed): IHandle =>
       this.createReverseHandle(fn),
-    runHandle: (handle: Handle, args: Array<any>): Promise<mixed> =>
+    runHandle: (handle: IHandle, args: Array<any>): Promise<mixed> =>
       this.workerApi.callMaster({handle: handle.id, args}, true),
     getSharedReference: (ref: SharedReference) =>
       this.sharedReferences.get(ref),

--- a/packages/core/workers/src/index.js
+++ b/packages/core/workers/src/index.js
@@ -40,4 +40,4 @@ if (!WorkerFarm.isWorker()) {
 export default WorkerFarm;
 export {bus};
 export {Handle} from './WorkerFarm';
-export type {WorkerApi, FarmOptions, SharedReference} from './WorkerFarm';
+export type {WorkerApi, FarmOptions} from './WorkerFarm';

--- a/packages/core/workers/src/process/ProcessChild.js
+++ b/packages/core/workers/src/process/ProcessChild.js
@@ -1,11 +1,7 @@
 // @flow
 
-import type {
-  ChildImpl,
-  MessageHandler,
-  ExitHandler,
-  WorkerMessage,
-} from '../types';
+import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
+import type {WorkerMessage} from '@parcel/types';
 import nullthrows from 'nullthrows';
 import {setChild} from '../childState';
 import {Child} from '../child';

--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -5,8 +5,8 @@ import type {
   MessageHandler,
   ErrorHandler,
   ExitHandler,
-  WorkerMessage,
 } from '../types';
+import type {WorkerMessage} from '@parcel/types';
 import childProcess, {type ChildProcess} from 'child_process';
 import path from 'path';
 import {serialize, deserialize} from '@parcel/core';

--- a/packages/core/workers/src/threads/ThreadsChild.js
+++ b/packages/core/workers/src/threads/ThreadsChild.js
@@ -1,17 +1,12 @@
 // @flow
 
-import type {
-  ChildImpl,
-  MessageHandler,
-  ExitHandler,
-  WorkerMessage,
-} from '../types';
+import type {ChildImpl, MessageHandler, ExitHandler} from '../types';
 import {isMainThread, parentPort} from 'worker_threads';
 import nullthrows from 'nullthrows';
 import {setChild} from '../childState';
 import {Child} from '../child';
 import {prepareForSerialization, restoreDeserializedObject} from '@parcel/core';
-
+import type {WorkerMessage} from '@parcel/types';
 export default class ThreadsChild implements ChildImpl {
   onMessage: MessageHandler;
   onExit: ExitHandler;

--- a/packages/core/workers/src/threads/ThreadsChild.js
+++ b/packages/core/workers/src/threads/ThreadsChild.js
@@ -7,6 +7,7 @@ import {setChild} from '../childState';
 import {Child} from '../child';
 import {prepareForSerialization, restoreDeserializedObject} from '@parcel/core';
 import type {WorkerMessage} from '@parcel/types';
+
 export default class ThreadsChild implements ChildImpl {
   onMessage: MessageHandler;
   onExit: ExitHandler;

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -5,8 +5,8 @@ import type {
   MessageHandler,
   ErrorHandler,
   ExitHandler,
-  WorkerMessage,
 } from '../types';
+import type {WorkerMessage} from '@parcel/types';
 import {Worker} from 'worker_threads';
 import path from 'path';
 import {prepareForSerialization, restoreDeserializedObject} from '@parcel/core';

--- a/packages/core/workers/src/types.js
+++ b/packages/core/workers/src/types.js
@@ -1,49 +1,5 @@
 // @flow
-import type {Diagnostic} from '@parcel/diagnostic';
-import type {FilePath} from '@parcel/types';
-
-export type LocationCallRequest = {|
-  args: $ReadOnlyArray<mixed>,
-  location: string,
-  method?: string,
-|};
-
-export type HandleCallRequest = {|
-  args: $ReadOnlyArray<mixed>,
-  handle: number,
-|};
-
-export type CallRequest = LocationCallRequest | HandleCallRequest;
-
-export type WorkerRequest = {|
-  args: $ReadOnlyArray<any>,
-  awaitResponse?: boolean,
-  child?: ?number,
-  idx?: number,
-  location?: FilePath,
-  method?: ?string,
-  type: 'request',
-  handle?: number,
-|};
-
-export type WorkerDataResponse = {|
-  idx?: number,
-  child?: number,
-  type: 'response',
-  contentType: 'data',
-  content: string,
-|};
-
-export type WorkerErrorResponse = {|
-  idx?: number,
-  child?: number,
-  type: 'response',
-  contentType: 'error',
-  content: Diagnostic | Array<Diagnostic>,
-|};
-
-export type WorkerResponse = WorkerDataResponse | WorkerErrorResponse;
-export type WorkerMessage = WorkerRequest | WorkerResponse;
+import type {WorkerMessage} from '@parcel/types';
 
 export type MessageHandler = (data: WorkerMessage) => void;
 export type ErrorHandler = (err: Error) => void;

--- a/packages/dev/esm-fuzzer/package.json
+++ b/packages/dev/esm-fuzzer/package.json
@@ -10,6 +10,8 @@
     "@babel/generator": "^7.9.0",
     "@babel/template": "^7.8.6",
     "@babel/types": "^7.9.0",
+    "@parcel/core": "2.9.3",
+    "@parcel/fs": "2.9.3",
     "nanoid": "^3.1.12",
     "nullthrows": "^1.1.1"
   }

--- a/packages/reporters/cli/src/bundleReport.js
+++ b/packages/reporters/cli/src/bundleReport.js
@@ -1,6 +1,10 @@
 // @flow
-import type {BundleGraph, FilePath, PackagedBundle} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {
+  FileSystem,
+  BundleGraph,
+  FilePath,
+  PackagedBundle,
+} from '@parcel/types';
 
 import {generateBuildMetrics, prettifyTime} from '@parcel/utils';
 import filesize from 'filesize';

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -2,6 +2,7 @@
 
 import type {DevServerOptions, Request, Response} from './types.js.flow';
 import type {
+  FileSystem,
   BuildSuccessEvent,
   BundleGraph,
   FilePath,
@@ -9,7 +10,6 @@ import type {
   PackagedBundle,
 } from '@parcel/types';
 import type {Diagnostic} from '@parcel/diagnostic';
-import type {FileSystem} from '@parcel/fs';
 import type {HTTPServer, FormattedCodeFrame} from '@parcel/utils';
 
 import invariant from 'assert';

--- a/packages/reporters/dev-server/src/types.js.flow
+++ b/packages/reporters/dev-server/src/types.js.flow
@@ -1,8 +1,6 @@
 // @flow
-import type {ServerOptions, PluginLogger, HMROptions} from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
+import type {FileSystem, ServerOptions, PackageManager, PluginLogger, HMROptions} from '@parcel/types';
 import type {HTTPServer} from '@parcel/utils';
-import type {PackageManager} from '@parcel/package-manager';
 import {
   IncomingMessage as HTTPIncomingMessage,
   ServerResponse as HTTPServerResponse,

--- a/packages/transformers/image/src/loadSharp.js
+++ b/packages/transformers/image/src/loadSharp.js
@@ -1,6 +1,5 @@
 // @flow
-import type {PackageManager} from '@parcel/package-manager';
-import type {FilePath} from '@parcel/types';
+import type {FilePath, PackageManager} from '@parcel/types';
 
 const SHARP_RANGE = '^0.31.1';
 

--- a/packages/transformers/postcss/src/loadPlugins.js
+++ b/packages/transformers/postcss/src/loadPlugins.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {FilePath, PluginOptions} from '@parcel/types';
-import type {PackageManager} from '@parcel/package-manager';
+import type {FilePath, PackageManager, PluginOptions} from '@parcel/types';
 
 export default async function loadExternalPlugins(
   plugins: Array<string> | {|+[pluginName: string]: mixed|},

--- a/packages/transformers/posthtml/src/loadPlugins.js
+++ b/packages/transformers/posthtml/src/loadPlugins.js
@@ -1,7 +1,6 @@
 // @flow
 
-import type {FilePath, PluginOptions} from '@parcel/types';
-import type {PackageManager} from '@parcel/package-manager';
+import type {FilePath, PackageManager, PluginOptions} from '@parcel/types';
 
 export default async function loadExternalPlugins(
   plugins: Array<string> | {+[pluginName: string]: mixed, ...},

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -1,16 +1,16 @@
 // @flow
 import type {
   FilePath,
+  FileSystem,
   SpecifierType,
   SemverRange,
   Environment,
   SourceLocation,
   BuildMode,
+  PackageManager,
   ResolveResult,
   PluginLogger,
 } from '@parcel/types';
-import type {FileSystem} from '@parcel/fs';
-import type {PackageManager} from '@parcel/package-manager';
 import type {Diagnostic} from '@parcel/diagnostic';
 import {NodeFS} from '@parcel/fs';
 import {init, Resolver} from '../native';

--- a/packages/utils/ts-utils/src/CompilerHost.js
+++ b/packages/utils/ts-utils/src/CompilerHost.js
@@ -1,6 +1,10 @@
 // @flow
-import type {FileSystem} from '@parcel/fs';
-import type {FilePath, PackageJSON, PluginLogger} from '@parcel/types';
+import type {
+  FileSystem,
+  FilePath,
+  PackageJSON,
+  PluginLogger,
+} from '@parcel/types';
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import type {CompilerOptions, SourceFile} from 'typescript';
 import typeof {ScriptTarget} from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies

--- a/packages/utils/ts-utils/src/FSHost.js
+++ b/packages/utils/ts-utils/src/FSHost.js
@@ -1,6 +1,5 @@
 // @flow
-import type {FileSystem} from '@parcel/fs';
-import type {FilePath} from '@parcel/types';
+import type {FileSystem, FilePath} from '@parcel/types';
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import path from 'path';
 

--- a/packages/utils/ts-utils/src/LanguageServiceHost.js
+++ b/packages/utils/ts-utils/src/LanguageServiceHost.js
@@ -1,6 +1,5 @@
 // @flow
-import type {FileSystem} from '@parcel/fs';
-import type {FilePath} from '@parcel/types';
+import type {FileSystem, FilePath} from '@parcel/types';
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import type {
   CompilerOptions,

--- a/packages/utils/ts-utils/src/ParseConfigHost.js
+++ b/packages/utils/ts-utils/src/ParseConfigHost.js
@@ -1,6 +1,5 @@
 // @flow
-import type {FileSystem} from '@parcel/fs';
-import type {FilePath} from '@parcel/types';
+import type {FileSystem, FilePath} from '@parcel/types';
 import typeof TypeScriptModule from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import type {ParseConfigHost as IParseConfigHost} from 'typescript'; // eslint-disable-line import/no-extraneous-dependencies
 import {FSHost} from './FSHost';

--- a/packages/validators/eslint/package.json
+++ b/packages/validators/eslint/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@parcel/plugin": "2.9.3",
     "@parcel/utils": "2.9.3",
+    "@parcel/diagnostic": "2.9.3",
     "chalk": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Currently Parcel has several package cycles, all because of circular dependencies on `@parcel/types`.

This is problematic because currently if you have, say, a simple plugin that just depends on `@parcel/plugin` and `@parcel/types` you bring in a lot of transitive dependencies - like for example types depends on workers which depends on core as small example. Some are a bit worse because they bring in Rust based binaries.

This Draft PR removes dependencies from `@parcel/types` to any package that has a dependency on `@parcel/types`. This list was:

* @parcel/fs
* @parcel/cache
* @parcel/pacakge-manager
* @parcel/workers

Moving the types for FS, Cache, and Package Manager was relatively straightforward - the messier one was `@parcel/workers` - this is because currently the class for `Worker` and `WorkerFarm` are used as a type, and also there are a lot of required types to be moved and exported from `@parcel/types` to satisfy all of the dependencies.

This is a draft PR to foster some discussion on how to proceed, here are some open questions:

- [ ] Since `@parcel/types` is the public API, how can we mark things exported as "Not API"? For example, `WorkerFarm` is a property of the options object, which is why it was imported, but it's effectively an opaque type.. but also, because it's required by options, does that transitively actually make it API, and this cycle removal is actually just surfacing the underlying issue?
- [ ] Is there a better way to break the cycles without moving everything to `@parcel/types` for these packages?
- [ ] Changing `Worker`, `WorkerFarm`, and `Handle` to `interface`s instead of using the `class` as a type means we lose the `static` methods from the type signature. I don't think there's any way around that?

## 🚨 Test instructions

`yarn flow` has no errors.

