### PR TITLE
Use a non-circular type to fix TS generation

### DIFF
--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -48,6 +48,7 @@ export type DiagnosticCodeFrame = {|
 
 /** A JSON object (as in "map") */
 type JSONObject = {
+  // $FlowFixMe
   [key: string]: any,
 };
 

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -46,17 +46,10 @@ export type DiagnosticCodeFrame = {|
   codeHighlights: Array<DiagnosticCodeHighlight>,
 |};
 
-type JSONValue =
-  | null
-  | void // ? Is this okay?
-  | boolean
-  | number
-  | string
-  | Array<JSONValue>
-  | JSONObject;
-
 /** A JSON object (as in "map") */
-type JSONObject = {[key: string]: JSONValue, ...};
+type JSONObject = {
+  [key: string]: any,
+};
 
 /**
  * A style agnostic way of emitting errors, warnings and info.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

The `build-ts` script is currently failing due to a circular referencing type. This means releases are blocked until this is fixed. I decided to just use `any` as the type for now as a workaround. Shout out if there's something better I could do. 


## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
