### PR TITLE
Limit default number of JS workers to 4

### DIFF
--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -628,7 +628,7 @@ export default class WorkerFarm extends EventEmitter {
   static getNumWorkers(): number {
     return process.env.PARCEL_WORKERS
       ? parseInt(process.env.PARCEL_WORKERS, 10)
-      : Math.ceil(cpuCount() / 2);
+      : Math.min(4, Math.ceil(cpuCount() / 2));
   }
 
   static isWorker(): boolean {


### PR DESCRIPTION
This limits the default number of JS worker threads to 4, even if there are more CPUs available. Now that we run the JS transformer and resolver in native Rust threads (#9147), the JS threads don't have as much to do. Benchmarking indicates that > 4 JS threads has negligible to negative performance impact, and limiting the number reduces memory usage a lot.

The `PARCEL_WORKERS` environment variable can still be set to override this if the default doesn't work for a particular project.

Closes #5617. Closes #5072.