### PR TITLE
Write tmp files to the OS tmp directory

### DIFF
--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -238,7 +238,7 @@ function shouldUseOsTmpDir(filePath) {
     const tmpDirStats = nativeFS.statSync(tmpDir);
     const filePathStats = nativeFS.statSync(filePath);
     // Check the tmpdir is on the same partition as the target directory.
-    // This is required to allow renaming to occur.
+    // This is required to ensure renaming is an atomic operation.
     useOsTmpDir = tmpDirStats.dev === filePathStats.dev;
   } catch (e) {
     // We don't have read/write access to the OS tmp directory

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -12,6 +12,8 @@ import type {
 import fs from 'graceful-fs';
 import nativeFS from 'fs';
 import ncp from 'ncp';
+import path from 'path';
+import {tmpdir} from 'os';
 import {promisify} from 'util';
 import {registerSerializableClass} from '@parcel/core';
 import {hashFile} from '@parcel/utils';
@@ -222,11 +224,43 @@ try {
   //
 }
 
+let useOsTmpDir;
+function shouldUseOsTmpDir(filePath) {
+  if (useOsTmpDir != null) {
+    return useOsTmpDir;
+  }
+  try {
+    const tmpDir = tmpdir();
+    nativeFS.accessSync(
+      tmpDir,
+      nativeFS.constants.R_OK | nativeFS.constants.W_OK,
+    );
+    const tmpDirStats = nativeFS.statSync(tmpDir);
+    const filePathStats = nativeFS.statSync(filePath);
+    // Check the tmpdir is on the same partition as the target directory.
+    // This is required to allow renaming to occur.
+    useOsTmpDir = tmpDirStats.dev === filePathStats.dev;
+  } catch (e) {
+    // We don't have read/write access to the OS tmp directory
+    useOsTmpDir = false;
+  }
+  return useOsTmpDir;
+}
+
 // Generate a temporary file path used for atomic writing of files.
 function getTempFilePath(filePath: FilePath) {
   writeStreamCalls = writeStreamCalls % Number.MAX_SAFE_INTEGER;
+
+  let tmpFilePath = filePath;
+
+  // If possible, write the tmp file to the OS tmp directory
+  // This reduces the amount of FS events the watcher needs to process during the build
+  if (shouldUseOsTmpDir(filePath)) {
+    tmpFilePath = path.join(tmpdir(), path.basename(filePath));
+  }
+
   return (
-    filePath +
+    tmpFilePath +
     '.' +
     process.pid +
     (threadId != null ? '.' + threadId : '') +


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR attempts to utilize the OS tmp directory for temporary files when streaming content to files. This greatly reduces the amount of events the watcher needs to process during the build. We only use the tmp directory when the following are true:
- The process has read/write access to the tmp directory
- The tmp directory is on the same partition as the target directory

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
We've tested this approach extensively internally. 

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
