### PR TITLE
Only include registerLoadedBundle call if async bundle runtime is included

### DIFF
--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/empty.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/empty.js
@@ -1,0 +1,1 @@
+// Just a comment

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -5956,4 +5956,34 @@ describe('scope hoisting', function () {
 
     assert.deepEqual(await result, ['a', 'b', 'c']);
   });
+
+  it('should not add experimental bundle queue runtime to empty bundles', async function () {
+    let b = await bundle(
+      [path.join(__dirname, 'integration/bundle-queue-runtime/empty.js')],
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+          shouldOptimize: false,
+          outputFormat: 'esmodule',
+        },
+      },
+    );
+
+    let contents = await outputFS.readFile(
+      b.getBundles().find(b => /empty.*\.js/.test(b.filePath)).filePath,
+      'utf8',
+    );
+
+    assert(
+      !contents.includes('$parcel$global.rlb('),
+      "Empty bundle should not include 'runLoadedBundle' code",
+    );
+
+    try {
+      await run(b);
+    } catch (e) {
+      assert.fail('Expected the empty bundle to still run');
+    }
+  });
 });

--- a/packages/packagers/js/src/ESMOutputFormat.js
+++ b/packages/packagers/js/src/ESMOutputFormat.js
@@ -106,7 +106,10 @@ export class ESMOutputFormat implements OutputFormat {
       lines++;
     }
 
-    if (this.packager.shouldBundleQueue(this.packager.bundle)) {
+    if (
+      this.packager.needsPrelude &&
+      this.packager.shouldBundleQueue(this.packager.bundle)
+    ) {
       // Should be last thing the bundle executes on intial eval
       res += `\n$parcel$global.rlb(${JSON.stringify(
         this.packager.bundle.publicId,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes a bug with unstable async runtimes where an empty bundle would end up with a dangling `registerLoadedBundle` call without any other code, which would cause it to fail at runtime.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
Added a new integration test for this.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
