### PR TITLE
Rename "parentAsset" to "root" for Manual Shared Bundle config

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -31,7 +31,7 @@ type ManualSharedBundles = Array<{|
   name: string,
   assets: Array<Glob>,
   types?: Array<string>,
-  parent?: string,
+  root?: string,
   split?: number,
 |}>;
 
@@ -41,7 +41,7 @@ type BaseBundlerConfig = {|
   minBundleSize?: number,
   maxParallelRequests?: number,
   disableSharedBundles?: boolean,
-  unstable_manualSharedBundles?: ManualSharedBundles,
+  manualSharedBundles?: ManualSharedBundles,
 |};
 
 type BundlerConfig = {|
@@ -437,8 +437,8 @@ function createIdealGraph(
     let parentsToConfig = new DefaultMap(() => []);
 
     for (let c of config.manualSharedBundles) {
-      if (c.parent != null) {
-        parentsToConfig.get(path.join(config.projectRoot, c.parent)).push(c);
+      if (c.root != null) {
+        parentsToConfig.get(path.join(config.projectRoot, c.root)).push(c);
       }
     }
     let numParentsToFind = parentsToConfig.size;
@@ -462,7 +462,7 @@ function createIdealGraph(
     // Process in reverse order so earlier configs take precedence
     for (let c of config.manualSharedBundles.reverse()) {
       invariant(
-        c.parent == null || configToParentAsset.has(c),
+        c.root == null || configToParentAsset.has(c),
         'Invalid manual shared bundle. Could not find parent asset.',
       );
 
@@ -1700,7 +1700,7 @@ const CONFIG_SCHEMA: SchemaEntity = {
       type: 'number',
       enum: Object.keys(HTTP_OPTIONS).map(k => Number(k)),
     },
-    unstable_manualSharedBundles: {
+    manualSharedBundles: {
       type: 'array',
       items: {
         type: 'object',
@@ -1720,7 +1720,7 @@ const CONFIG_SCHEMA: SchemaEntity = {
               type: 'string',
             },
           },
-          parent: {
+          root: {
             type: 'string',
           },
           split: {
@@ -1889,12 +1889,12 @@ async function loadBundlerConfig(
     });
   }
 
-  if (modeConfig.unstable_manualSharedBundles) {
-    let nameArray = modeConfig.unstable_manualSharedBundles.map(a => a.name);
+  if (modeConfig.manualSharedBundles) {
+    let nameArray = modeConfig.manualSharedBundles.map(a => a.name);
     let nameSet = new Set(nameArray);
     invariant(
       nameSet.size == nameArray.length,
-      'The name field must be unique for property unstable_manualSharedBundles',
+      'The name field must be unique for property manualSharedBundles',
     );
   }
 
@@ -1922,7 +1922,7 @@ async function loadBundlerConfig(
     disableSharedBundles:
       modeConfig.disableSharedBundles ?? defaults.disableSharedBundles,
     manualSharedBundles:
-      modeConfig.unstable_manualSharedBundles ?? defaults.manualSharedBundles,
+      modeConfig.manualSharedBundles ?? defaults.manualSharedBundles,
   };
 }
 

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -1223,7 +1223,7 @@ describe('bundler', function () {
         {
           "@parcel/bundler-default": {
             "minBundleSize": 0,
-            "unstable_manualSharedBundles": [{
+            "manualSharedBundles": [{
               "name": "vendor",
               "assets": ["vendor*.*"]
             }]
@@ -1305,7 +1305,7 @@ describe('bundler', function () {
       package.json:
         {
           "@parcel/bundler-default": {
-            "unstable_manualSharedBundles": [{
+            "manualSharedBundles": [{
               "name": "manual-inline",
               "assets": ["shared.js"]
             }]
@@ -1386,7 +1386,7 @@ describe('bundler', function () {
         {
           "@parcel/bundler-default": {
             "minBundleSize": 0,
-            "unstable_manualSharedBundles": [{
+            "manualSharedBundles": [{
               "name": "vendor",
               "assets": ["vendor*.*"],
               "types": ["js"]
@@ -1471,9 +1471,9 @@ describe('bundler', function () {
         {
           "@parcel/bundler-default": {
             "minBundleSize": 0,
-            "unstable_manualSharedBundles": [{
+            "manualSharedBundles": [{
               "name": "vendor",
-              "parent": "math/math.js",
+              "root": "math/math.js",
               "assets": ["math/!(divide).js"]
             }]
           }
@@ -1542,7 +1542,7 @@ describe('bundler', function () {
           },
           "@parcel/bundler-default": {
             "minBundleSize": 0,
-            "unstable_manualSharedBundles": [{
+            "manualSharedBundles": [{
               "name": "vendor",
               "assets": ["vendor*.*"],
               "types": ["js"]
@@ -1614,9 +1614,9 @@ describe('bundler', function () {
           },
           "@parcel/bundler-default": {
             "minBundleSize": 0,
-            "unstable_manualSharedBundles": [{
+            "manualSharedBundles": [{
               "name": "vendor",
-              "parent": "manual.js",
+              "root": "manual.js",
               "assets": ["**/*"],
               "types": ["js"]
             }]
@@ -1682,9 +1682,9 @@ describe('bundler', function () {
           {
             "@parcel/bundler-default": {
               "minBundleSize": 0,
-              "unstable_manualSharedBundles": [{
+              "manualSharedBundles": [{
                 "name": "vendor",
-                "parent": "vendor.js",
+                "root": "vendor.js",
                 "assets": ["**/*"],
                 "split": 3
               }]


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
In a previous meeting we discussed rolling out usage documentation for Manual Shared Bundles, and agreed that while the feature is experimental, it is not unstable. We also discussed clarity of naming for the "parent" parameter and agreed on "root".

This PR removes "unstable" from `unstable_manualSharedBundles` config option **and** renames the "parent" field to "root" instead, for clarity. 

The [usage PR](https://github.com/parcel-bundler/website/pull/1099) already references these names, as will any contributor documentation. 