### PR TITLE
Sort assets before splitting for unstable MSBs

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -1402,7 +1402,13 @@ function createIdealGraph(
         bundleGraph.getNode([...manualBundle.sourceBundles][0]),
       );
       invariant(firstSourceBundle !== 'root');
-      let firstAsset = [...manualBundle.assets][0];
+      let assetArr = [...manualBundle.assets];
+      let firstAsset = assetArr[0];
+      if (manualAssetToConfig.get(firstAsset)?.split == null) {
+        continue;
+      }
+      assetArr.sort((a, b) => a.id.localeCompare(b.id));
+      manualBundle.assets = new Set(assetArr);
       let manualSharedObject = manualAssetToConfig.get(firstAsset);
       invariant(manualSharedObject != null);
       let modNum = manualAssetToConfig.get(firstAsset)?.split;


### PR DESCRIPTION
# ↪️ Pull Request

Sort Manual Shared Bundle assets before splitting. Should we sort based on a different property or is `localeCompare(assets.id)` good enough? 

Note this didn't change the order of assets in our test case.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
