### PR TITLE
Fix Parcel failing in Yarn PnP mode (and peer dependency warning)

### DIFF
--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -48,6 +48,7 @@
     "check-ts": "tsc --noEmit index.d.ts"
   },
   "dependencies": {
+    "@parcel/core": "2.9.3",
     "@parcel/rust": "2.9.3",
     "@parcel/types": "2.9.3",
     "@parcel/utils": "2.9.3",


### PR DESCRIPTION
# ↪️ Pull Request

This fixes the error when installing Parcel using Yarn in PnP mode:

> @parcel/fs tried to access @parcel/core (a peer dependency) but it isn't provided by its ancestors

Fixes #9114

## 🚨 Test instructions

* In Yarn v2/v3/v4 repository in PnP mode, run `yarn add --dev parcel; yarn parcel index.html`
* After this change, it should no longer crash

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
