### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: Continuous Integration
 
 on:
   pull_request:
+  push:
+    branches:
+      - v2
 
 permissions:
   contents: read
@@ -112,8 +115,8 @@ jobs:
   # Deployment steps taken from https://github.com/colinwilson/static-site-to-vercel/blob/master/.github/workflows/deploy-preview.yml
   repl_build:
     name: Build REPL
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [unit_tests]
     permissions:
       deployments: write
     steps:
@@ -137,11 +140,8 @@ jobs:
       - name: Bump max inotify watches
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
       - run: yarn --frozen-lockfile
-      - name: Download @parcel/rust Linux Binaries artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: Rust Linux Binaries
-          path: packages/core/rust
+      - name: Build native packages
+        run: yarn build-native-release
       - run: yarn build
       - run: yarn build-native-wasm
       - run: yarn workspace @parcel/repl build


### PR DESCRIPTION
# ↪️ Pull Request

Updates the CI workflow
* **Add v2 branch push trigger to CI:** This lets branches that originate from v2 to consume the same cache as per Github [cache isolation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)
* **Update repl build:** It no longer downloads the artifact from unit tests, and simply builds it itself like in the tag-release workflow, to increase parallelism of jobs

## 💻 Examples

None

## 🚨 Test instructions

Add custom push branches to each workflow and observe changes
