### PR TITLE
Do not wrap duplicated assets when they are in different targets

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1122,8 +1122,12 @@ export default class BundleGraph {
   }
 
   isAssetReferenced(bundle: Bundle, asset: Asset): boolean {
-    // If the asset is available in multiple bundles, it's referenced.
-    if (this.getBundlesWithAsset(asset).length > 1) {
+    // If the asset is available in multiple bundles in the same target, it's referenced.
+    if (
+      this.getBundlesWithAsset(asset).filter(
+        b => b.target.distDir === bundle.target.distDir,
+      ).length > 1
+    ) {
       return true;
     }
 


### PR DESCRIPTION
This fixes a regression from #9109. When an asset is duplicated, that PR caused it to be wrapped so it gets deduplicated at runtime. However, if the duplication occurs in separate targets, this is not necessary. It resulted in `parcelRequire` getting added to library builds, causing downstream errors in poorly written bundlers trying to detect CJS usage (https://github.com/vercel/next.js/issues/57649) (and also unnecessary global variables). The fix is to detect whether the duplication occurs within the same target.