### PR TITLE
Use modern node versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     name: Unit tests (${{matrix.os}}, Node ${{matrix.node}})
     strategy:
       matrix:
-        node: [14, 16]
+        node: [18, 20]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{matrix.os}}
     steps:
@@ -75,7 +75,7 @@ jobs:
     name: Integration tests (${{matrix.os}}, Node ${{matrix.node}})
     strategy:
       matrix:
-        node: [14, 16]
+        node: [18, 20]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # These tend to be quite flakey, so one failed instance shouldn't stop
       # others from potentially succeeding


### PR DESCRIPTION
Both Node 14 and 16 are EOL now

At some point we should also upgrade
https://github.com/parcel-bundler/parcel/blob/943fb40931cc8a47b9f5675ea8100de8e3238178/.github/workflows/nightly-release.yml#L42