### PR TITLE
to-fs-fixture: Support nested fixtures and bundler options via identifier

### DIFF
--- a/scripts/to-fs-fixture.js
+++ b/scripts/to-fs-fixture.js
@@ -408,38 +408,64 @@ function replaceInputFS(test, {jscodeshift: j}, {verbose}) {
       case 'bundler': {
         let options = args[1];
         if (options) {
-          if (options.type !== 'ObjectExpression') {
-            throw new Error(`Expected options to be an object`);
-          }
-          let inputFS = options.properties.find(
-            prop => prop.key.name === 'inputFS',
-          );
-          if (!inputFS) {
-            shouldReplace = true;
-            options.properties.push(
+          if (options.type === 'Identifier') {
+            args[1] = j.objectExpression([
               j.property(
                 'init',
                 j.identifier('inputFS'),
                 j.identifier('overlayFS'),
               ),
-            );
+              j.spreadElement(options),
+            ]);
             if (verbose) {
               console.log(
                 chalk.dim(
                   `Adding ${chalk.yellow(
                     'inputFS: overlayFS',
-                  )} option to ${chalk.yellow(name)} call at ${printLoc(loc)}`,
+                  )} option arg to ${chalk.yellow(name)} call at ${printLoc(
+                    loc,
+                  )}`,
                 ),
               );
             }
-          } else if (verbose) {
-            console.log(
-              chalk.yellow(
-                `Skipping ${name} call at ${printLoc(
-                  loc,
-                )} because it already had an inputFS option.`,
-              ),
+          } else {
+            if (options.type !== 'ObjectExpression') {
+              throw new Error(
+                `Expected options to be an object, but saw ${options.type}`,
+              );
+            }
+            let inputFS = options.properties.find(
+              prop => prop.key.name === 'inputFS',
             );
+            if (!inputFS) {
+              shouldReplace = true;
+              options.properties.push(
+                j.property(
+                  'init',
+                  j.identifier('inputFS'),
+                  j.identifier('overlayFS'),
+                ),
+              );
+              if (verbose) {
+                console.log(
+                  chalk.dim(
+                    `Adding ${chalk.yellow(
+                      'inputFS: overlayFS',
+                    )} option to ${chalk.yellow(name)} call at ${printLoc(
+                      loc,
+                    )}`,
+                  ),
+                );
+              }
+            } else if (verbose) {
+              console.log(
+                chalk.yellow(
+                  `Skipping ${name} call at ${printLoc(
+                    loc,
+                  )} because it already had an inputFS option.`,
+                ),
+              );
+            }
           }
         } else {
           shouldReplace = true;

--- a/scripts/to-fs-fixture.js
+++ b/scripts/to-fs-fixture.js
@@ -18,6 +18,37 @@ const {toFixture} = require('@parcel/test-utils/src/fsFixture');
 const {isGlobMatch} = require('@parcel/utils/src/glob');
 /* eslint-enable import/no-extraneous-dependencies */
 
+/**
+ * Some fixture dirs are organized in nested dirs, e.g.:
+ *   integration/
+ *     scope-hoisting/
+ *       commonjs/
+ *         fixture-dir/
+ *
+ * Keeping a list of these dirnames gives us a better chance of
+ * identifying the fixture files without including extraneous files.
+ */
+const POSSIBLE_ROOTS = ['commonjs', 'es6', 'integration'];
+
+/**
+ * A reciprocal pattern to `POSSIBLE_ROOTS` that is used
+ * to rewrite fixture paths to match the new fs-fixture path.
+ */
+const ROOT_PATTERN =
+  /(\/)?integration(?:\/scope-hoisting\/(?:(?:commonjs)|(?:es6)))?\//;
+
+/** Where integration test fixtures are found */
+const FIXTURE_PATH = path.resolve(
+  __dirname,
+  '../packages/core/integration-tests/test',
+);
+
+/** Where to insert the `overlayFS` argument for various test utils. */
+const TEST_UTIL_ARITY = {
+  ncp: 3,
+  assertESMExports: 5,
+};
+
 /** A simple promisified exec(). */
 function execAsync(cmd) {
   return new Promise((resolve, reject) => {
@@ -236,17 +267,17 @@ function findFixturePaths(test, api, {verbose, keep}) {
 function resolveFixturePath(value) {
   let filePath = value;
   let dirname = path.dirname(filePath);
-  while (path.basename(dirname) !== 'integration') {
+  while (POSSIBLE_ROOTS.every(root => path.basename(dirname) !== root)) {
     if (filePath === dirname) {
-      throw new Error(`Could not find integration/ in path: ${value}`);
+      throw new Error(
+        `Could not find one of ${POSSIBLE_ROOTS} in path: ${value}`,
+      );
     }
     filePath = dirname;
     dirname = path.dirname(filePath);
   }
 
-  filePath = path.resolve(
-    path.join(__dirname, '../packages/core/integration-tests/test', filePath),
-  );
+  filePath = path.resolve(path.join(FIXTURE_PATH, filePath));
   return filePath;
 }
 
@@ -351,22 +382,14 @@ function replaceFixturePaths(fixturePaths, api) {
   let j = api.jscodeshift;
 
   for (let match of fixturePaths.literals.paths().map(p => j(p))) {
-    match.replaceWith(p => p.value.raw.replace(/(\/)?integration\//, '$1'));
+    match.replaceWith(p => p.value.raw.replace(ROOT_PATTERN, '$1'));
   }
 
   for (let match of fixturePaths.templates.paths().map(p => j(p))) {
     // TODO: Update the path. this probably isn't the right way?
-    match.replaceWith(p =>
-      p.value.value.cooked.replace(/(\/)?integration\//, '$1'),
-    );
+    match.replaceWith(p => p.value.value.cooked.replace(ROOT_PATTERN, '$1'));
   }
 }
-
-/** Where to insert the `overlayFS` argument for various test utils. */
-const TEST_UTIL_ARITY = {
-  ncp: 3,
-  assertESMExports: 5,
-};
 
 /**
  * Where possible, specifies `overlayFS` as the input fs for the test.


### PR DESCRIPTION
The to-fs-fixture script learns:

- to extract fixtures that are nested, e.g.,
  a test using the path `integration/scope-hoisting/common-js/fixture-dir`
  is now extracted as `fixture-dir` instead of `scope-hoisting/common-js/fixture-dir`.

- to update bundler options that are bound to an identifier
  (as opposed to being defined inline), e.g.,
  `bundle(<path>, options)` becomes `bundle(<path>, {inputFS: overlayFS, ...options})`