### PR TITLE
Update WebExtensionTransformer.js resolve side_panel.defaul_path

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -29,6 +29,7 @@ const DEP_LOCS = [
   ['sandbox', 'pages'],
   ['sidebar_action', 'default_icon'],
   ['sidebar_action', 'default_panel'],
+  ['side_panel', 'default_path'],
   ['storage', 'managed_schema'],
   ['theme', 'images', 'theme_frame'],
   ['theme', 'images', 'additional_backgrounds'],


### PR DESCRIPTION
Chrome's config for side panels uses side_panel.config instead of sidebar_action.default_panel. 

https://developer.chrome.com/docs/extensions/reference/sidePanel/#use-cases

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Chrome uses a different property to configure side panels. It uses side_panel.default_path instead of sidebar_action.default_panel. As a result we can't configure a side panel for a chrome extension


## 💻 Examples

In a manifest.json use the following configuration for a side panel.
```
{
  "name": "My side panel extension",
  ...
  "side_panel": {
    "default_path": "sidepanel.html"
  }
  ...
}
```

## 🚨 Test instructions
Configure you manifest.json for to use a side panel. Check the bundle and it should transform side_panel.default_path 
{
  "name": "My side panel extension",
  ...
  "side_panel": {
    "default_path": "sidepanel.html"
  }
  ...
}


## ✔️ PR Todo

- [x] Added/updated unit tests for this change - No tests for this file
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ x] Included links to related issues/PRs - Did not find any

