### PR TITLE
Add lazy/eager cache key to avoid invalid change when switching modes

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -665,7 +665,8 @@ export default class PackagerRunner {
         bundleGraph.getHash(bundle) +
         JSON.stringify(configResults) +
         JSON.stringify(globalInfoResults) +
-        this.options.mode,
+        this.options.mode +
+        `${this.options.shouldBuildLazily ? 'lazy' : 'eager'}`,
     );
   }
 

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -666,7 +666,7 @@ export default class PackagerRunner {
         JSON.stringify(configResults) +
         JSON.stringify(globalInfoResults) +
         this.options.mode +
-        `${this.options.shouldBuildLazily ? 'lazy' : 'eager'}`,
+        (this.options.shouldBuildLazily ? 'lazy' : 'eager'),
     );
   }
 

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1198,7 +1198,9 @@ export function getWatcherOptions(options: ParcelOptions): WatcherOptions {
 }
 
 function getCacheKey(options) {
-  return `${PARCEL_VERSION}:${JSON.stringify(options.entries)}:${options.mode}`;
+  return `${PARCEL_VERSION}:${JSON.stringify(options.entries)}:${
+    options.mode
+  }:${options.shouldBuildLazily ? 'lazy' : 'eager'}`;
 }
 
 async function loadRequestGraph(options): Async<RequestGraph> {

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -161,7 +161,7 @@ export class AssetGraphBuilder {
       hashString(
         `${PARCEL_VERSION}${name}${JSON.stringify(entries) ?? ''}${
           options.mode
-        }`,
+        }${options.shouldBuildLazily ? 'lazy' : 'eager'}`,
       ) + '-AssetGraph';
 
     this.isSingleChangeRebuild =

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -193,7 +193,7 @@ class BundlerRunner {
       hashString(
         `${PARCEL_VERSION}:BundleGraph:${
           JSON.stringify(options.entries) ?? ''
-        }${options.mode}`,
+        }${options.mode}${options.shouldBuildLazily ? 'lazy' : 'eager'}`,
       ) + '-BundleGraph';
   }
 

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -6200,7 +6200,7 @@ describe('cache', function () {
             loadConfig({config, options}) {
               return DefaultBundler[CONFIG].loadConfig({config, options});
             },
-          
+
             bundle({bundleGraph, config}) {
               DefaultBundler[CONFIG].bundle({bundleGraph, config});
             },
@@ -6218,7 +6218,9 @@ describe('cache', function () {
         hashString(
           `${version}:BundleGraph:${
             JSON.stringify(resolvedOptions.entries) ?? ''
-          }${resolvedOptions.mode}`,
+          }${resolvedOptions.mode}${
+            resolvedOptions.shouldBuildLazily ? 'lazy' : 'eager'
+          }`,
         ) + '-BundleGraph';
 
       assert(
@@ -6787,5 +6789,44 @@ describe('cache', function () {
 
     let res = await run(build.bundleGraph);
     assert.deepEqual(res, {default: 'foo'});
+  });
+
+  it('invalidates correctly when switching from lazy to eager modes', async function () {
+    let overlayFSPackageManager = new NodePackageManager(overlayFS, __dirname);
+    let entry = 'source/index.js';
+    let options = {
+      mode: 'production',
+      defaultTargetOptions: {
+        shouldScopeHoist: false,
+      },
+      packageManager: overlayFSPackageManager,
+      shouldContentHash: false,
+      shouldDisableCache: false,
+      inputFS: overlayFS,
+      cacheDir: path.join(__dirname, '.parcel-cache'),
+    };
+
+    await fsFixture(overlayFS)`
+    source
+      lazy.js:
+
+        export default 'lazy-file';
+      index.js:
+        import('./lazy');
+
+        export default 'index-file';
+    `;
+
+    let lazyBundleGraph = await bundle(entry, {
+      ...options,
+      shouldBuildLazily: true,
+    });
+    assert.equal(lazyBundleGraph.getBundles().length, 1);
+
+    let eagerBundleGraph = await bundle(entry, {
+      ...options,
+      shouldBuildLazily: false,
+    });
+    assert.equal(eagerBundleGraph.getBundles().length, 2);
   });
 });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Simple change to consider whether lazy mode is enabled/disabled. This is required because launching with `--lazy`, then re-launching without `--lazy` will cause build errors.

## 🚨 Test instructions

1. `yarn parcel --lazy`
2. Shut down server
3. `yarn parcel`
4. Observe no build error
