### PR TITLE
Support `node:` prefix for CJS dependencies

### DIFF
--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -2297,6 +2297,18 @@ mod tests {
         .0,
       Resolution::Builtin("zlib".into())
     );
+    assert_eq!(
+      test_resolver()
+        .resolve(
+          "node:fs/promises",
+          &root().join("foo.js"),
+          SpecifierType::Cjs
+        )
+        .result
+        .unwrap()
+        .0,
+      Resolution::Builtin("fs/promises".into())
+    );
   }
 
   #[test]

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -136,8 +136,9 @@ impl<'a> Specifier<'a> {
             }
           }
           SpecifierType::Cjs => {
-            if BUILTINS.contains(&specifier) {
-              (Specifier::Builtin(Cow::Borrowed(specifier)), None)
+            let builtin = specifier.strip_prefix("node:").unwrap_or(specifier);
+            if BUILTINS.contains(&builtin) {
+              (Specifier::Builtin(Cow::Borrowed(builtin)), None)
             } else {
               #[cfg(windows)]
               if !flags.contains(Flags::ABSOLUTE_SPECIFIERS) {


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/8984

At least in current Node versions, `require("node:path")` works fine, so I guess we should support it for CJS dependencies as well. 

This broke as part of the resolver usage for dev deps (see linked issue).