### PR TITLE
Support parallel bundle imports in libraries

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -505,6 +505,7 @@ function createIdealGraph(
              */
             let bundleGroupRootAsset = nullthrows(bundleGroup.mainEntryAsset);
             if (
+              parentAsset.type !== childAsset.type &&
               entries.has(bundleGroupRootAsset) &&
               canMerge(bundleGroupRootAsset, childAsset) &&
               dependency.bundleBehavior == null

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/.parcelrc
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/.parcelrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@parcel/config-default",
+  "resolvers": ["./ParallelResolver", "..."]
+}

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/ParallelResolver.js
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/ParallelResolver.js
@@ -1,0 +1,12 @@
+const {Resolver} = require('@parcel/plugin');
+
+module.exports = new Resolver({
+  resolve({specifier}) {
+    if (specifier === './foo') {
+      return {
+        filePath: __dirname + '/foo.js',
+        priority: 'parallel'
+      };
+    }
+  }
+});

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/foo.js
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/foo.js
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/foo.js
@@ -1,1 +1,1 @@
-export const foo = 'foo';
+module.exports = 'foo';

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/index.js
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/index.js
@@ -1,0 +1,3 @@
+import {foo} from './foo';
+
+export default foo + ' bar';

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/index.js
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/index.js
@@ -1,3 +1,3 @@
-import {foo} from './foo';
+import * as foo from './foo';
 
 export default foo + ' bar';

--- a/packages/core/integration-tests/test/integration/library-parallel-deps/package.json
+++ b/packages/core/integration-tests/test/integration/library-parallel-deps/package.json
@@ -1,0 +1,3 @@
+{
+  "module": "dist/out.js"
+}

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1463,6 +1463,34 @@ describe('output formats', function () {
     assert.deepEqual(calls, [[['a', 10]]]);
   });
 
+  it('should support external parallel dependencies', async function () {
+    let b = await bundle(
+      path.join(__dirname, 'integration/library-parallel-deps/index.js'),
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldOptimize: false,
+        },
+      },
+    );
+
+    assertBundles(b, [
+      {
+        name: 'out.js',
+        assets: ['index.js'],
+      },
+      {
+        assets: ['foo.js'],
+      },
+    ]);
+
+    let res = await run(b);
+    assert.equal(res.default, 'foo bar');
+
+    let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(/import \{\s*foo.*\} from "\.\//.test(content));
+  });
+
   describe('global', function () {
     it.skip('should support split bundles between main script and workers', async function () {
       let b = await bundle(

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1488,7 +1488,7 @@ describe('output formats', function () {
     assert.equal(res.default, 'foo bar');
 
     let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(/import \{\s*foo.*\} from "\.\//.test(content));
+    assert(/import [a-z0-9$]+ from "\.\//.test(content));
   });
 
   describe('global', function () {

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -94,6 +94,7 @@ export class ScopeHoistingPackager {
   hoistedRequires: Map<string, Map<string, string>> = new Map();
   needsPrelude: boolean = false;
   usedHelpers: Set<string> = new Set();
+  externalAssets: Set<Asset> = new Set();
 
   constructor(
     options: PluginOptions,
@@ -130,9 +131,19 @@ export class ScopeHoistingPackager {
       this.bundle.env.isLibrary ||
       this.bundle.env.outputFormat === 'commonjs'
     ) {
-      let bundles = this.bundleGraph.getReferencedBundles(this.bundle);
-      for (let b of bundles) {
-        this.externals.set(relativeBundlePath(this.bundle, b), new Map());
+      for (let b of this.bundleGraph.getReferencedBundles(this.bundle)) {
+        let entry = b.getMainEntry();
+        let symbols = new Map();
+        if (entry && !this.isAsyncBundle && entry.type === 'js') {
+          this.externalAssets.add(entry);
+
+          let usedSymbols = this.bundleGraph.getUsedSymbols(entry) || new Set();
+          for (let s of usedSymbols) {
+            symbols.set(s, this.getSymbolResolution(entry, entry, s));
+          }
+        }
+
+        this.externals.set(relativeBundlePath(this.bundle, b), symbols);
       }
     }
 
@@ -756,6 +767,13 @@ ${code}
     }
   }
 
+  isWrapped(resolved: Asset, parentAsset: Asset): boolean {
+    return (
+      (!this.bundle.hasAsset(resolved) && !this.externalAssets.has(resolved)) ||
+      (this.wrappedAssets.has(resolved.id) && resolved !== parentAsset)
+    );
+  }
+
   getSymbolResolution(
     parentAsset: Asset,
     resolved: Asset,
@@ -777,12 +795,17 @@ ${code}
       return '{}';
     }
 
-    let isWrapped =
-      !this.bundle.hasAsset(resolvedAsset) ||
-      (this.wrappedAssets.has(resolvedAsset.id) &&
-        resolvedAsset !== parentAsset);
+    let isWrapped = this.isWrapped(resolvedAsset, parentAsset);
     let staticExports = resolvedAsset.meta.staticExports !== false;
     let publicId = this.bundleGraph.getAssetPublicId(resolvedAsset);
+
+    // External CommonJS dependencies need to be accessed as an object property rather than imported
+    // directly to maintain live binding.
+    let isExternalCommonJS =
+      !isWrapped &&
+      this.bundle.env.isLibrary &&
+      this.bundle.env.outputFormat === 'commonjs' &&
+      !this.bundle.hasAsset(resolvedAsset);
 
     // If the resolved asset is wrapped, but imported at the top-level by this asset,
     // then we hoist parcelRequire calls to the top of this asset so side effects run immediately.
@@ -849,7 +872,7 @@ ${code}
         return obj;
       }
     } else if (
-      (!staticExports || isWrapped || !symbol) &&
+      (!staticExports || isWrapped || !symbol || isExternalCommonJS) &&
       resolvedAsset !== parentAsset
     ) {
       // If the resolved asset is wrapped or has non-static exports,
@@ -887,9 +910,7 @@ ${code}
     let hoisted = this.hoistedRequires.get(dep.id);
     let res = '';
     let lineCount = 0;
-    let isWrapped =
-      !this.bundle.hasAsset(resolved) ||
-      (this.wrappedAssets.has(resolved.id) && resolved !== parentAsset);
+    let isWrapped = this.isWrapped(resolved, parentAsset);
 
     // If the resolved asset is wrapped and is imported in the top-level by this asset,
     // we need to run side effects when this asset runs. If the resolved asset is not

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -139,7 +139,13 @@ export class ScopeHoistingPackager {
 
           let usedSymbols = this.bundleGraph.getUsedSymbols(entry) || new Set();
           for (let s of usedSymbols) {
-            symbols.set(s, this.getSymbolResolution(entry, entry, s));
+            // If the referenced bundle is ESM, and we are importing '*', use 'default' instead.
+            // This matches the logic below in buildExportedSymbols.
+            let imported = s;
+            if (imported === '*' && b.env.outputFormat === 'esmodule') {
+              imported = 'default';
+            }
+            symbols.set(imported, this.getSymbolResolution(entry, entry, s));
           }
         }
 


### PR DESCRIPTION
The scope hoisting packager makes some assumptions about how to access code in other bundles that don't hold in library builds. One of these is that it tries to use `parcelRequire` to access dependencies in other bundles rather than using `import` or `require`. This PR keeps track of assets in referenced bundles and generates code to access them via the appropriate module system instead.

Right now this is only possible with a custom plugin that makes dependencies parallel. There was also a small bug in the bundler preventing that from working correctly (it used to merge them all into a single bundle like type changes). Eventually we might have a separate bundler for libraries that outputs a single asset per bundle, and the packager changes in this PR should also help with that.