### PR TITLE
Update integration test script

### DIFF
--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules NODE_ENV=test PARCEL_BUILD_ENV=test mocha",
+    "test": "cross-env NODE_ENV=test PARCEL_BUILD_ENV=test mocha --experimental-vm-modules",
     "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json"
   },
   "devDependencies": {


### PR DESCRIPTION
# ↪️ Pull Request

This change updates the integration test script so that `--experimental-vm-modules` is enabled as a CLI option rather than using the `NODE_OPTIONS` environment variable. Doing this enables debuggers, like VSCode, to attach breakpoints using default launch settings.

## 💻 Examples

N/A

## 🚨 Test instructions

* Import `vm` in any plugin or core code, like a transformer
* Ensure extra exports exist, e.g. `SourceTextModule` when running integration tests locally and for CI
