### PR TITLE
`node:` should always be a builtin

### DIFF
--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -136,9 +136,12 @@ impl<'a> Specifier<'a> {
             }
           }
           SpecifierType::Cjs => {
-            let builtin = specifier.strip_prefix("node:").unwrap_or(specifier);
-            if BUILTINS.contains(&builtin) {
-              (Specifier::Builtin(Cow::Borrowed(builtin)), None)
+            if let Some(node_prefixed) = specifier.strip_prefix("node:") {
+              return Ok((Specifier::Builtin(Cow::Borrowed(node_prefixed)), None));
+            }
+
+            if BUILTINS.contains(&specifier) {
+              (Specifier::Builtin(Cow::Borrowed(specifier)), None)
             } else {
               #[cfg(windows)]
               if !flags.contains(Flags::ABSOLUTE_SPECIFIERS) {


### PR DESCRIPTION
@ExE-Boss [pointed out that `node:` should always be a builtin](https://github.com/parcel-bundler/parcel/pull/9244#discussion_r1327985889). This is also what the ESM codepath does for `node:`