### PR TITLE
Change default resolver error message for custom specifiers

### DIFF
--- a/crates/node-bindings/src/resolver.rs
+++ b/crates/node-bindings/src/resolver.rs
@@ -343,6 +343,12 @@ impl Resolver {
         "esm" => SpecifierType::Esm,
         "commonjs" => SpecifierType::Cjs,
         "url" => SpecifierType::Url,
+        "custom" => {
+          return Err(napi::Error::new(
+            napi::Status::InvalidArg,
+            "Unsupported specifier type: custom",
+          ))
+        }
         _ => {
           return Err(napi::Error::new(
             napi::Status::InvalidArg,


### PR DESCRIPTION
See #9377

https://github.com/parcel-bundler/parcel/blob/d1f778f79e8c8fbab6ebc56e40da936f59441439/packages/core/types-internal/src/index.js#L548

Custom is not really invalid, it's just not supported by the default resolver. Might be a more helpful error message