### PR TITLE
Add async resolver and JS transformer functions using rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "parcel-dev-dep-resolver",
  "parcel-js-swc-core",
  "parcel-resolver",
+ "rayon",
  "xxhash-rust",
 ]
 

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-napi = {version =  "2.12.6", features = ["serde-json"]}
 napi-derive = "2.12.5"
 parcel-js-swc-core = { path = "../../packages/transformers/js/core" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
@@ -16,12 +15,15 @@ dashmap = "5.4.0"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+napi = {version =  "2.12.6", features = ["serde-json", "napi4"]}
 parcel-dev-dep-resolver = { path = "../../packages/utils/dev-dep-resolver" }
 oxipng = "8.0.0"
 mozjpeg-sys = "1.0.0"
 libc = "0.2"
+rayon = "1.7.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+napi = {version =  "2.12.6", features = ["serde-json"]}
 getrandom = { version = "0.2", features = ["custom"], default-features = false }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -8,3 +8,20 @@ pub fn transform(opts: JsObject, env: Env) -> Result<JsUnknown> {
   let result = parcel_js_swc_core::transform(config)?;
   env.to_js_value(&result)
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+#[napi]
+pub fn transform_async(opts: JsObject, env: Env) -> Result<JsObject> {
+  let config: parcel_js_swc_core::Config = env.from_js_value(opts)?;
+  let (deferred, promise) = env.create_deferred()?;
+
+  rayon::spawn(move || {
+    let res = parcel_js_swc_core::transform(config);
+    match res {
+      Ok(result) => deferred.resolve(move |env| env.to_js_value(&result)),
+      Err(err) => deferred.reject(err.into()),
+    }
+  });
+
+  Ok(promise)
+}

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -54,6 +54,7 @@ export interface JsInvalidations {
   invalidateOnStartup: boolean;
 }
 declare export function transform(opts: any): any;
+declare export function transformAsync(opts: any): Promise<any>;
 declare export class Hash {
   writeString(s: string): void;
   writeBuffer(b: Buffer): void;
@@ -71,5 +72,6 @@ export interface ResolverOptions {
 declare export class Resolver {
   constructor(projectRoot: string, options: ResolverOptions): Resolver;
   resolve(options: ResolveOptions): ResolveResult;
+  resolveAsync(options: ResolveOptions): Promise<ResolveResult>;
   getInvalidations(path: string): JsInvalidations;
 }

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -4,7 +4,7 @@ import type {SchemaEntity} from '@parcel/utils';
 import type {Diagnostic} from '@parcel/diagnostic';
 import SourceMap from '@parcel/source-map';
 import {Transformer} from '@parcel/plugin';
-import {transform} from '@parcel/rust';
+import {transform, transformAsync} from '@parcel/rust';
 import path from 'path';
 import browserslist from 'browserslist';
 import semver from 'semver';
@@ -401,7 +401,7 @@ export default (new Transformer({
       diagnostics,
       used_env,
       has_node_replacements,
-    } = transform({
+    } = await (transformAsync || transform)({
       filename: asset.filePath,
       code,
       module_id: asset.id,

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -141,10 +141,10 @@ export default class NodeResolver {
       process.versions.pnp == null;
 
     let res = canResolveAsync
-      // $FlowFixMe[incompatible-call] - parent is not null here.
-      ? await resolver.resolveAsync(options)
-      // $FlowFixMe[incompatible-call] - parent is not null here.
-      : resolver.resolve(options);
+      ? // $FlowFixMe[incompatible-call] - parent is not null here.
+        await resolver.resolveAsync(options)
+      : // $FlowFixMe[incompatible-call] - parent is not null here.
+        resolver.resolve(options);
 
     // Invalidate whenever the .pnp.js file changes.
     // TODO: only when we actually resolve a node_modules package?

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -134,8 +134,16 @@ export default class NodeResolver {
       }
     }
 
+    // Async resolver is only supported in non-WASM environments, and does not support JS callbacks (e.g. FS, PnP).
+    let canResolveAsync =
+      !init &&
+      this.options.fs instanceof NodeFS &&
+      process.versions.pnp == null;
+
     // $FlowFixMe[incompatible-call] - parent is not null here.
-    let res = resolver.resolve(options);
+    let res = canResolveAsync
+      ? await resolver.resolveAsync(options)
+      : resolver.resolve(options);
 
     // Invalidate whenever the .pnp.js file changes.
     // TODO: only when we actually resolve a node_modules package?

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -140,9 +140,10 @@ export default class NodeResolver {
       this.options.fs instanceof NodeFS &&
       process.versions.pnp == null;
 
-    // $FlowFixMe[incompatible-call] - parent is not null here.
     let res = canResolveAsync
+      // $FlowFixMe[incompatible-call] - parent is not null here.
       ? await resolver.resolveAsync(options)
+      // $FlowFixMe[incompatible-call] - parent is not null here.
       : resolver.resolve(options);
 
     // Invalidate whenever the .pnp.js file changes.


### PR DESCRIPTION
Depends on #9146.

With all of our rust modules in a single binary, we can now share a single Rayon thread pool between modules. This adds async versions of the resolver and JS transformer so that IO and processing can happen outside of the JS thread(s). **This results in a ~20% performance improvement on esbuild's benchmark.**

For the resolver, this is only supported when using a NodeFS, and when PnP is not enabled, because our implementation of calling JS functions from Rust is not currently thread safe. It could potentially be made so but this was a bunch of extra work for an edge case, so I think for now falling back to the sync version and accepting a small perf hit is fine.