### PR TITLE
Removal of globalThis polyfill

### DIFF
--- a/packages/core/core/src/public/Environment.js
+++ b/packages/core/core/src/public/Environment.js
@@ -124,6 +124,18 @@ const supportData = {
     and_qq: '12.12',
     op_mob: '64',
   },
+  'global-this': {
+    chrome: '75',
+    edge: '79',
+    safari: '12.1',
+    firefox: '65',
+    opera: '58',
+    node: '12',
+    and_chr: '71',
+    ios: '12.2',
+    android: '71',
+    samsung: '10.1',
+  },
 };
 
 const internalEnvironmentToEnvironment: WeakMap<

--- a/packages/core/integration-tests/test/integration/packager-global-this/index.html
+++ b/packages/core/integration-tests/test/integration/packager-global-this/index.html
@@ -1,0 +1,1 @@
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/packager-global-this/index.js
+++ b/packages/core/integration-tests/test/integration/packager-global-this/index.js
@@ -1,0 +1,2 @@
+import('./lazy').then(m => alert(m));
+emitGlobalThis(globalThis);

--- a/packages/core/integration-tests/test/integration/packager-global-this/lazy.js
+++ b/packages/core/integration-tests/test/integration/packager-global-this/lazy.js
@@ -1,0 +1,1 @@
+export const lazy = 'lazy value';

