### PR TITLE
Minor bug fix for exiting early when identifying requestGraph in loadGraphs

### DIFF
--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -46,7 +46,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
   const cache = new LMDBCache(cacheDir);
   for (let f of filesBySizeAndModifiedTime()) {
     // Empty filename or not the first chunk
-    if (path.extname(f) !== '' && !f.endsWith('-0')) continue;
+    if (path.extname(f) !== '' || !f.endsWith('-0')) continue;
     try {
       let file = await cache.getLargeBlob(
         path.basename(f).slice(0, -'-0'.length),


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The `loadGraph` function sorts the files in the cache by size and modification time and then iterates through these files to identify the `requestGraph`. Because the `requestGraph` is written to the cache with the `setLargeBlob` function, the file name always ends with '-0'. There's no need to waste time deserializing files that don't end with '-0' and checking to see if they are the `requestGraph`. However, there's currently a bug in this early stopping condition when identifying the `requestGraph`. This PR fixes that.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
Commented out the break condition and logged the files that could possibly being deserialized if the requestGraph wasn't found on the first try. Previously files that did not end with '-0' where being deserialized, now only files ending with '-0' will be.
## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
