### PR TITLE
Fix compilation when using TypeScript syntax in Vue <template>

### DIFF
--- a/packages/core/integration-tests/test/integration/vue-ts-template/App.vue
+++ b/packages/core/integration-tests/test/integration/vue-ts-template/App.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+let x: string | number = 1
+</script>
+
+<template>
+  {{ (x as number).toFixed(2) }}
+</template>

--- a/packages/core/integration-tests/test/vue.js
+++ b/packages/core/integration-tests/test/vue.js
@@ -113,4 +113,12 @@ describe('vue', function () {
     assert.equal(typeof output.render, 'function');
     assert.equal(typeof output.setup, 'function');
   });
+  it('should process template with TS when script is TS', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/vue-ts-template/App.vue'),
+    );
+    let output = (await run(b)).default;
+    assert.equal(typeof output.render, 'function');
+    assert.equal(typeof output.setup, 'function');
+  });
 });

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -199,6 +199,43 @@ function createDiagnostic(err, filePath) {
   return diagnostic;
 }
 
+function getScriptType(script) {
+  if (script.src) {
+    script.lang = extname(script.src).slice(1);
+  }
+  let type;
+  switch (script.lang || 'js') {
+    case 'javascript':
+    case 'js':
+      type = 'js';
+      break;
+    case 'jsx':
+      type = 'jsx';
+      break;
+    case 'typescript':
+    case 'ts':
+      type = 'ts';
+      break;
+    case 'tsx':
+      type = 'tsx';
+      break;
+    case 'coffeescript':
+    case 'coffee':
+      type = 'coffee';
+      break;
+    default:
+      // TODO: codeframe
+      throw new ThrowableDiagnostic({
+        diagnostic: {
+          message: md`Unknown script language: "${script.lang}"`,
+          origin: '@parcel/transformer-vue',
+        },
+      });
+  }
+
+  return type;
+}
+
 async function processPipeline({
   asset,
   template,
@@ -244,6 +281,14 @@ async function processPipeline({
         }
         content = await preprocessor.render(content, options);
       }
+
+      // if using TS, support TS syntax in template expressions
+      const expressionPlugins = config.compilerOptions?.expressionPlugins || [];
+      const type = getScriptType(script);
+      if (type === 'ts') {
+        expressionPlugins.push('typescript');
+      }
+
       let templateComp = compiler.compileTemplate({
         filename: asset.filePath,
         source: content,
@@ -253,6 +298,7 @@ async function processPipeline({
         compilerOptions: {
           ...config.compilerOptions,
           bindingMetadata: script ? script.bindings : undefined,
+          expressionPlugins,
         },
         isProd: options.mode === 'production',
         id,
@@ -265,7 +311,7 @@ async function processPipeline({
         });
       }
       let templateAsset: TransformerResult = {
-        type: 'js',
+        type,
         uniqueKey: asset.id + '-template',
         ...(!template.src &&
           asset.env.sourceMap && {
@@ -295,35 +341,7 @@ ${
         ).toString();
         script.lang = extname(script.src).slice(1);
       }
-      let type;
-      switch (script.lang || 'js') {
-        case 'javascript':
-        case 'js':
-          type = 'js';
-          break;
-        case 'jsx':
-          type = 'jsx';
-          break;
-        case 'typescript':
-        case 'ts':
-          type = 'ts';
-          break;
-        case 'tsx':
-          type = 'tsx';
-          break;
-        case 'coffeescript':
-        case 'coffee':
-          type = 'coffee';
-          break;
-        default:
-          // TODO: codeframe
-          throw new ThrowableDiagnostic({
-            diagnostic: {
-              message: md`Unknown script language: "${script.lang}"`,
-              origin: '@parcel/transformer-vue',
-            },
-          });
-      }
+      let type = getScriptType(script);
       let scriptAsset = {
         type,
         uniqueKey: asset.id + '-script',

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -200,6 +200,10 @@ function createDiagnostic(err, filePath) {
 }
 
 function getScriptType(script) {
+  if (!script) {
+    return 'js';
+  }
+
   if (script.src) {
     script.lang = extname(script.src).slice(1);
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Process Vue template using TypeScript if component script uses TypeScript. 

Fixes #9566

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

Support component like this:

```vue
<script setup lang="ts">
let x: string | number = 1
</script>

<template>
  {{ (x as number).toFixed(2) }}
</template>
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
