### PR TITLE
Remove `this` exports tracking for files with module syntax

### DIFF
--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -692,12 +692,7 @@ impl Visit for Collect {
         return;
       }
       Expr::This(_this) => {
-        if self.is_module {
-          // Don't track this bindings if ESM syntax is present
-          return;
-        }
-
-        if self.in_module_this {
+        if !self.is_module && self.in_module_this {
           handle_export!();
         } else if !self.in_class {
           if let MemberProp::Ident(prop) = &node.prop {

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -78,6 +78,7 @@ pub struct Collect {
   in_function: bool,
   in_assign: bool,
   in_class: bool,
+  is_module: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -120,12 +121,14 @@ impl Collect {
     ignore_mark: Mark,
     global_mark: Mark,
     trace_bailouts: bool,
+    is_module: bool,
   ) -> Self {
     Collect {
       source_map,
       decls,
       ignore_mark,
       global_mark,
+      is_module,
       static_cjs_exports: true,
       has_cjs_exports: false,
       is_esm: false,
@@ -768,7 +771,7 @@ impl Visit for Collect {
         }
       }
       Expr::Bin(bin_expr) => {
-        if self.in_module_this {
+        if self.is_module & self.in_module_this {
           // Some TSC polyfills use a pattern like below.
           // We want to avoid marking these modules as CJS
           // e.g. var _polyfill = (this && this.polyfill) || function () {}

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -692,8 +692,10 @@ impl Visit for Collect {
         return;
       }
       Expr::This(_this) => {
-        if !self.is_module && self.in_module_this {
-          handle_export!();
+        if self.in_module_this {
+          if !self.is_module { 
+            handle_export!();
+          }
         } else if !self.in_class {
           if let MemberProp::Ident(prop) = &node.prop {
             self.this_exprs.insert(id!(prop), (prop.clone(), node.span));

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -693,7 +693,7 @@ impl Visit for Collect {
       }
       Expr::This(_this) => {
         if self.in_module_this {
-          if !self.is_module { 
+          if !self.is_module {
             handle_export!();
           }
         } else if !self.in_class {

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -17,6 +17,7 @@ pub fn inline_fs<'a>(
   global_mark: Mark,
   project_root: &'a str,
   deps: &'a mut Vec<DependencyDescriptor>,
+  is_module: bool,
 ) -> impl Fold + 'a {
   InlineFS {
     filename: Path::new(filename).to_path_buf(),
@@ -26,6 +27,7 @@ pub fn inline_fs<'a>(
       Mark::fresh(Mark::root()),
       global_mark,
       false,
+      is_module,
     ),
     global_mark,
     project_root,

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1155,6 +1155,7 @@ mod tests {
               Mark::fresh(Mark::root()),
               global_mark,
               true,
+              true,
             );
             module.visit_with(&mut collect);
 

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1140,11 +1140,21 @@ mod tests {
     );
 
     let mut parser = Parser::new_from(lexer);
-    match parser.parse_module() {
-      Ok(module) => swc_core::common::GLOBALS.set(&Globals::new(), || {
+    match parser.parse_program() {
+      Ok(program) => swc_core::common::GLOBALS.set(&Globals::new(), || {
         swc_core::ecma::transforms::base::helpers::HELPERS.set(
           &swc_core::ecma::transforms::base::helpers::Helpers::new(false),
           || {
+            let is_module = program.is_module();
+            let module = match program {
+              Program::Module(module) => module,
+              Program::Script(script) => Module {
+                span: script.span,
+                shebang: None,
+                body: script.body.into_iter().map(ModuleItem::Stmt).collect(),
+              },
+            };
+
             let unresolved_mark = Mark::fresh(Mark::root());
             let global_mark = Mark::fresh(Mark::root());
             let module = module.fold_with(&mut resolver(unresolved_mark, global_mark, false));
@@ -1155,7 +1165,7 @@ mod tests {
               Mark::fresh(Mark::root()),
               global_mark,
               true,
-              true,
+              is_module,
             );
             module.visit_with(&mut collect);
 
@@ -1445,6 +1455,7 @@ mod tests {
     // We want to avoid marking these modules as CJS
     let (collect, _code, _hoist) = parse(
       r#"
+      import 'something';
       var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function () {}
     "#,
     );

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -252,6 +252,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                 ),
               ));
 
+              let is_module = module.is_module();
               // If it's a script, convert into module. This needs to happen after
               // the resolver (which behaves differently for non-/strict mode).
               let module = match module {
@@ -342,6 +343,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                       global_mark,
                       &config.project_root,
                       &mut fs_deps,
+                      is_module
                     ),
                     should_inline_fs
                   ),
@@ -448,6 +450,7 @@ pub fn transform(config: Config) -> Result<TransformResult, std::io::Error> {
                 ignore_mark,
                 global_mark,
                 config.trace_bailouts,
+                is_module,
               );
               module.visit_with(&mut collect);
               if let Some(bailouts) = &collect.bailouts {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The TSC polyfill check was breaking CJS files as we need to track `this` references for exports. This PR makes it so we disable `this` export tracking when any module syntax is present. 

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Included links to related issues/PRs
