### PR TITLE
Fix index page loading in dev server when bundle type isn't html

### DIFF
--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -186,7 +186,7 @@ export default class Server {
       // If the main asset is an HTML file, serve it
       let htmlBundleFilePaths = this.bundleGraph
         .getBundles()
-        .filter(bundle => bundle.type === 'html')
+        .filter(bundle => path.posix.extname(bundle.name) === '.html')
         .map(bundle => {
           return `/${relativePath(
             this.options.distDir,


### PR DESCRIPTION
In React Spectrum, we have a custom namer plugin that names JS bundles with an html extension because a packager will actually run the JS and output HTML. At some point the dev server stopped serving the index pages. This changes the bundle type check to use the extension of the bundle name instead.