### PR TITLE
fix: hasOwnProperty

### DIFF
--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -112,7 +112,7 @@ function $parcel$export(e, n, v, s) {
 const $parcel$exportWildcard = `
 function $parcel$exportWildcard(dest, source) {
   Object.keys(source).forEach(function(key) {
-    if (key === 'default' || key === '__esModule' || dest.hasOwnProperty(key)) {
+    if (key === 'default' || key === '__esModule' || Object.prototype.hasOwnProperty.call(dest, key)) {
       return;
     }
 

--- a/packages/transformers/js/src/esmodule-helpers.js
+++ b/packages/transformers/js/src/esmodule-helpers.js
@@ -8,7 +8,11 @@ exports.defineInteropFlag = function (a) {
 
 exports.exportAll = function (source, dest) {
   Object.keys(source).forEach(function (key) {
-    if (key === 'default' || key === '__esModule' || Object.prototype.hasOwnProperty.call(dest, key)) {
+    if (
+      key === 'default' ||
+      key === '__esModule' ||
+      Object.prototype.hasOwnProperty.call(dest, key)
+    ) {
       return;
     }
 

--- a/packages/transformers/js/src/esmodule-helpers.js
+++ b/packages/transformers/js/src/esmodule-helpers.js
@@ -8,7 +8,7 @@ exports.defineInteropFlag = function (a) {
 
 exports.exportAll = function (source, dest) {
   Object.keys(source).forEach(function (key) {
-    if (key === 'default' || key === '__esModule' || dest.hasOwnProperty(key)) {
+    if (key === 'default' || key === '__esModule' || Object.prototype.hasOwnProperty.call(dest, key)) {
       return;
     }
 


### PR DESCRIPTION
The current implementation makes a direct use of hasOwnProperty which misbehaves when a module exports a method named `hasOwnProperty` [see issue 9350](https://github.com/parcel-bundler/parcel/issues/9350).

This commit implements a [safer way to call hasOwnProperty](https://stackoverflow.com/questions/12017693/why-use-object-prototype-hasownproperty-callmyobj-prop-instead-of-myobj-hasow/12017703#12017703).

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
