### PR TITLE
Write BundleGraph to cache before shutdown 

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -877,7 +877,7 @@ export default class RequestTracker {
     }
   }
   storeResultDeep(nodeId: NodeId, result: mixed, cacheKey: ?string) {
-    // Store result in graph the immediately write to cache
+    // Store result in graph, then immediately write to cache
     this.storeResult(nodeId, result, cacheKey);
     this.writeNodeToCache(nodeId);
   }

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -441,7 +441,7 @@ class BundlerRunner {
       bundleGraphEdgeTypes,
     );
 
-    this.api.storeResult(
+    this.api.storeResultDeep(
       {
         bundleGraph: internalBundleGraph,
         changedAssets: new Map(),

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -85,6 +85,7 @@ describe('TargetResolver', () => {
       throw new Error('Not implemented');
     },
     storeResult() {},
+    storeResultDeep() {},
     canSkipSubrequest() {
       return false;
     },


### PR DESCRIPTION
# ↪️ [WIP] Write BundleGraph to cache earlier

In a large application, users must wait upwards of 10 seconds to shut down parcel, due to serialization of large graphs. This PR adds methods `storeResultDeep` and `writeNodeToCache` that store the result in the request tracker and then write the singular node/graph into the cache. 

## 🚨 Q's

- [ ] Can we ensure that users are not waiting an extra 3 seconds during re-bundling times on save, this would be semi counter productive if they wait extra. 
- [ ] Move assetgraph serialization to earlier

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
