### PR TITLE
Fix missing content key in symbol prop when asset is removed

### DIFF
--- a/packages/core/integration-tests/test/symbol-propagation.js
+++ b/packages/core/integration-tests/test/symbol-propagation.js
@@ -1,0 +1,33 @@
+import assert from 'assert';
+import path from 'path';
+import {bundler, run, overlayFS, fsFixture} from '@parcel/test-utils';
+
+describe('symbol propagation', () => {
+  it('should handle removed assets from previous failed builds', async () => {
+    await fsFixture(overlayFS, __dirname)`
+        broken.js:
+            module.exports = require('./missing.js');
+        working.js:
+            module.exports = 'ITS WORKING';
+        index.js:
+            module.exports = require('./broken.js');`;
+
+    let b = bundler(path.join(__dirname, 'index.js'), {
+      inputFS: overlayFS,
+      shouldDisableCache: false,
+    });
+
+    await assert.rejects(() => b.run(), {
+      message: `Failed to resolve './missing.js' from './broken.js'`,
+    });
+
+    await overlayFS.writeFile(
+      path.join(__dirname, 'index.js'),
+      `module.exports = require('./working.js');`,
+    );
+
+    let {bundleGraph} = await b.run();
+
+    assert(await run(bundleGraph), 'ITS WORKING');
+  });
+});


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR addresses a bug in incremental symbol propagation where assets are requested for propagation even if they are no longer contained within the AssetGraph. This can happen in the following circumstance:
- Build fails during the `AssetGraphRequest` but finds some new Assets for propagation
- Next build runs but the previously discovered Assets are no longer in the AssetGraph (e.g. removed import)

## 🚨 Test instructions

Integration test added
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
