### PR TITLE
Add actual values to assertion error

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -359,9 +359,13 @@ export class RequestGraph extends ContentGraph<
       return node;
     }
 
-    throw new AssertionError(
-      `Expected a request node: ${node.type} does not equal ${REQUEST}.`,
-    );
+    throw new AssertionError({
+      message: `Expected a request node: ${
+        node.type
+      } (${typeof node.type}) does not equal ${REQUEST} (${typeof REQUEST}).`,
+      expected: REQUEST,
+      actual: node.type,
+    });
   }
 
   replaceSubrequests(

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -19,6 +19,7 @@ import logger from '@parcel/logger';
 import {type Deferred} from '@parcel/utils';
 
 import invariant from 'assert';
+import {AssertionError} from 'assert';
 import nullthrows from 'nullthrows';
 import path from 'path';
 import {
@@ -353,8 +354,14 @@ export class RequestGraph extends ContentGraph<
 
   getRequestNode(nodeId: NodeId): RequestNode {
     let node = nullthrows(this.getNode(nodeId));
-    invariant(node.type === REQUEST);
-    return node;
+
+    if (node.type === REQUEST) {
+      return node;
+    }
+
+    throw new AssertionError(
+      `Expected a request node: ${node.type} does not equal ${REQUEST}.`,
+    );
   }
 
   replaceSubrequests(


### PR DESCRIPTION
We've been seeing an increase in errors related to the node type assertions in `getRequestNode`, but the standard `invariant` doesn't include any more information than "they don't match".

To try and track down the problem, we'd like to see what the values actually are. In just this one location, we're replacing the `invariant` call with a standard `if`, and creating a custom `AssertionError` message string to provide a bit more info.