### PR TITLE
[Web Extension] Add content script world property to manifest schema validation

### DIFF
--- a/packages/core/integration-tests/test/integration/webextension-mv3/manifest.json
+++ b/packages/core/integration-tests/test/integration/webextension-mv3/manifest.json
@@ -12,7 +12,8 @@
   ],
   "content_scripts": [{
     "matches": ["https://*.google.com/*"],
-    "js": ["other-content-script.js"]
+    "js": ["other-content-script.js"],
+    "world": "ISOLATED"
   }],
   "action": {
     "default_popup": "popup.html"

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -185,6 +185,10 @@ const commonProps = {
           enum: ['document_idle', 'document_start', 'document_end'],
         },
         all_frames: boolean,
+        world: {
+          type: 'string',
+          enum: ['ISOLATED', 'MAIN'],
+        },
       },
       additionalProperties: false,
       required: ['matches'],


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Resolves #9482.

Adds the [isolation context property `world`](https://developer.chrome.com/docs/extensions/reference/manifest/content-scripts#world-timings) to the `@parcel/transformer-webextension` schema validation code.

It's Chrome-only currently, but [I think that Firefox support is currently on the way](https://bugzilla.mozilla.org/show_bug.cgi?id=1736575).

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

This following `manifest.json` would throw an error while validating the schema because of `content_scripts[0].world`

```json
{
  "name": "MV3 Migration - content script example",
  "description": "Source: https://github.com/GoogleChrome/chrome-extensions-samples",
  "version": "0.1",
  "manifest_version": 3,
  "background": {
    "service_worker": "background.js"
  },
  "permissions": [
    "scripting",
    "activeTab"
  ],
  "content_scripts": [{
    "matches": ["https://*.google.com/*"],
    "js": ["other-content-script.js"],
    "world": "ISOLATED"
  }],
  "action": {
    "default_popup": "popup.html"
  },
  "side_panel": {
    "default_path": "side-panel.html"
  }
}
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

`cd packages/core/integration-tests && yarn test test/webextension.js`

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
