### PR TITLE
Do not create circular bundle references in library bundler

### DIFF
--- a/packages/bundlers/library/src/LibraryBundler.js
+++ b/packages/bundlers/library/src/LibraryBundler.js
@@ -63,7 +63,7 @@ export default (new Bundler({
         }
 
         // Reference the parent bundle so we create dependencies between them.
-        if (parentBundle) {
+        if (parentBundle && parentBundle !== bundle) {
           bundleGraph.createBundleReference(parentBundle, bundle);
           bundleGraph.createAssetReference(dependency, asset, bundle);
         }


### PR DESCRIPTION
The library bundler had an issue where it could create circular bundle references that led to a bundle in one target accidentally importing a bundle in a different target. That breaks at runtime because relative paths don't work after npm installing. A bundle should never reference itself, this was just creating an invalid graph structure that the packager misinterpreted.