### PR TITLE
Simplify invalidateOnFileChange() in Transformers

### DIFF
--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -104,15 +104,10 @@ export default (new Transformer({
       plugins: config.plugins,
     });
 
-    if (res.messages) {
-      await Promise.all(
-        res.messages.map(({type, file: filePath}) => {
-          if (type === 'dependency') {
-            return asset.invalidateOnFileChange(filePath);
-          }
-          return Promise.resolve();
-        }),
-      );
+    for (let {type, file: filePath} of res.messages) {
+      if (type === 'dependency') {
+        asset.invalidateOnFileChange(filePath);
+      }
     }
 
     asset.setAST({

--- a/packages/transformers/posthtml/src/PostHTMLTransformer.js
+++ b/packages/transformers/posthtml/src/PostHTMLTransformer.js
@@ -104,9 +104,11 @@ export default (new Transformer({
       plugins: config.plugins,
     });
 
-    for (let {type, file: filePath} of res.messages) {
-      if (type === 'dependency') {
-        asset.invalidateOnFileChange(filePath);
+    if (res.messages) {
+      for (let {type, file: filePath} of res.messages) {
+        if (type === 'dependency') {
+          asset.invalidateOnFileChange(filePath);
+        }
       }
     }
 

--- a/packages/transformers/pug/src/PugTransformer.js
+++ b/packages/transformers/pug/src/PugTransformer.js
@@ -31,7 +31,7 @@ export default (new Transformer({
     });
 
     for (let filePath of render.dependencies) {
-      await asset.invalidateOnFileChange(filePath);
+      asset.invalidateOnFileChange(filePath);
     }
 
     asset.type = 'html';

--- a/packages/transformers/stylus/src/StylusTransformer.js
+++ b/packages/transformers/stylus/src/StylusTransformer.js
@@ -198,7 +198,7 @@ async function getDependencies(
       // Recursively process resolved files as well to get nested deps
       for (let resolved of found) {
         if (!seen.has(resolved)) {
-          await asset.invalidateOnFileChange(resolved);
+          asset.invalidateOnFileChange(resolved);
 
           let code = await asset.fs.readFile(resolved, 'utf8');
           for (let [path, resolvedPath] of await getDependencies(


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
In [docs](https://parceljs.org/plugin-system/transformer/#DependencyOptions)/code:

```
invalidateOnFileChange(FilePath): void
```

You don't need to add await before

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
