### PR TITLE
Cache bundle graph on failure

### DIFF
--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -376,6 +376,17 @@ class BundlerRunner {
         await this.runDevDepRequest(devDepRequest);
       }
     } catch (e) {
+      if (internalBundleGraph != null) {
+        this.api.storeResult(
+          {
+            bundleGraph: internalBundleGraph,
+            changedAssets: new Map(),
+            assetRequests: [],
+          },
+          this.cacheKey,
+        );
+      }
+
       throw new ThrowableDiagnostic({
         diagnostic: errorToDiagnostic(e, {
           origin: name,

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -32,7 +32,7 @@ import resolveOptions from '@parcel/core/src/resolveOptions';
 import logger from '@parcel/logger';
 import sinon from 'sinon';
 import {version} from '@parcel/core/package.json';
-import v8 from 'v8';
+import {deserialize} from '@parcel/core/src/serializer';
 import {hashString} from '@parcel/rust';
 
 let inputDir: string;
@@ -6220,12 +6220,11 @@ describe('cache', function () {
         }${resolvedOptions.mode}`,
       );
 
-      let bundleGraphPath = path.join(
-        resolvedOptions.cacheDir,
-        bundleGraphCacheKey + '-0',
+      assert(
+        deserialize(
+          await resolvedOptions.cache.getLargeBlob(bundleGraphCacheKey),
+        ),
       );
-
-      assert(v8.deserialize(overlayFS.readFileSync(bundleGraphPath)));
     });
 
     it('should invalidate when a terser config is modified', async function () {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
This PR adds logic to write Parcel's bundle graph to the cache if an error occurs during bundling.

Currently Parcel’s `requestGraph` is written to the cache at the end of a build or when interrupted with ctrl-c. Parcel’s `bundleGraph` is stored in `node.value.results` in the `requestGraph` and is written to the cache as part of the `requestGraph`'s write to cache. If an error occurs during bundling however, the `bundleGraph` is never stored in a `requestGraph` node and as a result isn't written to the cache. This PR adds code to also store the `bundleGraph` in a `requestGraph` node if an error occurs during bundling.

Ideally, we'd eventually like to be able to replicate failed builds from the Parcel cache and this PR is a step towards that.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
NA

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
NA

## ✔️ PR Todo

- [X] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
