### PR TITLE
Fix signal type error in cli

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -339,8 +339,8 @@ async function run(
 
     // In non-tty cases, respond to SIGINT by cleaning up. Since we're watching,
     // a 0 success code is acceptable.
-    process.on('SIGINT', exit);
-    process.on('SIGTERM', exit);
+    process.on('SIGINT', () => exit());
+    process.on('SIGTERM', () => exit());
   } else {
     try {
       await parcel.run();


### PR DESCRIPTION
# ↪️ Pull Request

This PR fixes the runtime type error that occurs when trying to interrupt Parcel in non-tty watching mode. Previously it gave the following error:
```
TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('SIGINT')
    at process.set [as exitCode] (node:internal/bootstrap/node:123:9)
    at process.exit (node:internal/process/per_thread:188:24)
    at process.exit (/home/dima/space/src/js/doodle-draw/client/node_modules/parcel/lib/cli.js:241:13) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

As it's said in [Node.js documentation](https://nodejs.org/api/process.html#signal-events), "_The signal handler will receive the signal's name ('SIGINT', 'SIGTERM', etc.) as the first argument._", but `exit` function expects a `number`.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

The easiest way to reproduce it is to forward parcel's output to some interactive screen environment, like `less`:
`$ parcel watch | less`
Also reproduces with the [`concurrently`](https://www.npmjs.com/package/concurrently) tool:
`$ npx concurrently "parcel watch"`
Then try to interrupt it with ctrl-c and you will get the mentioned error.

I'm not sure how to write a test for the CLI, sorry. If someone provides an example or a suggestion, I will be glad to do it.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
