### PR TITLE
Fix loading request graph in parcel-query

### DIFF
--- a/packages/core/integration-tests/test/parcel-query.js
+++ b/packages/core/integration-tests/test/parcel-query.js
@@ -1,0 +1,34 @@
+// @flow
+import assert from 'assert';
+import path from 'path';
+import {overlayFS, bundle, fsFixture} from '@parcel/test-utils';
+import {loadGraphs} from '../../../dev/query/src';
+
+describe('parcel-query', () => {
+  it('loadGraphs', async function () {
+    let entries = 'index.js';
+    let options = {
+      mode: 'production',
+      defaultTargetOptions: {
+        shouldScopeHoist: false,
+      },
+      shouldDisableCache: false,
+      inputFS: overlayFS,
+      cacheDir: path.join(__dirname, '.parcel-cache'),
+    };
+
+    await fsFixture(overlayFS)`
+        index.js:
+            export default 1;`;
+
+    await bundle(entries, options);
+
+    const {assetGraph, bundleGraph, requestTracker, bundleInfo} =
+      await loadGraphs(options.cacheDir);
+
+    assert(bundleInfo, 'Could not load bundleInfo');
+    assert(bundleGraph, 'Could not load bundleGraph');
+    assert(assetGraph, 'Could not load assetGraph');
+    assert(requestTracker, 'Count not load requestTracker');
+  });
+});

--- a/packages/dev/query/package.json
+++ b/packages/dev/query/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "bin": {
-    "parcel-query": "lib/bin.js"
+    "parcel-query": "src/bin.js"
   },
   "main": "src/index.js",
   "dependencies": {

--- a/packages/dev/query/package.json
+++ b/packages/dev/query/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "bin": {
-    "parcel-query": "src/bin.js"
+    "parcel-query": "lib/bin.js"
   },
   "main": "src/index.js",
   "dependencies": {

--- a/packages/dev/query/src/deep-imports.js
+++ b/packages/dev/query/src/deep-imports.js
@@ -6,6 +6,7 @@ import typeof BundleGraph, {
 } from '@parcel/core/src/BundleGraph.js';
 import typeof RequestTracker, {
   RequestGraph,
+  readAndDeserializeRequestGraph,
 } from '@parcel/core/src/RequestTracker.js';
 import typeof {requestGraphEdgeTypes} from '@parcel/core/src/RequestTracker.js';
 import typeof {LMDBCache} from '@parcel/cache/src/LMDBCache.js';
@@ -49,6 +50,7 @@ module.exports = (v: {|
   },
   RequestTracker: {
     default: RequestTracker,
+    readAndDeserializeRequestGraph: readAndDeserializeRequestGraph,
     RequestGraph: RequestGraph,
     requestGraphEdgeTypes: requestGraphEdgeTypes,
     ...


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The latest request tracker changes broke parcel query. This PR shares the code for loading the request graph from cache between parcel query and the main code. 

## 🚨 Test instructions

I have added a new parcel query test suite that ensures we can at least load graphs from cache. 

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
