### PR TITLE
Fix dependency retargeting with ambiguous reexports

### DIFF
--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/entry.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/entry.js
@@ -1,0 +1,3 @@
+if (Date.now() > 0) {
+	output = require("./index.js").default;
+}

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/index.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/index.js
@@ -1,0 +1,3 @@
+import { b,c } from "./lib";
+
+export default b + " " + c;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-a.js
@@ -1,0 +1,2 @@
+module.exports = {};
+// export const a = 89;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-b.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-b.js
@@ -1,0 +1,1 @@
+export const b = 123;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-c.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-c.js
@@ -1,0 +1,1 @@
+export { c2 as c } from "./lib-c2.js";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-c2.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib-c2.js
@@ -1,0 +1,1 @@
+export const c2 = 999;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/lib.js
@@ -1,0 +1,3 @@
+export * from "./lib-a";
+export * from "./lib-b";
+export * from "./lib-c";

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/package.json
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/re-export-all-ambiguous/package.json
@@ -1,0 +1,10 @@
+{
+	"sideEffects": [
+		"entry.js",
+		"index.js",
+		"lib-a.js",
+		"lib-b.js",
+		"lib-c2.js",
+		"lib.js"
+	]
+}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -148,7 +148,7 @@ describe('scope hoisting', function () {
       assert.equal(output, 2);
     });
 
-    it('supports import * as from a library that has export *', async function () {
+    it('supports dependency rewriting for import * as from a library that has export *', async function () {
       let b = await bundle(
         path.join(
           __dirname,
@@ -401,6 +401,21 @@ describe('scope hoisting', function () {
         'utf8',
       );
       assert.match(contents, /output="foo bar"/);
+    });
+
+    it('supports re-exporting all with ambiguous CJS and non-renaming and renaming dependency retargeting', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/re-export-all-ambiguous/entry.js',
+        ),
+        {
+          mode: 'production',
+        },
+      );
+
+      let output = await run(b);
+      assert.strictEqual(output, '123 999');
     });
 
     it('supports re-exporting all exports from an external module', async function () {


### PR DESCRIPTION
Fix a regression of #9331 that broke the REPL

For the usual problem of ambiguous reexport-all, the first reexport would simply win (but in reality this should be determined at runtime) and sets itself in the importer asset's symbols. (lib-a.js is empty, the other two branches contain pure ESM exports of `b` and `c` respectively)

<img width="1125" alt="Bildschirm­foto 2023-11-13 um 15 54 41" src="https://github.com/parcel-bundler/parcel/assets/4586894/3b48eeae-0723-4780-be0b-749d5b3ae8aa">

If the exports aren't renamed (`from == as`) then we can just add a `* -> *` reexport-all dependency. This doesn't require changing the importers symbols (which can only list a single, therefore unambiguous, resolution). All ambiguous situation should fall in this non-renaming case


At some point, we should really rethink how we want to support reexporting from non-statically analyzable CJS...