### PR TITLE
Add parcel query option to view de/serialization times & graph size

### DIFF
--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -608,7 +608,8 @@ export async function run(input: string[]) {
     for (let [k, v] of nullthrows(cacheInfo).entries()) {
       let s = serialized.get(k);
       invariant(s != null);
-      table.push([k, ...v, s]);
+      let name = k.includes('_request') ? k.split('_request')[0] : k;
+      table.push([name, ...v, s]);
     }
     function getColumnSum(t: Array<Array<string | number>>, col: number) {
       if (t == null) {

--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -38,9 +38,8 @@ export async function run(input: string[]) {
   }
 
   console.log('Loading graphs...');
-  let {assetGraph, bundleGraph, bundleInfo, requestTracker} = await loadGraphs(
-    cacheDir,
-  );
+  let {assetGraph, bundleGraph, bundleInfo, requestTracker, cacheInfo} =
+    await loadGraphs(cacheDir);
 
   if (requestTracker == null) {
     console.error('Request Graph could not be found');
@@ -592,7 +591,8 @@ export async function run(input: string[]) {
 
     return entryBundleGroup;
   }
-  function inspectCache() {
+  // eslint-disable-next-line no-unused-vars
+  function inspectCache(_) {
     // displays sizing of various entries of the cache
     let table: Array<Array<string | number>> = [];
     table.push([
@@ -637,11 +637,11 @@ export async function run(input: string[]) {
     let bundlegraph_st = Date.now();
     serialize(bundleGraph);
     bundlegraph_st = Date.now() - bundlegraph_st;
-    serializeTime.set('BundleGraph', bundlegraph_st);
+    serializeTime.set('bundle_graph_request', bundlegraph_st);
     let assetgraph_st = Date.now();
     serialize(assetGraph);
     assetgraph_st = Date.now() - assetgraph_st;
-    serializeTime.set('AssetGraph', assetgraph_st);
+    serializeTime.set('asset_graph_request', assetgraph_st);
 
     return serializeTime;
   }
@@ -944,7 +944,7 @@ export async function run(input: string[]) {
       [
         'inspectCache',
         {
-          help: 'args: <>',
+          help: 'Cache Information',
           action: inspectCache,
         },
       ],

--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -601,7 +601,10 @@ export async function run(input: string[]) {
       'Deserialize (ms)',
       'Serialize (ms)',
     ]);
-    let serialized: Map<string, number> = getSerializeTimes();
+    let serialized: Map<string, number> = new Map();
+    serialized.set('RequestGraph', timeSerialize(requestTracker));
+    serialized.set('bundle_graph_request', timeSerialize(bundleGraph));
+    serialized.set('asset_graph_request', timeSerialize(assetGraph));
     for (let [k, v] of nullthrows(cacheInfo).entries()) {
       let s = serialized.get(k);
       invariant(s != null);
@@ -628,22 +631,12 @@ export async function run(input: string[]) {
     ]);
     _printStatsTable('Cache Info', table);
   }
-  function getSerializeTimes(): Map<string, number> {
-    let serializeTime = new Map<string, number>();
-    let requestgraph_st = Date.now();
-    serialize(requestTracker);
-    requestgraph_st = Date.now() - requestgraph_st;
-    serializeTime.set('RequestGraph', requestgraph_st);
-    let bundlegraph_st = Date.now();
-    serialize(bundleGraph);
-    bundlegraph_st = Date.now() - bundlegraph_st;
-    serializeTime.set('bundle_graph_request', bundlegraph_st);
-    let assetgraph_st = Date.now();
-    serialize(assetGraph);
-    assetgraph_st = Date.now() - assetgraph_st;
-    serializeTime.set('asset_graph_request', assetgraph_st);
 
-    return serializeTime;
+  function timeSerialize(graph) {
+    let date = Date.now();
+    serialize(graph);
+    date = Date.now() - date;
+    return date;
   }
   function _printStatsTable(header, data) {
     const config = {

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -25,6 +25,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
   bundleGraph: ?BundleGraph,
   requestTracker: ?RequestTracker,
   bundleInfo: ?Map<ContentKey, PackagedBundleInfo>,
+  cacheInfo: ?Map<string, Array<string | number>>,
 |}> {
   function filesBySizeAndModifiedTime() {
     let files = fs.readdirSync(cacheDir).map(f => {
@@ -38,21 +39,34 @@ export async function loadGraphs(cacheDir: string): Promise<{|
     return files.map(([f]) => f);
   }
 
+  let cacheInfo: Map<string, Array<string | number>> = new Map();
+  let timeToDeserialize = 0;
+  let timeToDeserialize_AssetGraph = 0;
+  let timeToDeserialize_BundleGraph = 0;
+
   let requestTracker;
   const cache = new LMDBCache(cacheDir);
   for (let f of filesBySizeAndModifiedTime()) {
     // Empty filename or not the first chunk
     if (path.extname(f) !== '' && !f.endsWith('-0')) continue;
     try {
-      let obj = v8.deserialize(
-        await cache.getLargeBlob(path.basename(f).slice(0, -'-0'.length)),
+      let file = await cache.getLargeBlob(
+        path.basename(f).slice(0, -'-0'.length),
       );
+
+      cacheInfo.set('RequestGraph', [Buffer.byteLength(file)]);
+
+      timeToDeserialize = Date.now();
+      let obj = v8.deserialize(file);
+      timeToDeserialize = Date.now() - timeToDeserialize;
+
       /* if (obj.assetGraph != null && obj.assetGraph.value.hash != null) {
         assetGraph = AssetGraph.deserialize(obj.assetGraph.value);
       } else if (obj.bundleGraph != null) {
         bundleGraph = BundleGraph.deserialize(obj.bundleGraph.value);
       } else */
       if (obj['$$type']?.endsWith('RequestGraph')) {
+        let date = Date.now();
         requestTracker = new RequestTracker({
           graph: RequestGraph.deserialize(obj.value),
           // $FlowFixMe
@@ -60,6 +74,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
           // $FlowFixMe
           options: null,
         });
+        timeToDeserialize += Date.now() - date;
         break;
       }
     } catch (e) {
@@ -93,22 +108,46 @@ export async function loadGraphs(cacheDir: string): Promise<{|
     n => n.type === 'request' && n.value.type === 'bundle_graph_request',
   );
   if (bundleGraphRequestNode != null) {
+    let bundleGraphBytes = Buffer.byteLength(
+      fs.readFileSync(
+        path.join(
+          cacheDir,
+          nullthrows(bundleGraphRequestNode.value.resultCacheKey),
+        ),
+      ),
+    );
+    cacheInfo.set('BundleGraph', [bundleGraphBytes]);
+    let date = Date.now();
     bundleGraph = BundleGraph.deserialize(
       (await loadLargeBlobRequestRequest(cache, bundleGraphRequestNode))
         .bundleGraph.value,
     );
+    timeToDeserialize_BundleGraph = Date.now() - date;
 
     let assetGraphRequest = getSubRequests(
       requestTracker.graph.getNodeIdByContentKey(bundleGraphRequestNode.id),
     ).find(n => n.type === 'request' && n.value.type === 'asset_graph_request');
     if (assetGraphRequest != null) {
+      let assetgraphbytes = Buffer.byteLength(
+        fs.readFileSync(
+          path.join(
+            cacheDir,
+            nullthrows(assetGraphRequest.value.resultCacheKey),
+          ),
+        ),
+      );
+      cacheInfo.set('AssetGraph', [assetgraphbytes]);
+      date = Date.now();
       assetGraph = AssetGraph.deserialize(
         (await loadLargeBlobRequestRequest(cache, assetGraphRequest)).assetGraph
           .value,
       );
+      timeToDeserialize_AssetGraph = Date.now() - date;
     }
   }
-
+  cacheInfo.get('BundleGraph')?.push(timeToDeserialize_BundleGraph);
+  cacheInfo.get('AssetGraph')?.push(timeToDeserialize_AssetGraph);
+  cacheInfo.get('RequestGraph')?.push(timeToDeserialize);
   let writeBundlesRequest = buildRequestSubRequests.find(
     n => n.type === 'request' && n.value.type === 'write_bundles_request',
   );
@@ -121,7 +160,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
     >);
   }
 
-  return {assetGraph, bundleGraph, requestTracker, bundleInfo};
+  return {assetGraph, bundleGraph, requestTracker, bundleInfo, cacheInfo};
 }
 
 async function loadLargeBlobRequestRequest(cache, node) {

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -121,11 +121,6 @@ export async function loadGraphs(cacheDir: string): Promise<{|
       requestTracker.graph.getNodeIdByContentKey(bundleGraphRequestNode.id),
     ).find(n => n.type === 'request' && n.value.type === 'asset_graph_request');
     if (assetGraphRequest != null) {
-      invariant(
-        assetGraphRequest.value != null &&
-          typeof assetGraphRequest.value != 'string',
-      );
-
       assetGraph = AssetGraph.deserialize(
         (await loadLargeBlobRequestRequest(cache, assetGraphRequest, cacheInfo))
           .assetGraph.value,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

We'd like to make cache improvements, so having a quick way to display size/serialization times would be helpful. This PR adds `cacheInfo` structure to hold deserialization times / graph size and a new option to parcel-query called `.inspect-cache`
## 💻 Examples
Example of table
<img width="632" alt="inspectCache" src="https://github.com/parcel-bundler/parcel/assets/29166446/1103d4fb-675c-468f-8590-cc3a0198bbee">

## ✔️ Q's

- Are there any other serialization times we need to take into account besides those of the graphs 
