### PR TITLE
Avoid non-identifier export names in non-entry library bundles

### DIFF
--- a/packages/core/integration-tests/test/library-bundler.js
+++ b/packages/core/integration-tests/test/library-bundler.js
@@ -414,7 +414,7 @@ describe('library bundler', function () {
     assert.equal(res.test(), 'foo');
 
     // foo.js should only export default, to avoid non-identifier symbols.
-    let foo = await runBundle(b, b.getBundles()[1]);
+    let foo: any = await runBundle(b, b.getBundles()[1]);
     assert.deepEqual(Object.keys(foo), ['default']);
     assert.deepEqual(foo.default, {'foo-bar': 'foo'});
   });

--- a/packages/core/integration-tests/test/library-bundler.js
+++ b/packages/core/integration-tests/test/library-bundler.js
@@ -3,6 +3,7 @@ import assert from 'assert';
 import path from 'path';
 import {
   bundle,
+  run,
   runBundle,
   overlayFS,
   outputFS,
@@ -366,5 +367,55 @@ describe('library bundler', function () {
     );
     assert.equal(cjs.foo(), 'foo');
     assert.equal(cjs.bar(), 2);
+  });
+
+  it('should export CJS namespaces as default', async function () {
+    await fsFixture(overlayFS, dir)`
+      yarn.lock:
+
+      .parcelrc:
+        {
+          "extends": "@parcel/config-default",
+          "bundler": "@parcel/bundler-library"
+        }
+
+      package.json:
+        {
+          "module": "dist/module.js",
+          "engines": { "node": "*" }
+        }
+
+      index.js:
+        import ns from './foo.js';
+        export function test() {
+          return ns['foo-bar'];
+        }
+
+      foo.js:
+        exports['foo-bar'] = 'foo';
+    `;
+
+    let b = await bundle(path.join(dir, '/index.js'), {
+      inputFS: overlayFS,
+      mode: 'production',
+    });
+
+    assertBundles(b, [
+      {
+        assets: ['index.js'],
+      },
+      {
+        type: 'js',
+        assets: ['foo.js'],
+      },
+    ]);
+
+    let res = await run(b);
+    assert.equal(res.test(), 'foo');
+
+    // foo.js should only export default, to avoid non-identifier symbols.
+    let foo = await runBundle(b, b.getBundles()[1]);
+    assert.deepEqual(Object.keys(foo), ['default']);
+    assert.deepEqual(foo.default, {'foo-bar': 'foo'});
   });
 });


### PR DESCRIPTION
Followup from https://github.com/parcel-bundler/parcel/pull/9489#issuecomment-2001352753. It turns out that webpack 4 doesn't support parsing string export syntax, and it is still pretty widely used, so we should try to avoid this. This PR strikes a balance: it will still export non-identifier symbols if the CJS module was an entry (since the author probably has control over this) but it will avoid it for internal bundles where we already only use the `default` export to import the namespace anyway. This passes our existing test and fixes the cases we need for React Spectrum.