--- a/packages/core/integration-tests/test/packager.js
+++ b/packages/core/integration-tests/test/packager.js
@@ -1,0 +1,81 @@
+import assert from 'assert';
+import path from 'path';
+import nullthrows from 'nullthrows';
+import {normalizePath} from '@parcel/utils';
+import {createWorkerFarm} from '@parcel/core';
+import {md} from '@parcel/diagnostic';
+import {
+  assertBundles,
+  bundle as _bundle,
+  bundler as _bundler,
+  distDir,
+  findAsset,
+  findDependency,
+  getNextBuild,
+  mergeParcelOptions,
+  outputFS,
+  overlayFS,
+  run,
+  runBundle,
+} from '@parcel/test-utils';
+
+const runBundler = (name, opts = {}) => {
+  return _bundle(
+    name,
+    // $FlowFixMe
+    mergeParcelOptions({}, opts),
+  );
+};
+
+const bundler = (name, opts = {}) => {
+  return _bundler(
+    name,
+    // $FlowFixMe
+    mergeParcelOptions({}, opts),
+  );
+};
+
+describe.only('packager', function () {
+  describe('globalThis polyfill', function () {
+    describe('es6', function () {
+      it('should include globalThis polyfill in ie11 builds', async function () {
+        const entryPoint = path.join(
+          __dirname,
+          'integration/html-js-dynamic/index.html',
+        );
+        const options = {
+          defaultTargetOptions: {
+            shouldOptimize: true,
+            engines: {
+              browsers: 'last 2 Chrome version',
+              node: '18',
+            },
+          },
+        };
+        const bundleGraph = await runBundler(entryPoint, options);
+
+        for (const b of bundleGraph.getBundles()) {
+          let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
+          console.log(b.name);
+          console.log(code);
+          console.log();
+          console.log();
+        }
+      });
+    });
+  });
+
+  // describe('commonjs', function () {
+  //   it('supports require of commonjs modules', async function () {
+  //     let b = await bundle(
+  //       path.join(
+  //         __dirname,
+  //         '/integration/scope-hoisting/commonjs/require/a.js',
+  //       ),
+  //     );
+
+  //     let output = await run(b);
+  //     assert.equal(output, 2);
+  //   });
+  // });
+});

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -111,7 +111,7 @@ export function getParcelOptions(
   entries: FilePath | Array<FilePath>,
   opts?: $Shape<InitialParcelOptions>,
 ): InitialParcelOptions {
-  const o = mergeParcelOptions(
+  return mergeParcelOptions(
     {
       entries,
       shouldDisableCache: true,
@@ -133,8 +133,6 @@ export function getParcelOptions(
     },
     opts,
   );
-  console.log(o);
-  return o;
 }
 
 export function bundler(

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -111,7 +111,7 @@ export function getParcelOptions(
   entries: FilePath | Array<FilePath>,
   opts?: $Shape<InitialParcelOptions>,
 ): InitialParcelOptions {
-  return mergeParcelOptions(
+  const o = mergeParcelOptions(
     {
       entries,
       shouldDisableCache: true,
@@ -133,6 +133,8 @@ export function getParcelOptions(
     },
     opts,
   );
+  console.log(o);
+  return o;
 }
 
 export function bundler(

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -196,7 +196,8 @@ export type EnvironmentFeature =
   | 'worker-module'
   | 'service-worker-module'
   | 'import-meta-url'
-  | 'arrow-functions';
+  | 'arrow-functions'
+  | 'global-this';
 
 /**
  * Defines the environment in for the output bundle

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -24,6 +24,7 @@
     "@parcel/hash": "2.9.3",
     "@parcel/plugin": "2.9.3",
     "@parcel/source-map": "^2.1.1",
+    "@parcel/types": "2.9.3",
     "@parcel/utils": "2.9.3",
     "globals": "^13.2.0",
     "nullthrows": "^1.1.1"

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1169,6 +1169,8 @@ ${code}
       this.usedHelpers.add('$parcel$global');
     }
 
+    console.log('um', this.bundle.env.supports('global-this'));
+
     for (let helper of this.usedHelpers) {
       let currentHelper = helpers[helper];
       if (typeof currentHelper === 'function') {

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1169,8 +1169,6 @@ ${code}
       this.usedHelpers.add('$parcel$global');
     }
 
-    console.log('um', this.bundle.env.supports('global-this'));
-
     for (let helper of this.usedHelpers) {
       let currentHelper = helpers[helper];
       if (typeof currentHelper === 'function') {

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1170,15 +1170,13 @@ ${code}
     }
 
     for (let helper of this.usedHelpers) {
-      let helperText = undefined;
-      if (typeof helper === 'function') {
-        helperText = helpers[helper](this.bundle.env);
-      } else {
-        helperText = helpers[helper];
+      let currentHelper = helpers[helper];
+      if (typeof currentHelper === 'function') {
+        currentHelper = helpers[helper](this.bundle.env);
       }
-      res += helperText;
+      res += currentHelper;
       if (enableSourceMaps) {
-        lines += countLines(helperText) - 1;
+        lines += countLines(currentHelper) - 1;
       }
     }
 

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1170,9 +1170,15 @@ ${code}
     }
 
     for (let helper of this.usedHelpers) {
-      res += helpers[helper];
+      let helperText = undefined;
+      if (typeof helper === 'function') {
+        helperText = helpers[helper](this.bundle.env);
+      } else {
+        helperText = helpers[helper];
+      }
+      res += helperText;
       if (enableSourceMaps) {
-        lines += countLines(helpers[helper]) - 1;
+        lines += countLines(helperText) - 1;
       }
     }
 

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -1,7 +1,10 @@
 // @flow strict-local
-export const prelude = (
-  parcelRequireName: string,
-): string => `var $parcel$modules = {};
+import type {Environment} from '@parcel/types';
+
+import {returnStatement} from '@babel/types';
+
+export const prelude = (parcelRequireName: string): string => `
+var $parcel$modules = {};
 var $parcel$inits = {};
 
 var parcelRequire = $parcel$global[${JSON.stringify(parcelRequireName)}];
@@ -31,12 +34,14 @@ if (parcelRequire == null) {
 }
 `;
 
-export const helpers = {
-  $parcel$export: `function $parcel$export(e, n, v, s) {
+const $parcel$export = `
+function $parcel$export(e, n, v, s) {
   Object.defineProperty(e, n, {get: v, set: s, enumerable: true, configurable: true});
 }
-`,
-  $parcel$exportWildcard: `function $parcel$exportWildcard(dest, source) {
+`;
+
+const $parcel$exportWildcard = `
+function $parcel$exportWildcard(dest, source) {
   Object.keys(source).forEach(function(key) {
     if (key === 'default' || key === '__esModule' || dest.hasOwnProperty(key)) {
       return;
@@ -52,15 +57,44 @@ export const helpers = {
 
   return dest;
 }
-`,
-  $parcel$interopDefault: `function $parcel$interopDefault(a) {
+`;
+
+const $parcel$interopDefault = `
+function $parcel$interopDefault(a) {
   return a && a.__esModule ? a.default : a;
 }
-`,
-  $parcel$global: `var $parcel$global = globalThis;
-`,
-  $parcel$defineInteropFlag: `function $parcel$defineInteropFlag(a) {
+`;
+
+const $parcel$global = (env: Environment): string => {
+  if (env.supports('esmodules')) {
+    return `
+      var $parcel$global = globalThis;
+    `;
+  }
+  return `
+      var $parcel$global =
+        typeof globalThis !== 'undefined'
+          ? globalThis
+          : typeof self !== 'undefined'
+          ? self
+          : typeof window !== 'undefined'
+          ? window
+          : typeof global !== 'undefined'
+          ? global
+          : {};
+  `;
+};
+
+const $parcel$defineInteropFlag = `
+function $parcel$defineInteropFlag(a) {
   Object.defineProperty(a, '__esModule', {value: true, configurable: true});
 }
-`,
+`;
+
+export const helpers = {
+  $parcel$export,
+  $parcel$exportWildcard,
+  $parcel$interopDefault,
+  $parcel$global,
+  $parcel$defineInteropFlag,
 };

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -57,16 +57,7 @@ export const helpers = {
   return a && a.__esModule ? a.default : a;
 }
 `,
-  $parcel$global: `var $parcel$global =
-typeof globalThis !== 'undefined'
-  ? globalThis
-  : typeof self !== 'undefined'
-  ? self
-  : typeof window !== 'undefined'
-  ? window
-  : typeof global !== 'undefined'
-  ? global
-  : {};
+  $parcel$global: `var $parcel$global = globalThis;
 `,
   $parcel$defineInteropFlag: `function $parcel$defineInteropFlag(a) {
   Object.defineProperty(a, '__esModule', {value: true, configurable: true});

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -1,8 +1,6 @@
 // @flow strict-local
 import type {Environment} from '@parcel/types';
 
-import {returnStatement} from '@babel/types';
-
 export const prelude = (parcelRequireName: string): string => `
 var $parcel$modules = {};
 var $parcel$inits = {};

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -64,7 +64,7 @@ function $parcel$interopDefault(a) {
 `;
 
 const $parcel$global = (env: Environment): string => {
-  if (env.supports('esmodules')) {
+  if (env.supports('global-this')) {
     return `
       var $parcel$global = globalThis;
     `;


### PR DESCRIPTION
# ↪️ Pull Request

This PR removes the `globalThis` polyfill from the JS packager. The polyfill will be added at transform time in projects that specify a browser in their browser list that requires the polyfill.

The reason for this change is that the `globalThis` polyfill is included in every bundle, which can add up in larger projects.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
