### PR TITLE
Statically evaluate constants referenced by macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "crossbeam-channel",
  "dashmap",
  "getrandom",
+ "indexmap 1.9.3",
  "jemallocator",
  "libc",
  "mimalloc",

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -22,6 +22,7 @@ mozjpeg-sys = "1.0.0"
 libc = "0.2"
 rayon = "1.7.0"
 crossbeam-channel = "0.5.6"
+indexmap = "1.9.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 napi = {version =  "2.12.6", features = ["serde-json"]}

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use napi::{Env, JsObject, JsUnknown};
 use napi_derive::napi;
 
@@ -177,12 +178,12 @@ mod native_only {
 
           let names = obj.get_property_names()?;
           let len = names.get_array_length()?;
-          let mut props = Vec::with_capacity(len as usize);
+          let mut props = IndexMap::with_capacity(len as usize);
           for i in 0..len {
             let prop = names.get_element::<JsString>(i)?;
             let name = prop.into_utf8()?.into_owned()?;
             let value = napi_to_js_value(obj.get_property(prop)?, env)?;
-            props.push((name, value));
+            props.insert(name, value);
           }
           Ok(JsValue::Object(props))
         }

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -13,13 +13,13 @@ pub fn transform(opts: JsObject, env: Env) -> napi::Result<JsUnknown> {
 mod native_only {
   use super::*;
   use crossbeam_channel::{Receiver, Sender};
+  use indexmap::IndexMap;
   use napi::{
     threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode},
     JsBoolean, JsFunction, JsNumber, JsString, ValueType,
   };
   use parcel_js_swc_core::{JsValue, SourceLocation};
   use std::sync::Arc;
-  use indexmap::IndexMap;
 
   // Allocate a single channel per thread to communicate with the JS thread.
   thread_local! {

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -1,4 +1,3 @@
-use indexmap::IndexMap;
 use napi::{Env, JsObject, JsUnknown};
 use napi_derive::napi;
 
@@ -20,6 +19,7 @@ mod native_only {
   };
   use parcel_js_swc_core::{JsValue, SourceLocation};
   use std::sync::Arc;
+  use indexmap::IndexMap;
 
   // Allocate a single channel per thread to communicate with the JS thread.
   thread_local! {

--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -693,6 +693,10 @@ describe('macros', function () {
         const arr = ['foo'];
         doSomething(arr);
         output3 = hashString(arr[0]);
+
+        const object3 = {foo: bar};
+        doSomething(object3[unknown]);
+        output4 = hashString(object3);
     `;
 
     try {
@@ -764,6 +768,29 @@ describe('macros', function () {
                   end: {
                     line: 14,
                     column: 15,
+                  },
+                },
+              ],
+            },
+          ],
+          hints: null,
+        },
+        {
+          message: 'Could not statically evaluate macro argument',
+          origin: '@parcel/transformer-js',
+          codeFrames: [
+            {
+              filePath: path.join(dir, 'index.js'),
+              codeHighlights: [
+                {
+                  message: undefined,
+                  start: {
+                    line: 18,
+                    column: 13,
+                  },
+                  end: {
+                    line: 18,
+                    column: 19,
                   },
                 },
               ],

--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -612,6 +612,10 @@ describe('macros', function () {
         const object = {foo: 'bar'};
         object.foo = 'test';
         output = hashString(object.foo);
+
+        const arr = ['foo'];
+        arr[0] = 'bar';
+        output = hashString(arr[0]);
     `;
 
     try {
@@ -644,6 +648,29 @@ describe('macros', function () {
           ],
           hints: null,
         },
+        {
+          message: 'Could not statically evaluate macro argument',
+          origin: '@parcel/transformer-js',
+          codeFrames: [
+            {
+              filePath: path.join(dir, 'index.js'),
+              codeHighlights: [
+                {
+                  message: undefined,
+                  start: {
+                    line: 7,
+                    column: 1,
+                  },
+                  end: {
+                    line: 7,
+                    column: 14,
+                  },
+                },
+              ],
+            },
+          ],
+          hints: null,
+        },
       ]);
     }
   });
@@ -662,6 +689,10 @@ describe('macros', function () {
         const object2 = {foo: bar, obj: {}};
         doSomething(object2.obj); // error (object could be mutated)
         output2 = hashString(object2);
+
+        const arr = ['foo'];
+        doSomething(arr);
+        output3 = hashString(arr[0]);
     `;
 
     try {
@@ -710,6 +741,29 @@ describe('macros', function () {
                   end: {
                     line: 10,
                     column: 19,
+                  },
+                },
+              ],
+            },
+          ],
+          hints: null,
+        },
+        {
+          message: 'Could not statically evaluate macro argument',
+          origin: '@parcel/transformer-js',
+          codeFrames: [
+            {
+              filePath: path.join(dir, 'index.js'),
+              codeHighlights: [
+                {
+                  message: undefined,
+                  start: {
+                    line: 14,
+                    column: 13,
+                  },
+                  end: {
+                    line: 14,
+                    column: 15,
                   },
                 },
               ],

--- a/packages/transformers/js/core/src/macros.rs
+++ b/packages/transformers/js/core/src/macros.rs
@@ -263,7 +263,10 @@ impl<'a> Fold for Macros<'a> {
       let value = self
         .eval(&*node.obj)
         .and_then(|obj| self.eval_member_prop(obj, &node));
-      if !matches!(value, Ok(JsValue::Object(..) | JsValue::Array(..))) {
+      if !matches!(
+        value,
+        Err(..) | Ok(JsValue::Object(..) | JsValue::Array(..))
+      ) {
         return node;
       }
     }

--- a/packages/transformers/js/core/src/macros.rs
+++ b/packages/transformers/js/core/src/macros.rs
@@ -263,7 +263,7 @@ impl<'a> Fold for Macros<'a> {
       let value = self
         .eval(&*node.obj)
         .and_then(|obj| self.eval_member_prop(obj, &node));
-      if !matches!(value, Ok(JsValue::Object(..))) {
+      if !matches!(value, Ok(JsValue::Object(..) | JsValue::Array(..))) {
         return node;
       }
     }
@@ -274,7 +274,7 @@ impl<'a> Fold for Macros<'a> {
   fn fold_ident(&mut self, node: Ident) -> Ident {
     if self.in_call {
       if let Some(constant) = self.constants.get_mut(&node.to_id()) {
-        if matches!(constant, Ok(JsValue::Object(..))) {
+        if matches!(constant, Ok(JsValue::Object(..) | JsValue::Array(..))) {
           // Mark access to constant object inside a call as an error since it could potentially be mutated.
           *constant = Err(node.span.clone());
         }

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -239,13 +239,13 @@ impl PartialOrd for SourceLocation {
   }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct CodeHighlight {
   pub message: Option<String>,
   pub loc: SourceLocation,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Diagnostic {
   pub message: String,
   pub code_highlights: Option<Vec<CodeHighlight>>,


### PR DESCRIPTION
This PR enables macro calls to include statically analyzable constants. For example:

```js
import { foo } from './macro' with {type: 'macro'};

const common = {
  foo: 'bar'
};

const result1 = foo({...common, bar: 'test'});
const result2 = foo({...common, bar: 'other'});
```

Constants must be declared with `const` to ensure that they cannot be mutated, as this would be much harder to analyze. Object and array patterns are supported in the declaration in addition to simple identifiers. The result of a macro may also be stored in a const variable, and later used in another macro call.

This also implements support for member expressions and optional chaining to access properties of statically known objects and arrays.

It may be helpful to review with whitespace disabled FYI.