### PR TITLE
replace serve-handler with serve-static

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "mocha-junit-reporter": "^2.0.0",
     "mocha-multi-reporters": "^1.5.1",
     "prettier": "2.4.1",
-    "punycode": "^1.4.1",
     "rimraf": "^5.0.5",
     "semver": "^7.5.2",
     "sinon": "^7.3.1"

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -42,7 +42,6 @@
     "launch-editor": "^2.3.0",
     "mime-types": "2.1.18",
     "nullthrows": "^1.1.1",
-    "serve-handler": "^6.0.0",
     "ws": "^7.0.0"
   }
 }

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -27,7 +27,7 @@ import serverErrors from './serverErrors';
 import fs from 'fs';
 import ejs from 'ejs';
 import connect from 'connect';
-import serveHandler from 'serve-handler';
+import serveStatic from 'serve-static';
 import {createProxyMiddleware} from 'http-proxy-middleware';
 import {URL, URLSearchParams} from 'url';
 import launchEditor from 'launch-editor';
@@ -362,20 +362,11 @@ export default class Server {
       return;
     }
 
-    return serveHandler(
-      req,
-      res,
-      {
-        public: root,
-        cleanUrls: false,
-      },
-      {
-        lstat: path => fs.stat(path),
-        realpath: path => fs.realpath(path),
-        createReadStream: (path, options) => fs.createReadStream(path, options),
-        readdir: path => fs.readdir(path),
-      },
-    );
+      // Serve up public/ftp folder
+      const serve = serveStatic(root, {
+        index: false,
+      })
+      return serve(req, res, next);
   }
 
   sendError(res: Response, statusCode: number) {

--- a/packages/utils/node-resolver-core/package.json
+++ b/packages/utils/node-resolver-core/package.json
@@ -46,7 +46,6 @@
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.0",
     "process": "^0.11.10",
-    "punycode": "^1.4.1",
     "querystring-es3": "^0.2.1",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.1.0",


### PR DESCRIPTION
This PR replaces `serve-handler` with `serve-static`

- [serve-handler](https://github.com/vercel/serve-handler) seems unmaintained by 2 years.
- [serve-static](https://github.com/expressjs/serve-static) is maintained by expressjs.

Hopefully this PR fixes #9390. I can't test this out myself since `yarn install` fails on my machine.

Can someone ~~test this for me~~ fix this?

## ✔️ PR Todo

- [ ] Actually run the tests
- [x] Included links to related issues/PRs
