### PR TITLE
Fixup CI again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ steps.deployment.outputs.env }}
+          env: Preview
           override: false
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -119,9 +119,11 @@ jobs:
           - target: x86_64-unknown-linux-musl
             strip: strip
             cflags: -msse4.2
+            arch: x86_64
           - target: aarch64-unknown-linux-musl
             strip: aarch64-linux-musl-strip
             cflags: ''
+            arch: aarch64
     name: ${{ matrix.target }}
     runs-on: ubuntu-20.04
     container:
@@ -149,7 +151,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-linux-musl
+          name: bindings-linux-musl-${{ matrix.arch }}
           path: packages/*/*/*.node
       - name: debug
         run: ls -l packages/*/*/*.node

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -39,7 +39,7 @@ jobs:
     container:
       image: docker.io/mischnic/centos7-node16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Install yarn
         run: npm install --global yarn@1
       - name: Install Rust

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -119,9 +119,11 @@ jobs:
           - target: x86_64-unknown-linux-musl
             strip: strip
             cflags: -msse4.2
+            arch: x86_64
           - target: aarch64-unknown-linux-musl
             strip: aarch64-linux-musl-strip
             cflags: ''
+            arch: aarch64
     name: ${{ matrix.target }}
     runs-on: ubuntu-20.04
     container:
@@ -149,7 +151,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: bindings-linux-musl
+          name: bindings-linux-musl-${{ matrix.arch }}
           path: packages/*/*/*.node
       - name: debug
         run: ls -l packages/*/*/*.node

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -39,7 +39,7 @@ jobs:
     container:
       image: docker.io/mischnic/centos7-node16
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Install yarn
         run: npm install --global yarn@1
       - name: Install Rust

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -63,6 +63,7 @@
     "@parcel/core": "^2.11.0"
   },
   "browser": {
+    "./src/NodePackageManager.js": false,
     "./src/Npm.js": false,
     "./src/Pnpm.js": false,
     "./src/Yarn.js": false


### PR DESCRIPTION
CentOS with legacy Node strikes again and fails with `actions/checkout@v4` 😐 

See failures here: https://github.com/parcel-bundler/parcel/actions/runs/7434707815/job/20229165773

