### PR TITLE
fsFixture: ignore empty lines in fixtures

### DIFF
--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -167,6 +167,8 @@ const TOKEN_TYPES = [
 // with the exception of the `indent` and `path` groups, which
 // capture patterns that should be subsequently matched on `TOKEN_TYPES`.
 const COMPOUND_TYPES = [
+  // Matches empty lines that are meant to be ignored.
+  /^(?<empty> *)\n/,
   // Matches are captured as `indent` and`path` groups,
   // which can then be matched to `TOKEN_TYPES`.
   /^(?<indent>(?: {2})*)(?<path>[^:>\n]+\b) *(?:\n|$)/,
@@ -207,6 +209,8 @@ export class FixtureTokenizer {
 
         // Additional tokens that aren't captured by `indent` and `path`.
         for (let type in groups) {
+          // Ignore empty lines.
+          if (type === 'empty') continue;
           // If the value is multiline, dedent each line.
           let value = groups[type]
             .trim()

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -225,6 +225,37 @@ describe('FixtureTokenizer', () => {
       {type: 'link', value: 'foo/bar/bat'},
     ]);
   });
+  it('ignores empty lines after dirnames', () => {
+    let tokens = new FixtureTokenizer(`lib\n  \n  \n  nested`).tokenize();
+
+    assert.deepEqual(tokens, [
+      {type: 'dirname', value: 'lib'},
+      {type: 'nest', value: ''},
+      {type: 'dirname', value: 'nested'},
+    ]);
+  });
+
+  it('ignores empty lines after links', () => {
+    let tokens = new FixtureTokenizer(`lib -> ./lib2\n \nlib2`).tokenize();
+
+    assert.deepEqual(tokens, [
+      {type: 'filename', value: 'lib'},
+      {type: 'link', value: './lib2'},
+      {type: 'dirname', value: 'lib2'},
+    ]);
+  });
+
+  it('ignores empty lines after file content', () => {
+    let tokens = new FixtureTokenizer(
+      `file:\n  \n  content\n\n  \ndir`,
+    ).tokenize();
+
+    assert.deepEqual(tokens, [
+      {type: 'filename', value: 'file'},
+      {type: 'content', value: 'content'},
+      {type: 'dirname', value: 'dir'},
+    ]);
+  });
 });
 
 describe('FixtureParser', () => {


### PR DESCRIPTION
fsFixture now lets you put cosmetic empty space between dirnames, links, and files.

See tests for some examples of cases that should now work.
