### PR TITLE
Optimise the Inline Requires plugin

### DIFF
--- a/packages/optimizers/inline-requires/src/RequireInliningVisitor.js
+++ b/packages/optimizers/inline-requires/src/RequireInliningVisitor.js
@@ -10,7 +10,6 @@ import type {
   Identifier,
 } from '@swc/core';
 import {Visitor} from '@swc/core/Visitor';
-import type {SideEffectsMap} from './types';
 import nullthrows from 'nullthrows';
 
 type VisitorOpts = {|

--- a/packages/optimizers/inline-requires/src/types.js
+++ b/packages/optimizers/inline-requires/src/types.js
@@ -1,2 +1,0 @@
-// @flow strict-local
-export type SideEffectsMap = {|sideEffects: boolean, filePath: string|};


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
In our large application build, the Inline Requires plugin adds about 25% to the build time (6 min) - so we have looked at some quick optimisation wins. 

While the ideal solution for inline requires would be to implement it in the `ScopeHoistingPackager`, a good time to do that would be when we move the packager to native code rather than working on a complex change to it now.

With a combination of tracing, profiling, and eyeballing (thanks @yamadapc!) we identified a few small performance improvements to the current implementation

* remove potentially expensive object allocation for comparing argument values and replace with a verbose `if` (this saves some GC overhead and provides a 10-15% perf improvement in our tests)
* remove unnecessary usage of an array from an earlier iteration where a boolean would suffice (this saves GC overhead and reduces time spent in the visitor)
* remove `verbose` logging - even when not logging, there was still significant overhead from this due to the volume (another 10-15%)

The main contributor now to this plugin's run time is the SWC `print` of the AST back to JS. We have considered a couple of other potential optimisations (that really still just avoid moving the code into the pacakger where it should be...):
* replace the SWC code with regex matching and replacement - not sure if this would be faster without trying it, but it would complicate source maps for sure.
* move the JS code to Rust - this will avoid serialising/deserialising the AST that SWC has to do with the `parse`/`print` pattern.
* implement minification support in the plugin - this means that we can skip running the SWC minifier, and just have this plugin produce the minified output - saving another `print`/`parse` that plugin has to do.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Verified application still works (unit tests for the visitor pass)

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
