### PR TITLE
Add dev release using a reusable workflow

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,15 @@
+# This workflow builds and releases all packages with a dev dist tag. Once published,
+# the packages can be installed to streamline the testing and validation of changes, both
+# locally and within CI, that have not yet been approved or merged into the main branch.
+name: dev-release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-release:
+    name: Build and release dev
+    uses: ./.github/workflows/release.yml
+    secrets: inherit
+    with:
+      release-command: yarn dev:release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,225 @@
+name: release
+
+on:
+  workflow_call:
+    inputs:
+      release-command:
+        description: 'The command that will release packages as part of the final step'
+        required: true
+        type: string
+    secrets:
+      GHCR_TOKEN:
+        required: true
+      NPM_TOKEN:
+        required: true
+
+permissions:
+  contents: read # for actions/checkout
+
+jobs:
+  build-macos-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: aarch64-apple-darwin
+            os: macos-latest
+            target: aarch64-apple-darwin
+
+          - name: macos-latest
+            os: macos-latest
+
+          - name: windows-latest
+            os: windows-latest
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - uses: bahmutov/npm-install@v1.8.35
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.name }}
+      - name: Remove CommandLineTools SDKs
+        if: ${{ matrix.target == 'aarch64-apple-darwin' }}
+        run: sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*;
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        if: ${{ runner.os == 'macOS' }}
+        run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-${{ matrix.name }}
+          path: packages/*/*/*.node
+      - name: Debug
+        if: ${{ runner.os == 'macOS' }}
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        if: ${{ !matrix.target }}
+        run: node -e "require('@parcel/rust')"
+
+  build-linux-gnu-x64:
+    name: linux-gnu-x64
+    runs-on: ubuntu-20.04
+    container:
+      image: docker.io/mischnic/centos7-node16
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install yarn
+        run: npm install --global yarn@1
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - uses: bahmutov/npm-install@v1.8.35
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: strip packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-linux-gnu-x64
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        run: node -e 'require("@parcel/rust")'
+
+  build-linux-gnu-arm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: arm-unknown-linux-gnueabihf
+            arch: armhf
+            strip: arm-linux-gnueabihf-strip
+            cflags: -mfpu=neon
+          - target: aarch64-unknown-linux-gnu
+            arch: arm64
+            strip: aarch64-linux-gnu-strip
+            cflags: ''
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - name: Install cross compile toolchains
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
+      - uses: bahmutov/npm-install@v1.8.35
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.target }}
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+          CFLAGS: ${{ matrix.cflags }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: ${{ matrix.strip }} packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-${{ matrix.target }}
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Configure binfmt-support
+        run: docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: Smoke test
+        uses: addnab/docker-run-action@v1
+        with:
+          image: ghcr.io/devongovett/multiarch-node:node14-${{ matrix.arch }}-focal
+          options: -v ${{github.workspace}}:/work
+          run: cd /work && node -e "require('@parcel/rust')"
+
+  build-linux-musl:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            strip: strip
+            cflags: -msse4.2
+            arch: x86_64
+          - target: aarch64-unknown-linux-musl
+            strip: aarch64-linux-musl-strip
+            cflags: ''
+            arch: aarch64
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-20.04
+    container:
+      image: ghcr.io/napi-rs/napi-rs/nodejs-rust@sha256:5a99e45446355d25c20e95d35231d84e9ce472280d8c0b1be53281bade905f09
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install build tools
+        run: apk add --no-cache python3 make gcc g++ musl-dev curl
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+      - uses: bahmutov/npm-install@v1.8.35
+      - name: Build native packages
+        run: yarn build-native-release
+        env:
+          RUST_TARGET: ${{ matrix.target }}
+          CFLAGS: ${{ matrix.cflags }}
+      - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
+        run: ${{ matrix.strip }} packages/*/*/*.node
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: bindings-linux-musl-${{ matrix.arch }}
+          path: packages/*/*/*.node
+      - name: debug
+        run: ls -l packages/*/*/*.node
+      - name: Smoke test
+        if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        run: node -e 'require("@parcel/rust")'
+
+  build-and-release:
+    runs-on: ubuntu-20.04
+    name: Build and release
+    needs:
+      - build-macos-windows
+      - build-linux-musl
+      - build-linux-gnu-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: bahmutov/npm-install@v1.8.35
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Move artifacts
+        run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+      - name: Debug
+        run: ls -l packages/*/*/*.node
+      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: ${{ inputs.release-command }}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test:integration": "yarn workspace @parcel/integration-tests test",
     "test:integration-ci": "yarn workspace @parcel/integration-tests test-ci",
     "test": "yarn test:unit && yarn test:integration",
+    "dev:release": "lerna publish -y --canary --preid dev --dist-tag=dev --exact --force-publish=* --no-git-tag-version --no-push",
     "nightly:release": "lerna publish -y --canary --preid nightly --dist-tag=nightly --exact --force-publish=* --no-git-tag-version --no-push",
     "tag:prerelease": "lerna version --exact --force-publish=* --no-git-tag-version --no-push && yarn adjust-versions --exact",
     "tag:release": "lerna version --exact --force-publish=* --no-git-tag-version --no-push && yarn adjust-versions",


### PR DESCRIPTION
# ↪️ Pull Request

These changes introduce a new dev release workflow that can be manually triggered in Github Actions. It aims to give contributors a way to validate changes not yet on the main branch.

The `dev-release` workflow calls a reusable `release` workflow that performs the majority of the work, and will soon begin to **replace** the `tag-release` and `nightly-release` workflows in the same way. Other additions include:
* Merge `build-apple-silicon` into the `build` job (now renamed to `build-macos-windows`)
* Remove `JEMALLOC_SYS_WITH_LG_PAGE` that existed in `build-apple-silicon` as the underlying issue should be fixed [here](https://github.com/swc-project/swc/pull/6541)
* Add Rust caching to non-dockerized jobs
  * `aarch64-apple-darwin`
  * `macos-latest` and `windows-latest` (this will match the CI cache names, though I did not validate whether they'll get used or if it breaches Githubs cache isolation)
  * `arm-unknown-linux-gnueabihf`
  * `aarch64-unknown-linux-gnu`

## 💻 Examples

Observe the successful workflow build [here](https://github.com/parcel-bundler/parcel/actions/runs/8088762649/job/22103855246)

## 🚨 Test instructions

Test on your own branch by adding a push trigger with your branch name to `dev-release`, as you cannot manually trigger an workflow until it is on the main branch
