### PR TITLE
Fix HMR on .localhost domains

### DIFF
--- a/packages/reporters/dev-server/src/templates/500.html
+++ b/packages/reporters/dev-server/src/templates/500.html
@@ -90,7 +90,7 @@
       // Reload the page when an HMR update occurs.
       var protocol =
         (location.protocol == 'https:' &&
-          !/localhost|127.0.0.1|0.0.0.0/.test(hostname))
+          !['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname))
           ? 'wss'
           : 'ws';
       var hostname = <%- JSON.stringify(hmrOptions.host || null) %> || location.protocol.indexOf('http') === 0 ? location.hostname : 'localhost';

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -93,7 +93,7 @@ if ((!parent || !parent.isParcelRequire) && typeof WebSocket !== 'undefined') {
   var protocol =
     HMR_SECURE ||
     (location.protocol == 'https:' &&
-      !/localhost|127.0.0.1|0.0.0.0/.test(hostname))
+      !['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname))
       ? 'wss'
       : 'ws';
 


### PR DESCRIPTION
# ↪️ Pull Request

Fix HMR on .localhost domains (e.g. https://project.localhost).

Fixes #7490

## 💻 Examples

Before, it was trying to connect to the HMR websocket over the `ws://` protocol, even though https://project.localhost is a secure domain. Now, it correctly uses the `wss://` protocol.

## 🚨 Test instructions

Set up a project on https://project.localhost. An easy way is with caddy.

```sh
brew install caddy
printf "project.localhost {\n\treverse_proxy localhost:1234\n}\n" > $HOMEBREW_PREFIX/Caddyfile
brew services start caddy
parcel src/index.html # start a parcel project on port 1234
open https://project.localhost
```

Verify that the HMR websocket connection is made to wss://project.localhost/, not ws://project.localhost/

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
