### PR TITLE
Also emit swc recoverable errors

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -6438,6 +6438,53 @@ describe('javascript', function () {
     }
   });
 
+  it(`should also fail on recoverable parse errors`, async () => {
+    await fsFixture(overlayFS, __dirname)`
+      js-recoverable-parse-errors
+        index.js:
+          1 / {2}`;
+
+    const fixture = path.join(
+      __dirname,
+      '/js-recoverable-parse-errors/index.js',
+    );
+
+    await assert.rejects(
+      () =>
+        bundle(fixture, {
+          inputFS: overlayFS,
+        }),
+      {
+        name: 'BuildError',
+        diagnostics: [
+          {
+            origin: '@parcel/transformer-js',
+            message: 'Unexpected token `}`. Expected identifier',
+            hints: null,
+            codeFrames: [
+              {
+                filePath: fixture,
+                codeHighlights: [
+                  {
+                    message: undefined,
+                    start: {
+                      column: 7,
+                      line: 1,
+                    },
+                    end: {
+                      column: 7,
+                      line: 1,
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
+  });
+
   for (let shouldScopeHoist of [false, true]) {
     let options = {
       defaultTargetOptions: {

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -548,6 +548,7 @@ fn parse(
       export_default_from: true,
       decorators: config.decorators,
       import_attributes: true,
+      allow_return_outside_function: true,
       ..Default::default()
     })
   };


### PR DESCRIPTION
Closes https://github.com/parcel-bundler/parcel/issues/9649

Apparently, swc now returns fatal parser errors via the `PResult` type, but more (recoverable) errors have to be retrieved with `parser.take_errors()`.

We didn't do the latter and the partially invalid AST was then passed to transforms.