### PR TITLE
Declare correct Yarn version in the Parcel monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/parcel"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
# ↪️ Pull Request

Node ships with Corepack, a "package manager manager". It works by reading `packageManager` entry in `package.json` and downloading required binaries transparently, on-the-fly. Therefore it ensures that all developers using Corepack run the same version of package manager:

- reducing changes for any incompatibilities that might be caused by different versions,
- making installation seamless - Yarn is installed transparently without any intervention, provided you have Corepack enabled
- making migration to e.g. modern Yarn or pnpm very easy, as developers don't need to take any further actions besides pulling the latest changes from origin

This PR does not break the repository for those using Yarn Classic (v1) installed using standalone installer, while adding an easy way to contribute for those who did not install it.


## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

* Do NOT install Yarn classic (v1) on your machine
* Have Node.js installed
* Run `corepack enable`
* When inside parcel repository, execute `yarn -v`
* Yarn will be downloaded transparently and in a few seconds, you should see `1.22.19` as an output

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
