### PR TITLE
Improve macro error handling

### DIFF
--- a/packages/core/core/src/requests/DevDepRequest.js
+++ b/packages/core/core/src/requests/DevDepRequest.js
@@ -49,7 +49,12 @@ export async function createDevDependency(
   let resolveFromAbsolute = fromProjectPath(options.projectRoot, resolveFrom);
 
   // Ensure that the package manager has an entry for this resolution.
-  await options.packageManager.resolve(specifier, resolveFromAbsolute);
+  try {
+    await options.packageManager.resolve(specifier, resolveFromAbsolute);
+  } catch (err) {
+    // ignore
+  }
+
   let invalidations = options.packageManager.getInvalidations(
     specifier,
     resolveFromAbsolute,

--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -1,5 +1,6 @@
 // @flow strict-local
 import assert from 'assert';
+import invariant from 'assert';
 import path from 'path';
 import {
   bundle,
@@ -624,6 +625,7 @@ describe('macros', function () {
 
       buildEvent = await getNextBuild(b);
       assert.equal(buildEvent.type, 'buildSuccess');
+      invariant(buildEvent.type === 'buildSuccess'); // flow
 
       let res = await overlayFS.readFile(
         buildEvent.bundleGraph.getBundles()[0].filePath,
@@ -632,7 +634,7 @@ describe('macros', function () {
       let match = res.match(/output=(\d+)/);
       assert(match);
     } finally {
-      await subscription.unsubscribe();
+      await subscription?.unsubscribe();
     }
   });
 

--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -1,7 +1,14 @@
 // @flow strict-local
 import assert from 'assert';
 import path from 'path';
-import {bundle, run, overlayFS, fsFixture} from '@parcel/test-utils';
+import {
+  bundle,
+  bundler,
+  run,
+  overlayFS,
+  fsFixture,
+  getNextBuild,
+} from '@parcel/test-utils';
 
 describe('macros', function () {
   let count = 0;
@@ -368,7 +375,7 @@ describe('macros', function () {
     } catch (err) {
       assert.deepEqual(err.diagnostics, [
         {
-          message: `Error evaluating macro: Could not resolve module "./macro.js" from "${path.join(
+          message: `Error loading macro: Could not resolve module "./macro.js" from "${path.join(
             dir,
             'index.js',
           )}"`,
@@ -380,12 +387,12 @@ describe('macros', function () {
                 {
                   message: undefined,
                   start: {
-                    line: 2,
-                    column: 10,
+                    line: 1,
+                    column: 1,
                   },
                   end: {
-                    line: 2,
-                    column: 19,
+                    line: 1,
+                    column: 57,
                   },
                 },
               ],
@@ -559,6 +566,74 @@ describe('macros', function () {
     let match2 = res.match(/output=(\d+)/);
     assert(match2);
     assert.notEqual(match[1], match2[1]);
+  });
+
+  it('should only error once if a macro errors during loading', async function () {
+    await fsFixture(overlayFS, dir)`
+      index.js:
+        import { test } from "./macro.js" with { type: "macro" };
+        output = test(1, 2);
+        output2 = test(1, 3);
+
+      macro.js:
+        export function test() {
+          return Date.now(
+        }
+    `;
+
+    try {
+      await bundle(path.join(dir, '/index.js'), {
+        inputFS: overlayFS,
+        mode: 'production',
+      });
+    } catch (err) {
+      assert.equal(err.diagnostics.length, 1);
+    }
+  });
+
+  it('should rebuild in watch mode after fixing an error', async function () {
+    await fsFixture(overlayFS, dir)`
+      index.js:
+        import { test } from "./macro.ts" with { type: "macro" };
+        output = test('test.txt');
+
+      macro.ts:
+        export function test() {
+          return Date.now(
+        }
+    `;
+
+    let b = await bundler(path.join(dir, '/index.js'), {
+      inputFS: overlayFS,
+      mode: 'production',
+      shouldDisableCache: false,
+    });
+
+    let subscription;
+    try {
+      subscription = await b.watch();
+      let buildEvent = await getNextBuild(b);
+      assert.equal(buildEvent.type, 'buildFailure');
+
+      await fsFixture(overlayFS, dir)`
+        macro.ts:
+          export function test() {
+            return Date.now();
+          }
+      `;
+
+      buildEvent = await getNextBuild(b);
+      assert.equal(buildEvent.type, 'buildSuccess');
+
+      let res = await overlayFS.readFile(
+        buildEvent.bundleGraph.getBundles()[0].filePath,
+        'utf8',
+      );
+      let match = res.match(/output=(\d+)/);
+      assert(match);
+    } finally {
+      await subscription.unsubscribe();
+    }
   });
 
   it('should support evaluating constants', async function () {

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -53,8 +53,8 @@ use node_replacer::NodeReplacer;
 use typeof_replacer::*;
 use utils::{error_buffer_to_diagnostics, Diagnostic, DiagnosticSeverity, ErrorBuffer, SourceType};
 
-pub use crate::macros::JsValue;
 use crate::macros::Macros;
+pub use crate::macros::{JsValue, MacroError};
 pub use utils::SourceLocation;
 
 type SourceMapBuffer = Vec<(swc_core::common::BytePos, swc_core::common::LineCol)>;

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -474,15 +474,20 @@ export default (new Transformer({
       inline_constants: config.inlineConstants,
       callMacro: asset.isSource
         ? async (err, src, exportName, args, loc) => {
+            let mod;
             try {
-              let mod = await options.packageManager.require(
-                src,
-                asset.filePath,
-              );
+              mod = await options.packageManager.require(src, asset.filePath);
               if (!Object.hasOwnProperty.call(mod, exportName)) {
                 throw new Error(`"${src}" does not export "${exportName}".`);
               }
+            } catch (err) {
+              throw {
+                kind: 1,
+                message: err.message,
+              };
+            }
 
+            try {
               if (typeof mod[exportName] === 'function') {
                 let ctx: MacroContext = {
                   // Allows macros to emit additional assets to add as dependencies (e.g. css).
@@ -564,7 +569,10 @@ export default (new Transformer({
                 }
                 message += '\n' + line;
               }
-              throw message;
+              throw {
+                kind: 2,
+                message,
+              };
             }
           }
         : null,


### PR DESCRIPTION
This fixes two issues with macro error handling:

1. If you made a syntax error in a macro (or any dev dependency), fixing it would not trigger a rebuild in watch mode. This is because errors thrown by transformers short-circuit adding dev dependencies for plugins in Transformation.js. This is fixed by adding a try...finally around that code.
2. If you have a single macro import that is used multiple times in the same file, it will output the same load error multiple times. Now we distinguish between errors loading the macro file (e.g. resolution + syntax), from execution errors and only show load errors once. The diagnostic also shows the import statement as the location rather than each call.