### PR TITLE
Fix dev release

### DIFF
--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -43,9 +43,9 @@ async function build() {
   }
 }
 
-// This forces Clang/LLVM to be used as a C compiler instead of GCC.
-// This is necessary for cross-compilation for Apple Silicon in GitHub Actions.
+// This setup is necessary for cross-compilation for Apple Silicon in GitHub Actions.
 function setupMacBuild() {
+  // This forces Clang/LLVM to be used as a C compiler instead of GCC.
   process.env.CC = execSync('xcrun -f clang', {encoding: 'utf8'}).trim();
   process.env.CXX = execSync('xcrun -f clang++', {encoding: 'utf8'}).trim();
 
@@ -54,4 +54,10 @@ function setupMacBuild() {
   }).trim();
   process.env.CFLAGS = `-isysroot ${sysRoot} -isystem ${sysRoot}`;
   process.env.MACOSX_DEPLOYMENT_TARGET = '10.9';
+
+  if (process.env.RUST_TARGET === 'aarch64-apple-darwin') {
+    // Prevents the "<jemalloc>: Unsupported system page size" error when
+    // requiring parcel-node-bindings.darwin-arm64.node
+    process.env.JEMALLOC_SYS_WITH_LG_PAGE = 14;
+  }
 }


### PR DESCRIPTION
# ↪️ Pull Request

These changes fix the new dev release by reinstating the `JEMALLOC_SYS_WITH_LG_PAGE` variable. It has been placed in the `build-native` script which already contains similar logic, and because Github Actions is severely limited when it comes to conditionally creating environment variables. For example:
* `fromJson` expression coerces null / undefined to an empty string, and is not necessarily equivalent as other jobs use undefined
* using an inline bash / shell `run` command is messy, and leaks the env to other steps
* conditional steps are confusing in this case, but do work

## 💻 Examples

Successful workflow [here](https://github.com/parcel-bundler/parcel/actions/runs/8092381402/job/22113244804)

## 🚨 Test instructions

* Create a test parcel project
* Install parcel version `parcel@2.0.0-dev.1513+9d5643b9b` on a M1 Macbook (or equivalent architecture)
* Run parcel, and ensure there are no startup errors

I verified the dev build works correctly on my machine, the previous build did fail with the error Devon mentioned as noted in the comments
