### PR TITLE
Update CI caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
-on: pull_request
-
 name: Continuous Integration
+
+on:
+  pull_request:
 
 permissions:
   contents: read
@@ -18,7 +19,6 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: Swatinem/rust-cache@v2
       # use `--frozen-lockfile` to fail immediately if the committed yarn.lock needs updates
       # https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile
       - run: yarn --frozen-lockfile
@@ -45,31 +45,32 @@ jobs:
           PARCEL_BENCHMARK_APIKEY: ${{ secrets.PARCEL_BENCHMARK_APIKEY }}
 
   unit_tests:
-    name: Unit tests (${{matrix.os}}, Node ${{matrix.node}})
+    name: Unit tests (${{ matrix.os }}, Node ${{ matrix.node }})
     strategy:
       matrix:
         node: [18, 20]
         os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: ${{matrix.node}}
+          node-version: ${{ matrix.node }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.os }}
       - name: Bump max inotify watches (Linux only)
+        if: ${{ runner.os == 'Linux' }}
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
-        if: ${{matrix.os == 'ubuntu-latest'}}
       - run: yarn --frozen-lockfile
       - run: yarn build-native-release
       - run: yarn test:unit
-      - name: Upload @parcel/rust Linux Binaries artifact
-        if: ${{matrix.os == 'ubuntu-latest' && matrix.node == 20}}
+      - name: Upload @parcel/rust artifacts on Linux with Node v20
+        if: ${{ runner.os == 'Linux' && matrix.node == 20 }}
         uses: actions/upload-artifact@v3
         with:
           name: Rust Linux Binaries
@@ -79,7 +80,7 @@ jobs:
             packages/core/rust/*.node
 
   integration_tests:
-    name: Integration tests (${{matrix.os}}, Node ${{matrix.node}})
+    name: Integration tests (${{ matrix.os }}, Node ${{ matrix.node }})
     strategy:
       matrix:
         node: [18, 20]
@@ -87,21 +88,22 @@ jobs:
       # These tend to be quite flakey, so one failed instance shouldn't stop
       # others from potentially succeeding
       fail-fast: false
-    runs-on: ${{matrix.os}}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: ${{matrix.node}}
+          node-version: ${{ matrix.node }}
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          components: rustfmt
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.os }}
       - name: Bump max inotify watches (Linux only)
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
-        if: ${{matrix.os == 'ubuntu-latest'}}
+        if: ${{ runner.os == 'Linux' }}
       - run: yarn --frozen-lockfile
       - run: yarn build-native-release
       - run: yarn build

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,5 @@
 name: 'Close stale issues'
+
 on:
   schedule:
     - cron: '0 */12 * * *'
@@ -6,6 +7,7 @@ on:
     types: [created]
 
 permissions: {}
+
 jobs:
   stale:
     permissions:


### PR DESCRIPTION
# ↪️ Pull Request

These changes update the CI workflow Rust caching so that it can be better reused across jobs, halving the storage used from 1849MB → 920MB. The specific changes include:
* Remove linting cache as it takes the same amount of time as without a cache, and only wastes a bit of space given the 10GB limit in Github
* Remove unused `components: rustfmt` installation from test jobs
* Reuse the cache between integration and unit tests by adding a `shared-key` — this overrides the default per job cache and is more effective since we are using the same set of OS + targets for both jobs
* Update workflows to make them consistent by placing `name` at the top and using `${{ }}` over `${{}}` for expressions
* Use `runner.os` over `matrix.os` as it is always available

## 💻 Examples

Observe the CI workflow behaviour, given the following [example](https://github.com/parcel-bundler/parcel/actions/runs/8088762629/job/22103450027):
* [Linting](https://github.com/parcel-bundler/parcel/actions/runs/8088762629/job/22103450027) still takes 30s without a cache, the same as this [branch](https://github.com/parcel-bundler/parcel/actions/runs/8088323312/job/22102139137) that has caching
* Same cache is found for unit and integration tests across node versions
  * `v0-rust-ubuntu-latest-a554fcb7-c1764bc1`
  * `v0-rust-macos-latest-4be4b021-c1764bc1`
  * `v0-rust-windows-latest-569c1dff-c1764bc1`
* Linux step only runs on ubuntu jobs
* Build native release takes ~1-3min, the same as the branch [here](https://github.com/parcel-bundler/parcel/actions/runs/8088323312/job/22102140018)
* Observe caches [here](https://github.com/parcel-bundler/parcel/actions/caches) which are ~200-250MB for each target
* [Missed cache](https://github.com/parcel-bundler/parcel/actions/runs/8075525378/job/22062579729) takes ~2x as long to build native release compared to [cache hit](https://github.com/parcel-bundler/parcel/actions/runs/8088762629/job/22103452301)

*Note:* REPL fails here because it is tested on push not pull request, and windows has been consistently failing on main branch

## 🚨 Test instructions

Look at the CI step for this pull request, or otherwise test on your own branch by adding a push trigger