### PR TITLE
Use rimraf for Windows compat for build-bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "build": "yarn build-bundles && cross-env NODE_ENV=production PARCEL_BUILD_ENV=production gulp",
-    "build-bundles": "rm -rf packages/*/*/lib && cross-env NODE_ENV=production PARCEL_BUILD_ENV=production PARCEL_SELF_BUILD=true parcel build packages/core/{fs,codeframe,package-manager,utils} packages/reporters/{cli,dev-server} packages/utils/{parcel-lsp,parcel-lsp-protocol}",
+    "build-bundles": "rimraf packages/*/*/lib && cross-env NODE_ENV=production PARCEL_BUILD_ENV=production PARCEL_SELF_BUILD=true parcel build packages/core/{fs,codeframe,package-manager,utils} packages/reporters/{cli,dev-server} packages/utils/{parcel-lsp,parcel-lsp-protocol}",
     "build-ts": "lerna run build-ts && lerna run check-ts",
     "build-native": "node scripts/build-native.js",
     "build-native-release": "node scripts/build-native.js --release",


### PR DESCRIPTION
# ↪️ Pull Request

The `build-bundles` npm script starts with `rm -rf`, which fails on Windows with an error like this:
>'rm' is not recognized as an internal or external command, operable program or batch file.

`rimraf` is a cross-platform package with the functionality of `rm -rf` and is already in use in the `clean` and `clean-test` npm scripts.

This PR updates the `build-bundles` script to use `rimraf` instead of `rm -rf`.

## 🚨 Test instructions

Run `yarn run build` on a Windows machine.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
  -  #5672 
