### PR TITLE
Fix new ESM loader runtime by moving to abs URLs

### DIFF
--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -50,8 +50,11 @@ function nameRuntimeBundle(
   let {hashReference} = bundle;
 
   let name = nullthrows(siblingBundle.name)
-    .replace(`.${bundle.type}`, `.runtime.${hashReference}.${bundle.type}`)
-    .replace(siblingBundle.hashReference, 'sib-hash');
+    // Remove the existing hash from standard file patterns
+    // e.g. 'main.[hash].js' -> 'main.js' or 'main~[hash].js' -> 'main.js'
+    .replace(new RegExp(`[\\.~\\-_]?${siblingBundle.hashReference}`), '')
+    // Ensure the file ends with 'runtime.[hash].js'
+    .replace(`.${bundle.type}`, `.runtime.${hashReference}.${bundle.type}`);
 
   bundle.name = name;
   bundle.displayName = name.replace(hashReference, '[hash]');

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -45,7 +45,7 @@ function nameRuntimeBundle(
   siblingBundle: InternalBundle,
 ) {
   // We don't run custom namers on runtime bundles as the runtime assumes that they are
-  // located at the same nesting level as they're owning bundle. Custom naming could
+  // located at the same nesting level as their owning bundle. Custom naming could
   // be added in future as long as the custom name is validated.
   let {hashReference} = bundle;
 

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -49,7 +49,7 @@ function nameRuntimeBundle(
   // be added in future as long as the custom name is validated.
   let {hashReference} = bundle;
 
-  let name = siblingBundle.name
+  let name = nullthrows(siblingBundle.name)
     .replace(`.${bundle.type}`, `.runtime.${hashReference}.${bundle.type}`)
     .replace(siblingBundle.hashReference, 'sib-hash');
 

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -411,8 +411,6 @@ class BundlerRunner {
         previousDevDeps: this.previousDevDeps,
         devDepRequests: this.devDepRequests,
         configs: this.configs,
-        nameRuntimeBundle: bundle =>
-          this.nameBundle(namers, bundle, internalBundleGraph),
       });
 
       // Add dev deps for namers, AFTER running them to account for lazy require().

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -280,22 +280,21 @@ describe('bundler', function () {
         assets: ['b.html'],
       },
       {
-        assets: ['a.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: ['a.js', 'cacheLoader.js', 'js-loader.js'],
       },
       {
-        assets: ['bundle-manifest.js'], // manifest bundle
+        assets: ['bundle-manifest.js', 'bundle-url.js'], // manifest bundle
       },
       {
         assets: [
           'b.js',
-          'bundle-url.js',
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
         ],
       },
       {
-        assets: ['bundle-manifest.js'], // manifest bundle
+        assets: ['bundle-manifest.js', 'bundle-url.js'], // manifest bundle
       },
       {
         assets: ['c.js'],
@@ -305,7 +304,7 @@ describe('bundler', function () {
     let aManifestBundle = b
       .getBundles()
       .find(
-        bundle => !bundle.getMainEntry() && /a\.HASH_REF/.test(bundle.name),
+        bundle => !bundle.getMainEntry() && bundle.name.includes('runtime'),
       );
 
     let bBundles = b

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -25,7 +25,7 @@ import Logger from '@parcel/logger';
 import nullthrows from 'nullthrows';
 import {md} from '@parcel/diagnostic';
 
-describe('javascript', function () {
+describe.only('javascript', function () {
   beforeEach(async () => {
     await removeDistDirectory();
   });
@@ -2095,7 +2095,10 @@ describe('javascript', function () {
   it('should create a shared bundle between browser and worker contexts', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/html-shared-worker/index.html'),
-      {mode: 'production', defaultTargetOptions: {shouldScopeHoist: false}},
+      {
+        mode: 'production',
+        defaultTargetOptions: {shouldScopeHoist: false, shouldOptimize: false},
+      },
     );
 
     assertBundles(b, [
@@ -2109,11 +2112,10 @@ describe('javascript', function () {
           'get-worker-url.js',
           'lodash.js',
           'esmodule-helpers.js',
-          'bundle-url.js',
         ],
       },
       {
-        assets: ['bundle-manifest.js'],
+        assets: ['bundle-manifest.js', 'bundle-url.js'],
       },
       {
         assets: ['worker.js', 'lodash.js', 'esmodule-helpers.js'],

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2095,10 +2095,7 @@ describe('javascript', function () {
   it('should create a shared bundle between browser and worker contexts', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/html-shared-worker/index.html'),
-      {
-        mode: 'production',
-        defaultTargetOptions: {shouldScopeHoist: false, shouldOptimize: false},
-      },
+      {mode: 'production', defaultTargetOptions: {shouldScopeHoist: false}},
     );
 
     assertBundles(b, [

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -25,7 +25,7 @@ import Logger from '@parcel/logger';
 import nullthrows from 'nullthrows';
 import {md} from '@parcel/diagnostic';
 
-describe.only('javascript', function () {
+describe('javascript', function () {
   beforeEach(async () => {
     await removeDistDirectory();
   });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -968,7 +968,10 @@ export async function runESM(
 ): Promise<Array<{|[string]: mixed|}>> {
   let id = instanceId++;
   let cache = new Map();
-  function load(specifier, referrer, code = null) {
+  function load(inputSpecifier, referrer, code = null) {
+    // ESM can request bundles with an absolute URL. Normalize this to the baseDir.
+    let specifier = inputSpecifier.replace('http://localhost', baseDir);
+
     if (path.isAbsolute(specifier) || specifier.startsWith('.')) {
       let extname = path.extname(specifier);
       if (extname && extname !== '.js' && extname !== '.mjs') {

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -654,7 +654,7 @@ function getRegisterCode(
   let baseUrl =
     entryBundle.env.outputFormat === 'esmodule' &&
     entryBundle.env.supports('import-meta-url')
-      ? 'new __parcel__URL__("").toString()' // <-- this isn't ideal. We should use `import.meta.url` directly but it get's replaced currently
+      ? 'new __parcel__URL__("").toString()' // <-- this isn't ideal. We should use `import.meta.url` directly but it gets replaced currently
       : `require('./helpers/bundle-url').getBundleURL('${entryBundle.publicId}')`;
 
   return `require('./helpers/bundle-manifest').register(${baseUrl},JSON.parse(${JSON.stringify(

--- a/packages/runtimes/js/src/helpers/browser/esm-js-loader.js
+++ b/packages/runtimes/js/src/helpers/browser/esm-js-loader.js
@@ -1,9 +1,6 @@
-function load(id, base) {
-  let bundleId = require('../bundle-manifest').resolve(id);
-  let request = base ? './' + base + bundleId : './' + bundleId;
-
+function load(id) {
   // eslint-disable-next-line no-undef
-  return __parcel__import__(request);
+  return __parcel__import__(require('../bundle-manifest').resolve(id));
 }
 
 module.exports = load;

--- a/packages/runtimes/js/src/helpers/bundle-manifest.js
+++ b/packages/runtimes/js/src/helpers/bundle-manifest.js
@@ -1,18 +1,17 @@
-var mapping = {};
+var mapping = new Map();
 
-function register(pairs) {
-  var keys = Object.keys(pairs);
-  for (var i = 0; i < keys.length; i++) {
-    mapping[keys[i]] = pairs[keys[i]];
+function register(baseUrl, pairs) {
+  for (var i = 0; i < pairs.length; i++) {
+    mapping.set(pairs[i][0], {baseUrl, path: pairs[i][1]});
   }
 }
 
 function resolve(id) {
-  var resolved = mapping[id];
+  var resolved = mapping.get(id);
   if (resolved == null) {
     throw new Error('Could not resolve bundle with id ' + id);
   }
-  return resolved;
+  return new URL(resolved.path, resolved.baseUrl).toString();
 }
 
 module.exports.register = register;

--- a/packages/runtimes/js/src/helpers/bundle-manifest.js
+++ b/packages/runtimes/js/src/helpers/bundle-manifest.js
@@ -1,8 +1,11 @@
 var mapping = new Map();
 
-function register(baseUrl, pairs) {
-  for (var i = 0; i < pairs.length; i++) {
-    mapping.set(pairs[i][0], {baseUrl, path: pairs[i][1]});
+function register(baseUrl, manifest) {
+  for (var i = 0; i < manifest.length - 1; i += 2) {
+    mapping.set(manifest[i], {
+      baseUrl: baseUrl,
+      path: manifest[i + 1],
+    });
   }
 }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR fixes the ESM loader runtime by making the bundle-manifest return absolute URLs. It also makes the following changes:
- Faster manifest registration by using a Map and entries list rather than an object
- Removes the ability to custom name runtime asset bundles
  - This is because it could break the absolute URL resolution

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
