### PR TITLE
Implements a `getFeatureFlag` to avoid option drilling

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -53,6 +53,7 @@ import {
   fromProjectPathRelative,
 } from './projectPath';
 import {tracer} from '@parcel/profiler';
+import {setFeatureFlags} from '@parcel/feature-flags';
 
 registerCoreWithSerializer();
 
@@ -107,6 +108,8 @@ export default class Parcel {
     this.#resolvedOptions = resolvedOptions;
     let {config} = await loadParcelConfig(resolvedOptions);
     this.#config = new ParcelConfig(config, resolvedOptions);
+
+    setFeatureFlags(resolvedOptions.featureFlags);
 
     if (this.#initialOptions.workerFarm) {
       if (this.#initialOptions.workerFarm.ending) {

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -26,6 +26,7 @@ import {clearBuildCaches} from './buildCache';
 import {init as initSourcemaps} from '@parcel/source-map';
 import {init as initRust} from '@parcel/rust';
 import WorkerFarm from '@parcel/workers';
+import {setFeatureFlags} from '@parcel/feature-flags';
 
 import '@parcel/cache'; // register with serializer
 import '@parcel/package-manager';
@@ -78,6 +79,9 @@ async function loadConfig(cachePath, options) {
   );
   config = new ParcelConfig(processedConfig, options);
   parcelConfigCache.set(cachePath, config);
+
+  setFeatureFlags(options.featureFlags);
+
   return config;
 }
 

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -9,3 +9,13 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   exampleFeature: false,
   configKeyInvalidation: false,
 };
+
+let featureFlags: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};
+
+export function setFeatureFlags(flags: FeatureFlags) {
+  featureFlags = flags;
+}
+
+export function getFeatureFlag(flagName: $Keys<FeatureFlags>): boolean {
+  return featureFlags[flagName];
+}

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -10,12 +10,12 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   configKeyInvalidation: false,
 };
 
-let featureFlags: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};
+let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};
 
 export function setFeatureFlags(flags: FeatureFlags) {
-  featureFlags = flags;
+  featureFlagValues = flags;
 }
 
 export function getFeatureFlag(flagName: $Keys<FeatureFlags>): boolean {
-  return featureFlags[flagName];
+  return featureFlagValues[flagName];
 }

--- a/packages/core/feature-flags/test/feature-flags.test.js
+++ b/packages/core/feature-flags/test/feature-flags.test.js
@@ -1,0 +1,21 @@
+// @flow strict
+import assert from 'assert';
+import {getFeatureFlag, DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../src';
+
+describe('feature-flag test', () => {
+  beforeEach(() => {
+    setFeatureFlags(DEFAULT_FEATURE_FLAGS);
+  });
+
+  it('has defaults', () => {
+    assert.equal(
+      getFeatureFlag('exampleFeature'),
+      DEFAULT_FEATURE_FLAGS.exampleFeature,
+    );
+  });
+
+  it('can override', () => {
+    setFeatureFlags({exampleFeature: true, configKeyInvalidation: true});
+    assert.equal(getFeatureFlag('exampleFeature'), true);
+  });
+});

--- a/packages/core/feature-flags/test/feature-flags.test.js
+++ b/packages/core/feature-flags/test/feature-flags.test.js
@@ -15,7 +15,7 @@ describe('feature-flag test', () => {
   });
 
   it('can override', () => {
-    setFeatureFlags({exampleFeature: true, configKeyInvalidation: true});
+    setFeatureFlags({...DEFAULT_FEATURE_FLAGS, exampleFeature: true});
     assert.equal(getFeatureFlag('exampleFeature'), true);
   });
 });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Sometimes it's inconvenient to drill options into a new place just to access feature flags, passing feature flag values around also can make cleanup of a feature more complicated. This change implements a `getFeatureFlag` export from` @parcel/feature-flags` that allows you to get a feature flag value from anywhere.

Code is added to initialise the values in core, as well as in workers.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
