### PR TITLE
Convert Request Graph node types + request node requestTypes to numbers

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -765,7 +765,7 @@ export class RequestGraph extends ContentGraph<
       // re-run all requests.
       if (type === 'create' && filePath === '') {
         for (let [id, node] of this.nodes.entries()) {
-          if (node?.type === 'request') {
+          if (node?.type === REQUEST) {
             this.invalidNodeIds.add(id);
           }
         }
@@ -1032,7 +1032,7 @@ export default class RequestTracker {
       requestId != null ? this.graph.getInvalidations(requestId) : [];
     let {requestNodeId, deferred} = this.startRequest({
       id: request.id,
-      type: 'request',
+      type: REQUEST,
       requestType: request.type,
       invalidateReason: INITIAL_BUILD,
     });

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -122,21 +122,40 @@ type RequestNode = {|
   hash?: string,
 |};
 
-type RequestType =
-  | 'parcel_build_request'
-  | 'bundle_graph_request'
-  | 'asset_graph_request'
-  | 'entry_request'
-  | 'target_request'
-  | 'parcel_config_request'
-  | 'path_request'
-  | 'dev_dep_request'
-  | 'asset_request'
-  | 'config_request'
-  | 'write_bundles_request'
-  | 'package_request'
-  | 'write_bundle_request'
-  | 'validation_request';
+// type RequestType =
+//   | 'parcel_build_request'
+//   | 'bundle_graph_request'
+//   | 'asset_graph_request'
+//   | 'entry_request'
+//   | 'target_request'
+//   | 'parcel_config_request'
+//   | 'path_request'
+//   | 'dev_dep_request'
+//   | 'asset_request'
+//   | 'config_request'
+//   | 'write_bundles_request'
+//   | 'package_request'
+//   | 'write_bundle_request'
+//   | 'validation_request';
+
+export const requestTypes = {
+  parcel_build_request: 1,
+  bundle_graph_request: 2,
+  asset_graph_request: 3,
+  entry_request: 4,
+  target_request: 5,
+  parcel_config_request: 6,
+  path_request: 7,
+  dev_dep_request: 8,
+  asset_request: 9,
+  config_request: 10,
+  write_bundles_request: 11,
+  package_request: 12,
+  write_bundle_request: 13,
+  validation_request: 14,
+};
+
+type RequestType = $Values<typeof requestTypes>;
 
 type RequestGraphNode =
   | RequestNode

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -128,22 +128,6 @@ type RequestNode = {|
   hash?: string,
 |};
 
-// type RequestType =
-//   | 'parcel_build_request'
-//   | 'bundle_graph_request'
-//   | 'asset_graph_request'
-//   | 'entry_request'
-//   | 'target_request'
-//   | 'parcel_config_request'
-//   | 'path_request'
-//   | 'dev_dep_request'
-//   | 'asset_request'
-//   | 'config_request'
-//   | 'write_bundles_request'
-//   | 'package_request'
-//   | 'write_bundle_request'
-//   | 'validation_request';
-
 export const requestTypes = {
   parcel_build_request: 1,
   bundle_graph_request: 2,

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -767,7 +767,7 @@ export class RequestGraph extends ContentGraph<
       } else if (type === 'create') {
         let basename = path.basename(filePath);
         let fileNameNode = this.getNodeByContentKey('file_name:' + basename);
-        if (fileNameNode != null && fileNameNode?.type === 'file_name') {
+        if (fileNameNode != null && fileNameNode?.type === FILE_NAME) {
           let fileNameNodeId = this.getNodeIdByContentKey(
             'file_name:' + basename,
           );

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -84,12 +84,12 @@ type SerializedRequestGraph = {|
   invalidateOnBuildNodeIds: Set<NodeId>,
 |};
 
-const FILE = 0;
-const REQUEST = 1;
-const FILE_NAME = 2;
-const ENV = 3;
-const OPTION = 4;
-const GLOB = 5;
+const FILE: 0 = 0;
+const REQUEST: 1 = 1;
+const FILE_NAME: 2 = 2;
+const ENV: 3 = 3;
+const OPTION: 4 = 4;
+const GLOB: 5 = 5;
 
 type FileNode = {|id: ContentKey, +type: typeof FILE, value: InternalFile|};
 type GlobNode = {|id: ContentKey, +type: typeof GLOB, value: InternalGlob|};
@@ -767,7 +767,7 @@ export class RequestGraph extends ContentGraph<
       } else if (type === 'create') {
         let basename = path.basename(filePath);
         let fileNameNode = this.getNodeByContentKey('file_name:' + basename);
-        if (fileNameNode != null && fileNameNode?.type === FILE_NAME) {
+        if (fileNameNode != null && fileNameNode.type === FILE_NAME) {
           let fileNameNodeId = this.getNodeIdByContentKey(
             'file_name:' + basename,
           );
@@ -924,7 +924,7 @@ export default class RequestTracker {
     this.graph.incompleteNodeIds.delete(nodeId);
     this.graph.incompleteNodePromises.delete(nodeId);
     let node = this.graph.getNode(nodeId);
-    if (node?.type === REQUEST) {
+    if (node && node.type === REQUEST) {
       node.invalidateReason = VALID;
     }
   }

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -32,6 +32,7 @@ import createPathRequest from './PathRequest';
 import {type ProjectPath, fromProjectPathRelative} from '../projectPath';
 import dumpGraphToGraphViz from '../dumpGraphToGraphViz';
 import {propagateSymbols} from '../SymbolPropagation';
+import {requestTypes} from '../RequestTracker';
 
 type AssetGraphRequestInput = {|
   entries?: Array<ProjectPath>,
@@ -62,7 +63,7 @@ type RunInput = {|
 
 type AssetGraphRequest = {|
   id: string,
-  +type: 'asset_graph_request',
+  +type: typeof requestTypes.asset_graph_request,
   run: RunInput => Async<AssetGraphRequestResult>,
   input: AssetGraphRequestInput,
 |};
@@ -71,7 +72,7 @@ export default function createAssetGraphRequest(
   input: AssetGraphRequestInput,
 ): AssetGraphRequest {
   return {
-    type: 'asset_graph_request',
+    type: requestTypes.asset_graph_request,
     id: input.name,
     run: async input => {
       let prevResult =

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -20,6 +20,7 @@ import {runDevDepRequest} from './DevDepRequest';
 import {runConfigRequest} from './ConfigRequest';
 import {fromProjectPath, fromProjectPathRelative} from '../projectPath';
 import {report} from '../ReporterRunner';
+import {requestTypes} from '../RequestTracker';
 
 type RunInput<TResult> = {|
   input: AssetRequestInput,
@@ -28,7 +29,7 @@ type RunInput<TResult> = {|
 
 export type AssetRequest = {|
   id: ContentKey,
-  +type: 'asset_request',
+  +type: typeof requestTypes.asset_request,
   run: (RunInput<AssetRequestResult>) => Async<AssetRequestResult>,
   input: AssetRequestInput,
 |};
@@ -37,7 +38,7 @@ export default function createAssetRequest(
   input: AssetRequestInput,
 ): AssetRequest {
   return {
-    type: 'asset_request',
+    type: requestTypes.asset_request,
     id: getId(input),
     run,
     input,
@@ -81,7 +82,7 @@ async function run({input, api, farm, invalidateReason, options}) {
     await Promise.all(
       api
         .getSubRequests()
-        .filter(req => req.requestType === 'dev_dep_request')
+        .filter(req => req.requestType === requestTypes.dev_dep_request)
         .map(async req => [
           req.id,
           nullthrows(await api.getRequestResult<DevDepRequest>(req.id)),

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -55,6 +55,7 @@ import {
 } from '../projectPath';
 import createAssetGraphRequest from './AssetGraphRequest';
 import {tracer, PluginTracer} from '@parcel/profiler';
+import {requestTypes} from '../RequestTracker';
 
 type BundleGraphRequestInput = {|
   requestedAssetIds: Set<string>,
@@ -79,7 +80,7 @@ export type BundleGraphResult = {|
 
 type BundleGraphRequest = {|
   id: string,
-  +type: 'bundle_graph_request',
+  +type: typeof requestTypes.bundle_graph_request,
   run: RunInput => Async<BundleGraphResult>,
   input: BundleGraphRequestInput,
 |};
@@ -88,7 +89,7 @@ export default function createBundleGraphRequest(
   input: BundleGraphRequestInput,
 ): BundleGraphRequest {
   return {
-    type: 'bundle_graph_request',
+    type: requestTypes.bundle_graph_request,
     id: 'BundleGraph',
     run: async input => {
       let {options, api, invalidateReason} = input;

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -26,6 +26,7 @@ import {optionsProxy} from '../utils';
 import {getInvalidationHash} from '../assetUtils';
 import {Hash} from '@parcel/rust';
 import {PluginTracer} from '@parcel/profiler';
+import {requestTypes} from '../RequestTracker';
 
 export type PluginWithLoadConfig = {
   loadConfig?: ({|
@@ -125,7 +126,7 @@ export async function runConfigRequest<TResult>(
 
   await api.runRequest<null, void>({
     id: 'config_request:' + configRequest.id,
-    type: 'config_request',
+    type: requestTypes.config_request,
     run: ({api}) => {
       for (let filePath of invalidateOnFileChange) {
         api.invalidateOnFileUpdate(filePath);

--- a/packages/core/core/src/requests/DevDepRequest.js
+++ b/packages/core/core/src/requests/DevDepRequest.js
@@ -18,6 +18,7 @@ import {
   fromProjectPathRelative,
   toProjectPath,
 } from '../projectPath';
+import {requestTypes} from '../RequestTracker';
 
 // A cache of dev dep requests keyed by invalidations.
 // If the package manager returns the same invalidation object, then
@@ -108,7 +109,7 @@ export async function getDevDepRequests<TResult>(
     await Promise.all(
       api
         .getSubRequests()
-        .filter(req => req.requestType === 'dev_dep_request')
+        .filter(req => req.requestType === requestTypes.dev_dep_request)
         .map(async req => [
           req.id,
           nullthrows(await api.getRequestResult<DevDepRequest>(req.id)),
@@ -183,7 +184,7 @@ export async function runDevDepRequest<TResult>(
 ) {
   await api.runRequest<null, DevDepRequestResult | void>({
     id: 'dev_dep_request:' + devDepRequest.specifier + ':' + devDepRequest.hash,
-    type: 'dev_dep_request',
+    type: requestTypes.dev_dep_request,
     run: ({api}) => {
       for (let filePath of nullthrows(devDepRequest.invalidateOnFileChange)) {
         api.invalidateOnFileUpdate(filePath);

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -18,6 +18,7 @@ import ThrowableDiagnostic, {
 } from '@parcel/diagnostic';
 import path from 'path';
 import {parse, type Mapping} from '@mischnic/json-sourcemap';
+import {requestTypes} from '../RequestTracker';
 import {
   type ProjectPath,
   fromProjectPath,
@@ -32,7 +33,7 @@ type RunOpts<TResult> = {|
 
 export type EntryRequest = {|
   id: string,
-  +type: 'entry_request',
+  +type: typeof requestTypes.entry_request,
   run: (RunOpts<EntryResult>) => Async<EntryResult>,
   input: ProjectPath,
 |};
@@ -47,7 +48,7 @@ const type = 'entry_request';
 export default function createEntryRequest(input: ProjectPath): EntryRequest {
   return {
     id: `${type}:${fromProjectPathRelative(input)}`,
-    type,
+    type: requestTypes.entry_request,
     run,
     input,
   };

--- a/packages/core/core/src/requests/PackageRequest.js
+++ b/packages/core/core/src/requests/PackageRequest.js
@@ -5,6 +5,7 @@ import type {Async} from '@parcel/types';
 import type {SharedReference} from '@parcel/workers';
 
 import type {StaticRunOpts} from '../RequestTracker';
+import {requestTypes} from '../RequestTracker';
 import type {Bundle} from '../types';
 import type BundleGraph from '../BundleGraph';
 import type {BundleInfo, PackageRequestResult} from '../PackagerRunner';
@@ -30,7 +31,7 @@ type RunInput<TResult> = {|
 
 export type PackageRequest = {|
   id: ContentKey,
-  +type: 'package_request',
+  +type: typeof requestTypes.package_request,
   run: (RunInput<BundleInfo>) => Async<BundleInfo>,
   input: PackageRequestInput,
 |};
@@ -39,7 +40,7 @@ export function createPackageRequest(
   input: PackageRequestInput,
 ): PackageRequest {
   return {
-    type: 'package_request',
+    type: requestTypes.package_request,
     id: input.bundleGraph.getHash(input.bundle),
     run,
     input,

--- a/packages/core/core/src/requests/ParcelBuildRequest.js
+++ b/packages/core/core/src/requests/ParcelBuildRequest.js
@@ -22,6 +22,7 @@ import {NamedBundle} from '../public/Bundle';
 import {assetFromValue} from '../public/Asset';
 
 import {tracer} from '@parcel/profiler';
+import {requestTypes} from '../RequestTracker';
 
 type ParcelBuildRequestInput = {|
   optionsRef: SharedReference,
@@ -43,7 +44,7 @@ type RunInput<TResult> = {|
 
 export type ParcelBuildRequest = {|
   id: ContentKey,
-  +type: 'parcel_build_request',
+  +type: typeof requestTypes.parcel_build_request,
   run: (RunInput<ParcelBuildRequestResult>) => Async<ParcelBuildRequestResult>,
   input: ParcelBuildRequestInput,
 |};
@@ -52,7 +53,7 @@ export default function createParcelBuildRequest(
   input: ParcelBuildRequestInput,
 ): ParcelBuildRequest {
   return {
-    type: 'parcel_build_request',
+    type: requestTypes.parcel_build_request,
     id: 'parcel_build_request',
     run,
     input,

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -37,6 +37,7 @@ import {optionsProxy} from '../utils';
 import ParcelConfig from '../ParcelConfig';
 import {createBuildCache} from '../buildCache';
 import {toProjectPath} from '../projectPath';
+import {requestTypes} from '../RequestTracker';
 
 type ConfigMap<K, V> = {[K]: V, ...};
 
@@ -52,7 +53,7 @@ type RunOpts<TResult> = {|
 
 export type ParcelConfigRequest = {|
   id: string,
-  type: 'parcel_config_request',
+  type: typeof requestTypes.parcel_config_request,
   input: null,
   run: (RunOpts<ConfigAndCachePath>) => Async<ConfigAndCachePath>,
 |};
@@ -67,7 +68,7 @@ const type = 'parcel_config_request';
 export default function createParcelConfigRequest(): ParcelConfigRequest {
   return {
     id: type,
-    type,
+    type: requestTypes[type],
     async run({api, options}) {
       let {
         config,

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -51,10 +51,11 @@ import {
   runDevDepRequest,
 } from './DevDepRequest';
 import {tracer, PluginTracer} from '@parcel/profiler';
+import {requestTypes} from '../RequestTracker';
 
 export type PathRequest = {|
   id: string,
-  +type: 'path_request',
+  +type: typeof requestTypes.path_request,
   run: (RunOpts<?AssetGroup>) => Async<?AssetGroup>,
   input: PathRequestInput,
 |};
@@ -69,7 +70,6 @@ type RunOpts<TResult> = {|
   ...StaticRunOpts<TResult>,
 |};
 
-const type = 'path_request';
 const PIPELINE_REGEX = /^([a-z0-9-]+?):(.*)$/i;
 
 export default function createPathRequest(
@@ -77,7 +77,7 @@ export default function createPathRequest(
 ): PathRequest {
   return {
     id: input.dependency.id + ':' + input.name,
-    type,
+    type: requestTypes.path_request,
     run,
     input,
   };

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -48,6 +48,7 @@ import {
 import {BROWSER_ENVS} from '../public/Environment';
 import {optionsProxy, toInternalSourceLocation} from '../utils';
 import {fromProjectPath, toProjectPath, joinProjectPath} from '../projectPath';
+import {requestTypes} from '../RequestTracker';
 
 type RunOpts<TResult> = {|
   input: Entry,
@@ -89,7 +90,7 @@ const DEFAULT_ENGINES = {
 
 export type TargetRequest = {|
   id: string,
-  +type: 'target_request',
+  +type: typeof requestTypes.target_request,
   run: (RunOpts<Array<Target>>) => Async<Array<Target>>,
   input: Entry,
 |};
@@ -99,7 +100,7 @@ const type = 'target_request';
 export default function createTargetRequest(input: Entry): TargetRequest {
   return {
     id: `${type}:${hashObject(input)}`,
-    type,
+    type: requestTypes.target_request,
     run,
     input,
   };

--- a/packages/core/core/src/requests/ValidationRequest.js
+++ b/packages/core/core/src/requests/ValidationRequest.js
@@ -10,10 +10,11 @@ import ParcelConfig from '../ParcelConfig';
 import {report} from '../ReporterRunner';
 import Validation from '../Validation';
 import createParcelConfigRequest from './ParcelConfigRequest';
+import {requestTypes} from '../RequestTracker';
 
 type ValidationRequest = {|
   id: string,
-  +type: 'validation_request',
+  +type: typeof requestTypes.validation_request,
   run: (RunOpts<void>) => Async<void>,
   input: ValidationRequestInput,
 |};
@@ -33,7 +34,7 @@ export default function createValidationRequest(
 ): ValidationRequest {
   return {
     id: 'validation',
-    type: 'validation_request',
+    type: requestTypes.validation_request,
     run: async ({input: {assetRequests, optionsRef}, api, options, farm}) => {
       let {config: processedConfig, cachePath} = nullthrows(
         await api.runRequest<null, ConfigAndCachePath>(

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -39,6 +39,7 @@ import {
 import ParcelConfig from '../ParcelConfig';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@parcel/diagnostic';
 import {PluginTracer, tracer} from '@parcel/profiler';
+import {requestTypes} from '../RequestTracker';
 
 const HASH_REF_PREFIX_LEN = HASH_REF_PREFIX.length;
 const BOUNDARY_LENGTH = HASH_REF_PREFIX.length + 32 - 1;
@@ -57,7 +58,7 @@ type RunInput<TResult> = {|
 
 export type WriteBundleRequest = {|
   id: ContentKey,
-  +type: 'write_bundle_request',
+  +type: typeof requestTypes.write_bundle_request,
   run: (RunInput<PackagedBundleInfo>) => Async<PackagedBundleInfo>,
   input: WriteBundleRequestInput,
 |};
@@ -74,7 +75,7 @@ export default function createWriteBundleRequest(
   );
   return {
     id: `${input.bundle.id}:${input.info.hash}:${nameHash}:${name}`,
-    type: 'write_bundle_request',
+    type: requestTypes.write_bundle_request,
     run,
     input,
   };

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -4,6 +4,7 @@ import type {ContentKey} from '@parcel/graph';
 import type {Async} from '@parcel/types';
 import type {SharedReference} from '@parcel/workers';
 import type {StaticRunOpts} from '../RequestTracker';
+import {requestTypes} from '../RequestTracker';
 import type {PackagedBundleInfo} from '../types';
 import type BundleGraph from '../BundleGraph';
 import type {BundleInfo} from '../PackagerRunner';
@@ -27,7 +28,7 @@ type RunInput<TResult> = {|
 
 export type WriteBundlesRequest = {|
   id: ContentKey,
-  +type: 'write_bundles_request',
+  +type: typeof requestTypes.write_bundles_request,
   run: (
     RunInput<Map<string, PackagedBundleInfo>>,
   ) => Async<Map<string, PackagedBundleInfo>>,
@@ -41,7 +42,7 @@ export default function createWriteBundlesRequest(
   input: WriteBundlesRequestInput,
 ): WriteBundlesRequest {
   return {
-    type: 'write_bundles_request',
+    type: requestTypes.write_bundles_request,
     id: 'write_bundles:' + input.bundleGraph.getBundleGraphHash(),
     run,
     input,

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -16,14 +16,14 @@ describe('RequestTracker', () => {
     let tracker = new RequestTracker({farm, options});
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: () => {},
       input: null,
     });
     let called = false;
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: () => {
         called = true;
       },
@@ -36,7 +36,7 @@ describe('RequestTracker', () => {
     let tracker = new RequestTracker({farm, options});
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: () => {},
       input: null,
     });
@@ -47,7 +47,7 @@ describe('RequestTracker', () => {
     let called = false;
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: () => {
         called = true;
       },
@@ -60,11 +60,11 @@ describe('RequestTracker', () => {
     let tracker = new RequestTracker({farm, options});
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}) => {
         await api.runRequest({
           id: 'xyz',
-          type: 'path_request',
+          type: 7,
           run: () => {},
           input: null,
         });
@@ -88,7 +88,7 @@ describe('RequestTracker', () => {
     await tracker
       .runRequest({
         id: 'abc',
-        type: 'path_request',
+        type: 7,
         run: async () => {
           await Promise.resolve();
           throw new Error('woops');
@@ -110,11 +110,11 @@ describe('RequestTracker', () => {
     let tracker = new RequestTracker({farm, options});
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}) => {
         await api.runRequest({
           id: 'xyz',
-          type: 'path_request',
+          type: 7,
           run: () => {},
           input: null,
         });
@@ -125,11 +125,11 @@ describe('RequestTracker', () => {
     tracker.graph.invalidateNode(nodeId, INITIAL_BUILD);
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}) => {
         await api.runRequest({
           id: '123',
-          type: 'path_request',
+          type: 7,
           run: () => {},
           input: null,
         });
@@ -143,7 +143,7 @@ describe('RequestTracker', () => {
     let tracker = new RequestTracker({farm, options});
     await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
         let result = await Promise.resolve('hello');
         api.storeResult(result);
@@ -152,7 +152,7 @@ describe('RequestTracker', () => {
     });
     let result = await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async () => {},
       input: null,
     });
@@ -164,7 +164,7 @@ describe('RequestTracker', () => {
     let p = tracker
       .runRequest({
         id: 'abc',
-        type: 'path_request',
+        type: 7,
         run: async () => {
           await Promise.resolve('hello');
         },
@@ -192,7 +192,7 @@ describe('RequestTracker', () => {
 
     let requestA = tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}: {api: RunAPI<string>, ...}) => {
         await lockA.promise;
         api.storeResult('a');
@@ -204,7 +204,7 @@ describe('RequestTracker', () => {
     let calledB = false;
     let requestB = tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}: {api: RunAPI<string>, ...}) => {
         calledB = true;
         await lockB.promise;
@@ -224,7 +224,7 @@ describe('RequestTracker', () => {
 
     let cachedResult = await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: () => {},
       input: null,
     });
@@ -240,7 +240,7 @@ describe('RequestTracker', () => {
     let requestA = tracker
       .runRequest({
         id: 'abc',
-        type: 'path_request',
+        type: 7,
         run: async () => {
           await lockA.promise;
           throw new Error('whoops');
@@ -253,7 +253,7 @@ describe('RequestTracker', () => {
 
     let requestB = tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
         await lockB.promise;
         api.storeResult('b');
@@ -269,7 +269,7 @@ describe('RequestTracker', () => {
     let called = false;
     let cachedResult = await tracker.runRequest({
       id: 'abc',
-      type: 'path_request',
+      type: 7,
       run: () => {
         called = true;
       },

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -9,6 +9,7 @@ import v8 from 'v8';
 import nullthrows from 'nullthrows';
 import invariant from 'assert';
 import {LMDBCache} from '@parcel/cache/src/LMDBCache';
+import {requestTypes} from '@parcel/core/src/RequestTracker.js';
 
 const {
   AssetGraph,
@@ -19,7 +20,6 @@ const {
     requestGraphEdgeTypes,
   },
 } = require('./deep-imports.js');
-import {requestTypes} from '../../../core/core/src/RequestTracker';
 
 export async function loadGraphs(cacheDir: string): Promise<{|
   assetGraph: ?AssetGraph,

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -80,13 +80,13 @@ export function loadGraphs(cacheDir: string): {|
     requestTracker.graph.getNode(buildRequestId),
   );
   invariant(
-    buildRequestNode.type === 'request' &&
+    buildRequestNode.type === 1 &&
       buildRequestNode.value.type === 'parcel_build_request',
   );
   let buildRequestSubRequests = getSubRequests(buildRequestId);
 
   let bundleGraphRequestNode = buildRequestSubRequests.find(
-    n => n.type === 'request' && n.value.type === 'bundle_graph_request',
+    n => n.type === 1 && n.value.type === 'bundle_graph_request',
   );
   if (bundleGraphRequestNode != null) {
     bundleGraph = BundleGraph.deserialize(
@@ -96,7 +96,7 @@ export function loadGraphs(cacheDir: string): {|
 
     let assetGraphRequest = getSubRequests(
       requestTracker.graph.getNodeIdByContentKey(bundleGraphRequestNode.id),
-    ).find(n => n.type === 'request' && n.value.type === 'asset_graph_request');
+    ).find(n => n.type === 1 && n.value.type === 'asset_graph_request');
     if (assetGraphRequest != null) {
       assetGraph = AssetGraph.deserialize(
         loadLargeBlobRequestRequestSync(cacheDir, assetGraphRequest).assetGraph
@@ -106,10 +106,10 @@ export function loadGraphs(cacheDir: string): {|
   }
 
   let writeBundlesRequest = buildRequestSubRequests.find(
-    n => n.type === 'request' && n.value.type === 'write_bundles_request',
+    n => n.type === 1 && n.value.type === 'write_bundles_request',
   );
   if (writeBundlesRequest != null) {
-    invariant(writeBundlesRequest.type === 'request');
+    invariant(writeBundlesRequest.type === 1);
     // $FlowFixMe[incompatible-cast]
     bundleInfo = (nullthrows(writeBundlesRequest.value.result): Map<
       ContentKey,
@@ -121,7 +121,7 @@ export function loadGraphs(cacheDir: string): {|
 }
 
 function loadLargeBlobRequestRequestSync(cacheDir, node) {
-  invariant(node.type === 'request');
+  invariant(node.type === 1);
   return v8.deserialize(
     fs.readFileSync(path.join(cacheDir, nullthrows(node.value.resultCacheKey))),
   );


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples
Example `request` node before:
```
{
  id: 'target_request:6a6450d10c82f7d2',
  type: 'request',
  requestType: 'target_request',
  invalidateReason: 0
}
```

After (`type` and `requestType`s are now numbers):
```
{
  id: 'target_request:6a6450d10c82f7d2',
  type: 1,
  requestType: 5,
  invalidateReason: 0
}
```
Example `file` node before:
```
{ id: 'node_modules/fast-glob/out/utils/errno.js', type: 'file' }
```
After (`type` is now a number):
```
{ id: 'node_modules/fast-glob/out/utils/errno.js', type: 0 }
```

