### PR TITLE
Remove Flow suppression for require.resolve options

### DIFF
--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -228,7 +228,6 @@ async function run(
   let options = await normalizeOptions(command, fs);
   let parcel = new Parcel({
     entries,
-    // $FlowFixMe[extra-arg] - flow doesn't know about the `paths` option (added in Node v8.9.0)
     defaultConfig: require.resolve('@parcel/config-default', {
       paths: [fs.cwd(), __dirname],
     }),


### PR DESCRIPTION
# ↪️ Pull Request

Cleans up Flow error suppression comment for `require.resolve` options param in `cli.js`.

This comment was [needed](https://github.com/parcel-bundler/parcel/pull/5127#issuecomment-691149869) when the use of `require.resolve` was added, but the type has [since been fixed](https://github.com/facebook/flow/blob/v0.184/lib/core.js#L2431) in Flow in [0.153.0](https://github.com/facebook/flow/releases/tag/v0.153.0). Parcel is using `0.184.0`.

## 💻 Examples

n/a

## 🚨 Test instructions

`yarn flow check` does not error with the comment removed.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
