### PR TITLE
Add public publish config to types-internal

### DIFF
--- a/packages/core/types-internal/package.json
+++ b/packages/core/types-internal/package.json
@@ -8,7 +8,9 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "publishConfig": {},
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build-ts": "./scripts/build-ts.sh",
     "check-ts": "tsc --noEmit lib/index.d.ts"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Make the `@parcel/types-internal` package publicly publishable to unblock the release pipeline. 