### PR TITLE
Ensure nested member expressions are marked used in dev mode

### DIFF
--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -654,8 +654,10 @@ impl Visit for Collect {
       Expr::Member(member) => {
         if match_member_expr(member, vec!["module", "exports"], &self.decls) {
           handle_export!();
+          return;
+        } else {
+          member.visit_with(self);
         }
-        return;
       }
       Expr::Ident(ident) => {
         if &*ident.sym == "exports" && !self.decls.contains(&id!(ident)) {

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1322,7 +1322,7 @@ mod tests {
     c();
     log(x);
     y.foo();
-    c(e.foo.bar);
+    e.foo.bar();
     "#,
     );
     assert_eq_set!(

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1313,7 +1313,7 @@ mod tests {
 
     let (collect, _code, _hoist) = parse(
       r#"
-    import { a, b, c, d } from "other";
+    import { a, b, c, d, e } from "other";
     import * as x from "other";
     import * as y from "other";
 
@@ -1322,11 +1322,12 @@ mod tests {
     c();
     log(x);
     y.foo();
+    c(e.foo.bar);
     "#,
     );
     assert_eq_set!(
       collect.used_imports,
-      set! { w!("a"), w!("b"), w!("c"), w!("x"), w!("y") }
+      set! { w!("a"), w!("b"), w!("c"), w!("e"), w!("x"), w!("y") }
     );
     assert_eq_imports!(
       collect.imports,
@@ -1335,6 +1336,7 @@ mod tests {
         w!("b") => (w!("other"), w!("b"), false),
         w!("c") => (w!("other"), w!("c"), false),
         w!("d") => (w!("other"), w!("d"), false),
+        w!("e") => (w!("other"), w!("e"), false),
         w!("x") => (w!("other"), w!("*"), false),
         w!("y") => (w!("other"), w!("*"), false)
       }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Currently with scope hoisting disabled, nested member expressions are not tracked for import usage correctly. This can cause runtime errors as the import is ignored when the module is side-effect free. 

The fix is to ensure we continue to visit the nested member expressions until we find the root. 

## 💻 Examples

Example where foo would not be marked as used:
```js
import {foo} from 'foo';
foo.a.b();
```

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
