### PR TITLE
Don't hide error when diagnostic is malformed

### DIFF
--- a/packages/core/codeframe/src/codeframe.js
+++ b/packages/core/codeframe/src/codeframe.js
@@ -260,6 +260,9 @@ export default function codeFrame(
             characters += startCol - lastCol;
           }
 
+          // Don't crash (and swallow the original message) if the diagnostic is malformed (end is before start).
+          characters = Math.max(1, characters);
+
           // Append the highlight indicators
           highlightLine += highlighter('^'.repeat(characters));
 

--- a/packages/core/codeframe/test/codeframe.test.js
+++ b/packages/core/codeframe/test/codeframe.test.js
@@ -796,4 +796,27 @@ describe('codeframe', () => {
     assert.equal(lines[3], '   9 | ');
     assert.equal(lines[4], '  10 | /**');
   });
+
+  it('should still generate a codeframe when end is before start', () => {
+    let codeframeString = codeframe(
+      'hello world',
+      [
+        {
+          start: {
+            column: 5,
+            line: 1,
+          },
+          end: {
+            column: 1,
+            line: 1,
+          },
+        },
+      ],
+      {useColor: false},
+    );
+
+    let lines = codeframeString.split(LINE_END);
+    assert.equal(lines[0], '> 1 | hello world');
+    assert.equal(lines[1], '>   |     ^');
+  });
 });


### PR DESCRIPTION
Still print diagnostics when the `end` column is before the `start` column (and just silently ignore the `end` in that case). Previously this caused a `RangeError: Invalid count value` without ever printing the original error.

"Fixes" #9112 (now the actual error should be printed, but the underlying diagnostic is of course still malformed)