### PR TITLE
fix: exclude `use-openssl-ca` from threads worker args

### DIFF
--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -26,7 +26,7 @@ export default class ThreadsWorker implements WorkerImpl {
     onError: ErrorHandler,
     onExit: ExitHandler,
   ) {
-    this.execArgv = execArgv;
+    this.execArgv = execArgv.filter(arg => !/use-openssl-ca/.test(arg));
     this.onMessage = onMessage;
     this.onError = onError;
     this.onExit = onExit;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

`use-openssl-ca` should not send to `Worker` because it's not supported.
- closes #6569

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

We use a node wrapper wich calls `node --use-openssl-ca ...` and that fails with default threads worker

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
