### PR TITLE
Small LSP bugfixes

### DIFF
--- a/packages/reporters/lsp-reporter/src/LspReporter.js
+++ b/packages/reporters/lsp-reporter/src/LspReporter.js
@@ -100,7 +100,7 @@ async function watchLspActive(): Promise<FSWatcher> {
   });
 }
 
-async function doWatchStart() {
+async function doWatchStart(options) {
   await fs.promises.mkdir(BASEDIR, {recursive: true});
 
   // For each existing file, check if the pid matches a running process.
@@ -141,7 +141,7 @@ async function doWatchStart() {
   await fs.promises.writeFile(
     META_FILE,
     JSON.stringify({
-      projectRoot: process.cwd(),
+      projectRoot: options.projectRoot,
       pid: process.pid,
       argv: process.argv,
     }),
@@ -158,7 +158,7 @@ export default (new Reporter({
 
     if (watchStarted && lspStarted) {
       if (!watchStartPromise) {
-        watchStartPromise = doWatchStart();
+        watchStartPromise = doWatchStart(options);
       }
       await watchStartPromise;
     }

--- a/packages/utils/parcel-lsp/src/LspServer.ts
+++ b/packages/utils/parcel-lsp/src/LspServer.ts
@@ -227,7 +227,7 @@ function findClient(document: DocumentUri): Client | undefined {
   return bestClient;
 }
 
-function parseMetafile(filepath: string) {
+function loadMetafile(filepath: string) {
   const file = fs.readFileSync(filepath, 'utf-8');
   return JSON.parse(file);
 }
@@ -295,7 +295,7 @@ fs.writeFileSync(path.join(BASEDIR, LSP_SENTINEL_FILENAME), '');
 for (let filename of fs.readdirSync(BASEDIR)) {
   if (!filename.endsWith('.json')) continue;
   let filepath = path.join(BASEDIR, filename);
-  const contents = parseMetafile(filepath);
+  const contents = loadMetafile(filepath);
   const {projectRoot} = contents;
 
   if (WORKSPACE_ROOT === projectRoot) {
@@ -312,8 +312,7 @@ watcher.subscribe(BASEDIR, async (err, events) => {
 
   for (let event of events) {
     if (event.type === 'create' && event.path.endsWith('.json')) {
-      const file = fs.readFileSync(event.path, 'utf-8');
-      const contents = parseMetafile(file);
+      const contents = loadMetafile(event.path);
       const {projectRoot} = contents;
 
       if (WORKSPACE_ROOT === projectRoot) {


### PR DESCRIPTION
- The project root isn't always `process.cwd`, so just use the real project root
- loading the metafile didn't work when starting Parcel after the LSP server