### PR TITLE
Improve large watcher events payload experience

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -426,10 +426,9 @@ export default class Parcel {
         }
 
         let isInvalid = this.#requestTracker.respondToFSEvents(
-          events.map(e => ({
-            type: e.type,
-            path: toProjectPath(resolvedOptions.projectRoot, e.path),
-          })),
+          events,
+          resolvedOptions.projectRoot,
+          Number.POSITIVE_INFINITY,
         );
         if (isInvalid && this.#watchQueue.getNumWaiting() === 0) {
           if (this.#watchAbortController) {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1413,7 +1413,7 @@ async function loadRequestGraph(options): Async<RequestGraph> {
     }, 5000);
     let startTime = Date.now();
     let events = await options.inputFS.getEventsSince(
-      options.projectRoot,
+      options.watchDir,
       snapshotPath,
       opts,
     );

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -31,7 +31,7 @@ import type {FileSystem} from '@parcel/fs';
 import type {Cache} from '@parcel/cache';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ProjectPath} from './projectPath';
-import type {EventType} from '@parcel/watcher';
+import type {Event} from '@parcel/watcher';
 import type {FeatureFlags} from '@parcel/feature-flags';
 import type {BackendType} from '@parcel/watcher';
 
@@ -295,10 +295,7 @@ export type ParcelOptions = {|
   shouldTrace: boolean,
   shouldPatchConsole: boolean,
   detailedReport?: ?DetailedReportOptions,
-  unstableFileInvalidations?: Array<{|
-    path: FilePath,
-    type: EventType,
-  |}>,
+  unstableFileInvalidations?: Array<Event>,
 
   inputFS: FileSystem,
   outputFS: FileSystem,

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -46,6 +46,18 @@ export type DiagnosticCodeFrame = {|
   codeHighlights: Array<DiagnosticCodeHighlight>,
 |};
 
+type JSONValue =
+  | null
+  | void // ? Is this okay?
+  | boolean
+  | number
+  | string
+  | Array<JSONValue>
+  | JSONObject;
+
+/** A JSON object (as in "map") */
+type JSONObject = {[key: string]: JSONValue, ...};
+
 /**
  * A style agnostic way of emitting errors, warnings and info.
  * Reporters are responsible for rendering the message, codeframes, hints, ...
@@ -72,6 +84,9 @@ export type Diagnostic = {|
 
   /** A URL to documentation to learn more about the diagnostic. */
   documentationURL?: string,
+
+  /** Diagnostic specific metadata (optional) */
+  meta?: JSONObject,
 |};
 
 // This type should represent all error formats Parcel can encounter...

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -15,7 +15,7 @@ import type {Cache} from '@parcel/cache';
 import type {AST as _AST, ConfigResult as _ConfigResult} from './unsafe';
 import type {TraceMeasurement} from '@parcel/profiler';
 import type {FeatureFlags} from '@parcel/feature-flags';
-import type {EventType, BackendType} from '@parcel/watcher';
+import type {Event, BackendType} from '@parcel/watcher';
 
 /** Plugin-specific AST, <code>any</code> */
 export type AST = _AST;
@@ -313,7 +313,7 @@ export type InitialParcelOptions = {|
   +lazyIncludes?: string[],
   +lazyExcludes?: string[],
   +shouldBundleIncrementally?: boolean,
-  +unstableFileInvalidations?: Array<{|path: FilePath, type: EventType|}>,
+  +unstableFileInvalidations?: Array<Event>,
 
   +inputFS?: FileSystem,
   +outputFS?: FileSystem,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

On large projects after branch changes or yarn installs the watcher can take a very long time to respond with the changed files. The cache invalidation in `respondToFSEvents` can then often take an extremely long time to process all the events. This PR attempts to make the experience nicer with the following changes:
- Add a timeout threshold to `RequestGraph.respondToFSEvents` which will result in using a fresh cache if it times out
  - This has been implemented by attempting to predict how long the events will take to process by extrapolating the time taken to process a small batch of events. It's currently set to 10 seconds. 
-  Move the project relative file events logic to `respondToFSEvents`, this ensures we don't do extra work when bailouts occur
- Add a warning to notify users that the watcher is taking a long time to respond if it takes more than 5 seconds. This helps reassure users that the build is not actually stuck. 

I've also added bonus change. I've added a new `meta` property to the `Diagnostic` type. This allows us to forward extra information to our reporters from the logger for analytics purposes. 

```js
logger.warn({
  origin: '@parcel/core',
  message: 'Building with clean cache. Cache invalidation took too long.',
  meta: {
    trackableEvent: 'cache_invalidation_timeout',
    watcherEventCount: events.length,
    predictedTime,
  },
});
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
