### PR TITLE
Mark previously deferred assets as dirty for symbol prop

### DIFF
--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -369,6 +369,13 @@ export class AssetGraphBuilder {
         if (!previouslyDeferred && childNode.deferred) {
           this.assetGraph.markParentsWithHasDeferred(childNodeId);
         } else if (previouslyDeferred && !childNode.deferred) {
+          // Mark Asset and Dependency as dirty for symbol propagation as it was
+          // previously deferred and it's used symbols may have changed
+          this.changedAssetsPropagation.add(node.id);
+          node.usedSymbolsDownDirty = true;
+          this.changedAssetsPropagation.add(childNode.id);
+          childNode.usedSymbolsDownDirty = true;
+
           this.assetGraph.unmarkParentsWithHasDeferred(childNodeId);
         }
 

--- a/packages/core/integration-tests/test/lazy-compile.js
+++ b/packages/core/integration-tests/test/lazy-compile.js
@@ -275,7 +275,7 @@ describe('lazy compile', function () {
     subscription.unsubscribe();
   });
 
-  it.only('should lazy compile properly when an assets needs to be re-visited in symbol propagation', async () => {
+  it('should lazy compile properly when an assets needs to be re-visited in symbol propagation', async () => {
     await fsFixture(overlayFS, __dirname)`
       lazy-compile-import-symbols
         index.js:


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR fixes an issue in incremental symbol propagation + lazy mode builds where you have a lazy asset that depends on an asset which is also lazy itself. The issue occurs because `propagateSymbolsDown` is skipped but `propagateSymbolsUp` runs after the lazy bundle is requested. This can cause an incorrect "X does not export 'Y'" error to show as the `usedSymbolsDown` property has not been populated correctly. 

```mermaid
flowchart LR
    Main -.-> Async
    Main -.-> SharedAsync
    Async --> SharedAsync
```

This fix here is to mark previously deferred assets and their dependencies as changed/dirty so symbol propagation knows to re-process them.  

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
