### PR TITLE
Detect TSC polyfills to avoid marking them as CJS

### DIFF
--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -768,22 +768,24 @@ impl Visit for Collect {
         }
       }
       Expr::Bin(bin_expr) => {
-        // Some TSC polyfills use a pattern like below.
-        // We want to avoid marking these modules as CJS
-        // e.g. var _polyfill = (this && this.polyfill) || function () {}
-        if matches!(*bin_expr.left, Expr::This(..)) {
-          match &*bin_expr.right {
-            Expr::Member(member_expr) => {
-              if matches!(*member_expr.obj, Expr::This(..))
-                && matches!(member_expr.prop, MemberProp::Ident(..))
-              {
-                return;
+        if self.in_module_this {
+          // Some TSC polyfills use a pattern like below.
+          // We want to avoid marking these modules as CJS
+          // e.g. var _polyfill = (this && this.polyfill) || function () {}
+          if matches!(bin_expr.op, BinaryOp::LogicalAnd) && matches!(*bin_expr.left, Expr::This(..))
+          {
+            match &*bin_expr.right {
+              Expr::Member(member_expr) => {
+                if matches!(*member_expr.obj, Expr::This(..))
+                  && matches!(member_expr.prop, MemberProp::Ident(..))
+                {
+                  return;
+                }
               }
+              _ => {}
             }
-            _ => {}
           }
         }
-
         node.visit_children_with(self);
       }
       _ => {

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -767,6 +767,25 @@ impl Visit for Collect {
           self.used_imports.insert(id!(ident));
         }
       }
+      Expr::Bin(bin_expr) => {
+        // Some TSC polyfills use a pattern like below.
+        // We want to avoid marking these modules as CJS
+        // e.g. var _polyfill = (this && this.polyfill) || function () {}
+        if matches!(*bin_expr.left, Expr::This(..)) {
+          match &*bin_expr.right {
+            Expr::Member(member_expr) => {
+              if matches!(*member_expr.obj, Expr::This(..))
+                && matches!(member_expr.prop, MemberProp::Ident(..))
+              {
+                return;
+              }
+            }
+            _ => {}
+          }
+        }
+
+        node.visit_children_with(self);
+      }
       _ => {
         node.visit_children_with(self);
       }

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1425,6 +1425,32 @@ mod tests {
   }
 
   #[test]
+  fn collect_has_cjs_exports() {
+    let (collect, _code, _hoist) = parse(
+      r#"
+      module.exports = {};
+    "#,
+    );
+    assert!(collect.has_cjs_exports);
+
+    let (collect, _code, _hoist) = parse(
+      r#"
+      this.someExport = 'true';
+    "#,
+    );
+    assert!(collect.has_cjs_exports);
+
+    // Some TSC polyfills use a pattern like below.
+    // We want to avoid marking these modules as CJS
+    let (collect, _code, _hoist) = parse(
+      r#"
+      var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function () {}
+    "#,
+    );
+    assert!(!collect.has_cjs_exports);
+  }
+
+  #[test]
   fn collect_should_wrap() {
     let (collect, _code, _hoist) = parse(
       r#"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Some TSC polyfills check for prior existence of themselves via a `this._polyfill` check. Currently Parcel marks any file using a top-level `this` as CJS. This can de-opt or even break packaged output in some cases. 

This PR adds a check in the JSTransformer to ensure we don't de-opt ESM modules that contain these TSC polyfills. It currently checks for the following AST pattern `this && this._polyfills`, which is a binary expression containing a this reference and a member expression with `this` and an identifier. This is a little naive but probably enough?

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
