### PR TITLE
Use clz32 for counting trailing zeroes.

### DIFF
--- a/packages/core/graph/src/BitSet.js
+++ b/packages/core/graph/src/BitSet.js
@@ -1,18 +1,13 @@
 // @flow strict-local
 
-// Small wasm program that exposes the `ctz` instruction.
-// https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Numeric/Count_trailing_zeros
-const wasmBuf = new Uint8Array([
-  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60, 0x01,
-  0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x0d, 0x01, 0x09, 0x74, 0x72,
-  0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x30, 0x00, 0x00, 0x0a, 0x07, 0x01, 0x05,
-  0x00, 0x20, 0x00, 0x68, 0x0b, 0x00, 0x0f, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x02,
-  0x08, 0x01, 0x00, 0x01, 0x00, 0x03, 0x6e, 0x75, 0x6d,
-]);
-
-// eslint-disable-next-line
-const {trailing0} = new WebAssembly.Instance(new WebAssembly.Module(wasmBuf))
-  .exports;
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32#implementing_count_leading_ones_and_beyond
+function ctz32(n: number): number {
+  if (n === 0) {
+    return 32;
+  }
+  let reversed = n & -n;
+  return 31 - Math.clz32(reversed);
+}
 
 export class BitSet {
   bits: Uint32Array;
@@ -95,7 +90,7 @@ export class BitSet {
       while (v !== 0) {
         let t = (v & -v) >>> 0;
         // $FlowFixMe
-        fn((k << 5) + trailing0(v));
+        fn((k << 5) + ctz32(v));
         v ^= t;
       }
     }


### PR DESCRIPTION
This changes the implementation of `BitSet` to use `Math.clz32` to count trailing zeroes instead of the current WebAssembly-based approach. This makes the implementation IMO slightly more readable to those of us without a brain to parse hex-encoded WebAssembly. 😄

Additionally this approach should yield slightly better performance for the iteration of the `BitSet`s. At least that's what running the following micro-benchmark on my machine indicates:

<details>
<summary>Benchmark Source Code</summary>

```javascript
const wasmBuf = new Uint8Array([
  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 0x60, 0x01,
  0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x0d, 0x01, 0x09, 0x74, 0x72,
  0x61, 0x69, 0x6c, 0x69, 0x6e, 0x67, 0x30, 0x00, 0x00, 0x0a, 0x07, 0x01, 0x05,
  0x00, 0x20, 0x00, 0x68, 0x0b, 0x00, 0x0f, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x02,
  0x08, 0x01, 0x00, 0x01, 0x00, 0x03, 0x6e, 0x75, 0x6d,
]);

const {trailing0} = new WebAssembly.Instance(new WebAssembly.Module(wasmBuf)).exports;

function ctz32(n) {
  if (n === 0) {
    return 32;
  }
  n = n & -n;
  return 31 - Math.clz32(n);
}

const MAX_U32 = 0xffffffff;

function expectEqual(a, b) {
  if (a !== b) {
    throw new Error(`${a} !== ${b}`);
  }
}

function bench(name, f, N = 1e6) {
  console.time(name);
  f(N);
  console.timeEnd(name);
}

for (let i = 0; i < 1e6; i++) {
  expectEqual(trailing0(i), ctz32(i));
  expectEqual(trailing0(MAX_U32 - i), ctz32(MAX_U32 - i));
}

const { platform, arch, release, cpus } = require("os");
console.log("node", process.version, platform(), arch(), release());
console.log(cpus()[0].model);

bench("trailing0", function (N) {
  for (let i = 0; i < N; i++) {
    trailing0(i);
    trailing0(MAX_U32 - i);
  }
});

bench("ctz32", function (N) {
  for (let i = 0; i < N; i++) {
    ctz32(i);
    ctz32(MAX_U32 - i);
  }
});
```
</details>

Giving the output:

```
node v16.16.0 darwin x64 23.0.0
Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
trailing0: 18.292ms
ctz32: 3.429ms
```