### PR TITLE
Use centos image with newer Node 16

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -39,7 +39,7 @@ jobs:
     name: linux-gnu-x64
     runs-on: ubuntu-20.04
     container:
-      image: docker.io/adrienv1520/nodejs-16-centos7
+      image: docker.io/mischnic/centos7-node16
     steps:
       - uses: actions/checkout@v3
       - name: Install yarn

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -39,7 +39,7 @@ jobs:
     name: linux-gnu-x64
     runs-on: ubuntu-20.04
     container:
-      image: docker.io/adrienv1520/nodejs-16-centos7
+      image: docker.io/mischnic/centos7-node16
     steps:
       - uses: actions/checkout@v3
       - name: Install yarn


### PR DESCRIPTION
Centos 7 doesn't support anything newer than Node 16 by the way

https://hub.docker.com/r/mischnic/centos7-node16

To solve this in the release workflows:
```
error lru-cache@10.1.0: The engine "node" is incompatible with this module. Expected version "14 || >=16.14". Got "16.3.0"
```