### PR TITLE
Filter `--expose-gc` and `--max-semi-space-size` execArgv Node args from workers

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -51,7 +51,10 @@ export default class Worker extends EventEmitter {
     let filteredArgs = [];
     if (process.execArgv) {
       filteredArgs = process.execArgv.filter(
-        v => !/^--(debug|inspect|no-opt|max-old-space-size=)/.test(v),
+        v =>
+          !/^--(debug|inspect|no-opt|max-old-space-size=|max-semi-space-size=|expose-gc)/.test(
+            v,
+          ),
       );
 
       for (let i = 0; i < filteredArgs.length; i++) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This filters `--expose-gc` and `--max-semi-space-size` flags from being passed to Parcel workers to fix the issue described at #9398, allowing Parcel workers to function when these flags are used, such as within an AWS Lambda environment.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
See #9398 for details of the AWS execution environment and Node options it sets.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
`test.js`:
```js
const { createWorkerFarm } = require('@parcel/core');
createWorkerFarm();
```
Run with `node --expose-gc --max-semi-space-size=17 test.js` and ensure no exceptions were raised.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
