### PR TITLE
Fix cleanupIds field in HTMLNano and SVGO config

### DIFF
--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -73,7 +73,7 @@ export default (new Optimizer({
                 // Do not minify ids or remove unreferenced elements in
                 // inline SVGs because they could actually be referenced
                 // by a separate inline SVG.
-                cleanupIDs: false,
+                cleanupIds: false,
               },
             },
           },

--- a/packages/optimizers/svgo/src/SVGOOptimizer.js
+++ b/packages/optimizers/svgo/src/SVGOOptimizer.js
@@ -31,7 +31,7 @@ export default (new Optimizer({
           params: {
             overrides: {
               // Removing ids could break SVG sprites.
-              cleanupIDs: false,
+              cleanupIds: false,
               // <style> elements and attributes are already minified before they
               // are re-inserted by the packager.
               minifyStyles: false,


### PR DESCRIPTION
# ↪️ Pull Request
Found this in 2.10.2 version, we have some changes in cfg:  https://github.com/svg/svgo/releases/tag/v3.0.0
```
cleanupIDs plugin is renamed to cleanupIds
```
## Currently 

In logs you can see:
```
...
You are trying to configure cleanupIDs which is not part of preset-default.
Try to put it before or after, for example

plugins: [
  {
    name: 'preset-default',
  },
  'cleanupIDs'
]
✨ Built in 4.02s
```

## 🚨 Test instructions

Build new project with svg inside.

## ✔️ PR Todo

- [X] Included links to related issues/PRs
  - https://github.com/parcel-bundler/parcel/issues/9171#issuecomment-1671228529
  - https://github.com/svg/svgo/issues/1723
  - https://github.com/parcel-bundler/parcel/pull/9045

