### PR TITLE
Bug fix for async Parcel-query

### DIFF
--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -915,8 +915,10 @@ export async function run(input: string[]) {
   // -------------------------------------------------------
 
   if (initialCmd != null) {
-    eval(initialCmd);
-    process.exit(0);
+    (async () => {
+      await eval(initialCmd);
+      process.exit(0);
+    })();
   } else {
     console.log(
       'See .help. The graphs can be accessed via `assetGraph`, `bundleGraph` and `requestTracker`.',


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This PR fixes a bug in Parcel-query that is causing race conditions. The run function in Parcel-query was [recently changed ](https://github.com/parcel-bundler/parcel/pull/9355)to be asynchronous. Occasionally the given query fails to complete successfully (missing outputs, etc.) due to the process exiting before the command is finished being evaluated. 

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
For example `getBundles` occassionally fails to provide any of the bundles, but this issue isn't cause by failure to load `bundleGraph` or `bundleInfo`, but rather because the process has exited before the logs can be outputted.

## 🚨 Test instructions
Ran into this issue on a different [branch,](https://github.com/parcel-bundler/parcel/commit/3437e7f3566c668f5baeaf9a0a3a0c7f905312af) tested fix which resolved issue.
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
