### PR TITLE
Unstable File Invalidations

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1219,6 +1219,9 @@ async function loadRequestGraph(options): Async<RequestGraph> {
       snapshotPath,
       opts,
     );
+    if (options.nodeModuleInvalidations != null) {
+      events.push(...options.nodeModuleInvalidations);
+    }
     requestGraph.invalidateUnpredictableNodes();
     requestGraph.invalidateOnBuildNodes();
     requestGraph.invalidateEnvNodes(options.env);

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1219,15 +1219,12 @@ async function loadRequestGraph(options): Async<RequestGraph> {
       snapshotPath,
       opts,
     );
-    if (options.nodeModuleInvalidations != null) {
-      events.push(...options.nodeModuleInvalidations);
-    }
     requestGraph.invalidateUnpredictableNodes();
     requestGraph.invalidateOnBuildNodes();
     requestGraph.invalidateEnvNodes(options.env);
     requestGraph.invalidateOptionNodes(options);
     requestGraph.respondToFSEvents(
-      events.map(e => ({
+      (options.unstableFileInvalidations || events).map(e => ({
         type: e.type,
         path: toProjectPath(options.projectRoot, e.path),
       })),

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -147,6 +147,13 @@ export default async function resolveOptions(
 
   let port = determinePort(initialOptions.serveOptions, env.PORT);
 
+  let nodeModuleInvalidations = initialOptions.nodeModuleInvalidations?.map(
+    path => ({
+      type: 'create',
+      path,
+    }),
+  );
+
   return {
     config: getRelativeConfigSpecifier(
       inputFS,
@@ -166,6 +173,7 @@ export default async function resolveOptions(
     shouldBuildLazily,
     lazyIncludes,
     lazyExcludes,
+    nodeModuleInvalidations,
     shouldBundleIncrementally: initialOptions.shouldBundleIncrementally ?? true,
     shouldContentHash,
     serveOptions: initialOptions.serveOptions

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -147,13 +147,6 @@ export default async function resolveOptions(
 
   let port = determinePort(initialOptions.serveOptions, env.PORT);
 
-  let nodeModuleInvalidations = initialOptions.nodeModuleInvalidations?.map(
-    path => ({
-      type: 'create',
-      path,
-    }),
-  );
-
   return {
     config: getRelativeConfigSpecifier(
       inputFS,
@@ -173,7 +166,7 @@ export default async function resolveOptions(
     shouldBuildLazily,
     lazyIncludes,
     lazyExcludes,
-    nodeModuleInvalidations,
+    unstableFileInvalidations: initialOptions.unstableFileInvalidations,
     shouldBundleIncrementally: initialOptions.shouldBundleIncrementally ?? true,
     shouldContentHash,
     serveOptions: initialOptions.serveOptions

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -281,7 +281,7 @@ export type ParcelOptions = {|
   shouldTrace: boolean,
   shouldPatchConsole: boolean,
   detailedReport?: ?DetailedReportOptions,
-  nodeModuleInvalidations?: Array<{|
+  unstableFileInvalidations?: Array<{|
     path: FilePath,
     type: EventType,
   |}>,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -31,6 +31,7 @@ import type {FileSystem} from '@parcel/fs';
 import type {Cache} from '@parcel/cache';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ProjectPath} from './projectPath';
+import type {EventType} from '@parcel/watcher';
 
 export type ParcelPluginNode = {|
   packageName: PackageName,
@@ -280,6 +281,10 @@ export type ParcelOptions = {|
   shouldTrace: boolean,
   shouldPatchConsole: boolean,
   detailedReport?: ?DetailedReportOptions,
+  nodeModuleInvalidations?: Array<{|
+    path: FilePath,
+    type: EventType,
+  |}>,
 
   inputFS: FileSystem,
   outputFS: FileSystem,

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -101,6 +101,9 @@ const commonOptions = {
     },
     [],
   ],
+  '--node-module-invalidations <path>': [
+    'Comma separated list of file paths of node_module packages to be invalidated',
+  ],
 };
 
 var hmrOptions = {
@@ -466,10 +469,11 @@ async function normalizeOptions(
 
   let mode = command.name() === 'build' ? 'production' : 'development';
 
-  const normalizeIncludeExcludeList = (input?: string): string[] => {
+  const normalizeCommaSeparatedList = (input?: string): string[] => {
     if (typeof input !== 'string') return [];
     return input.split(',').map(value => value.trim());
   };
+
   return {
     shouldDisableCache: command.cache === false,
     cacheDir: command.cacheDir,
@@ -484,8 +488,11 @@ async function normalizeOptions(
     shouldProfile: command.profile,
     shouldTrace: command.trace,
     shouldBuildLazily: typeof command.lazy !== 'undefined',
-    lazyIncludes: normalizeIncludeExcludeList(command.lazy),
-    lazyExcludes: normalizeIncludeExcludeList(command.lazyExclude),
+    lazyIncludes: normalizeCommaSeparatedList(command.lazy),
+    lazyExcludes: normalizeCommaSeparatedList(command.lazyExclude),
+    nodeModuleInvalidations: normalizeCommaSeparatedList(
+      command.nodeModuleInvalidations,
+    ),
     shouldBundleIncrementally:
       process.env.PARCEL_INCREMENTAL_BUNDLING === 'false' ? false : true,
     detailedReport:

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -101,9 +101,6 @@ const commonOptions = {
     },
     [],
   ],
-  '--node-module-invalidations <path>': [
-    'Comma separated list of file paths of node_module packages to be invalidated',
-  ],
 };
 
 var hmrOptions = {
@@ -469,11 +466,10 @@ async function normalizeOptions(
 
   let mode = command.name() === 'build' ? 'production' : 'development';
 
-  const normalizeCommaSeparatedList = (input?: string): string[] => {
+  const normalizeIncludeExcludeList = (input?: string): string[] => {
     if (typeof input !== 'string') return [];
     return input.split(',').map(value => value.trim());
   };
-
   return {
     shouldDisableCache: command.cache === false,
     cacheDir: command.cacheDir,
@@ -488,11 +484,8 @@ async function normalizeOptions(
     shouldProfile: command.profile,
     shouldTrace: command.trace,
     shouldBuildLazily: typeof command.lazy !== 'undefined',
-    lazyIncludes: normalizeCommaSeparatedList(command.lazy),
-    lazyExcludes: normalizeCommaSeparatedList(command.lazyExclude),
-    nodeModuleInvalidations: normalizeCommaSeparatedList(
-      command.nodeModuleInvalidations,
-    ),
+    lazyIncludes: normalizeIncludeExcludeList(command.lazy),
+    lazyExcludes: normalizeIncludeExcludeList(command.lazyExclude),
     shouldBundleIncrementally:
       process.env.PARCEL_INCREMENTAL_BUNDLING === 'false' ? false : true,
     detailedReport:

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -306,6 +306,7 @@ export type InitialParcelOptions = {|
   +lazyIncludes?: string[],
   +lazyExcludes?: string[],
   +shouldBundleIncrementally?: boolean,
+  +nodeModuleInvalidations?: Array<FilePath>,
 
   +inputFS?: FileSystem,
   +outputFS?: FileSystem,

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -14,6 +14,7 @@ import type {Cache} from '@parcel/cache';
 
 import type {AST as _AST, ConfigResult as _ConfigResult} from './unsafe';
 import type {TraceMeasurement} from '@parcel/profiler';
+import type {EventType} from '@parcel/watcher';
 
 /** Plugin-specific AST, <code>any</code> */
 export type AST = _AST;
@@ -306,7 +307,7 @@ export type InitialParcelOptions = {|
   +lazyIncludes?: string[],
   +lazyExcludes?: string[],
   +shouldBundleIncrementally?: boolean,
-  +nodeModuleInvalidations?: Array<FilePath>,
+  +unstableFileInvalidations?: Array<{|path: FilePath, type: EventType|}>,
 
   +inputFS?: FileSystem,
   +outputFS?: FileSystem,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR allows passing in file paths through FS Event objects as an option through Parcel's node API. These are then converted to events and invalidated in the `RequestTracker`.  This should support the ability to invalidate `node_module` packages in CI when combined with a list that is generated by comparing an old vs new copy of the `yarn.lock` (of the project being built).

## 💻 Examples

Example usage:

```
const bundler = new Parcel({
  entries: 'src/entry.tsx',
  shouldDisableCache: false,
  unstableFileInvalidations: [
    {path: 'node_modules/react-dom/profiling.js', type: 'create'},
    {
      path: 'node_modules/react/cjs/react.production.min.js',
      type: 'create',
    },
    {
      path: 'src/foo.tsx',
      type: 'update',
    },
  ]
});
```

## 🚨 Test instructions
(These reference the example above):
- Did a build of `src/entry.tsx` without `unstableFileInvalidations`
- Then did another build of the same entry (without clearing the cache) with `unstableFileInvalidations` passed in as an option
- Verified that both `node_modules/react-dom/profiling.js`, `node_modules/react/cjs/react.production.min.js`, and `src/foo.tsx` are all rebuilt