### PR TITLE
FIX[dev-server]: Fix html file matching from URL

### DIFF
--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -177,9 +177,11 @@ describe('server', function () {
     assert.equal(await get('/something', port), rootIndex);
     assert.equal(await get('/other', port), other);
     assert.equal(await get('/foo', port), fooIndex);
+    assert.equal(await get('/foo?foo=bar', port), fooIndex);
     assert.equal(await get('/foo/', port), fooIndex);
     assert.equal(await get('/foo/bar', port), fooIndex);
     assert.equal(await get('/foo/other', port), fooOther);
+    assert.equal(await get('/foo/other?foo=bar', port), fooOther);
   });
 
   it('should serve a default page if the single HTML bundle is not called index', async function () {

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -196,6 +196,12 @@ export default class Server {
         });
 
       let indexFilePath = null;
+      let {pathname: reqURL} = url.parse(req.originalUrl || req.url);
+
+      if (!reqURL) {
+        reqURL = '/';
+      }
+
       if (htmlBundleFilePaths.length === 1) {
         indexFilePath = htmlBundleFilePaths[0];
       } else {
@@ -212,11 +218,11 @@ export default class Server {
           let matchesIsIndex = null;
           if (
             isIndex &&
-            (req.url.startsWith(bundleDirSubdir) || req.url === bundleDir)
+            (reqURL.startsWith(bundleDirSubdir) || reqURL === bundleDir)
           ) {
             // bundle is /bar/index.html and (/bar or something inside of /bar/** was requested was requested)
             matchesIsIndex = true;
-          } else if (req.url == path.posix.join(bundleDir, withoutExtension)) {
+          } else if (reqURL == path.posix.join(bundleDir, withoutExtension)) {
             // bundle is /bar/foo.html and /bar/foo was requested
             matchesIsIndex = false;
           }


### PR DESCRIPTION
Closes #9211 

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
In this PR we rethink how we server the HTML bundle for a given URL in the dev server.

## 💻 Examples
We get all the `htmlBundleFilePaths` and sort them based on `/`(depth)

Example:
For URL `/other` and let's say we have sorted htmlBundleFilePaths as `['/other.html', 'other/index.html' ]`
So for `/other` URL should be served with `/other.html` file. 

And if we have sorted htmlBundleFilePaths as `['other/index.html' ]`
For `/other` URL should be served with `/other/index.html` file. 

## 🚨 Test instructions
Extend the `html` example(packages/examples/HTML).

**Create multiple directories like**

<img width="352" alt="Screenshot 2023-10-29 at 12 12 16 PM" src="https://github.com/parcel-bundler/parcel/assets/25791025/3ab75f15-b852-4ff3-b400-b8141385ebf8">

**Add source and dev command** in `package.json`

```javascript
  "scripts": {
    "dev": "parcel",
    "demo": "parcel build src/index.html"
  },
  "source": [
		"src/index.html",
		"src/other.html",
		"src/temp/index.html",
		"src/temp/other.html",
                 "src/other/index.html",
		"src/other/other.html"
	],
```
Run **yarn run dev** to use the local dev server.

**Expected Behavior**

- `/other?foo=bar` correctly returns the content of `packages/examples/html/src/other.html`
- `/other.html?foo=bar` correctly returns the content of `packages/examples/html/src/other.html`
- `/other` correctly returns the content of `packages/examples/html/src/other.html`
- `/other.html` correctly returns the content of `packages/examples/html/src/other.html`
- `/other/other?foo=bar` correctly returns `packages/examples/html/src/other/other.html`
- `/other/other` correctly returns `packages/examples/html/src/other/other.html`
- `/other/index` correctly returns `packages/examples/html/src/other/index.html`



## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
