### PR TITLE
Change inline-requires to only run when optimizing

### DIFF
--- a/packages/optimizers/inline-requires/README.md
+++ b/packages/optimizers/inline-requires/README.md
@@ -8,12 +8,9 @@ Add this optimizer to run _first_ (before minification), for JS bundles.
 
 ```json
 {
-    "optimizers": {
-        "*.js": {
-            "parcel-optimizer-inline-requires",
-            "..."
-        }
-    }
+  "optimizers": {
+    "*.js": ["@parcel/optimizer-inline-requires", "..."]
+  }
 }
 ```
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
Just some minor cleanup.

Changes the plugin so that rather than always running in production mode, will instead only run when doing an optimized build.

Also removes some of the verbose logging, replacing measurement with tracing.

Fixes the example config in `README.md`.

## 🚨 Test instructions

Tested manually that it still works with prod builds.

## ✔️ PR Todo

- [n/a ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
