### PR TITLE
changed logger error to warn

### DIFF
--- a/packages/optimizers/inline-requires/src/InlineRequires.js
+++ b/packages/optimizers/inline-requires/src/InlineRequires.js
@@ -94,7 +94,7 @@ module.exports = new Optimizer<empty, BundleConfig>({
         return {contents, map: sourceMap};
       }
     } catch (err) {
-      logger.error({
+      logger.warn({
         origin: 'parcel-optimizer-experimental-inline-requires',
         message: `Unable to optimise requires for ${bundle.name}: ${err.message}`,
         stack: err.stack,


### PR DESCRIPTION
# ↪️ Pull Request
We catch the error when inlining require statements fails on a bundle and log it, however, this doesn't really fail builds and can cause noise so we are downgrading it to a warning.


## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
