### PR TITLE
do not remove svg viewbox by default

### DIFF
--- a/packages/optimizers/svgo/src/SVGOOptimizer.js
+++ b/packages/optimizers/svgo/src/SVGOOptimizer.js
@@ -35,6 +35,8 @@ export default (new Optimizer({
               // <style> elements and attributes are already minified before they
               // are re-inserted by the packager.
               minifyStyles: false,
+              // viewBox removal breaks SVG automatic scaling 
+              removeViewBox: false,
             },
           },
         },


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Removing the viewBox from an SVG file breaks automatic SVG scaling, resulting in rendering that is radically different in production versus in development. SVGs are assumed to be scalable by default by most designers.

SVGO has changed their defaults to remove the viewBox, which has been the source of much drama, and their maintainers have been historically resistant in changing it. Until this situation changes, manually disable viewBox removal.

See https://github.com/parcel-bundler/parcel/issues/4314

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

Use any SVG with a viewbox. You can use the following:

```svg
<svg xmlns="http://www.w3.org/2000/svg" width="41.402" height="48.027" viewBox="0 0 41.402 48.027" fill="none"><path d="M10.971 23.349l3.522 2.023v-4.566l9.586-5.606-3.465-2.138-9.643 5.664z" fill="#3b4550"/><path d="M20.615 0l7.969 4.624L7.622 17.05v10.692L0 23.291v-11.27z" fill="#64bc4f"/><path d="M26.158 16.414l-3.522 2.023 4.042 2.37-.058 10.808 3.522-2.023V18.726z" fill="#3b4550"/><path d="M41.402 35.891l-7.969 4.739V16.876l-9.643-5.664 8.084-4.681 9.528 5.548z" fill="#64bc4f"/><path d="M24.599 32.885v-3.93l-4.042 2.37-9.585-5.606v3.93l9.643 5.606z" fill="#3b4550"/><path d="M0 36.064v-8.785l20.615 11.79 9.47-5.664.058 9.132-9.297 5.49z" fill="#64bc4f"/></svg>
```

Notice that optimising it by default removes the `viewBox` property.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

1. Create any bundle importing an SVG with a viewBox, eg through `bundle-text`.
2. Create an optimised bundle (usually production bundle).
3. Confirm that the viewBox is not removed by examining the source code.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
