### PR TITLE
Allow constants to be used in macros inside a call expression

### DIFF
--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -642,7 +642,7 @@ describe('macros', function () {
     await fsFixture(overlayFS, dir)`
       index.js:
         import { hashString } from "@parcel/rust" with { type: "macro" };
-        import { test } from './macro' with { type: "macro" };
+        import { test, test2 } from './macro' with { type: "macro" };
         const hi = "hi";
         const ref = hi;
         const arr = [hi];
@@ -664,10 +664,16 @@ describe('macros', function () {
         output11 = hashString(f.y);
         output12 = hashString(f?.y);
         output13 = hashString(res);
+        output14 = test2(obj)();
 
       macro.js:
+        import { hashString } from "@parcel/rust";
         export function test() {
           return "hi";
+        }
+
+        export function test2(obj) {
+          return new Function('return "' + hashString(obj.a.b) + '"');
         }
     `;
 
@@ -677,7 +683,7 @@ describe('macros', function () {
     });
 
     let res = await overlayFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    for (let i = 1; i <= 13; i++) {
+    for (let i = 1; i <= 14; i++) {
       assert(res.includes(`output${i}="2a2300bbd7ea6e9a"`));
     }
   });

--- a/packages/transformers/js/core/src/macros.rs
+++ b/packages/transformers/js/core/src/macros.rs
@@ -218,7 +218,9 @@ impl<'a> Fold for Macros<'a> {
                 let src = specifier.src.to_string();
                 let imported = imported.to_string();
                 let span = specifier.span;
+                let in_call = std::mem::take(&mut self.in_call);
                 let call = call.fold_with(self);
+                self.in_call = in_call;
                 return handle_error(
                   self.call_macro(src, imported, call, span),
                   &mut self.diagnostics,
@@ -238,7 +240,9 @@ impl<'a> Fold for Macros<'a> {
                   let src = specifier.src.to_string();
                   let imported = prop.0.to_string();
                   let span = specifier.span;
+                  let in_call = std::mem::take(&mut self.in_call);
                   let call = call.fold_with(self);
+                  self.in_call = in_call;
                   return handle_error(
                     self.call_macro(src, imported, call, span),
                     &mut self.diagnostics,


### PR DESCRIPTION
This fixes a small bug where if a constant were passed to a macro, and the result of that macro was immediately called as a function, a "could not statically evaluate macro argument" error would be thrown. This was due to `in_call` being set to true by the outer call expression, and not resetting it to false when calling a known macro function.