### PR TITLE
Log project root create, init reporters before the request tracker

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -141,17 +141,21 @@ export default class Parcel {
     this.#watchEvents = new ValueEmitter();
     this.#disposable.add(() => this.#watchEvents.dispose());
 
-    this.#requestTracker = await RequestTracker.init({
-      farm: this.#farm,
-      options: resolvedOptions,
-    });
-
     this.#reporterRunner = new ReporterRunner({
       config: this.#config,
       options: resolvedOptions,
       workerFarm: this.#farm,
     });
     this.#disposable.add(this.#reporterRunner);
+
+    logger.verbose({
+      origin: '@parcel/core',
+      message: 'Intializing request tracker...',
+    });
+    this.#requestTracker = await RequestTracker.init({
+      farm: this.#farm,
+      options: resolvedOptions,
+    });
 
     this.#initialized = true;
   }

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -16,6 +16,7 @@ import type {
   InternalFileCreateInvalidation,
   InternalGlob,
 } from './types';
+import logger from '@parcel/logger';
 import type {Deferred} from '@parcel/utils';
 
 import invariant from 'assert';
@@ -759,6 +760,13 @@ export class RequestGraph extends ContentGraph<
       // this means the project root was moved and we need to
       // re-run all requests.
       if (type === 'create' && filePath === '') {
+        // $FlowFixMe(incompatible-call) `trackableEvent` isn't part of the Diagnostic interface
+        logger.verbose({
+          origin: '@parcel/core',
+          message:
+            'Watcher reported project root create event. Invalidate all nodes.',
+          trackableEvent: 'project_root_create',
+        });
         for (let [id, node] of this.nodes.entries()) {
           if (node?.type === REQUEST) {
             this.invalidNodeIds.add(id);

--- a/packages/core/integration-tests/test/babel.js
+++ b/packages/core/integration-tests/test/babel.js
@@ -101,13 +101,12 @@ describe('babel', function () {
   it('should support compiling with babel using babel.config.json config without warnings', async function () {
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     await bundle(
       path.join(__dirname, '/integration/babel-config-json-custom/index.js'),
-      {
-        logLevel: 'verbose',
-      },
     );
     loggerDisposable.dispose();
 
@@ -621,7 +620,9 @@ describe('babel', function () {
   it('should warn when a babel config contains only redundant plugins', async function () {
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let filePath = path.join(__dirname, '/integration/babel-warn-all/index.js');
     await bundle(filePath);
@@ -699,7 +700,9 @@ describe('babel', function () {
   it('should warn when a babel config contains redundant plugins', async function () {
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let filePath = path.join(
       __dirname,
@@ -755,7 +758,9 @@ describe('babel', function () {
   it('should warn when a JSON5 babel config contains redundant plugins', async function () {
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let filePath = path.join(
       __dirname,

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -117,7 +117,9 @@ describe('bundler', function () {
 
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let b = await bundle(
       path.join(__dirname, 'disable-shared-bundles-true-parallel/index.js'),
@@ -200,7 +202,9 @@ describe('bundler', function () {
 
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let b = await bundle(
       path.join(
@@ -286,7 +290,9 @@ describe('bundler', function () {
 
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let b = await bundle(
       path.join(__dirname, 'disable-shared-bundles-true-min-bundles/index.js'),
@@ -371,7 +377,9 @@ describe('bundler', function () {
 
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let b = await bundle(
       path.join(
@@ -481,7 +489,9 @@ describe('bundler', function () {
 
     let messages = [];
     let loggerDisposable = Logger.onLog(message => {
-      messages.push(message);
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
     });
     let b = await bundle(
       path.join(__dirname, 'disable-shared-bundles-false/index.js'),

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3264,7 +3264,11 @@ describe('javascript', function () {
 
   it('should warn on process.env mutations in node_modules', async function () {
     let logs = [];
-    let disposable = Logger.onLog(d => logs.push(d));
+    let disposable = Logger.onLog(d => {
+      if (d.level !== 'verbose') {
+        logs.push(d);
+      }
+    });
     let b = await bundle(
       path.join(__dirname, '/integration/env-mutate/warn.js'),
     );


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This PR makes two changes:

- Add a new log message for when the project root create event happens. I've also added a `trackableEvent` property to the diagnostic which allows us to easily locate the log event in our reporter. I chose not to open the `Diagnostic` type info can of worms and just flow ignore the error. Happy to hear other suggestions though. 

- Initialise the reporters before the request tracker. This allows any log events that occur during `RequestTracker.init` to hit the reporters. 

