### PR TITLE
Move macro implementation to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,11 +1203,24 @@ dependencies = [
  "dunce",
  "indexmap 1.9.3",
  "indoc",
+ "parcel-macros",
  "path-slash",
  "pathdiff",
  "serde",
  "serde_bytes",
  "sha-1",
+ "swc_core",
+]
+
+[[package]]
+name = "parcel-macros"
+version = "0.1.0"
+dependencies = [
+ "crossbeam-channel",
+ "indexmap 1.9.3",
+ "napi",
+ "napi-derive",
+ "serde",
  "swc_core",
 ]
 
@@ -1229,6 +1242,7 @@ dependencies = [
  "oxipng",
  "parcel-dev-dep-resolver",
  "parcel-js-swc-core",
+ "parcel-macros",
  "parcel-resolver",
  "rayon",
  "xxhash-rust",

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors = ["Devon Govett <devongovett@gmail.com>"]
+name = "parcel-macros"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+napi = ["dep:napi", "dep:napi-derive", "dep:crossbeam-channel"]
+
+[dependencies]
+indexmap = "1.9.2"
+swc_core = { version = "0.86.93", features = [
+  "common",
+  "common_ahash",
+  "common_sourcemap",
+  "ecma_ast",
+  "ecma_parser",
+  "ecma_visit",
+] }
+serde = "1.0.123"
+napi-derive = { version = "2.12.5", optional = true }
+napi = { version =  "2.12.6", features = ["serde-json", "napi4", "napi5"], optional = true }
+crossbeam-channel = { version = "0.5.6", optional = true }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -9,7 +9,7 @@ napi = ["dep:napi", "dep:napi-derive", "dep:crossbeam-channel"]
 
 [dependencies]
 indexmap = "1.9.2"
-swc_core = { version = "0.86.93", features = [
+swc_core = { version = "0.89.6", features = [
   "common",
   "common_ahash",
   "common_sourcemap",

--- a/crates/macros/src/napi.rs
+++ b/crates/macros/src/napi.rs
@@ -1,0 +1,204 @@
+use std::sync::Arc;
+
+use crate::{JsValue, Location, MacroCallback, MacroError};
+use crossbeam_channel::{Receiver, Sender};
+use indexmap::IndexMap;
+use napi::{
+  threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode},
+  Env, JsBoolean, JsFunction, JsNumber, JsObject, JsString, JsUnknown, ValueType,
+};
+use napi_derive::napi;
+use swc_core::common::DUMMY_SP;
+
+struct CallMacroMessage {
+  src: String,
+  export: String,
+  args: Vec<JsValue>,
+  loc: Location,
+}
+
+#[napi(object)]
+struct JsMacroError {
+  pub kind: u32,
+  pub message: String,
+}
+
+// Allocate a single channel per thread to communicate with the JS thread.
+thread_local! {
+  static CHANNEL: (Sender<Result<JsValue, MacroError>>, Receiver<Result<JsValue, MacroError>>) = crossbeam_channel::unbounded();
+}
+
+/// Creates a macro callback from a JS function.
+pub fn create_macro_callback(function: JsFunction, env: Env) -> napi::Result<MacroCallback> {
+  let call_macro_tsfn = env.create_threadsafe_function(
+    &function,
+    0,
+    |ctx: ThreadSafeCallContext<CallMacroMessage>| {
+      let src = ctx.env.create_string(&ctx.value.src)?.into_unknown();
+      let export = ctx.env.create_string(&ctx.value.export)?.into_unknown();
+      let args = js_value_to_napi(JsValue::Array(ctx.value.args), ctx.env)?;
+      let loc = ctx.env.to_js_value(&ctx.value.loc)?;
+      Ok(vec![src, export, args, loc])
+    },
+  )?;
+
+  // Get around Env not being Send. See safety note below.
+  let unsafe_env = env.raw() as usize;
+
+  Ok(Arc::new(move |src, export, args, loc| {
+    CHANNEL.with(|channel| {
+      // Call JS function to run the macro.
+      let tx = channel.0.clone();
+      call_macro_tsfn.call_with_return_value(
+        Ok(CallMacroMessage {
+          src,
+          export,
+          args,
+          loc,
+        }),
+        ThreadsafeFunctionCallMode::Blocking,
+        move |v: JsUnknown| {
+          // When the JS function returns, await the promise, and send the result
+          // through the channel back to the native thread.
+          // SAFETY: this function is called from the JS thread.
+          await_promise(unsafe { Env::from_raw(unsafe_env as _) }, v, tx)?;
+          Ok(())
+        },
+      );
+      // Lock the transformer thread until the JS thread returns a result.
+      channel.1.recv().expect("receive failure")
+    })
+  }))
+}
+
+/// Convert a JsValue macro argument from the transformer to a napi value.
+fn js_value_to_napi(value: JsValue, env: Env) -> napi::Result<napi::JsUnknown> {
+  match value {
+    JsValue::Undefined => Ok(env.get_undefined()?.into_unknown()),
+    JsValue::Null => Ok(env.get_null()?.into_unknown()),
+    JsValue::Bool(b) => Ok(env.get_boolean(b)?.into_unknown()),
+    JsValue::Number(n) => Ok(env.create_double(n)?.into_unknown()),
+    JsValue::String(s) => Ok(env.create_string_from_std(s)?.into_unknown()),
+    JsValue::Regex { source, flags } => {
+      let regexp_class: JsFunction = env.get_global()?.get_named_property("RegExp")?;
+      let source = env.create_string_from_std(source)?;
+      let flags = env.create_string_from_std(flags)?;
+      let re = regexp_class.new_instance(&[source, flags])?;
+      Ok(re.into_unknown())
+    }
+    JsValue::Array(arr) => {
+      let mut res = env.create_array(arr.len() as u32)?;
+      for (i, val) in arr.into_iter().enumerate() {
+        res.set(i as u32, js_value_to_napi(val, env)?)?;
+      }
+      Ok(res.coerce_to_object()?.into_unknown())
+    }
+    JsValue::Object(obj) => {
+      let mut res = env.create_object()?;
+      for (k, v) in obj {
+        res.set_named_property(&k, js_value_to_napi(v, env)?)?;
+      }
+      Ok(res.into_unknown())
+    }
+    JsValue::Function(_) => {
+      // Functions can only be returned from macros, not passed in.
+      unreachable!()
+    }
+  }
+}
+
+/// Convert a napi value returned as a result of a macro to a JsValue for the transformer.
+fn napi_to_js_value(value: napi::JsUnknown, env: Env) -> napi::Result<JsValue> {
+  match value.get_type()? {
+    ValueType::Undefined => Ok(JsValue::Undefined),
+    ValueType::Null => Ok(JsValue::Null),
+    ValueType::Number => Ok(JsValue::Number(
+      unsafe { value.cast::<JsNumber>() }.get_double()?,
+    )),
+    ValueType::Boolean => Ok(JsValue::Bool(
+      unsafe { value.cast::<JsBoolean>() }.get_value()?,
+    )),
+    ValueType::String => Ok(JsValue::String(
+      unsafe { value.cast::<JsString>() }
+        .into_utf8()?
+        .into_owned()?,
+    )),
+    ValueType::Object => {
+      let obj = unsafe { value.cast::<JsObject>() };
+      if obj.is_array()? {
+        let len = obj.get_array_length()?;
+        let mut arr = Vec::with_capacity(len as usize);
+        for i in 0..len {
+          let elem = napi_to_js_value(obj.get_element(i)?, env)?;
+          arr.push(elem);
+        }
+        Ok(JsValue::Array(arr))
+      } else {
+        let regexp_class: JsFunction = env.get_global()?.get_named_property("RegExp")?;
+        if obj.instanceof(regexp_class)? {
+          let source: JsString = obj.get_named_property("source")?;
+          let flags: JsString = obj.get_named_property("flags")?;
+          return Ok(JsValue::Regex {
+            source: source.into_utf8()?.into_owned()?,
+            flags: flags.into_utf8()?.into_owned()?,
+          });
+        }
+
+        let names = obj.get_property_names()?;
+        let len = names.get_array_length()?;
+        let mut props = IndexMap::with_capacity(len as usize);
+        for i in 0..len {
+          let prop = names.get_element::<JsString>(i)?;
+          let name = prop.into_utf8()?.into_owned()?;
+          let value = napi_to_js_value(obj.get_property(prop)?, env)?;
+          props.insert(name, value);
+        }
+        Ok(JsValue::Object(props))
+      }
+    }
+    ValueType::Function => {
+      let f = unsafe { value.cast::<JsFunction>() };
+      let source = f.coerce_to_string()?.into_utf8()?.into_owned()?;
+      Ok(JsValue::Function(source))
+    }
+    ValueType::Symbol | ValueType::External | ValueType::Unknown => Err(napi::Error::new(
+      napi::Status::GenericFailure,
+      "Could not convert value returned from macro to AST.",
+    )),
+  }
+}
+
+fn await_promise(
+  env: Env,
+  result: JsUnknown,
+  tx: Sender<Result<JsValue, MacroError>>,
+) -> napi::Result<()> {
+  // If the result is a promise, wait for it to resolve, and send the result to the channel.
+  // Otherwise, send the result immediately.
+  if result.is_promise()? {
+    let result: JsObject = result.try_into()?;
+    let then: JsFunction = result.get_named_property("then")?;
+    let tx2 = tx.clone();
+    let cb = env.create_function_from_closure("callback", move |ctx| {
+      let res = napi_to_js_value(ctx.get::<JsUnknown>(0)?, env)?;
+      tx.send(Ok(res)).expect("send failure");
+      ctx.env.get_undefined()
+    })?;
+    let eb = env.create_function_from_closure("error_callback", move |ctx| {
+      let res = ctx.get::<JsMacroError>(0)?;
+      let err = match res.kind {
+        1 => MacroError::LoadError(res.message, DUMMY_SP),
+        2 => MacroError::ExecutionError(res.message, DUMMY_SP),
+        _ => MacroError::LoadError("Invalid error kind".into(), DUMMY_SP),
+      };
+      tx2.send(Err(err)).expect("send failure");
+      ctx.env.get_undefined()
+    })?;
+    then.call(Some(&result), &[cb, eb])?;
+  } else {
+    tx.send(Ok(napi_to_js_value(result, env)?))
+      .expect("send failure");
+  }
+
+  Ok(())
+}

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -17,6 +17,7 @@ xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 napi = {version =  "2.12.6", features = ["serde-json", "napi4", "napi5"]}
 parcel-dev-dep-resolver = { path = "../../packages/utils/dev-dep-resolver" }
+parcel-macros = { path = "../macros", features = ["napi"] }
 oxipng = "8.0.0"
 mozjpeg-sys = "1.0.0"
 libc = "0.2"

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -12,49 +12,14 @@ pub fn transform(opts: JsObject, env: Env) -> napi::Result<JsUnknown> {
 #[cfg(not(target_arch = "wasm32"))]
 mod native_only {
   use super::*;
-  use crossbeam_channel::{Receiver, Sender};
-  use indexmap::IndexMap;
-  use napi::{
-    threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode},
-    JsBoolean, JsFunction, JsNumber, JsString, ValueType,
-  };
-  use parcel_js_swc_core::{JsValue, MacroError, SourceLocation};
-  use std::sync::Arc;
-
-  // Allocate a single channel per thread to communicate with the JS thread.
-  thread_local! {
-    static CHANNEL: (Sender<Result<JsValue, MacroError>>, Receiver<Result<JsValue, MacroError>>) = crossbeam_channel::unbounded();
-  }
-
-  struct CallMacroMessage {
-    src: String,
-    export: String,
-    args: Vec<JsValue>,
-    loc: SourceLocation,
-  }
-
-  #[napi(object)]
-  struct JsMacroError {
-    pub kind: u32,
-    pub message: String,
-  }
+  use parcel_macros::napi::create_macro_callback;
 
   #[napi]
   pub fn transform_async(opts: JsObject, env: Env) -> napi::Result<JsObject> {
-    let call_macro_tsfn = if opts.has_named_property("callMacro")? {
+    let call_macro = if opts.has_named_property("callMacro")? {
       let func = opts.get_named_property::<JsUnknown>("callMacro")?;
       if let Ok(func) = func.try_into() {
-        Some(env.create_threadsafe_function(
-          &func,
-          0,
-          |ctx: ThreadSafeCallContext<CallMacroMessage>| {
-            let src = ctx.env.create_string(&ctx.value.src)?.into_unknown();
-            let export = ctx.env.create_string(&ctx.value.export)?.into_unknown();
-            let args = js_value_to_napi(JsValue::Array(ctx.value.args), ctx.env)?;
-            let loc = ctx.env.to_js_value(&ctx.value.loc)?.into_unknown();
-            Ok(vec![src, export, args, loc])
-          },
-        )?)
+        Some(create_macro_callback(func, env)?)
       } else {
         None
       }
@@ -65,41 +30,8 @@ mod native_only {
     let config: parcel_js_swc_core::Config = env.from_js_value(opts)?;
     let (deferred, promise) = env.create_deferred()?;
 
-    // Get around Env not being Send. See safety note below.
-    let unsafe_env = env.raw() as usize;
-
     rayon::spawn(move || {
-      let res = parcel_js_swc_core::transform(
-        config,
-        if let Some(tsfn) = call_macro_tsfn {
-          Some(Arc::new(move |src, export, args, loc| {
-            CHANNEL.with(|channel| {
-              // Call JS function to run the macro.
-              let tx = channel.0.clone();
-              tsfn.call_with_return_value(
-                Ok(CallMacroMessage {
-                  src,
-                  export,
-                  args,
-                  loc,
-                }),
-                ThreadsafeFunctionCallMode::Blocking,
-                move |v: JsUnknown| {
-                  // When the JS function returns, await the promise, and send the result
-                  // through the channel back to the native thread.
-                  // SAFETY: this function is called from the JS thread.
-                  await_promise(unsafe { Env::from_raw(unsafe_env as _) }, v, tx)?;
-                  Ok(())
-                },
-              );
-              // Lock the transformer thread until the JS thread returns a result.
-              channel.1.recv().expect("receive failure")
-            })
-          }))
-        } else {
-          None
-        },
-      );
+      let res = parcel_js_swc_core::transform(config, call_macro);
       match res {
         Ok(result) => deferred.resolve(move |env| env.to_js_value(&result)),
         Err(err) => deferred.reject(err.into()),
@@ -107,137 +39,5 @@ mod native_only {
     });
 
     Ok(promise)
-  }
-
-  /// Convert a JsValue macro argument from the transformer to a napi value.
-  fn js_value_to_napi(value: JsValue, env: Env) -> napi::Result<napi::JsUnknown> {
-    match value {
-      JsValue::Undefined => Ok(env.get_undefined()?.into_unknown()),
-      JsValue::Null => Ok(env.get_null()?.into_unknown()),
-      JsValue::Bool(b) => Ok(env.get_boolean(b)?.into_unknown()),
-      JsValue::Number(n) => Ok(env.create_double(n)?.into_unknown()),
-      JsValue::String(s) => Ok(env.create_string_from_std(s)?.into_unknown()),
-      JsValue::Regex { source, flags } => {
-        let regexp_class: JsFunction = env.get_global()?.get_named_property("RegExp")?;
-        let source = env.create_string_from_std(source)?;
-        let flags = env.create_string_from_std(flags)?;
-        let re = regexp_class.new_instance(&[source, flags])?;
-        Ok(re.into_unknown())
-      }
-      JsValue::Array(arr) => {
-        let mut res = env.create_array(arr.len() as u32)?;
-        for (i, val) in arr.into_iter().enumerate() {
-          res.set(i as u32, js_value_to_napi(val, env)?)?;
-        }
-        Ok(res.coerce_to_object()?.into_unknown())
-      }
-      JsValue::Object(obj) => {
-        let mut res = env.create_object()?;
-        for (k, v) in obj {
-          res.set_named_property(&k, js_value_to_napi(v, env)?)?;
-        }
-        Ok(res.into_unknown())
-      }
-      JsValue::Function(_) => {
-        // Functions can only be returned from macros, not passed in.
-        unreachable!()
-      }
-    }
-  }
-
-  /// Convert a napi value returned as a result of a macro to a JsValue for the transformer.
-  fn napi_to_js_value(value: napi::JsUnknown, env: Env) -> napi::Result<JsValue> {
-    match value.get_type()? {
-      ValueType::Undefined => Ok(JsValue::Undefined),
-      ValueType::Null => Ok(JsValue::Null),
-      ValueType::Number => Ok(JsValue::Number(
-        unsafe { value.cast::<JsNumber>() }.get_double()?,
-      )),
-      ValueType::Boolean => Ok(JsValue::Bool(
-        unsafe { value.cast::<JsBoolean>() }.get_value()?,
-      )),
-      ValueType::String => Ok(JsValue::String(
-        unsafe { value.cast::<JsString>() }
-          .into_utf8()?
-          .into_owned()?,
-      )),
-      ValueType::Object => {
-        let obj = unsafe { value.cast::<JsObject>() };
-        if obj.is_array()? {
-          let len = obj.get_array_length()?;
-          let mut arr = Vec::with_capacity(len as usize);
-          for i in 0..len {
-            let elem = napi_to_js_value(obj.get_element(i)?, env)?;
-            arr.push(elem);
-          }
-          Ok(JsValue::Array(arr))
-        } else {
-          let regexp_class: JsFunction = env.get_global()?.get_named_property("RegExp")?;
-          if obj.instanceof(regexp_class)? {
-            let source: JsString = obj.get_named_property("source")?;
-            let flags: JsString = obj.get_named_property("flags")?;
-            return Ok(JsValue::Regex {
-              source: source.into_utf8()?.into_owned()?,
-              flags: flags.into_utf8()?.into_owned()?,
-            });
-          }
-
-          let names = obj.get_property_names()?;
-          let len = names.get_array_length()?;
-          let mut props = IndexMap::with_capacity(len as usize);
-          for i in 0..len {
-            let prop = names.get_element::<JsString>(i)?;
-            let name = prop.into_utf8()?.into_owned()?;
-            let value = napi_to_js_value(obj.get_property(prop)?, env)?;
-            props.insert(name, value);
-          }
-          Ok(JsValue::Object(props))
-        }
-      }
-      ValueType::Function => {
-        let f = unsafe { value.cast::<JsFunction>() };
-        let source = f.coerce_to_string()?.into_utf8()?.into_owned()?;
-        Ok(JsValue::Function(source))
-      }
-      ValueType::Symbol | ValueType::External | ValueType::Unknown => Err(napi::Error::new(
-        napi::Status::GenericFailure,
-        "Could not convert value returned from macro to AST.",
-      )),
-    }
-  }
-
-  fn await_promise(
-    env: Env,
-    result: JsUnknown,
-    tx: Sender<Result<JsValue, MacroError>>,
-  ) -> napi::Result<()> {
-    // If the result is a promise, wait for it to resolve, and send the result to the channel.
-    // Otherwise, send the result immediately.
-    if result.is_promise()? {
-      let result: JsObject = result.try_into()?;
-      let then: JsFunction = result.get_named_property("then")?;
-      let tx2 = tx.clone();
-      let cb = env.create_function_from_closure("callback", move |ctx| {
-        let res = napi_to_js_value(ctx.get::<JsUnknown>(0)?, env)?;
-        tx.send(Ok(res)).expect("send failure");
-        ctx.env.get_undefined()
-      })?;
-      let eb = env.create_function_from_closure("error_callback", move |ctx| {
-        let res = ctx.get::<JsMacroError>(0)?;
-        let err = match res.kind {
-          1 => MacroError::LoadError(res.message),
-          2 => MacroError::ExecutionError(res.message),
-          _ => MacroError::LoadError("Invalid error kind".into()),
-        };
-        tx2.send(Err(err)).expect("send failure");
-        ctx.env.get_undefined()
-      })?;
-      then.call(Some(&result), &[cb, eb])?;
-    } else {
-      tx.send(Ok(napi_to_js_value(result, env)?))
-        .expect("send failure");
-    }
-
-    Ok(())
   }
 }

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -34,3 +34,4 @@ dunce = "1.0.1"
 pathdiff = "0.2.0"
 path-slash = "0.1.4"
 indexmap = "1.9.2"
+parcel-macros = { path = "../../../../crates/macros" }

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -508,8 +508,8 @@ export default (new Transformer({
                             },
                             source: asset.filePath,
                             original: {
-                              line: loc.start_line,
-                              column: loc.start_col - 1,
+                              line: loc.line,
+                              column: loc.col,
                             },
                           });
                           line++;


### PR DESCRIPTION
This moves the macro implementation to a separate `parcel-macros` crate (should the name not be specific to parcel??), which can be reused outside of our JS transformer in other Rust programs. It now has its own simpler `MacroError` type, which we can convert to a parcel Diagnostic when needed. The napi bridge is also moved into this crate (under a feature flag) so it can be used standalone as well.