### PR TITLE
Allow background.type for MV2

### DIFF
--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -82,6 +82,10 @@ const mv2Background = {
     scripts: arrStr,
     page: string,
     persistent: boolean,
+    type: {
+      type: 'string',
+      enum: ['classic', 'module'],
+    },
   },
   additionalProperties: false,
 };


### PR DESCRIPTION
No need to be overly restrictive here. Though we don't actually use that value in the transformer right now

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background
