### PR TITLE
Fix flaky integration test

### DIFF
--- a/packages/core/utils/src/alternatives.js
+++ b/packages/core/utils/src/alternatives.js
@@ -141,6 +141,5 @@ export async function findAlternativeFiles(
     });
   }
 
-  // Order is not consistent which can make integration tests flaky so we sort the result.
   return fuzzySearch(potentialFiles.sort(), fileSpecifier).slice(0, 2);
 }

--- a/packages/core/utils/src/alternatives.js
+++ b/packages/core/utils/src/alternatives.js
@@ -142,5 +142,5 @@ export async function findAlternativeFiles(
   }
 
   // Order is not consistent which can make integration tests flaky so we sort the result.
-  return fuzzySearch(potentialFiles, fileSpecifier).slice(0, 2).sort();
+  return fuzzySearch(potentialFiles.sort(), fileSpecifier).slice(0, 2);
 }

--- a/packages/core/utils/src/alternatives.js
+++ b/packages/core/utils/src/alternatives.js
@@ -141,5 +141,6 @@ export async function findAlternativeFiles(
     });
   }
 
-  return fuzzySearch(potentialFiles, fileSpecifier).slice(0, 2);
+  // Order is not consistent which can make integration tests flaky so we sort the result.
+  return fuzzySearch(potentialFiles, fileSpecifier).slice(0, 2).sort();
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Fixes occasional flake in the `should throw a codeframe for a missing file in worker constructor with URL and import.meta.url` integration test. 


## 💻 Examples

Example error:
```
1) javascript
       should throw a codeframe for a missing file in worker constructor with URL and import.meta.url:
     AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected ... Lines skipped

  Comparison {
    diagnostics: [
...
      {
        hints: [
+         "Did you mean '__./index.js__'?",
+         "Did you mean '__./dynamic.js__'?"
-         "Did you mean '__./dynamic.js__'?",
-         "Did you mean '__./index.js__'?"
        ],
...
    ],
    name: 'BuildError'
  }
      at Context.<anonymous> (test/javascript.js:1900:5)
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
