### PR TITLE
Add CLI support to set Feature Flag values

### DIFF
--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "lib/bin.js",
+  "bin": "src/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "engines": {

--- a/packages/core/parcel/package.json
+++ b/packages/core/parcel/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "bin": "src/bin.js",
+  "bin": "lib/bin.js",
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "engines": {
@@ -25,6 +25,7 @@
     "@parcel/core": "2.12.0",
     "@parcel/diagnostic": "2.12.0",
     "@parcel/events": "2.12.0",
+    "@parcel/feature-flags": "2.12.0",
     "@parcel/fs": "2.12.0",
     "@parcel/logger": "2.12.0",
     "@parcel/package-manager": "2.12.0",

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -104,7 +104,7 @@ const commonOptions = {
     },
     [],
   ],
-  '-F, --feature-flag <name=value>': [
+  '--feature-flag <name=value>': [
     'sets the value of a feature flag',
     (value, previousValue) => {
       let [name, val] = value.split('=');

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -110,7 +110,6 @@ const commonOptions = {
       let [name, val] = value.split('=');
       if (name in DEFAULT_FEATURE_FLAGS) {
         let featureFlagValue;
-        console.log(typeof DEFAULT_FEATURE_FLAGS[name]);
         if (typeof DEFAULT_FEATURE_FLAGS[name] === 'boolean') {
           if (val !== 'true' && val !== 'false') {
             throw new Error(

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -12,6 +12,7 @@ import commander from 'commander';
 import path from 'path';
 import getPort from 'get-port';
 import {version} from '../package.json';
+import {DEFAULT_FEATURE_FLAGS} from '@parcel/feature-flags';
 
 const program = new commander.Command();
 
@@ -102,6 +103,31 @@ const commonOptions = {
       return acc;
     },
     [],
+  ],
+  '-F, --feature-flag <name=value>': [
+    'sets the value of a feature flag',
+    (value, previousValue) => {
+      let [name, val] = value.split('=');
+      if (name in DEFAULT_FEATURE_FLAGS) {
+        let featureFlagValue;
+        console.log(typeof DEFAULT_FEATURE_FLAGS[name]);
+        if (typeof DEFAULT_FEATURE_FLAGS[name] === 'boolean') {
+          if (val !== 'true' && val !== 'false') {
+            throw new Error(
+              `Feature flag ${name} must be set to true or false`,
+            );
+          }
+          featureFlagValue = val;
+        }
+        previousValue[name] = featureFlagValue ?? String(val);
+      } else {
+        INTERNAL_ORIGINAL_CONSOLE.warn(
+          `Unknown feature flag ${name} specified, it will be ignored`,
+        );
+      }
+      return previousValue;
+    },
+    {},
   ],
 };
 
@@ -509,5 +535,6 @@ async function normalizeOptions(
       publicUrl: command.publicUrl,
       distDir: command.distDir,
     },
+    featureFlags: command.featureFlag,
   };
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Follows up on #9551 and adds support to the CLI to pass `featureFlags` into `InitialParcelOptions`.

The approach to this is a single `-F` or `--feature-flag` flag that takes a `name=value` argument. Validation is done to ensure the name is a valid feature flag, and `value` matches the expected type - at the moment this is either `string` or `boolean`, though I'd expect `boolean` to be the most common.

## 💻 Examples

`parcel build --feature-flag makeItFaster=true src/index.js`

## 🚨 Test instructions

Manually tested to ensure that validation and setting the arguments in `InitialParcelOptions` works as expected.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
