### PR TITLE
Fix types for typescript + FeatureFlags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
       - run: yarn --frozen-lockfile
       - run: yarn flow check
 
+  ts-types:
+    name: TypeScript types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: yarn
+      - run: yarn --frozen-lockfile
+      - run: yarn build-ts
+
   benchmarks:
     name: Benchmarks
     runs-on: ubuntu-latest

--- a/packages/core/feature-flags/package.json
+++ b/packages/core/feature-flags/package.json
@@ -16,7 +16,11 @@
   },
   "main": "lib/index.js",
   "source": "src/index.js",
-  "types": "index.d.ts",
+  "types": "lib/types.d.ts",
+  "scripts": {
+    "build-ts": "mkdir -p lib && flow-to-ts src/types.js > lib/types.d.ts",
+    "check-ts": "tsc --noEmit lib/types.d.ts"
+  },
   "engines": {
     "node": ">= 16.0.0"
   }

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -1,9 +1,9 @@
 // @flow strict
 
-export type FeatureFlags = {|
-  // This feature flag mostly exists to test the feature flag system, and doesn't have any build/runtime effect
-  +exampleFeature: boolean,
-|};
+import type {FeatureFlags as _FeatureFlags} from './types';
+// We need to do these gymnastics as we don't want flow-to-ts to touch DEFAULT_FEATURE_FLAGS,
+// but we want to export FeatureFlags for Flow
+export type FeatureFlags = _FeatureFlags;
 
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   exampleFeature: false,

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -1,0 +1,6 @@
+// @flow strict
+
+export type FeatureFlags = {|
+  // This feature flag mostly exists to test the feature flag system, and doesn't have any build/runtime effect
+  +exampleFeature: boolean,
+|};


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Fixes issues with `FeatureFlags` types when using Parcel in a TypeScript project.

Generate TypeScript types for `FeatureFlags`, and ensure correct `types` entry in `package.json` exists.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Created a separate project, used `parcel-link` to link to my checkout - verified that creating a plugin with TypeScript would show `any` type for `options.featureFlags`.

After my changes, TypeScript now shows the correct `boolean` type.

~~Ideally the previous behaviour would fail in CI, but I'm not sure how to make it do that?~~

I've added `yarn ts-build` to the CI workflow for pull requests which will validate that the TypeScript types generated are correct.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
