### PR TITLE
Update rustfmt

### DIFF
--- a/crates/json-comments-rs/src/lib.rs
+++ b/crates/json-comments-rs/src/lib.rs
@@ -389,9 +389,10 @@ fn in_line_comment(c: &mut u8) -> State {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use std::io::ErrorKind;
   use std::io::Read;
+
+  use super::*;
 
   fn strip_string(input: &str) -> String {
     let mut out = String::new();

--- a/crates/json-comments-rs/src/lib.rs
+++ b/crates/json-comments-rs/src/lib.rs
@@ -41,10 +41,10 @@
 //! # }
 //! ```
 //!
-use std::{
-  io::{ErrorKind, Read, Result},
-  slice::IterMut,
-};
+use std::io::ErrorKind;
+use std::io::Read;
+use std::io::Result;
+use std::slice::IterMut;
 
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 enum State {
@@ -390,7 +390,8 @@ fn in_line_comment(c: &mut u8) -> State {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use std::io::{ErrorKind, Read};
+  use std::io::ErrorKind;
+  use std::io::Read;
 
   fn strip_string(input: &str) -> String {
     let mut out = String::new();

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,8 +1,8 @@
-use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use indexmap::IndexMap;
 use swc_core::common::util::take::Take;
 use swc_core::common::SourceMap;
 use swc_core::common::Span;

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,14 +1,21 @@
 use indexmap::IndexMap;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use swc_core::common::util::take::Take;
-use swc_core::common::{SourceMap, Span, DUMMY_SP};
+use swc_core::common::SourceMap;
+use swc_core::common::Span;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::{js_word, JsWord};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::parser::error::Error;
 use swc_core::ecma::parser::lexer::Lexer;
-use swc_core::ecma::parser::{error::Error, Parser, StringInput};
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::parser::Parser;
+use swc_core::ecma::parser::StringInput;
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 #[cfg(feature = "napi")]
 pub mod napi;

--- a/crates/macros/src/napi.rs
+++ b/crates/macros/src/napi.rs
@@ -1,12 +1,22 @@
 use std::sync::Arc;
 
-use crate::{JsValue, Location, MacroCallback, MacroError};
-use crossbeam_channel::{Receiver, Sender};
+use crate::JsValue;
+use crate::Location;
+use crate::MacroCallback;
+use crate::MacroError;
+use crossbeam_channel::Receiver;
+use crossbeam_channel::Sender;
 use indexmap::IndexMap;
-use napi::{
-  threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunctionCallMode},
-  Env, JsBoolean, JsFunction, JsNumber, JsObject, JsString, JsUnknown, ValueType,
-};
+use napi::threadsafe_function::ThreadSafeCallContext;
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
+use napi::Env;
+use napi::JsBoolean;
+use napi::JsFunction;
+use napi::JsNumber;
+use napi::JsObject;
+use napi::JsString;
+use napi::JsUnknown;
+use napi::ValueType;
 use napi_derive::napi;
 use swc_core::common::DUMMY_SP;
 

--- a/crates/macros/src/napi.rs
+++ b/crates/macros/src/napi.rs
@@ -1,9 +1,5 @@
 use std::sync::Arc;
 
-use crate::JsValue;
-use crate::Location;
-use crate::MacroCallback;
-use crate::MacroError;
 use crossbeam_channel::Receiver;
 use crossbeam_channel::Sender;
 use indexmap::IndexMap;
@@ -19,6 +15,11 @@ use napi::JsUnknown;
 use napi::ValueType;
 use napi_derive::napi;
 use swc_core::common::DUMMY_SP;
+
+use crate::JsValue;
+use crate::Location;
+use crate::MacroCallback;
+use crate::MacroError;
 
 struct CallMacroMessage {
   src: String,

--- a/crates/node-bindings/src/fs_search.rs
+++ b/crates/node-bindings/src/fs_search.rs
@@ -1,5 +1,6 @@
-use napi_derive::napi;
 use std::path::Path;
+
+use napi_derive::napi;
 
 #[napi]
 pub fn find_ancestor_file(filenames: Vec<String>, from: String, root: String) -> Option<String> {

--- a/crates/node-bindings/src/hash.rs
+++ b/crates/node-bindings/src/hash.rs
@@ -1,8 +1,9 @@
 #![allow(clippy::new_without_default)]
 
+use std::hash::Hasher;
+
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
-use std::hash::Hasher;
 use xxhash_rust::xxh3::xxh3_64;
 use xxhash_rust::xxh3::Xxh3;
 

--- a/crates/node-bindings/src/hash.rs
+++ b/crates/node-bindings/src/hash.rs
@@ -3,7 +3,8 @@
 use napi::bindgen_prelude::Buffer;
 use napi_derive::napi;
 use std::hash::Hasher;
-use xxhash_rust::xxh3::{xxh3_64, Xxh3};
+use xxhash_rust::xxh3::xxh3_64;
+use xxhash_rust::xxh3::Xxh3;
 
 #[napi]
 pub fn hash_string(s: String) -> String {

--- a/crates/node-bindings/src/image.rs
+++ b/crates/node-bindings/src/image.rs
@@ -1,8 +1,13 @@
 use mozjpeg_sys::*;
 use napi::bindgen_prelude::*;
-use napi::{Env, Error, JsBuffer, Result};
+use napi::Env;
+use napi::Error;
+use napi::JsBuffer;
+use napi::Result;
 use napi_derive::napi;
-use oxipng::{optimize_from_memory, Headers, Options};
+use oxipng::optimize_from_memory;
+use oxipng::Headers;
+use oxipng::Options;
 use std::mem;
 use std::ptr;
 use std::slice;

--- a/crates/node-bindings/src/image.rs
+++ b/crates/node-bindings/src/image.rs
@@ -1,3 +1,7 @@
+use std::mem;
+use std::ptr;
+use std::slice;
+
 use mozjpeg_sys::*;
 use napi::bindgen_prelude::*;
 use napi::Env;
@@ -8,9 +12,6 @@ use napi_derive::napi;
 use oxipng::optimize_from_memory;
 use oxipng::Headers;
 use oxipng::Options;
-use std::mem;
-use std::ptr;
-use std::slice;
 
 #[napi]
 pub fn optimize_image(kind: String, buf: Buffer, env: Env) -> Result<JsBuffer> {

--- a/crates/node-bindings/src/init_sentry/sentry.rs
+++ b/crates/node-bindings/src/init_sentry/sentry.rs
@@ -1,3 +1,8 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
 use napi::Error;
 use napi::Result;
 use napi::Status;
@@ -7,10 +12,6 @@ use sentry::configure_scope;
 use sentry::init;
 use sentry::ClientInitGuard;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::time::Duration;
 use whoami::username;
 
 static SENTRY_GUARD: Lazy<Arc<Mutex<Option<ClientInitGuard>>>> =

--- a/crates/node-bindings/src/init_sentry/sentry.rs
+++ b/crates/node-bindings/src/init_sentry/sentry.rs
@@ -4,13 +4,13 @@ use napi::Status;
 use napi_derive::napi;
 use once_cell::sync::Lazy;
 use sentry::configure_scope;
-use sentry::{init, ClientInitGuard};
+use sentry::init;
+use sentry::ClientInitGuard;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::{
-  sync::{Arc, Mutex},
-  time::Duration,
-};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
 use whoami::username;
 
 static SENTRY_GUARD: Lazy<Arc<Mutex<Option<ClientInitGuard>>>> =

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -3,7 +3,9 @@
 mod init_sentry;
 
 #[cfg(target_arch = "wasm32")]
-use std::alloc::{alloc, Layout};
+use std::alloc::alloc;
+#[cfg(target_arch = "wasm32")]
+use std::alloc::Layout;
 
 #[cfg(target_os = "macos")]
 #[global_allocator]

--- a/crates/node-bindings/src/resolver.rs
+++ b/crates/node-bindings/src/resolver.rs
@@ -1,24 +1,37 @@
 use dashmap::DashMap;
-use napi::{
-  bindgen_prelude::Either3, Env, JsBoolean, JsBuffer, JsFunction, JsObject, JsString, JsUnknown,
-  Ref, Result,
-};
+use napi::bindgen_prelude::Either3;
+use napi::Env;
+use napi::JsBoolean;
+use napi::JsBuffer;
+use napi::JsFunction;
+use napi::JsObject;
+use napi::JsString;
+use napi::JsUnknown;
+use napi::Ref;
+use napi::Result;
 use napi_derive::napi;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::atomic::Ordering;
-use std::{
-  borrow::Cow,
-  collections::HashMap,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use std::sync::Arc;
 
+use parcel_resolver::ExportsCondition;
+use parcel_resolver::Extensions;
+use parcel_resolver::Fields;
+use parcel_resolver::FileCreateInvalidation;
+use parcel_resolver::FileSystem;
+use parcel_resolver::Flags;
+use parcel_resolver::IncludeNodeModules;
+use parcel_resolver::Invalidations;
+use parcel_resolver::ModuleType;
 #[cfg(not(target_arch = "wasm32"))]
 use parcel_resolver::OsFileSystem;
-use parcel_resolver::{
-  ExportsCondition, Extensions, Fields, FileCreateInvalidation, FileSystem, Flags,
-  IncludeNodeModules, Invalidations, ModuleType, Resolution, ResolverError, SpecifierType,
-};
+use parcel_resolver::Resolution;
+use parcel_resolver::ResolverError;
+use parcel_resolver::SpecifierType;
 
 type NapiSideEffectsVariants = Either3<bool, Vec<String>, HashMap<String, bool>>;
 

--- a/crates/node-bindings/src/resolver.rs
+++ b/crates/node-bindings/src/resolver.rs
@@ -1,3 +1,11 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
 use dashmap::DashMap;
 use napi::bindgen_prelude::Either3;
 use napi::Env;
@@ -10,14 +18,6 @@ use napi::JsUnknown;
 use napi::Ref;
 use napi::Result;
 use napi_derive::napi;
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::path::Path;
-use std::path::PathBuf;
-#[cfg(not(target_arch = "wasm32"))]
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
 use parcel_resolver::ExportsCondition;
 use parcel_resolver::Extensions;
 use parcel_resolver::Fields;

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -13,8 +13,9 @@ pub fn transform(opts: JsObject, env: Env) -> napi::Result<JsUnknown> {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native_only {
-  use super::*;
   use parcel_macros::napi::create_macro_callback;
+
+  use super::*;
 
   #[napi]
   pub fn transform_async(opts: JsObject, env: Env) -> napi::Result<JsObject> {

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -1,4 +1,6 @@
-use napi::{Env, JsObject, JsUnknown};
+use napi::Env;
+use napi::JsObject;
+use napi::JsUnknown;
 use napi_derive::napi;
 
 #[napi]

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build-repl": "yarn build-native-release && yarn build-native-wasm && yarn workspace @parcel/repl build",
     "clean-test": "rimraf packages/core/integration-tests/.parcel-cache && rimraf packages/core/integration-tests/dist",
     "clean": "yarn clean-test && lerna clean --yes && lerna exec -- rimraf ./lib && yarn",
-    "format": "prettier --write \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\" && cargo fmt --all",
+    "format": "prettier --write \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\" && cargo +nightly fmt --all",
     "link-all": "node scripts/link-all.js packages",
     "unlink-all": "node scripts/unlink-all.js packages",
     "check": "flow check",

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -1,3 +1,18 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use serde::Deserialize;
+use serde::Serialize;
+use swc_core::common::sync::Lrc;
+use swc_core::common::Mark;
+use swc_core::common::Span;
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::*;
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::visit::Visit;
+use swc_core::ecma::visit::VisitWith;
+
 use crate::id;
 use crate::utils::is_unresolved;
 use crate::utils::match_export_name;
@@ -9,19 +24,6 @@ use crate::utils::match_require;
 use crate::utils::Bailout;
 use crate::utils::BailoutReason;
 use crate::utils::SourceLocation;
-use serde::Deserialize;
-use serde::Serialize;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use swc_core::common::sync::Lrc;
-use swc_core::common::Mark;
-use swc_core::common::Span;
-use swc_core::common::DUMMY_SP;
-use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::js_word;
-use swc_core::ecma::atoms::JsWord;
-use swc_core::ecma::visit::Visit;
-use swc_core::ecma::visit::VisitWith;
 
 macro_rules! collect_visit_fn {
   ($name:ident, $type:ident) => {

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -1,14 +1,27 @@
 use crate::id;
-use crate::utils::{
-  is_unresolved, match_export_name, match_export_name_ident, match_import, match_member_expr,
-  match_property_name, match_require, Bailout, BailoutReason, SourceLocation,
-};
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
-use swc_core::common::{sync::Lrc, Mark, Span, DUMMY_SP};
+use crate::utils::is_unresolved;
+use crate::utils::match_export_name;
+use crate::utils::match_export_name_ident;
+use crate::utils::match_import;
+use crate::utils::match_member_expr;
+use crate::utils::match_property_name;
+use crate::utils::match_require;
+use crate::utils::Bailout;
+use crate::utils::BailoutReason;
+use crate::utils::SourceLocation;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use swc_core::common::sync::Lrc;
+use swc_core::common::Mark;
+use swc_core::common::Span;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::{js_word, JsWord};
-use swc_core::ecma::visit::{Visit, VisitWith};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::visit::Visit;
+use swc_core::ecma::visit::VisitWith;
 
 macro_rules! collect_visit_fn {
   ($name:ident, $type:ident) => {

--- a/packages/transformers/js/core/src/constant_module.rs
+++ b/packages/transformers/js/core/src/constant_module.rs
@@ -1,8 +1,14 @@
 use std::collections::HashSet;
 
-use swc_core::ecma::ast::{
-  Decl, Expr, Lit, Module, ModuleDecl, ModuleItem, Stmt, VarDeclKind, VarDeclarator,
-};
+use swc_core::ecma::ast::Decl;
+use swc_core::ecma::ast::Expr;
+use swc_core::ecma::ast::Lit;
+use swc_core::ecma::ast::Module;
+use swc_core::ecma::ast::ModuleDecl;
+use swc_core::ecma::ast::ModuleItem;
+use swc_core::ecma::ast::Stmt;
+use swc_core::ecma::ast::VarDeclKind;
+use swc_core::ecma::ast::VarDeclarator;
 use swc_core::ecma::atoms::JsWord;
 use swc_core::ecma::visit::Visit;
 
@@ -130,9 +136,13 @@ impl Visit for ConstantModule {
 mod tests {
   use super::*;
   use swc_core::common::comments::SingleThreadedComments;
-  use swc_core::common::{sync::Lrc, FileName, Globals, SourceMap};
+  use swc_core::common::sync::Lrc;
+  use swc_core::common::FileName;
+  use swc_core::common::Globals;
+  use swc_core::common::SourceMap;
   use swc_core::ecma::parser::lexer::Lexer;
-  use swc_core::ecma::parser::{Parser, StringInput};
+  use swc_core::ecma::parser::Parser;
+  use swc_core::ecma::parser::StringInput;
   use swc_core::ecma::visit::VisitWith;
   extern crate indoc;
 

--- a/packages/transformers/js/core/src/constant_module.rs
+++ b/packages/transformers/js/core/src/constant_module.rs
@@ -134,7 +134,6 @@ impl Visit for ConstantModule {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use swc_core::common::comments::SingleThreadedComments;
   use swc_core::common::sync::Lrc;
   use swc_core::common::FileName;
@@ -144,6 +143,8 @@ mod tests {
   use swc_core::ecma::parser::Parser;
   use swc_core::ecma::parser::StringInput;
   use swc_core::ecma::visit::VisitWith;
+
+  use super::*;
   extern crate indoc;
 
   fn is_constant_module(code: &str) -> bool {

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -3,18 +3,27 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
-use serde::{Deserialize, Serialize};
-use swc_core::common::{Mark, SourceMap, Span, DUMMY_SP};
-use swc_core::ecma::ast::{self, Callee, MemberProp};
-use swc_core::ecma::atoms::{js_word, JsWord};
-use swc_core::ecma::visit::{Fold, FoldWith};
+use serde::Deserialize;
+use serde::Serialize;
+use swc_core::common::Mark;
+use swc_core::common::SourceMap;
+use swc_core::common::Span;
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::Callee;
+use swc_core::ecma::ast::MemberProp;
+use swc_core::ecma::ast::{self};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 use crate::fold_member_expr_skip_prop;
 use crate::utils::*;
 use crate::Config;
 
 use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
+use std::hash::Hasher;
 macro_rules! hash {
   ($str:expr) => {{
     let mut hasher = DefaultHasher::new();
@@ -357,7 +366,8 @@ impl<'a> Fold for DependencyCollector<'a> {
   }
 
   fn fold_call_expr(&mut self, node: ast::CallExpr) -> ast::CallExpr {
-    use ast::{Expr::*, Ident};
+    use ast::Expr::*;
+    use ast::Ident;
 
     let kind = match &node.callee {
       Callee::Import(_) => DependencyKind::DynamicImport,

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -1,8 +1,11 @@
-use path_slash::PathBufExt;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::path::Path;
 
+use path_slash::PathBufExt;
 use serde::Deserialize;
 use serde::Serialize;
 use swc_core::common::Mark;
@@ -20,10 +23,6 @@ use swc_core::ecma::visit::FoldWith;
 use crate::fold_member_expr_skip_prop;
 use crate::utils::*;
 use crate::Config;
-
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hash;
-use std::hash::Hasher;
 macro_rules! hash {
   ($str:expr) => {{
     let mut hasher = DefaultHasher::new();

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -1,10 +1,13 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::vec;
 
-use swc_core::common::{Mark, DUMMY_SP};
+use swc_core::common::Mark;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast;
 use swc_core::ecma::atoms::JsWord;
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 use crate::utils::*;
 use ast::*;

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::vec;
 
+use ast::*;
 use swc_core::common::Mark;
 use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast;
@@ -10,7 +11,6 @@ use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 
 use crate::utils::*;
-use ast::*;
 
 pub struct EnvReplacer<'a> {
   pub replace_env: bool,

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -1,13 +1,8 @@
-use crate::collect::Collect;
-use crate::collect::Import;
-use crate::dependency_collector::DependencyDescriptor;
-use crate::dependency_collector::DependencyKind;
-use crate::id;
-use crate::utils::SourceLocation;
-use data_encoding::BASE64;
-use data_encoding::HEXLOWER;
 use std::path::Path;
 use std::path::PathBuf;
+
+use data_encoding::BASE64;
+use data_encoding::HEXLOWER;
 use swc_core::common::Mark;
 use swc_core::common::Span;
 use swc_core::common::DUMMY_SP;
@@ -16,6 +11,13 @@ use swc_core::ecma::atoms::JsWord;
 use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 use swc_core::ecma::visit::VisitWith;
+
+use crate::collect::Collect;
+use crate::collect::Import;
+use crate::dependency_collector::DependencyDescriptor;
+use crate::dependency_collector::DependencyKind;
+use crate::id;
+use crate::utils::SourceLocation;
 
 pub fn inline_fs<'a>(
   filename: &str,

--- a/packages/transformers/js/core/src/fs.rs
+++ b/packages/transformers/js/core/src/fs.rs
@@ -1,13 +1,21 @@
-use crate::collect::{Collect, Import};
-use crate::dependency_collector::{DependencyDescriptor, DependencyKind};
+use crate::collect::Collect;
+use crate::collect::Import;
+use crate::dependency_collector::DependencyDescriptor;
+use crate::dependency_collector::DependencyKind;
 use crate::id;
 use crate::utils::SourceLocation;
-use data_encoding::{BASE64, HEXLOWER};
-use std::path::{Path, PathBuf};
-use swc_core::common::{Mark, Span, DUMMY_SP};
+use data_encoding::BASE64;
+use data_encoding::HEXLOWER;
+use std::path::Path;
+use std::path::PathBuf;
+use swc_core::common::Mark;
+use swc_core::common::Span;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::*;
 use swc_core::ecma::atoms::JsWord;
-use swc_core::ecma::visit::{Fold, FoldWith, VisitWith};
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
+use swc_core::ecma::visit::VisitWith;
 
 pub fn inline_fs<'a>(
   filename: &str,

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -2,15 +2,24 @@ use indexmap::IndexMap;
 use path_slash::PathBufExt;
 use std::path::Path;
 
-use swc_core::common::{Mark, SourceMap, SyntaxContext, DUMMY_SP};
-use swc_core::ecma::ast::{self, ComputedPropName};
-use swc_core::ecma::atoms::{js_word, JsWord};
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::common::Mark;
+use swc_core::common::SourceMap;
+use swc_core::common::SyntaxContext;
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::ComputedPropName;
+use swc_core::ecma::ast::{self};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
-use crate::dependency_collector::{DependencyDescriptor, DependencyKind};
-use crate::utils::{
-  create_global_decl_stmt, create_require, is_unresolved, SourceLocation, SourceType,
-};
+use crate::dependency_collector::DependencyDescriptor;
+use crate::dependency_collector::DependencyKind;
+use crate::utils::create_global_decl_stmt;
+use crate::utils::create_require;
+use crate::utils::is_unresolved;
+use crate::utils::SourceLocation;
+use crate::utils::SourceType;
 
 pub struct GlobalReplacer<'a> {
   pub source_map: &'a SourceMap,
@@ -25,7 +34,10 @@ pub struct GlobalReplacer<'a> {
 
 impl<'a> Fold for GlobalReplacer<'a> {
   fn fold_expr(&mut self, node: ast::Expr) -> ast::Expr {
-    use ast::{Expr::*, Ident, MemberExpr, MemberProp};
+    use ast::Expr::*;
+    use ast::Ident;
+    use ast::MemberExpr;
+    use ast::MemberProp;
 
     // Do not traverse into the `prop` side of member expressions unless computed.
     let mut node = match node {

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -1,7 +1,7 @@
-use indexmap::IndexMap;
-use path_slash::PathBufExt;
 use std::path::Path;
 
+use indexmap::IndexMap;
+use path_slash::PathBufExt;
 use swc_core::common::Mark;
 use swc_core::common::SourceMap;
 use swc_core::common::SyntaxContext;

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1,19 +1,11 @@
-use crate::collect::Collect;
-use crate::collect::Export;
-use crate::collect::Import;
-use crate::collect::ImportKind;
-use crate::utils::get_undefined_ident;
-use crate::utils::is_unresolved;
-use crate::utils::match_export_name;
-use crate::utils::match_export_name_ident;
-use crate::utils::match_property_name;
-use indexmap::IndexMap;
-use serde::Deserialize;
-use serde::Serialize;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hasher;
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+use serde::Serialize;
 use swc_core::common::Mark;
 use swc_core::common::Span;
 use swc_core::common::SyntaxContext;
@@ -24,9 +16,18 @@ use swc_core::ecma::atoms::JsWord;
 use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 
+use crate::collect::Collect;
+use crate::collect::Export;
+use crate::collect::Import;
+use crate::collect::ImportKind;
 use crate::id;
+use crate::utils::get_undefined_ident;
+use crate::utils::is_unresolved;
+use crate::utils::match_export_name;
+use crate::utils::match_export_name_ident;
 use crate::utils::match_import;
 use crate::utils::match_member_expr;
+use crate::utils::match_property_name;
 use crate::utils::match_require;
 use crate::utils::CodeHighlight;
 use crate::utils::Diagnostic;
@@ -1135,9 +1136,8 @@ impl<'a> Hoist<'a> {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
-  use crate::utils::BailoutReason;
   use std::iter::FromIterator;
+
   use swc_core::common::chain;
   use swc_core::common::comments::SingleThreadedComments;
   use swc_core::common::sync::Lrc;
@@ -1153,6 +1153,9 @@ mod tests {
   use swc_core::ecma::transforms::base::hygiene::hygiene;
   use swc_core::ecma::transforms::base::resolver;
   use swc_core::ecma::visit::VisitWith;
+
+  use super::*;
+  use crate::utils::BailoutReason;
   extern crate indoc;
   use self::indoc::indoc;
 

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1,23 +1,37 @@
-use crate::collect::{Collect, Export, Import, ImportKind};
-use crate::utils::{
-  get_undefined_ident, is_unresolved, match_export_name, match_export_name_ident,
-  match_property_name,
-};
+use crate::collect::Collect;
+use crate::collect::Export;
+use crate::collect::Import;
+use crate::collect::ImportKind;
+use crate::utils::get_undefined_ident;
+use crate::utils::is_unresolved;
+use crate::utils::match_export_name;
+use crate::utils::match_export_name_ident;
+use crate::utils::match_property_name;
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::hash::Hasher;
-use swc_core::common::{Mark, Span, SyntaxContext, DUMMY_SP};
+use swc_core::common::Mark;
+use swc_core::common::Span;
+use swc_core::common::SyntaxContext;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::{js_word, JsWord};
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 use crate::id;
-use crate::utils::{
-  match_import, match_member_expr, match_require, CodeHighlight, Diagnostic, DiagnosticSeverity,
-  SourceLocation,
-};
+use crate::utils::match_import;
+use crate::utils::match_member_expr;
+use crate::utils::match_require;
+use crate::utils::CodeHighlight;
+use crate::utils::Diagnostic;
+use crate::utils::DiagnosticSeverity;
+use crate::utils::SourceLocation;
 
 macro_rules! hash {
   ($str:expr) => {{
@@ -1126,11 +1140,18 @@ mod tests {
   use std::iter::FromIterator;
   use swc_core::common::chain;
   use swc_core::common::comments::SingleThreadedComments;
-  use swc_core::common::{sync::Lrc, FileName, Globals, Mark, SourceMap};
+  use swc_core::common::sync::Lrc;
+  use swc_core::common::FileName;
+  use swc_core::common::Globals;
+  use swc_core::common::Mark;
+  use swc_core::common::SourceMap;
   use swc_core::ecma::codegen::text_writer::JsWriter;
   use swc_core::ecma::parser::lexer::Lexer;
-  use swc_core::ecma::parser::{Parser, StringInput};
-  use swc_core::ecma::transforms::base::{fixer::fixer, hygiene::hygiene, resolver};
+  use swc_core::ecma::parser::Parser;
+  use swc_core::ecma::parser::StringInput;
+  use swc_core::ecma::transforms::base::fixer::fixer;
+  use swc_core::ecma::transforms::base::hygiene::hygiene;
+  use swc_core::ecma::transforms::base::resolver;
   use swc_core::ecma::visit::VisitWith;
   extern crate indoc;
   use self::indoc::indoc;

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -16,8 +16,18 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use collect::Collect;
+use collect::CollectResult;
 use constant_module::ConstantModule;
+use dependency_collector::*;
+use env_replacer::*;
+use fs::inline_fs;
+use global_replacer::GlobalReplacer;
+use hoist::hoist;
+use hoist::HoistResult;
 use indexmap::IndexMap;
+use modules::esm2cjs;
+use node_replacer::NodeReplacer;
 use parcel_macros::MacroCallback;
 use parcel_macros::MacroError;
 use parcel_macros::Macros;
@@ -64,26 +74,14 @@ use swc_core::ecma::transforms::react;
 use swc_core::ecma::transforms::typescript;
 use swc_core::ecma::visit::FoldWith;
 use swc_core::ecma::visit::VisitWith;
-
-use collect::Collect;
-use collect::CollectResult;
-use dependency_collector::*;
-use env_replacer::*;
-use fs::inline_fs;
-use global_replacer::GlobalReplacer;
-use hoist::hoist;
-use hoist::HoistResult;
-use modules::esm2cjs;
-use node_replacer::NodeReplacer;
 use typeof_replacer::*;
 use utils::error_buffer_to_diagnostics;
 use utils::CodeHighlight;
 use utils::Diagnostic;
 use utils::DiagnosticSeverity;
 use utils::ErrorBuffer;
-use utils::SourceType;
-
 pub use utils::SourceLocation;
+use utils::SourceType;
 
 type SourceMapBuffer = Vec<(swc_core::common::BytePos, swc_core::common::LineCol)>;
 

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -10,49 +10,78 @@ mod node_replacer;
 mod typeof_replacer;
 mod utils;
 
-use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use constant_module::ConstantModule;
 use indexmap::IndexMap;
-use parcel_macros::{MacroCallback, MacroError, Macros};
+use parcel_macros::MacroCallback;
+use parcel_macros::MacroError;
+use parcel_macros::Macros;
 use path_slash::PathExt;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
+use swc_core::common::chain;
 use swc_core::common::comments::SingleThreadedComments;
 use swc_core::common::errors::Handler;
 use swc_core::common::pass::Optional;
 use swc_core::common::source_map::SourceMapGenConfig;
-use swc_core::common::{chain, sync::Lrc, FileName, Globals, Mark, SourceMap};
-use swc_core::ecma::ast::{Module, ModuleItem, Program};
+use swc_core::common::sync::Lrc;
+use swc_core::common::FileName;
+use swc_core::common::Globals;
+use swc_core::common::Mark;
+use swc_core::common::SourceMap;
+use swc_core::ecma::ast::Module;
+use swc_core::ecma::ast::ModuleItem;
+use swc_core::ecma::ast::Program;
 use swc_core::ecma::codegen::text_writer::JsWriter;
 use swc_core::ecma::parser::error::Error;
 use swc_core::ecma::parser::lexer::Lexer;
-use swc_core::ecma::parser::{EsConfig, Parser, StringInput, Syntax, TsConfig};
-use swc_core::ecma::preset_env::{preset_env, Mode::Entry, Targets, Version, Versions};
+use swc_core::ecma::parser::EsConfig;
+use swc_core::ecma::parser::Parser;
+use swc_core::ecma::parser::StringInput;
+use swc_core::ecma::parser::Syntax;
+use swc_core::ecma::parser::TsConfig;
+use swc_core::ecma::preset_env::preset_env;
+use swc_core::ecma::preset_env::Mode::Entry;
+use swc_core::ecma::preset_env::Targets;
+use swc_core::ecma::preset_env::Version;
+use swc_core::ecma::preset_env::Versions;
+use swc_core::ecma::transforms::base::fixer::fixer;
 use swc_core::ecma::transforms::base::fixer::paren_remover;
 use swc_core::ecma::transforms::base::helpers;
-use swc_core::ecma::transforms::base::{fixer::fixer, hygiene::hygiene, resolver, Assumptions};
+use swc_core::ecma::transforms::base::hygiene::hygiene;
+use swc_core::ecma::transforms::base::resolver;
+use swc_core::ecma::transforms::base::Assumptions;
+use swc_core::ecma::transforms::compat::reserved_words::reserved_words;
+use swc_core::ecma::transforms::optimization::simplify::dead_branch_remover;
+use swc_core::ecma::transforms::optimization::simplify::expr_simplifier;
 use swc_core::ecma::transforms::proposal::decorators;
-use swc_core::ecma::transforms::{
-  compat::reserved_words::reserved_words, optimization::simplify::dead_branch_remover,
-  optimization::simplify::expr_simplifier, react, typescript,
-};
-use swc_core::ecma::visit::{FoldWith, VisitWith};
+use swc_core::ecma::transforms::react;
+use swc_core::ecma::transforms::typescript;
+use swc_core::ecma::visit::FoldWith;
+use swc_core::ecma::visit::VisitWith;
 
-use collect::{Collect, CollectResult};
+use collect::Collect;
+use collect::CollectResult;
 use dependency_collector::*;
 use env_replacer::*;
 use fs::inline_fs;
 use global_replacer::GlobalReplacer;
-use hoist::{hoist, HoistResult};
+use hoist::hoist;
+use hoist::HoistResult;
 use modules::esm2cjs;
 use node_replacer::NodeReplacer;
 use typeof_replacer::*;
-use utils::{
-  error_buffer_to_diagnostics, CodeHighlight, Diagnostic, DiagnosticSeverity, ErrorBuffer,
-  SourceType,
-};
+use utils::error_buffer_to_diagnostics;
+use utils::CodeHighlight;
+use utils::Diagnostic;
+use utils::DiagnosticSeverity;
+use utils::ErrorBuffer;
+use utils::SourceType;
 
 pub use utils::SourceLocation;
 

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -1,12 +1,21 @@
 use crate::id;
-use crate::utils::{get_undefined_ident, match_export_name, match_export_name_ident};
+use crate::utils::get_undefined_ident;
+use crate::utils::match_export_name;
+use crate::utils::match_export_name_ident;
 use inflector::Inflector;
-use std::collections::{HashMap, HashSet};
-use swc_core::common::{Mark, Span, SyntaxContext, DUMMY_SP};
+use std::collections::HashMap;
+use std::collections::HashSet;
+use swc_core::common::Mark;
+use swc_core::common::Span;
+use swc_core::common::SyntaxContext;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast::*;
-use swc_core::ecma::atoms::{js_word, JsWord};
-use swc_core::ecma::preset_env::{Feature, Versions};
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::preset_env::Feature;
+use swc_core::ecma::preset_env::Versions;
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 use crate::fold_member_expr_skip_prop;
 

--- a/packages/transformers/js/core/src/modules.rs
+++ b/packages/transformers/js/core/src/modules.rs
@@ -1,10 +1,7 @@
-use crate::id;
-use crate::utils::get_undefined_ident;
-use crate::utils::match_export_name;
-use crate::utils::match_export_name_ident;
-use inflector::Inflector;
 use std::collections::HashMap;
 use std::collections::HashSet;
+
+use inflector::Inflector;
 use swc_core::common::Mark;
 use swc_core::common::Span;
 use swc_core::common::SyntaxContext;
@@ -18,6 +15,10 @@ use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 
 use crate::fold_member_expr_skip_prop;
+use crate::id;
+use crate::utils::get_undefined_ident;
+use crate::utils::match_export_name;
+use crate::utils::match_export_name_ident;
 
 pub fn esm2cjs(node: Module, unresolved_mark: Mark, versions: Option<Versions>) -> (Module, bool) {
   let mut fold = ESMFold {

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -2,15 +2,22 @@ use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::Path;
 
-use swc_core::common::{Mark, SourceMap, SyntaxContext, DUMMY_SP};
+use swc_core::common::Mark;
+use swc_core::common::SourceMap;
+use swc_core::common::SyntaxContext;
+use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast;
 use swc_core::ecma::atoms::JsWord;
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
-use crate::dependency_collector::{DependencyDescriptor, DependencyKind};
-use crate::utils::{
-  create_global_decl_stmt, create_require, is_unresolved, SourceLocation, SourceType,
-};
+use crate::dependency_collector::DependencyDescriptor;
+use crate::dependency_collector::DependencyKind;
+use crate::utils::create_global_decl_stmt;
+use crate::utils::create_require;
+use crate::utils::is_unresolved;
+use crate::utils::SourceLocation;
+use crate::utils::SourceType;
 
 pub struct NodeReplacer<'a> {
   pub source_map: &'a SourceMap,
@@ -26,7 +33,9 @@ pub struct NodeReplacer<'a> {
 
 impl<'a> Fold for NodeReplacer<'a> {
   fn fold_expr(&mut self, node: ast::Expr) -> ast::Expr {
-    use ast::{Expr::*, MemberExpr, MemberProp};
+    use ast::Expr::*;
+    use ast::MemberExpr;
+    use ast::MemberProp;
 
     // Do not traverse into the `prop` side of member expressions unless computed.
     let mut node = match node {

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -1,8 +1,12 @@
 use crate::utils::is_unresolved;
 use swc_core::common::Mark;
-use swc_core::ecma::ast::{Expr, Lit, Str, UnaryOp};
+use swc_core::ecma::ast::Expr;
+use swc_core::ecma::ast::Lit;
+use swc_core::ecma::ast::Str;
+use swc_core::ecma::ast::UnaryOp;
 use swc_core::ecma::atoms::js_word;
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 pub struct TypeofReplacer {
   pub unresolved_mark: Mark,

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -1,4 +1,3 @@
-use crate::utils::is_unresolved;
 use swc_core::common::Mark;
 use swc_core::ecma::ast::Expr;
 use swc_core::ecma::ast::Lit;
@@ -7,6 +6,8 @@ use swc_core::ecma::ast::UnaryOp;
 use swc_core::ecma::atoms::js_word;
 use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
+
+use crate::utils::is_unresolved;
 
 pub struct TypeofReplacer {
   pub unresolved_mark: Mark,

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -1,6 +1,7 @@
+use std::cmp::Ordering;
+
 use serde::Deserialize;
 use serde::Serialize;
-use std::cmp::Ordering;
 use swc_core::common::errors::DiagnosticBuilder;
 use swc_core::common::errors::Emitter;
 use swc_core::common::Mark;

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -1,16 +1,27 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use std::cmp::Ordering;
-use swc_core::common::errors::{DiagnosticBuilder, Emitter};
-use swc_core::common::{Mark, SourceMap, Span, SyntaxContext, DUMMY_SP};
-use swc_core::ecma::ast::{self, Ident};
-use swc_core::ecma::atoms::{js_word, JsWord};
+use swc_core::common::errors::DiagnosticBuilder;
+use swc_core::common::errors::Emitter;
+use swc_core::common::Mark;
+use swc_core::common::SourceMap;
+use swc_core::common::Span;
+use swc_core::common::SyntaxContext;
+use swc_core::common::DUMMY_SP;
+use swc_core::ecma::ast::Ident;
+use swc_core::ecma::ast::{self};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::atoms::JsWord;
 
 pub fn is_unresolved(ident: &Ident, unresolved_mark: Mark) -> bool {
   ident.span.ctxt.outer() == unresolved_mark
 }
 
 pub fn match_member_expr(expr: &ast::MemberExpr, idents: Vec<&str>, unresolved_mark: Mark) -> bool {
-  use ast::{Expr, Lit, MemberProp, Str};
+  use ast::Expr;
+  use ast::Lit;
+  use ast::MemberProp;
+  use ast::Str;
 
   let mut member = expr;
   let mut idents = idents;

--- a/packages/utils/dev-dep-resolver/src/lib.rs
+++ b/packages/utils/dev-dep-resolver/src/lib.rs
@@ -1,14 +1,23 @@
-use std::{
-  borrow::Cow,
-  path::{Component, Path, PathBuf},
-};
+use std::borrow::Cow;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
 
-use dashmap::{DashMap, DashSet};
-use es_module_lexer::{lex, ImportKind};
-use parcel_resolver::{
-  CacheCow, FileSystem, Invalidations, ModuleType, Resolution, ResolveOptions, Resolver,
-  ResolverError, Specifier, SpecifierError, SpecifierType,
-};
+use dashmap::DashMap;
+use dashmap::DashSet;
+use es_module_lexer::lex;
+use es_module_lexer::ImportKind;
+use parcel_resolver::CacheCow;
+use parcel_resolver::FileSystem;
+use parcel_resolver::Invalidations;
+use parcel_resolver::ModuleType;
+use parcel_resolver::Resolution;
+use parcel_resolver::ResolveOptions;
+use parcel_resolver::Resolver;
+use parcel_resolver::ResolverError;
+use parcel_resolver::Specifier;
+use parcel_resolver::SpecifierError;
+use parcel_resolver::SpecifierType;
 // use rayon::prelude::{ParallelBridge, ParallelIterator};
 
 #[derive(Debug)]

--- a/packages/utils/dev-dep-resolver/src/main.rs
+++ b/packages/utils/dev-dep-resolver/src/main.rs
@@ -1,7 +1,12 @@
 use std::borrow::Cow;
 
 use parcel_dev_dep_resolver::build_esm_graph;
-use parcel_resolver::{Cache, CacheCow, OsFileSystem, Resolution, Resolver, SpecifierType};
+use parcel_resolver::Cache;
+use parcel_resolver::CacheCow;
+use parcel_resolver::OsFileSystem;
+use parcel_resolver::Resolution;
+use parcel_resolver::Resolver;
+use parcel_resolver::SpecifierType;
 
 fn main() {
   let contents = std::fs::read_to_string("package.json").unwrap();

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -4,15 +4,16 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+use dashmap::DashMap;
+use elsa::sync::FrozenMap;
+use typed_arena::Arena;
+
 use crate::fs::FileSystem;
 use crate::package_json::PackageJson;
 use crate::package_json::SourceField;
 use crate::tsconfig::TsConfig;
 use crate::tsconfig::TsConfigWrapper;
 use crate::ResolverError;
-use dashmap::DashMap;
-use elsa::sync::FrozenMap;
-use typed_arena::Arena;
 
 pub struct Cache<Fs> {
   pub fs: Fs,

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -1,16 +1,15 @@
-use std::{
-  borrow::Cow,
-  ops::Deref,
-  path::{Path, PathBuf},
-  sync::Mutex,
-};
+use std::borrow::Cow;
+use std::ops::Deref;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
 
-use crate::{
-  fs::FileSystem,
-  package_json::{PackageJson, SourceField},
-  tsconfig::{TsConfig, TsConfigWrapper},
-  ResolverError,
-};
+use crate::fs::FileSystem;
+use crate::package_json::PackageJson;
+use crate::package_json::SourceField;
+use crate::tsconfig::TsConfig;
+use crate::tsconfig::TsConfigWrapper;
+use crate::ResolverError;
 use dashmap::DashMap;
 use elsa::sync::FrozenMap;
 use typed_arena::Arena;

--- a/packages/utils/node-resolver-rs/src/error.rs
+++ b/packages/utils/node-resolver-rs/src/error.rs
@@ -1,8 +1,9 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
 use crate::cache::JsonError;
 use crate::specifier::SpecifierError;
 use crate::PackageJsonError;
-use std::path::PathBuf;
-use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(tag = "type")]

--- a/packages/utils/node-resolver-rs/src/error.rs
+++ b/packages/utils/node-resolver-rs/src/error.rs
@@ -1,5 +1,6 @@
+use crate::cache::JsonError;
+use crate::specifier::SpecifierError;
 use crate::PackageJsonError;
-use crate::{cache::JsonError, specifier::SpecifierError};
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/packages/utils/node-resolver-rs/src/fs.rs
+++ b/packages/utils/node-resolver-rs/src/fs.rs
@@ -1,7 +1,6 @@
-use std::{
-  io::Result,
-  path::{Path, PathBuf},
-};
+use std::io::Result;
+use std::path::Path;
+use std::path::PathBuf;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::path::canonicalize;

--- a/packages/utils/node-resolver-rs/src/fs.rs
+++ b/packages/utils/node-resolver-rs/src/fs.rs
@@ -2,9 +2,10 @@ use std::io::Result;
 use std::path::Path;
 use std::path::PathBuf;
 
+use dashmap::DashMap;
+
 #[cfg(not(target_arch = "wasm32"))]
 use crate::path::canonicalize;
-use dashmap::DashMap;
 
 pub trait FileSystem: Send + Sync {
   fn canonicalize<P: AsRef<Path>>(

--- a/packages/utils/node-resolver-rs/src/invalidations.rs
+++ b/packages/utils/node-resolver-rs/src/invalidations.rs
@@ -1,11 +1,12 @@
-use std::{
-  path::{Path, PathBuf},
-  sync::atomic::{AtomicBool, Ordering},
-};
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 use dashmap::DashSet;
 
-use crate::{path::normalize_path, ResolverError};
+use crate::path::normalize_path;
+use crate::ResolverError;
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum FileCreateInvalidation {

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -1,14 +1,16 @@
 use bitflags::bitflags;
 use once_cell::unsync::OnceCell;
-use specifier::{parse_package_specifier, parse_scheme};
-use std::{
-  borrow::Cow,
-  collections::HashMap,
-  path::{Path, PathBuf},
-  sync::Arc,
-};
+use specifier::parse_package_specifier;
+use specifier::parse_scheme;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
 
-use package_json::{AliasValue, ExportsResolution, PackageJson};
+use package_json::AliasValue;
+use package_json::ExportsResolution;
+use package_json::PackageJson;
 use tsconfig::TsConfig;
 
 mod builtins;
@@ -22,14 +24,20 @@ mod specifier;
 mod tsconfig;
 mod url_to_path;
 
-pub use cache::{Cache, CacheCow};
+pub use cache::Cache;
+pub use cache::CacheCow;
 pub use error::ResolverError;
 pub use fs::FileSystem;
 #[cfg(not(target_arch = "wasm32"))]
 pub use fs::OsFileSystem;
 pub use invalidations::*;
-pub use package_json::{ExportsCondition, Fields, ModuleType, PackageJsonError};
-pub use specifier::{Specifier, SpecifierError, SpecifierType};
+pub use package_json::ExportsCondition;
+pub use package_json::Fields;
+pub use package_json::ModuleType;
+pub use package_json::PackageJsonError;
+pub use specifier::Specifier;
+pub use specifier::SpecifierError;
+pub use specifier::SpecifierType;
 
 use crate::path::resolve_path;
 

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -1,16 +1,16 @@
-use bitflags::bitflags;
-use once_cell::unsync::OnceCell;
-use specifier::parse_package_specifier;
-use specifier::parse_scheme;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use bitflags::bitflags;
+use once_cell::unsync::OnceCell;
 use package_json::AliasValue;
 use package_json::ExportsResolution;
 use package_json::PackageJson;
+use specifier::parse_package_specifier;
+use specifier::parse_scheme;
 use tsconfig::TsConfig;
 
 mod builtins;
@@ -1214,9 +1214,10 @@ impl<'a, Fs: FileSystem> ResolveRequest<'a, Fs> {
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashSet;
+
   use super::cache::Cache;
   use super::*;
-  use std::collections::HashSet;
 
   fn root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -1,19 +1,19 @@
 use bitflags::bitflags;
-use glob_match::{glob_match, glob_match_with_captures};
+use glob_match::glob_match;
+use glob_match::glob_match_with_captures;
 use indexmap::IndexMap;
 use serde::Deserialize;
-use std::{
-  borrow::Cow,
-  cmp::Ordering,
-  ops::Range,
-  path::{Component, Path, PathBuf},
-};
+use std::borrow::Cow;
+use std::cmp::Ordering;
+use std::ops::Range;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
 
-use crate::{
-  path::resolve_path,
-  specifier::decode_path,
-  specifier::{Specifier, SpecifierType},
-};
+use crate::path::resolve_path;
+use crate::specifier::decode_path;
+use crate::specifier::Specifier;
+use crate::specifier::SpecifierType;
 
 bitflags! {
   #[derive(serde::Serialize)]

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -1,14 +1,15 @@
-use bitflags::bitflags;
-use glob_match::glob_match;
-use glob_match::glob_match_with_captures;
-use indexmap::IndexMap;
-use serde::Deserialize;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::ops::Range;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
+
+use bitflags::bitflags;
+use glob_match::glob_match;
+use glob_match::glob_match_with_captures;
+use indexmap::IndexMap;
+use serde::Deserialize;
 
 use crate::path::resolve_path;
 use crate::specifier::decode_path;
@@ -800,8 +801,9 @@ impl<'a> Iterator for EntryIter<'a> {
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use indexmap::indexmap;
+
+  use super::*;
 
   // Based on https://github.com/lukeed/resolve.exports/blob/master/test/resolve.js,
   // https://github.com/privatenumber/resolve-pkg-maps/tree/develop/tests, and

--- a/packages/utils/node-resolver-rs/src/path.rs
+++ b/packages/utils/node-resolver-rs/src/path.rs
@@ -2,7 +2,9 @@
 use dashmap::DashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::VecDeque;
-use std::path::{Component, Path, PathBuf};
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
 
 pub fn normalize_path(path: &Path) -> PathBuf {
   // Normalize path components to resolve ".." and "." segments.

--- a/packages/utils/node-resolver-rs/src/path.rs
+++ b/packages/utils/node-resolver-rs/src/path.rs
@@ -1,10 +1,11 @@
 #[cfg(not(target_arch = "wasm32"))]
-use dashmap::DashMap;
-#[cfg(not(target_arch = "wasm32"))]
 use std::collections::VecDeque;
 use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
+
+#[cfg(not(target_arch = "wasm32"))]
+use dashmap::DashMap;
 
 pub fn normalize_path(path: &Path) -> PathBuf {
   // Normalize path components to resolve ".." and "." segments.
@@ -140,8 +141,9 @@ pub fn canonicalize(
 
 #[cfg(test)]
 mod test {
-  use super::*;
   use assert_fs::prelude::*;
+
+  use super::*;
 
   #[test]
   fn test_canonicalize() -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -1,9 +1,11 @@
-use crate::{builtins::BUILTINS, url_to_path::url_to_path, Flags};
+use crate::builtins::BUILTINS;
+use crate::url_to_path::url_to_path;
+use crate::Flags;
 use percent_encoding::percent_decode_str;
-use std::{
-  borrow::Cow,
-  path::{is_separator, Path, PathBuf},
-};
+use std::borrow::Cow;
+use std::path::is_separator;
+use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum SpecifierType {

--- a/packages/utils/node-resolver-rs/src/specifier.rs
+++ b/packages/utils/node-resolver-rs/src/specifier.rs
@@ -1,11 +1,13 @@
-use crate::builtins::BUILTINS;
-use crate::url_to_path::url_to_path;
-use crate::Flags;
-use percent_encoding::percent_decode_str;
 use std::borrow::Cow;
 use std::path::is_separator;
 use std::path::Path;
 use std::path::PathBuf;
+
+use percent_encoding::percent_decode_str;
+
+use crate::builtins::BUILTINS;
+use crate::url_to_path::url_to_path;
+use crate::Flags;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum SpecifierType {

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -1,13 +1,13 @@
-use std::{
-  borrow::Cow,
-  path::{Path, PathBuf},
-};
+use std::borrow::Cow;
+use std::path::Path;
+use std::path::PathBuf;
 
 use indexmap::IndexMap;
 use itertools::Either;
 use json_comments::strip_comments_in_place;
 
-use crate::{path::resolve_path, specifier::Specifier};
+use crate::path::resolve_path;
+use crate::specifier::Specifier;
 
 #[derive(serde::Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -186,8 +186,9 @@ fn base_url_iter<'a>(
 
 #[cfg(test)]
 mod tests {
-  use super::*;
   use indexmap::indexmap;
+
+  use super::*;
 
   #[test]
   fn test_paths() {

--- a/packages/utils/node-resolver-rs/src/url_to_path.rs
+++ b/packages/utils/node-resolver-rs/src/url_to_path.rs
@@ -1,11 +1,13 @@
 //! An implementation url.to_file_path that behaves like Unix on Wasm
 #![allow(clippy::items_after_test_module)]
 
-use crate::specifier::SpecifierError;
 #[cfg(any(target_arch = "wasm32", test))]
 use std::ffi::OsStr;
 use std::path::PathBuf;
+
 use url::Url;
+
+use crate::specifier::SpecifierError;
 
 pub fn url_to_path(input: &str) -> Result<PathBuf, SpecifierError> {
   let url = Url::parse(input)?;
@@ -32,9 +34,11 @@ fn os_str_from_bytes(slice: &[u8]) -> &OsStr {
 
 #[cfg(test)]
 mod test {
-  use crate::url_to_path::to_file_path;
   use std::path::PathBuf;
+
   use url::Url;
+
+  use crate::url_to_path::to_file_path;
 
   #[test]
   fn test() {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 tab_spaces = 2
+imports_granularity = "Item"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 tab_spaces = 2
 imports_granularity = "Item"
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
This PR adds 
```toml
imports_granularity = "Item"
group_imports = "StdExternalCrate"
``` 
to the Rustfmt.

https://rust-lang.github.io/rustfmt/?version=v1.7.0&search=imports_granularity#imports_granularity
https://rust-lang.github.io/rustfmt/?version=v1.7.0&search=#group_imports

This will change Rust imports so that they are split into individual line items that are grouped (in order) as `std`, `extern` and `crate`

example:

```rust
use swc_core::ecma::ast::{Atom, Span};
crate::{Baz, Buzz};
use std::foo::{Foo, Bar};
```

becomes

```rust
use std::foo::Bar;
use std::foo::Foo;

use swc_core::ecma::ast::Atom;
use swc_core::ecma::ast::Span;

use crate::Baz;
use crate::Buzz;
```

The import groupings rule enforces the import grouping convention used by the Rust community whist the import granularity rule makes it easier to read/tidy-up Rust imports and makes it easier to see changes in PRs

Most of the code changes are the formatting rules being applied.

Notable changes in the PR are:
- [package.json](https://github.com/parcel-bundler/parcel/pull/9669/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R24)
- [rustfmt.toml](https://github.com/parcel-bundler/parcel/pull/9669/files#diff-a947c9d2523f34e53b9cdcd6411174a3148f23ea03ad8a61c1aee7b3ea005440R2)

An example case where the applied rule improves readability
<img width="1450" alt="image" src="https://github.com/parcel-bundler/parcel/assets/12656294/9dbb113a-bc13-47cd-8dd5-026ded05805a">
