### PR TITLE
Add measure tracing API

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -396,51 +396,52 @@ export default class PackagerRunner {
 
     let packager = await this.config.getPackager(bundle.name);
     let {name, resolveFrom, plugin} = packager;
+    let measurement;
     try {
-      return await tracer.measure(
-        {
+      measurement =
+        tracer.enabled &&
+        tracer.createTraceMeasurement({
           name,
           args: {bundle: {name: bundle.name, type: bundle.type}},
           categories: ['packaging'],
+        });
+
+      return await plugin.package({
+        config: configs.get(name)?.result,
+        bundleConfig: bundleConfigs.get(name)?.result,
+        bundle,
+        bundleGraph: new BundleGraph<NamedBundleType>(
+          bundleGraph,
+          NamedBundle.get.bind(NamedBundle),
+          this.options,
+        ),
+        getSourceMapReference: map => {
+          return this.getSourceMapReference(bundle, map);
         },
-        () =>
-          plugin.package({
-            config: configs.get(name)?.result,
-            bundleConfig: bundleConfigs.get(name)?.result,
-            bundle,
-            bundleGraph: new BundleGraph<NamedBundleType>(
-              bundleGraph,
-              NamedBundle.get.bind(NamedBundle),
-              this.options,
-            ),
-            getSourceMapReference: map => {
-              return this.getSourceMapReference(bundle, map);
-            },
-            options: this.pluginOptions,
-            logger: new PluginLogger({origin: name}),
-            tracer: new PluginTracer({origin: name, category: 'package'}),
-            getInlineBundleContents: async (
-              bundle: BundleType,
-              bundleGraph: BundleGraphType<NamedBundleType>,
-            ) => {
-              if (bundle.bundleBehavior !== 'inline') {
-                throw new Error(
-                  'Bundle is not inline and unable to retrieve contents',
-                );
-              }
+        options: this.pluginOptions,
+        logger: new PluginLogger({origin: name}),
+        tracer: new PluginTracer({origin: name, category: 'package'}),
+        getInlineBundleContents: async (
+          bundle: BundleType,
+          bundleGraph: BundleGraphType<NamedBundleType>,
+        ) => {
+          if (bundle.bundleBehavior !== 'inline') {
+            throw new Error(
+              'Bundle is not inline and unable to retrieve contents',
+            );
+          }
 
-              let res = await this.getBundleResult(
-                bundleToInternalBundle(bundle),
-                // $FlowFixMe
-                bundleGraphToInternalBundleGraph(bundleGraph),
-                configs,
-                bundleConfigs,
-              );
+          let res = await this.getBundleResult(
+            bundleToInternalBundle(bundle),
+            // $FlowFixMe
+            bundleGraphToInternalBundleGraph(bundleGraph),
+            configs,
+            bundleConfigs,
+          );
 
-              return {contents: res.contents};
-            },
-          }),
-      );
+          return {contents: res.contents};
+        },
+      });
     } catch (e) {
       throw new ThrowableDiagnostic({
         diagnostic: errorToDiagnostic(e, {
@@ -449,6 +450,8 @@ export default class PackagerRunner {
         }),
       });
     } finally {
+      measurement && measurement.end();
+
       // Add dev dependency for the packager. This must be done AFTER running it due to
       // the potential for lazy require() that aren't executed until the request runs.
       let devDepRequest = await createDevDependency(
@@ -506,37 +509,37 @@ export default class PackagerRunner {
     };
 
     for (let optimizer of optimizers) {
+      let measurement;
       try {
-        await tracer.measure(
-          {
+        measurement =
+          tracer.enabled &&
+          tracer.createTraceMeasurement({
             name: optimizer.name,
             args: {bundle: bundle.name},
             categories: ['optimize'],
-          },
-          async () => {
-            let next = await optimizer.plugin.optimize({
-              config: configs.get(optimizer.name)?.result,
-              bundleConfig: bundleConfigs.get(optimizer.name)?.result,
-              bundle,
-              bundleGraph,
-              contents: optimized.contents,
-              map: optimized.map,
-              getSourceMapReference: map => {
-                return this.getSourceMapReference(bundle, map);
-              },
-              options: this.pluginOptions,
-              logger: new PluginLogger({origin: optimizer.name}),
-              tracer: new PluginTracer({
-                origin: optimizer.name,
-                category: 'optimize',
-              }),
-            });
+          });
 
-            optimized.type = next.type ?? optimized.type;
-            optimized.contents = next.contents;
-            optimized.map = next.map;
+        let next = await optimizer.plugin.optimize({
+          config: configs.get(optimizer.name)?.result,
+          bundleConfig: bundleConfigs.get(optimizer.name)?.result,
+          bundle,
+          bundleGraph,
+          contents: optimized.contents,
+          map: optimized.map,
+          getSourceMapReference: map => {
+            return this.getSourceMapReference(bundle, map);
           },
-        );
+          options: this.pluginOptions,
+          logger: new PluginLogger({origin: optimizer.name}),
+          tracer: new PluginTracer({
+            origin: optimizer.name,
+            category: 'optimize',
+          }),
+        });
+
+        optimized.type = next.type ?? optimized.type;
+        optimized.contents = next.contents;
+        optimized.map = next.map;
       } catch (e) {
         throw new ThrowableDiagnostic({
           diagnostic: errorToDiagnostic(e, {
@@ -545,6 +548,8 @@ export default class PackagerRunner {
           }),
         });
       } finally {
+        measurement && measurement.end();
+
         // Add dev dependency for the optimizer. This must be done AFTER running it due to
         // the potential for lazy require() that aren't executed until the request runs.
         let devDepRequest = await createDevDependency(

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -374,23 +374,25 @@ export default class Transformation {
         }
 
         try {
-          const measurement = tracer.createMeasurement(
-            transformer.name,
-            'transform',
-            fromProjectPathRelative(initialAsset.value.filePath),
+          let transformerResults = await tracer.measure(
+            {
+              name: transformer.name,
+              args: {
+                filename: fromProjectPathRelative(initialAsset.value.filePath),
+              },
+              categories: ['transform'],
+            },
+            () =>
+              this.runTransformer(
+                pipeline,
+                asset,
+                transformer.plugin,
+                transformer.name,
+                transformer.config,
+                transformer.configKeyPath,
+                this.parcelConfig,
+              ),
           );
-
-          let transformerResults = await this.runTransformer(
-            pipeline,
-            asset,
-            transformer.plugin,
-            transformer.name,
-            transformer.config,
-            transformer.configKeyPath,
-            this.parcelConfig,
-          );
-
-          measurement && measurement.end();
 
           for (let result of transformerResults) {
             if (result instanceof UncommittedAsset) {

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -374,25 +374,27 @@ export default class Transformation {
         }
 
         try {
-          let transformerResults = await tracer.measure(
-            {
+          let measurement =
+            tracer.enabled &&
+            tracer.createTraceMeasurement({
               name: transformer.name,
               args: {
                 filename: fromProjectPathRelative(initialAsset.value.filePath),
               },
               categories: ['transform'],
-            },
-            () =>
-              this.runTransformer(
-                pipeline,
-                asset,
-                transformer.plugin,
-                transformer.name,
-                transformer.config,
-                transformer.configKeyPath,
-                this.parcelConfig,
-              ),
+            });
+
+          let transformerResults = await this.runTransformer(
+            pipeline,
+            asset,
+            transformer.plugin,
+            transformer.name,
+            transformer.config,
+            transformer.configKeyPath,
+            this.parcelConfig,
           );
+
+          measurement && measurement.end();
 
           for (let result of transformerResults) {
             if (result instanceof UncommittedAsset) {

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -96,98 +96,100 @@ export default async function applyRuntimes<TResult>({
 
   for (let bundle of bundles) {
     for (let runtime of runtimes) {
-      let measurement;
       try {
         const namedBundle = NamedBundle.get(bundle, bundleGraph, options);
-        measurement = tracer.createMeasurement(
-          runtime.name,
-          'applyRuntime',
-          namedBundle.displayName,
-        );
-        let applied = await runtime.plugin.apply({
-          bundle: namedBundle,
-          bundleGraph: new BundleGraph<INamedBundle>(
-            bundleGraph,
-            NamedBundle.get.bind(NamedBundle),
-            options,
-          ),
-          config: configs.get(runtime.name)?.result,
-          options: pluginOptions,
-          logger: new PluginLogger({origin: runtime.name}),
-          tracer: new PluginTracer({
-            origin: runtime.name,
-            category: 'applyRuntime',
-          }),
-        });
 
-        if (applied) {
-          let runtimeAssets = Array.isArray(applied) ? applied : [applied];
-          for (let {
-            code,
-            dependency,
-            filePath,
-            isEntry,
-            env,
-            priority,
-          } of runtimeAssets) {
-            let sourceName = path.join(
-              path.dirname(filePath),
-              `runtime-${hashString(code)}.${bundle.type}`,
-            );
-
-            let assetGroup = {
-              code,
-              filePath: toProjectPath(options.projectRoot, sourceName),
-              env: mergeEnvironments(options.projectRoot, bundle.env, env),
-              // Runtime assets should be considered source, as they should be
-              // e.g. compiled to run in the target environment
-              isSource: true,
-            };
-
-            let connectionBundle = bundle;
-
-            if (priority === 'parallel' && !bundle.needsStableName) {
-              let bundleGroups =
-                bundleGraph.getBundleGroupsContainingBundle(bundle);
-
-              connectionBundle = nullthrows(
-                bundleGraph.createBundle({
-                  type: bundle.type,
-                  needsStableName: false,
-                  env: bundle.env,
-                  target: bundle.target,
-                  uniqueKey: 'runtime-manifest:' + bundle.id,
-                  shouldContentHash: options.shouldContentHash,
-                }),
-              );
-
-              for (let bundleGroup of bundleGroups) {
-                bundleGraph.addBundleToBundleGroup(
-                  connectionBundle,
-                  bundleGroup,
-                );
-              }
-              bundleGraph.createBundleReference(bundle, connectionBundle);
-
-              nameRuntimeBundle(connectionBundle, bundle);
-            }
-
-            connections.push({
-              bundle: connectionBundle,
-              assetGroup,
-              dependency,
-              isEntry,
+        await tracer.measure(
+          {
+            name: runtime.name,
+            args: {bundle: namedBundle.displayName},
+            categories: ['applyRuntime'],
+          },
+          async () => {
+            let applied = await runtime.plugin.apply({
+              bundle: namedBundle,
+              bundleGraph: new BundleGraph<INamedBundle>(
+                bundleGraph,
+                NamedBundle.get.bind(NamedBundle),
+                options,
+              ),
+              config: configs.get(runtime.name)?.result,
+              options: pluginOptions,
+              logger: new PluginLogger({origin: runtime.name}),
+              tracer: new PluginTracer({
+                origin: runtime.name,
+                category: 'applyRuntime',
+              }),
             });
-          }
-        }
+
+            if (applied) {
+              let runtimeAssets = Array.isArray(applied) ? applied : [applied];
+              for (let {
+                code,
+                dependency,
+                filePath,
+                isEntry,
+                env,
+                priority,
+              } of runtimeAssets) {
+                let sourceName = path.join(
+                  path.dirname(filePath),
+                  `runtime-${hashString(code)}.${bundle.type}`,
+                );
+
+                let assetGroup = {
+                  code,
+                  filePath: toProjectPath(options.projectRoot, sourceName),
+                  env: mergeEnvironments(options.projectRoot, bundle.env, env),
+                  // Runtime assets should be considered source, as they should be
+                  // e.g. compiled to run in the target environment
+                  isSource: true,
+                };
+
+                let connectionBundle = bundle;
+
+                if (priority === 'parallel' && !bundle.needsStableName) {
+                  let bundleGroups =
+                    bundleGraph.getBundleGroupsContainingBundle(bundle);
+
+                  connectionBundle = nullthrows(
+                    bundleGraph.createBundle({
+                      type: bundle.type,
+                      needsStableName: false,
+                      env: bundle.env,
+                      target: bundle.target,
+                      uniqueKey: 'runtime-manifest:' + bundle.id,
+                      shouldContentHash: options.shouldContentHash,
+                    }),
+                  );
+
+                  for (let bundleGroup of bundleGroups) {
+                    bundleGraph.addBundleToBundleGroup(
+                      connectionBundle,
+                      bundleGroup,
+                    );
+                  }
+                  bundleGraph.createBundleReference(bundle, connectionBundle);
+
+                  nameRuntimeBundle(connectionBundle, bundle);
+                }
+
+                connections.push({
+                  bundle: connectionBundle,
+                  assetGroup,
+                  dependency,
+                  isEntry,
+                });
+              }
+            }
+          },
+        );
       } catch (e) {
         throw new ThrowableDiagnostic({
           diagnostic: errorToDiagnostic(e, {
             origin: runtime.name,
           }),
         });
-      } finally {
-        measurement && measurement.end();
       }
     }
   }

--- a/packages/core/core/src/requests/ParcelBuildRequest.js
+++ b/packages/core/core/src/requests/ParcelBuildRequest.js
@@ -93,14 +93,21 @@ async function run({input, api, options}) {
     ),
   });
 
-  let packagingMeasurement = tracer.createMeasurement('packaging');
-  let writeBundlesRequest = createWriteBundlesRequest({
-    bundleGraph,
-    optionsRef,
-  });
+  let bundleInfo = await tracer.measure(
+    {
+      name: 'packaging',
+      categories: ['core'],
+    },
+    () => {
+      let writeBundlesRequest = createWriteBundlesRequest({
+        bundleGraph,
+        optionsRef,
+      });
 
-  let bundleInfo = await api.runRequest(writeBundlesRequest);
-  packagingMeasurement && packagingMeasurement.end();
+      return api.runRequest(writeBundlesRequest);
+    },
+  );
+
   assertSignalNotAborted(signal);
 
   return {bundleGraph, bundleInfo, changedAssets, assetRequests};

--- a/packages/core/core/src/requests/ParcelBuildRequest.js
+++ b/packages/core/core/src/requests/ParcelBuildRequest.js
@@ -93,20 +93,20 @@ async function run({input, api, options}) {
     ),
   });
 
-  let bundleInfo = await tracer.measure(
-    {
+  let measurement =
+    tracer.enabled &&
+    tracer.createTraceMeasurement({
       name: 'packaging',
       categories: ['core'],
-    },
-    () => {
-      let writeBundlesRequest = createWriteBundlesRequest({
-        bundleGraph,
-        optionsRef,
-      });
+    });
 
-      return api.runRequest(writeBundlesRequest);
-    },
-  );
+  let writeBundlesRequest = createWriteBundlesRequest({
+    bundleGraph,
+    optionsRef,
+  });
+
+  let bundleInfo = await api.runRequest(writeBundlesRequest);
+  measurement && measurement.end();
 
   assertSignalNotAborted(signal);
 

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -246,41 +246,41 @@ async function runCompressor(
   devDeps: Map<string, string>,
   api: RunAPI<PackagedBundleInfo>,
 ) {
+  let measurement;
   try {
-    await tracer.measure(
-      {
+    measurement =
+      tracer.enabled &&
+      tracer.createTraceMeasurement({
         name: compressor.name,
         args: {filename: path.relative(options.projectRoot, filePath)},
         categories: ['compress'],
-      },
-      async () => {
-        let res = await compressor.plugin.compress({
-          stream,
-          options: new PluginOptions(options),
-          logger: new PluginLogger({origin: compressor.name}),
-          tracer: new PluginTracer({
-            origin: compressor.name,
-            category: 'compress',
-          }),
-        });
+      });
 
-        if (res != null) {
-          await new Promise((resolve, reject) =>
-            pipeline(
-              res.stream,
-              outputFS.createWriteStream(
-                filePath + (res.type != null ? '.' + res.type : ''),
-                writeOptions,
-              ),
-              err => {
-                if (err) reject(err);
-                else resolve();
-              },
-            ),
-          );
-        }
-      },
-    );
+    let res = await compressor.plugin.compress({
+      stream,
+      options: new PluginOptions(options),
+      logger: new PluginLogger({origin: compressor.name}),
+      tracer: new PluginTracer({
+        origin: compressor.name,
+        category: 'compress',
+      }),
+    });
+
+    if (res != null) {
+      await new Promise((resolve, reject) =>
+        pipeline(
+          res.stream,
+          outputFS.createWriteStream(
+            filePath + (res.type != null ? '.' + res.type : ''),
+            writeOptions,
+          ),
+          err => {
+            if (err) reject(err);
+            else resolve();
+          },
+        ),
+      );
+    }
   } catch (err) {
     throw new ThrowableDiagnostic({
       diagnostic: errorToDiagnostic(err, {
@@ -288,6 +288,7 @@ async function runCompressor(
       }),
     });
   } finally {
+    measurement && measurement.end();
     // Add dev deps for compressor plugins AFTER running them, to account for lazy require().
     let devDepRequest = await createDevDependency(
       {

--- a/packages/core/integration-tests/test/tracing.js
+++ b/packages/core/integration-tests/test/tracing.js
@@ -1,35 +1,48 @@
 // @flow strict-local
 import assert from 'assert';
 import path from 'path';
-import {distDir, bundle, outputFS} from '@parcel/test-utils';
+import {createWorkerFarm} from '@parcel/core';
+import {MemoryFS} from '@parcel/fs';
+import {distDir, bundle, inputFS} from '@parcel/test-utils';
 
 describe('tracing', function () {
-  it('should produce a trace', async function () {
-    await bundle(
-      path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
-      {
-        shouldTrace: true,
-        targets: {
-          default: {distDir},
-        },
-        additionalReporters: [
-          {
-            packageName: '@parcel/reporter-tracer',
-            resolveFrom: __dirname,
-          },
-        ],
-        outputFS,
-      },
-    );
-
-    const files = outputFS.readdirSync(__dirname);
-    const profileFile = files.find(file => file.startsWith('parcel-trace'));
-    assert(profileFile !== null);
-    const content = await outputFS.readFile(
-      path.join(__dirname, profileFile),
-      'utf8',
-    );
-    const profileContent = JSON.parse(content + ']'); // Traces don't contain a closing ] as an optimisation for partial writes
-    assert(profileContent.length > 0);
+  let workerFarm = createWorkerFarm({
+    shouldTrace: true,
   });
+
+  let outputFS = new MemoryFS(workerFarm);
+
+  for (let mode of ['development', 'production']) {
+    it(`should produce a ${mode} trace`, async function () {
+      await bundle(
+        path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
+        {
+          additionalReporters: [
+            {
+              packageName: '@parcel/reporter-tracer',
+              resolveFrom: __dirname,
+            },
+          ],
+          inputFS,
+          mode,
+          outputFS,
+          shouldTrace: true,
+          targets: {
+            default: {distDir},
+          },
+          workerFarm,
+        },
+      );
+
+      const files = outputFS.readdirSync(__dirname);
+      const profileFile = files.find(file => file.startsWith('parcel-trace'));
+      assert(profileFile !== null);
+      const content = await outputFS.readFile(
+        path.join(__dirname, profileFile),
+        'utf8',
+      );
+      const profileContent = JSON.parse(content + ']'); // Traces don't contain a closing ] as an optimisation for partial writes
+      assert(profileContent.length > 0);
+    });
+  }
 });

--- a/packages/core/profiler/test/Tracer.test.js
+++ b/packages/core/profiler/test/Tracer.test.js
@@ -5,74 +5,123 @@ import assert from 'assert';
 describe('Tracer', () => {
   let onTrace;
   let traceDisposable;
+  let opts = {name: 'test', categories: ['tracer']};
+
   beforeEach(() => {
     onTrace = sinon.spy();
     traceDisposable = tracer.onTrace(onTrace);
     tracer.enable();
   });
+
   afterEach(() => {
     traceDisposable.dispose();
   });
 
-  it('returns no measurement when disabled', () => {
-    tracer.disable();
-    const measurement = tracer.createMeasurement('test');
-    assert(measurement == null);
-    assert(onTrace.notCalled);
-  });
-  it('emits a basic trace event', () => {
-    const measurement = tracer.createMeasurement('test');
-    measurement.end();
-    sinon.assert.calledWith(
-      onTrace,
-      sinon.match({
-        type: 'trace',
-        name: 'test',
-        args: undefined,
-        duration: sinon.match.number,
-      }),
-    );
-  });
-  it('emits a complex trace event', () => {
-    const measurement = tracer.createMeasurement('test', 'myPlugin', 'aaargh', {
-      extra: 'data',
-    });
-    measurement.end();
-    sinon.assert.calledWith(
-      onTrace,
-      sinon.match({
-        type: 'trace',
-        name: 'test',
-        categories: ['myPlugin'],
-        args: {extra: 'data', name: 'aaargh'},
-        duration: sinon.match.number,
-      }),
-    );
-  });
-  it('calling end twice on measurment should be a no-op', () => {
-    const measurement = tracer.createMeasurement('test');
-    measurement.end();
-    measurement.end();
-    sinon.assert.calledOnce(onTrace);
+  describe('measure()', () => {
+    let cases = [
+      ['synchronous', () => () => {}],
+      ['asynchronous', () => async () => {}],
+    ];
+
+    for (let [type, createFn] of cases) {
+      describe(`given a ${type} function`, () => {
+        it('does not trace when disabled', async () => {
+          tracer.disable();
+
+          let result = tracer.measure(opts, sinon.spy());
+          if (type === 'asynchronous') {
+            sinon.assert.notCalled(onTrace);
+            await result;
+          }
+
+          assert(onTrace.notCalled);
+        });
+
+        it('emits a basic trace event', async () => {
+          let result = tracer.measure(opts, createFn());
+          if (type === 'asynchronous') {
+            sinon.assert.notCalled(onTrace);
+            await result;
+          }
+
+          sinon.assert.calledOnce(onTrace);
+          sinon.assert.calledWith(
+            onTrace,
+            sinon.match({
+              type: 'trace',
+              name: 'test',
+              args: {},
+              categories: ['tracer'],
+              duration: sinon.match.number,
+            }),
+          );
+        });
+
+        it('emits a complex trace event', async () => {
+          let result = tracer.measure(
+            {...opts, args: {hello: 'world'}},
+            createFn(),
+          );
+          if (type === 'asynchronous') {
+            sinon.assert.notCalled(onTrace);
+            await result;
+          }
+
+          sinon.assert.calledOnce(onTrace);
+          sinon.assert.calledWith(
+            onTrace,
+            sinon.match({
+              type: 'trace',
+              name: 'test',
+              args: {hello: 'world'},
+              categories: ['tracer'],
+              duration: sinon.match.number,
+            }),
+          );
+        });
+      });
+    }
   });
 
   describe('PluginTracer', () => {
-    it('emits events with proper origin/category', () => {
-      const pluginTracer = new PluginTracer({
-        origin: 'origin',
-        category: 'cat',
+    const pluginTracer = new PluginTracer({
+      origin: 'origin',
+      category: 'cat',
+    });
+
+    describe(`measure()`, () => {
+      it('emits events with origin and category', () => {
+        pluginTracer.measure(opts, sinon.spy());
+
+        sinon.assert.calledOnce(onTrace);
+        sinon.assert.calledWith(
+          onTrace,
+          sinon.match({
+            type: 'trace',
+            name: 'test',
+            args: {origin: 'origin'},
+            categories: ['cat', 'tracer'],
+            duration: sinon.match.number,
+          }),
+        );
       });
-      const measurement = pluginTracer.createMeasurement('test', 'customCat');
-      measurement.end();
-      sinon.assert.calledWith(
-        onTrace,
-        sinon.match({
-          type: 'trace',
-          name: 'test',
-          categories: ['cat:origin:customCat'],
-          duration: sinon.match.number,
-        }),
-      );
+    });
+
+    describe('createMeasurement()', () => {
+      it('emits events with origin and category', () => {
+        pluginTracer.createMeasurement('test', 'customCat').end();
+
+        sinon.assert.calledOnce(onTrace);
+        sinon.assert.calledWith(
+          onTrace,
+          sinon.match({
+            type: 'trace',
+            name: 'test',
+            categories: ['cat:origin:customCat'],
+            duration: sinon.match.number,
+          }),
+        );
+      });
     });
   });
 });

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -2066,6 +2066,12 @@ export type AsyncSubscription = {|
   unsubscribe(): Promise<mixed>,
 |};
 
+export type MeasurementOptions = {|
+  args?: {[key: string]: mixed},
+  categories: string[],
+  name: string,
+|};
+
 export interface PluginTracer {
   /** Returns whether the tracer is enabled. Use this to avoid possibly expensive calculations
    * of arguments to `createMeasurement` - for example if you need to determine the entry of a bundle to pass it
@@ -2093,4 +2099,6 @@ export interface PluginTracer {
     argumentName?: string,
     otherArgs?: {[key: string]: mixed},
   ): TraceMeasurement | null;
+
+  measure<T>(options: MeasurementOptions, fn: () => T): T;
 }

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -2003,13 +2003,7 @@ export type ValidationEvent = {|
   +filePath: FilePath,
 |};
 
-/**
- * A trace event has occured.
- * Loosely modeled on Chrome's Trace Event format: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
- *
- * @section reporter
- */
-export type TraceEvent = {|
+export type TraceCompleteEvent = {|
   +type: 'trace',
   +ts: number,
   +duration: number,
@@ -2017,8 +2011,26 @@ export type TraceEvent = {|
   +tid: number,
   +pid: number,
   +categories: string[],
-  +args?: {[key: string]: mixed},
+  +args: {traceId: string, [key: string]: mixed},
 |};
+
+export type TraceStartEvent = {|
+  +type: 'traceStart',
+  +ts: number,
+  +name: string,
+  +tid: number,
+  +pid: number,
+  +categories: string[],
+  +args: {traceId: string, [key: string]: mixed},
+|};
+
+/**
+ * A trace event has occured.
+ * Loosely modeled on Chrome's Trace Event format: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
+ *
+ * @section reporter
+ */
+export type TraceEvent = TraceCompleteEvent | TraceStartEvent;
 
 export type CacheEvent = {|
   type: 'cache',
@@ -2100,5 +2112,5 @@ export interface PluginTracer {
     otherArgs?: {[key: string]: mixed},
   ): TraceMeasurement | null;
 
-  measure<T>(options: MeasurementOptions, fn: () => T): T;
+  createTraceMeasurement(options: MeasurementOptions): TraceMeasurement;
 }

--- a/packages/reporters/tracer/src/TracerReporter.js
+++ b/packages/reporters/tracer/src/TracerReporter.js
@@ -51,7 +51,7 @@ export default (new Reporter({
       case 'trace':
         // Due to potential race conditions at the end of the build, we ignore any trace events that occur
         // after we've closed the write stream.
-        if (tracer === null) return;
+        if (tracer == null) return;
 
         tracer.completeEvent({
           name: event.name,

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -88,16 +88,19 @@ export default async function babel7(
           pluginKey = path.relative(options.projectRoot, pluginKey);
         }
 
-        tracer.measure(
-          {
+        let measurement =
+          tracer.enabled &&
+          tracer.createTraceMeasurement({
             name: pluginKey,
             args: {
               filename: path.relative(options.projectRoot, asset.filePath),
             },
             categories: [nodeType],
-          },
-          () => fn.apply(this, arguments),
-        );
+          });
+
+        fn.apply(this, arguments);
+
+        measurement && measurement.end();
       };
     };
   }

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -87,13 +87,17 @@ export default async function babel7(
         if (pluginKey.startsWith(options.projectRoot)) {
           pluginKey = path.relative(options.projectRoot, pluginKey);
         }
-        const measurement = tracer.createMeasurement(
-          pluginKey,
-          nodeType,
-          path.relative(options.projectRoot, asset.filePath),
+
+        tracer.measure(
+          {
+            name: pluginKey,
+            args: {
+              filename: path.relative(options.projectRoot, asset.filePath),
+            },
+            categories: [nodeType],
+          },
+          () => fn.apply(this, arguments),
         );
-        fn.apply(this, arguments);
-        measurement && measurement.end();
       };
     };
   }


### PR DESCRIPTION
# ↪️ Pull Request

This change is similar to https://github.com/parcel-bundler/parcel/pull/9622 but instead introduces non-breaking changes that:
* Introduce a more flexible `createTraceMeasurement` API, by only instantiating relevant event data when tracing is enabled at the consumer side
* Add testing to prevent consumers from ending a measurement, using a new `traceStart` event

Additionally, some arguments have been updated to be more meaningful.

## 💻 Examples

N/A

## 🚨 Test instructions

Run with tracing enabled