### PR TITLE
Allow passing in of Partial feature flags

### DIFF
--- a/packages/core/types-internal/scripts/build-ts.js
+++ b/packages/core/types-internal/scripts/build-ts.js
@@ -11,5 +11,6 @@ contents = contents.replace(
 );
 contents = contents.replace(/\$ReadOnlyMap/g, 'ReadonlyMap');
 contents = contents.replace(/\$ReadOnlySet/g, 'ReadonlySet');
+contents = contents.replace(/\$Partial/g, 'Partial');
 
 fs.writeFileSync(typesPath, contents);

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -385,7 +385,7 @@ export type InitialParcelOptionsInternal<WorkerFarm> = {|
     resolveFrom: FilePath,
   |}>,
 
-  +featureFlags?: FeatureFlags,
+  +featureFlags?: $Partial<FeatureFlags>,
 
   // throwErrors
   // global?


### PR DESCRIPTION
The type of `featureFlags` on input options is currently complete, which means that users need to pass every single feature flag in when using the Node api.

This is annoying, so we've set the input type to `$Partial`, so you can just pass what you need. Unfortunately, TypeScript doesn't know what that is, so we've added another replace to the flow-to-ts output to cover for it.

If we were on a more modern version of Flow then we could use `Partial`, but that's a problem for another time.