### PR TITLE
feat: add getCurrentPackageManager

### DIFF
--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -23,7 +23,6 @@
   "scripts": {
     "build-ts": "mkdir -p lib && flow-to-ts src/types.js > lib/types.d.ts",
     "check-ts": "tsc --noEmit index.d.ts",
-    "log:agent": "node -e \"console.log(process.env.npm_config_user_agent)\"",
     "test": "mocha test"
   },
   "targets": {

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "build-ts": "mkdir -p lib && flow-to-ts src/types.js > lib/types.d.ts",
     "check-ts": "tsc --noEmit index.d.ts",
+    "log:agent": "node -e \"console.log(process.env.npm_config_user_agent)\"",
     "test": "mocha test"
   },
   "targets": {

--- a/packages/core/package-manager/src/getCurrentPackageManager.js
+++ b/packages/core/package-manager/src/getCurrentPackageManager.js
@@ -1,8 +1,8 @@
 // @flow
 
 export default function getCurrentPackageManager(
-  userAgent = process.env.npm_config_user_agent,
-) {
+  userAgent: ?string = process.env.npm_config_user_agent,
+): ?{|name: string, version: string|} {
   if (!userAgent) {
     return undefined;
   }

--- a/packages/core/package-manager/src/getCurrentPackageManager.js
+++ b/packages/core/package-manager/src/getCurrentPackageManager.js
@@ -1,0 +1,17 @@
+// @flow
+
+export default function getCurrentPackageManager(
+  userAgent = process.env.npm_config_user_agent,
+) {
+  if (!userAgent) {
+    return undefined;
+  }
+
+  const pmSpec = userAgent.split(' ')[0];
+  const separatorPos = pmSpec.lastIndexOf('/');
+  const name = pmSpec.substring(0, separatorPos);
+  return {
+    name: name,
+    version: pmSpec.substring(separatorPos + 1),
+  };
+}

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -174,13 +174,16 @@ async function determinePackageInstaller(
     return new Yarn();
   }
 
-  const name = getCurrentPackageManager().name;
-  if (name === 'npm') {
-    return new Npm();
-  } else if (name === 'yarn') {
-    return new Yarn();
-  } else if (name === 'pnpm') {
-    return new Pnpm();
+  const currentPackageManager = getCurrentPackageManager();
+  if (currentPackageManager) {
+    const name = currentPackageManager.name;
+    if (name === 'npm') {
+      return new Npm();
+    } else if (name === 'yarn') {
+      return new Yarn();
+    } else if (name === 'pnpm') {
+      return new Pnpm();
+    }
   }
 
   if (await Yarn.exists()) {

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -174,16 +174,13 @@ async function determinePackageInstaller(
     return new Yarn();
   }
 
-  const currentPackageManager = getCurrentPackageManager();
-  if (currentPackageManager) {
-    const name = currentPackageManager.name;
-    if (name === 'npm') {
-      return new Npm();
-    } else if (name === 'yarn') {
-      return new Yarn();
-    } else if (name === 'pnpm') {
-      return new Pnpm();
-    }
+  let currentPackageManager = getCurrentPackageManager()?.name;
+  if (currentPackageManager === 'npm') {
+    return new Npm();
+  } else if (currentPackageManager === 'yarn') {
+    return new Yarn();
+  } else if (currentPackageManager === 'pnpm') {
+    return new Pnpm();
   }
 
   if (await Yarn.exists()) {

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -26,6 +26,7 @@ import {Npm} from './Npm';
 import {Yarn} from './Yarn';
 import {Pnpm} from './Pnpm.js';
 import {getConflictingLocalDependencies} from './utils';
+import getCurrentPackageManager from './getCurrentPackageManager';
 import validateModuleSpecifier from './validateModuleSpecifier';
 
 async function install(
@@ -171,6 +172,15 @@ async function determinePackageInstaller(
     return new Pnpm();
   } else if (configName === 'yarn.lock') {
     return new Yarn();
+  }
+
+  const name = getCurrentPackageManager().name;
+  if (name === 'npm') {
+    return new Npm();
+  } else if (name === 'yarn') {
+    return new Yarn();
+  } else if (name === 'pnpm') {
+    return new Pnpm();
   }
 
   if (await Yarn.exists()) {

--- a/packages/core/package-manager/test/getCurrentPackageManager.test.js
+++ b/packages/core/package-manager/test/getCurrentPackageManager.test.js
@@ -1,0 +1,38 @@
+// @flow
+import assert from 'assert';
+import {Npm} from '../src/Npm';
+import {Yarn} from '../src/Yarn';
+import {Pnpm} from '../src/Pnpm.js';
+import {execSync} from 'child_process';
+import getCurrentPackageManager from '../src/getCurrentPackageManager';
+
+const pmlist = [
+  {
+    pm: 'npm',
+    installer: Npm,
+  },
+  {
+    pm: 'yarn',
+    installer: Yarn,
+  },
+  {
+    pm: 'pnpm',
+    installer: Pnpm,
+  },
+];
+
+describe('getCurrentPackageManager', () => {
+  for (const {pm, installer} of pmlist) {
+    it(pm, async () => {
+      const exists = installer.exists ? await installer.exists() : true;
+      if (exists) {
+        delete process.env.npm_config_user_agent;
+        const res = execSync(`${pm} -s run log:agent`, {
+          stdio: 'pipe',
+        }).toString();
+        const data = getCurrentPackageManager(res);
+        assert(data.name, pm);
+      }
+    });
+  }
+});

--- a/packages/core/package-manager/test/getCurrentPackageManager.test.js
+++ b/packages/core/package-manager/test/getCurrentPackageManager.test.js
@@ -1,38 +1,46 @@
 // @flow
 import assert from 'assert';
-import {Npm} from '../src/Npm';
 import {Yarn} from '../src/Yarn';
 import {Pnpm} from '../src/Pnpm.js';
 import {execSync} from 'child_process';
 import getCurrentPackageManager from '../src/getCurrentPackageManager';
 
-const pmlist = [
+const pmlist: Array<{exists: () => Promise<boolean>, pm: string, ...}> = [
   {
     pm: 'npm',
-    installer: Npm,
+    exists: () => Promise.resolve(true),
   },
   {
     pm: 'yarn',
-    installer: Yarn,
+    exists: () => Yarn.exists(),
   },
   {
     pm: 'pnpm',
-    installer: Pnpm,
+    exists: () => Pnpm.exists(),
   },
 ];
 
 describe('getCurrentPackageManager', () => {
-  for (const {pm, installer} of pmlist) {
-    it(pm, async () => {
-      const exists = installer.exists ? await installer.exists() : true;
-      if (exists) {
-        delete process.env.npm_config_user_agent;
-        const res = execSync(`${pm} -s run log:agent`, {
-          stdio: 'pipe',
-        }).toString();
-        const data = getCurrentPackageManager(res);
-        assert(data.name, pm);
-      }
-    });
-  }
+  it('yarn', () => {
+    const npm_config_user_agent = 'yarn/1.22.21 npm/? node/v21.1.0 darwin x64';
+    const currentPackageManager = getCurrentPackageManager(
+      npm_config_user_agent,
+    );
+    assert(currentPackageManager?.name, 'yarn');
+  });
+  it('npm', () => {
+    const npm_config_user_agent =
+      'npm/10.2.0 node/v21.1.0 darwin x64 workspaces/true';
+    const currentPackageManager = getCurrentPackageManager(
+      npm_config_user_agent,
+    );
+    assert(currentPackageManager?.name, 'npm');
+  });
+  it('pnpm', () => {
+    const npm_config_user_agent = 'pnpm/8.14.2 npm/? node/v18.17.1 darwin x64';
+    const currentPackageManager = getCurrentPackageManager(
+      npm_config_user_agent,
+    );
+    assert(currentPackageManager?.name, 'pnpm');
+  });
 });

--- a/packages/core/package-manager/test/getCurrentPackageManager.test.js
+++ b/packages/core/package-manager/test/getCurrentPackageManager.test.js
@@ -1,24 +1,6 @@
 // @flow
 import assert from 'assert';
-import {Yarn} from '../src/Yarn';
-import {Pnpm} from '../src/Pnpm.js';
-import {execSync} from 'child_process';
 import getCurrentPackageManager from '../src/getCurrentPackageManager';
-
-const pmlist: Array<{exists: () => Promise<boolean>, pm: string, ...}> = [
-  {
-    pm: 'npm',
-    exists: () => Promise.resolve(true),
-  },
-  {
-    pm: 'yarn',
-    exists: () => Yarn.exists(),
-  },
-  {
-    pm: 'pnpm',
-    exists: () => Pnpm.exists(),
-  },
-];
 
 describe('getCurrentPackageManager', () => {
   it('yarn', () => {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

my repo is monorepo by pnpm-workspace protocal and is installed with pnpm.
It will create pnpm-lock yaml in root directory.
When I run parcel build with types in subpackage, it will auto install @parcel/transformer-typescript-types with yarn.

I check the source code and find the result is that the library of package manager will detect current package manager by lockfile.
If the current work directory has no lockfile, it will run in ['yarn', 'pnpm', 'npm'] order.
It is not my expect. I want to it works for pnpm.

So I want to add a function named getCurrentPackageManager, it will detect the current package manager with `process.env.npm_config_user_agent`.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
