### PR TITLE
Fix parcel query's inspect cache

### DIFF
--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -603,13 +603,12 @@ export async function run(input: string[]) {
     ]);
     let serialized: Map<string, number> = new Map();
     serialized.set('RequestGraph', timeSerialize(requestTracker));
-    serialized.set('bundle_graph_request', timeSerialize(bundleGraph));
-    serialized.set('asset_graph_request', timeSerialize(assetGraph));
-    for (let [k, v] of nullthrows(cacheInfo).entries()) {
-      let s = serialized.get(k);
+    serialized.set('BundleGraph', timeSerialize(bundleGraph));
+    serialized.set('AssetGraph', timeSerialize(assetGraph));
+    for (let [name, info] of nullthrows(cacheInfo).entries()) {
+      let s = serialized.get(name);
       invariant(s != null);
-      let name = k.includes('_request') ? k.split('_request')[0] : k;
-      table.push([name, ...v, s]);
+      table.push([name, ...info, s]);
     }
     function getColumnSum(t: Array<Array<string | number>>, col: number) {
       if (t == null) {

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -9,7 +9,6 @@ import v8 from 'v8';
 import nullthrows from 'nullthrows';
 import invariant from 'assert';
 import {LMDBCache} from '@parcel/cache/src/LMDBCache';
-import {requestTypes} from '@parcel/core/src/RequestTracker.js';
 
 const {
   AssetGraph,

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -145,12 +145,20 @@ async function loadLargeBlobRequestRequest(cache, node, cacheInfo) {
   invariant(node.type === 1);
 
   let cachedFile = await cache.getLargeBlob(nullthrows(node.resultCacheKey));
-  cacheInfo.get(requestTypes[node.requestType])?.push(cachedFile.byteLength); //Add size
 
   let TTD = Date.now();
   let result = v8.deserialize(cachedFile);
   TTD = Date.now() - TTD;
-  cacheInfo.get(requestTypes[node.requestType])?.push(TTD);
+
+  if (node.requestType === 2) {
+    cacheInfo.get('bundle_graph_request')?.push(cachedFile.byteLength); //Add size
+    cacheInfo.get('bundle_graph_request')?.push(TTD);
+  }
+
+  if (node.requestType === 3) {
+    cacheInfo.get('asset_graph_request')?.push(cachedFile.byteLength); //Add size
+    cacheInfo.get('asset_graph_request')?.push(TTD);
+  }
 
   return result;
 }

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -89,8 +89,8 @@ export async function loadGraphs(cacheDir: string): Promise<{|
 
   // Load graphs by finding the main subrequests and loading their results
   let assetGraph, bundleGraph, bundleInfo;
-  cacheInfo.set('bundle_graph_request', []);
-  cacheInfo.set('asset_graph_request', []);
+  cacheInfo.set('BundleGraph', []);
+  cacheInfo.set('AssetGraph', []);
   invariant(requestTracker);
   let buildRequestId = requestTracker.graph.getNodeIdByContentKey(
     'parcel_build_request',
@@ -151,13 +151,13 @@ async function loadLargeBlobRequestRequest(cache, node, cacheInfo) {
   TTD = Date.now() - TTD;
 
   if (node.requestType === 2) {
-    cacheInfo.get('bundle_graph_request')?.push(cachedFile.byteLength); //Add size
-    cacheInfo.get('bundle_graph_request')?.push(TTD);
+    cacheInfo.get('BundleGraph')?.push(cachedFile.byteLength); //Add size
+    cacheInfo.get('BundleGraph')?.push(TTD);
   }
 
   if (node.requestType === 3) {
-    cacheInfo.get('asset_graph_request')?.push(cachedFile.byteLength); //Add size
-    cacheInfo.get('asset_graph_request')?.push(TTD);
+    cacheInfo.get('AssetGraph')?.push(cachedFile.byteLength);
+    cacheInfo.get('AssetGraph')?.push(TTD);
   }
 
   return result;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Currently Parcel-query's `inspectCache()` function fails with the error `throw new Error('Table must have a consistent number of cells.');` This is because the size and deserialization time of the `bundleGraph` and `assetGraph` fail to be populated in `cacheInfo` due to a bug in getting the `cacheInfo` keys in `loadLargeBlobRequestRequest`. This PR fixes this bug and gets `inspectCache` working correctly. 

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
Ran Parcel-query with `inspectCache` on a `.parcel-cache` in Jira Frontend.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
