### PR TITLE
Don't append timestamp to CJS require dependency specifiers

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -6485,6 +6485,43 @@ describe('javascript', function () {
     );
   });
 
+  it('should generate valid dependency specifiers for Node with dynamic imports and HMR', async function () {
+    await fsFixture(overlayFS, __dirname)`
+      node-dynamic-import-hmr
+        package.json:
+          {
+            "engines": {
+              "node": ">= 10.0.0"
+            }
+          }
+
+        index.js:
+          output(import("./foo"));
+
+        foo.js:
+          export const foo = 123;
+
+        yarn.lock:
+
+    `;
+
+    let b = await bundle(
+      path.join(__dirname, 'node-dynamic-import-hmr/index.js'),
+      {
+        inputFS: overlayFS,
+        hmrOptions: {},
+      },
+    );
+
+    let output;
+    await run(b, {
+      output(v) {
+        output = v;
+      },
+    });
+    assert.deepEqual(await output, {foo: 123});
+  });
+
   for (let shouldScopeHoist of [false, true]) {
     let options = {
       defaultTargetOptions: {

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -672,7 +672,7 @@ function getRelativePathExpr(
 ): string {
   let relativePath = relativeBundlePath(from, to, {leadingDotSlash: false});
   let res = JSON.stringify(relativePath);
-  if (options.hmrOptions) {
+  if (options.hmrOptions && from.env.outputFormat !== 'commonjs') {
     res += ' + "?" + Date.now()';
   }
 


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/9375

I think that `?1699714897282` added for cache invalidation will always be invalid when the `from` bundle is CommonJS, so just leave it out in that case.

Not sure if HMR actually works in Node, but this certainly fixes this error