### PR TITLE
Add unstable async bundle runtime to the JS Packager

### DIFF
--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.html
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.html
@@ -1,0 +1,1 @@
+<script type="module" src="./a.js"></script>

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/b.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/c.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/c.js
@@ -1,0 +1,1 @@
+export default 'c';

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.html
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.html
@@ -1,0 +1,1 @@
+<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.js
@@ -1,0 +1,5 @@
+import a from './a';
+import b from './b';
+import c from './c';
+
+result([a, b, c]);

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/package.json
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/package.json
@@ -1,0 +1,8 @@
+{
+    "@parcel/bundler-default": {
+        "minBundleSize": 0
+    },
+    "@parcel/packager-js": {
+        "unstable_asyncBundleRuntime": true
+    }
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -16,7 +16,6 @@ import {
   outputFS,
   overlayFS,
   run,
-  inputFS,
   runBundle,
 } from '@parcel/test-utils';
 
@@ -5863,7 +5862,7 @@ describe('scope hoisting', function () {
     });
   });
 
-  it.only('should add experimental bundle queue runtime for out of order bundle execution', async function () {
+  it('should add experimental bundle queue runtime for out of order bundle execution', async function () {
     let b = await bundle(
       [
         path.join(__dirname, 'integration/bundle-queue-runtime/index.html'),

--- a/packages/packagers/js/src/ESMOutputFormat.js
+++ b/packages/packagers/js/src/ESMOutputFormat.js
@@ -106,6 +106,14 @@ export class ESMOutputFormat implements OutputFormat {
       lines++;
     }
 
+    if (this.packager.shouldBundleQueue(this.packager.bundle)) {
+      // Should be last thing the bundle executes on intial eval
+      res += `\n$parcel$global.rlg(${JSON.stringify(
+        this.packager.bundle.publicId,
+      )})`;
+      lines++;
+    }
+
     return [res, lines];
   }
 }

--- a/packages/packagers/js/src/ESMOutputFormat.js
+++ b/packages/packagers/js/src/ESMOutputFormat.js
@@ -108,7 +108,7 @@ export class ESMOutputFormat implements OutputFormat {
 
     if (this.packager.shouldBundleQueue(this.packager.bundle)) {
       // Should be last thing the bundle executes on intial eval
-      res += `\n$parcel$global.rlg(${JSON.stringify(
+      res += `\n$parcel$global.rlb(${JSON.stringify(
         this.packager.bundle.publicId,
       )})`;
       lines++;

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -27,7 +27,7 @@ import path from 'path';
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
 import {GlobalOutputFormat} from './GlobalOutputFormat';
-import {prelude, helpers} from './helpers';
+import {prelude, helpers, bundleQueuePrelude, fnExpr} from './helpers';
 import {replaceScriptDependencies, getSpecifier} from './utils';
 
 // https://262.ecma-international.org/6.0/#sec-names-and-keywords
@@ -202,6 +202,8 @@ export class ScopeHoistingPackager {
       mainEntry = null;
     }
 
+    let needsBundleQueue = this.shouldBundleQueue(this.bundle);
+
     // If any of the entry assets are wrapped, call parcelRequire so they are executed.
     for (let entry of entries) {
       if (this.wrappedAssets.has(entry.id) && !this.isScriptEntry(entry)) {
@@ -210,13 +212,22 @@ export class ScopeHoistingPackager {
         )});\n`;
 
         let entryExports = entry.symbols.get('*')?.local;
+
         if (
           entryExports &&
           entry === mainEntry &&
           this.exportedSymbols.has(entryExports)
         ) {
+          invariant(
+            !needsBundleQueue,
+            'Entry exports are not yet compaitble with async bundles',
+          );
           res += `\nvar ${entryExports} = ${parcelRequire}`;
         } else {
+          if (needsBundleQueue) {
+            parcelRequire = this.runWhenReady(this.bundle, parcelRequire);
+          }
+
           res += `\n${parcelRequire}`;
         }
 
@@ -262,6 +273,38 @@ export class ScopeHoistingPackager {
       contents: res,
       map: sourceMap,
     };
+  }
+
+  shouldBundleQueue(bundle: NamedBundle): boolean {
+    return (
+      Boolean(process.env.PARCEL_EXPERIMENTAL_ASYNC_RUNTIME) &&
+      bundle.type === 'js' &&
+      bundle.bundleBehavior !== 'inline' &&
+      bundle.env.outputFormat === 'esmodule' &&
+      !bundle.env.isIsolated() &&
+      bundle.bundleBehavior !== 'isolated' &&
+      !this.bundleGraph.hasParentBundleOfType(bundle, 'js')
+    );
+  }
+
+  runWhenReady(bundle: NamedBundle, codeToRun: string): string {
+    let deps = this.bundleGraph
+      .getReferencedBundles(bundle)
+      .filter(b => this.shouldBundleQueue(b))
+      .map(b => b.publicId);
+
+    if (deps.length === 0) {
+      // If no deps we can safely execute immediately
+      return codeToRun;
+    }
+
+    let params = [
+      JSON.stringify(this.bundle.publicId),
+      fnExpr(this.bundle.env, [], [codeToRun]),
+      JSON.stringify(deps),
+    ];
+
+    return `$parcel$global.rwr(${params.join(', ')});`;
   }
 
   async loadAssets(): Promise<Array<Asset>> {
@@ -594,6 +637,14 @@ ${code}
           sourceMap.addSourceMap(map, lineCount);
         }
         lineCount += lines + 1;
+      }
+
+      if (
+        !shouldWrap &&
+        this.shouldBundleQueue(this.bundle) &&
+        this.bundle.getEntryAssets().some(entry => entry.id === asset.id)
+      ) {
+        code = this.runWhenReady(this.bundle, code);
       }
 
       this.needsPrelude = true;
@@ -1198,6 +1249,14 @@ ${code}
         res += preludeCode;
         if (enableSourceMaps) {
           lines += countLines(preludeCode) - 1;
+        }
+
+        if (this.shouldBundleQueue(this.bundle)) {
+          let bundleQueuePreludeCode = bundleQueuePrelude(this.bundle.env);
+          res += bundleQueuePreludeCode;
+          if (enableSourceMaps) {
+            lines += countLines(bundleQueuePreludeCode) - 1;
+          }
         }
       } else {
         // Otherwise, get the current parcelRequire global.

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -639,15 +639,15 @@ ${code}
         lineCount += lines + 1;
       }
 
-      if (
-        !shouldWrap &&
-        this.shouldBundleQueue(this.bundle) &&
-        this.bundle.getEntryAssets().some(entry => entry.id === asset.id)
-      ) {
-        code = this.runWhenReady(this.bundle, code);
-      }
-
       this.needsPrelude = true;
+    }
+
+    if (
+      !shouldWrap &&
+      this.shouldBundleQueue(this.bundle) &&
+      this.bundle.getEntryAssets().some(entry => entry.id === asset.id)
+    ) {
+      code = this.runWhenReady(this.bundle, code);
     }
 
     return [code, sourceMap, lineCount];

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -74,6 +74,7 @@ export class ScopeHoistingPackager {
   bundleGraph: BundleGraph<NamedBundle>;
   bundle: NamedBundle;
   parcelRequireName: string;
+  useAsyncBundleRuntime: boolean;
   outputFormat: OutputFormat;
   isAsyncBundle: boolean;
   globalNames: $ReadOnlySet<string>;
@@ -101,11 +102,13 @@ export class ScopeHoistingPackager {
     bundleGraph: BundleGraph<NamedBundle>,
     bundle: NamedBundle,
     parcelRequireName: string,
+    useAsyncBundleRuntime: boolean,
   ) {
     this.options = options;
     this.bundleGraph = bundleGraph;
     this.bundle = bundle;
     this.parcelRequireName = parcelRequireName;
+    this.useAsyncBundleRuntime = useAsyncBundleRuntime;
 
     let OutputFormat = OUTPUT_FORMATS[this.bundle.env.outputFormat];
     this.outputFormat = new OutputFormat(this);
@@ -277,7 +280,7 @@ export class ScopeHoistingPackager {
 
   shouldBundleQueue(bundle: NamedBundle): boolean {
     return (
-      Boolean(process.env.PARCEL_EXPERIMENTAL_ASYNC_RUNTIME) &&
+      this.useAsyncBundleRuntime &&
       bundle.type === 'js' &&
       bundle.bundleBehavior !== 'inline' &&
       bundle.env.outputFormat === 'esmodule' &&

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -77,10 +77,10 @@ if (!$parcel$global.lb) {
           `return i.d.every(${fnExpr(
             env,
             ['dep'],
-            ['return $parcel$global.lb.has(dep));'],
+            ['return $parcel$global.lb.has(dep);'],
           )};`,
         ],
-      )}`,
+      )};`,
       'if (runnableEntry) {',
       `$parcel$global.bq = $parcel$global.bq.filter(${fnExpr(
         env,

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -78,9 +78,9 @@ if (!$parcel$global.lb) {
             env,
             ['dep'],
             ['return $parcel$global.lb.has(dep);'],
-          )};`,
+          )});`,
         ],
-      )};`,
+      )});`,
       'if (runnableEntry) {',
       `$parcel$global.bq = $parcel$global.bq.filter(${fnExpr(
         env,

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -32,6 +32,66 @@ if (parcelRequire == null) {
 }
 `;
 
+export const fnExpr = (
+  env: Environment,
+  params: Array<string>,
+  body: Array<string>,
+): string => {
+  let block = `{ ${body.join(' ')} }`;
+
+  if (env.supports('arrow-functions')) {
+    return `(${params.join(', ')}) => ${block}`;
+  }
+
+  return `function (${params.join(', ')}) ${block}`;
+};
+
+export const bundleQueuePrelude = (env: Environment): string => `
+if (!$parcel$global.lb) {
+  $parcel$global.lb = new Set();
+  $parcel$global.bq = [];
+
+  // Register loaded bundle
+  $parcel$global.rlb = ${fnExpr(
+    env,
+    ['bundle'],
+    ['$parcel$global.lb.add(bundle)', '$parcel$global.pq();'],
+  )}
+
+  // Run when ready
+  $parcel$global.rwr = ${fnExpr(
+    env,
+    ['b', 'r', 'd'],
+    [
+      '$parcel$global.bq.push({b: bundle, r: run, d: deps});',
+      '$parcel$global.pq();',
+    ],
+  )}
+
+  // Process queue
+  $parcel$global.pq = ${fnExpr(
+    env,
+    [],
+    [
+      `var runnableEntry = $parcel$global.bq.find(${fnExpr(
+        env,
+        ['i'],
+        ['return i.d.every(dep => $parcel$global.lb.has(dep));'],
+      )}`,
+      'if (runnableEntry) {',
+      `$parcel$global.bq = $parcel$global.bq.filter(${fnExpr(
+        env,
+        ['i'],
+        ['return i.b !== runnableEntry.b;'],
+      )});`,
+      'runnableEntry.r();',
+      '$parcel$global.pq();',
+      '}',
+    ],
+  )}
+}
+`;
+
 const $parcel$export = `
 function $parcel$export(e, n, v, s) {
   Object.defineProperty(e, n, {get: v, set: s, enumerable: true, configurable: true});

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -48,7 +48,9 @@ export const fnExpr = (
 
 export const bundleQueuePrelude = (env: Environment): string => `
 if (!$parcel$global.lb) {
+  // Set of loaded bundles
   $parcel$global.lb = new Set();
+  // Queue of bundles to execute once they're dep bundles are loaded
   $parcel$global.bq = [];
 
   // Register loaded bundle
@@ -61,6 +63,9 @@ if (!$parcel$global.lb) {
   // Run when ready
   $parcel$global.rwr = ${fnExpr(
     env,
+    // b = bundle public id
+    // r = run function to execute the bundle entry
+    // d = list of dependent bundles this bundle requires before executing
     ['b', 'r', 'd'],
     ['$parcel$global.bq.push({b, r, d});', '$parcel$global.pq();'],
   )}

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -55,17 +55,14 @@ if (!$parcel$global.lb) {
   $parcel$global.rlb = ${fnExpr(
     env,
     ['bundle'],
-    ['$parcel$global.lb.add(bundle)', '$parcel$global.pq();'],
+    ['$parcel$global.lb.add(bundle);', '$parcel$global.pq();'],
   )}
 
   // Run when ready
   $parcel$global.rwr = ${fnExpr(
     env,
     ['b', 'r', 'd'],
-    [
-      '$parcel$global.bq.push({b: bundle, r: run, d: deps});',
-      '$parcel$global.pq();',
-    ],
+    ['$parcel$global.bq.push({b, r, d});', '$parcel$global.pq();'],
   )}
 
   // Process queue
@@ -76,7 +73,13 @@ if (!$parcel$global.lb) {
       `var runnableEntry = $parcel$global.bq.find(${fnExpr(
         env,
         ['i'],
-        ['return i.d.every(dep => $parcel$global.lb.has(dep));'],
+        [
+          `return i.d.every(${fnExpr(
+            env,
+            ['dep'],
+            ['return $parcel$global.lb.has(dep));'],
+          )};`,
+        ],
       )}`,
       'if (runnableEntry) {',
       `$parcel$global.bq = $parcel$global.bq.filter(${fnExpr(

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -2,24 +2,62 @@
 import type {Async} from '@parcel/types';
 import type SourceMap from '@parcel/source-map';
 import {Packager} from '@parcel/plugin';
-import {replaceInlineReferences, replaceURLReferences} from '@parcel/utils';
+import {
+  replaceInlineReferences,
+  replaceURLReferences,
+  validateSchema,
+  type SchemaEntity,
+} from '@parcel/utils';
+import {encodeJSONKeyComponent} from '@parcel/diagnostic';
 import {hashString} from '@parcel/hash';
 import path from 'path';
 import nullthrows from 'nullthrows';
 import {DevPackager} from './DevPackager';
 import {ScopeHoistingPackager} from './ScopeHoistingPackager';
 
+type JSPackagerConfig = {|
+  parcelRequireName: string,
+  unstable_asyncBundleRuntime: boolean,
+|};
+
+const CONFIG_SCHEMA: SchemaEntity = {
+  type: 'object',
+  properties: {
+    unstable_asyncBundleRuntime: {
+      type: 'boolean',
+    },
+  },
+  additionalProperties: false,
+};
+
 export default (new Packager({
-  async loadConfig({config, options}) {
+  async loadConfig({config, options}): Promise<JSPackagerConfig> {
     // Generate a name for the global parcelRequire function that is unique to this project.
     // This allows multiple parcel builds to coexist on the same page.
     let pkg = await config.getConfigFrom(
       path.join(options.projectRoot, 'index'),
       ['package.json'],
     );
+
+    let packageKey = '@parcel/packager-js';
+    validateSchema.diagnostic(
+      CONFIG_SCHEMA,
+      {
+        data: pkg?.contents[packageKey],
+        source: await options.inputFS.readFile(pkg.filePath, 'utf8'),
+        filePath: pkg.filePath,
+        prependKey: `/${encodeJSONKeyComponent(packageKey)}`,
+      },
+      packageKey,
+      `Invalid config for ${packageKey}`,
+    );
+
     let name = pkg?.contents?.name ?? '';
     return {
       parcelRequireName: 'parcelRequire' + hashString(name).slice(-4),
+      unstable_asyncBundleRuntime: Boolean(
+        pkg?.contents[packageKey]?.unstable_asyncBundleRuntime,
+      ),
     };
   },
   async package({
@@ -51,6 +89,7 @@ export default (new Packager({
             bundleGraph,
             bundle,
             nullthrows(config).parcelRequireName,
+            nullthrows(config).unstable_asyncBundleRuntime,
           )
         : new DevPackager(
             options,

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -34,10 +34,9 @@ export default (new Packager({
   async loadConfig({config, options}): Promise<JSPackagerConfig> {
     // Generate a name for the global parcelRequire function that is unique to this project.
     // This allows multiple parcel builds to coexist on the same page.
-    let pkg = nullthrows(
-      await config.getConfigFrom(path.join(options.projectRoot, 'index'), [
-        'package.json',
-      ]),
+    let pkg = await config.getConfigFrom(
+      path.join(options.projectRoot, 'index'),
+      ['package.json'],
     );
 
     let packageKey = '@parcel/packager-js';

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -41,17 +41,20 @@ export default (new Packager({
     );
 
     let packageKey = '@parcel/packager-js';
-    validateSchema.diagnostic(
-      CONFIG_SCHEMA,
-      {
-        data: pkg?.contents[packageKey],
-        source: await options.inputFS.readFile(pkg.filePath, 'utf8'),
-        filePath: pkg.filePath,
-        prependKey: `/${encodeJSONKeyComponent(packageKey)}`,
-      },
-      packageKey,
-      `Invalid config for ${packageKey}`,
-    );
+
+    if (pkg?.contents[packageKey]) {
+      validateSchema.diagnostic(
+        CONFIG_SCHEMA,
+        {
+          data: pkg?.contents[packageKey],
+          source: await options.inputFS.readFile(pkg.filePath, 'utf8'),
+          filePath: pkg.filePath,
+          prependKey: `/${encodeJSONKeyComponent(packageKey)}`,
+        },
+        packageKey,
+        `Invalid config for ${packageKey}`,
+      );
+    }
 
     let name = pkg?.contents?.name ?? '';
     return {

--- a/packages/packagers/js/src/index.js
+++ b/packages/packagers/js/src/index.js
@@ -34,9 +34,10 @@ export default (new Packager({
   async loadConfig({config, options}): Promise<JSPackagerConfig> {
     // Generate a name for the global parcelRequire function that is unique to this project.
     // This allows multiple parcel builds to coexist on the same page.
-    let pkg = await config.getConfigFrom(
-      path.join(options.projectRoot, 'index'),
-      ['package.json'],
+    let pkg = nullthrows(
+      await config.getConfigFrom(path.join(options.projectRoot, 'index'), [
+        'package.json',
+      ]),
     );
 
     let packageKey = '@parcel/packager-js';


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR adds an experimental bundle queueing runtime to the JS packager, allowing bundles to be loaded out of order. Our primary use-case is when loading scripts with `type="module" async`. This allows scripts to start executing ASAP but without any order guarantees. 

The runtime only caters to scope hoisted ESM bundles for now and can be enabled by setting the following config in the root package.json. 

```json
"@parcel/packager-js": {
    "unstable_asyncBundleRuntime": true
}
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

I've added a test which enables the feature, ensures the runtime is present and executes the bundles. 

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
