### PR TITLE
Check Asset Graph for source asset when dependency retargeting

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -310,7 +310,10 @@ export default class BundleGraph {
                       local,
                       loc: reexportAllLoc,
                     });
-                    if (node.value.sourceAssetId != null) {
+                    if (
+                      node.value.sourceAssetId != null &&
+                      assetGraph.hasContentKey(node.value.sourceAssetId)
+                    ) {
                       let sourceAssetId = nullthrows(
                         assetGraphNodeIdToBundleGraphNodeId.get(
                           assetGraph.getNodeIdByContentKey(


### PR DESCRIPTION
# ↪️ Pull Request

Removing this check caused a regression when upgrading a project from 2.10.2, where the content key did not yet exist [here](https://github.com/parcel-bundler/parcel/blob/v2/packages/core/core/src/BundleGraph.js#L316).

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
