### PR TITLE
Add parcel version to PluginOptions

### DIFF
--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -13,7 +13,6 @@ import type {FileSystem} from '@parcel/fs';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ParcelOptions} from '../types';
 import {type FeatureFlags} from '@parcel/feature-flags';
-import {PARCEL_VERSION} from '../constants';
 
 let parcelOptionsToPluginOptions: WeakMap<ParcelOptions, PluginOptions> =
   new WeakMap();
@@ -45,7 +44,7 @@ export default class PluginOptions implements IPluginOptions {
   }
 
   get parcelVersion(): string {
-    return PARCEL_VERSION;
+    return this.#options.parcelVersion;
   }
 
   get hmrOptions(): ?HMROptions {

--- a/packages/core/core/src/public/PluginOptions.js
+++ b/packages/core/core/src/public/PluginOptions.js
@@ -13,6 +13,7 @@ import type {FileSystem} from '@parcel/fs';
 import type {PackageManager} from '@parcel/package-manager';
 import type {ParcelOptions} from '../types';
 import {type FeatureFlags} from '@parcel/feature-flags';
+import {PARCEL_VERSION} from '../constants';
 
 let parcelOptionsToPluginOptions: WeakMap<ParcelOptions, PluginOptions> =
   new WeakMap();
@@ -41,6 +42,10 @@ export default class PluginOptions implements IPluginOptions {
 
   get env(): EnvMap {
     return this.#options.env;
+  }
+
+  get parcelVersion(): string {
+    return PARCEL_VERSION;
   }
 
   get hmrOptions(): ?HMROptions {

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -26,6 +26,7 @@ import {toProjectPath} from './projectPath';
 import {getResolveFrom} from './requests/ParcelConfigRequest';
 
 import {DEFAULT_FEATURE_FLAGS} from '@parcel/feature-flags';
+import {PARCEL_VERSION} from './constants';
 
 // Default cache directory name
 const DEFAULT_CACHE_DIRNAME = '.parcel-cache';
@@ -223,6 +224,7 @@ export default async function resolveOptions(
       isLibrary: initialOptions?.defaultTargetOptions?.isLibrary,
     },
     featureFlags: {...DEFAULT_FEATURE_FLAGS, ...initialOptions?.featureFlags},
+    parcelVersion: PARCEL_VERSION,
   };
 }
 

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -274,6 +274,7 @@ export type ParcelOptions = {|
   config?: DependencySpecifier,
   defaultConfig?: DependencySpecifier,
   env: EnvMap,
+  parcelVersion: string,
   targets: ?(Array<string> | {+[string]: TargetDescriptor, ...}),
   shouldDisableCache: boolean,
   cacheDir: FilePath,

--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -17,6 +17,7 @@ cache.ensure();
 
 export const DEFAULT_OPTIONS: ParcelOptions = {
   cacheDir: path.join(__dirname, '.parcel-cache'),
+  parcelVersion: '',
   watchDir: __dirname,
   watchIgnore: undefined,
   watchBackend: undefined,

--- a/packages/core/integration-tests/.mocharc.json
+++ b/packages/core/integration-tests/.mocharc.json
@@ -2,5 +2,7 @@
   "require": ["@parcel/babel-register", "@parcel/test-utils/src/mochaSetup.js"],
   "timeout": 50000,
   // TODO: Remove this when https://github.com/nodejs/node/pull/28788 is resolved
-  "exit": true
+  "exit": true,
+  // This helps reduce CI flakiness of the Mac OS test run
+  "retries": 2
 }

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -1,7 +1,16 @@
 // @flow strict-local
 import path from 'path';
 import assert from 'assert';
-import {distDir, bundle, assertBundles, outputFS} from '@parcel/test-utils';
+import {
+  distDir,
+  bundle,
+  assertBundles,
+  outputFS,
+  overlayFS,
+  fsFixture,
+} from '@parcel/test-utils';
+
+import {PARCEL_VERSION} from '../../core/src/constants';
 
 describe('JS API', function () {
   it('should respect distEntry', async function () {
@@ -48,5 +57,53 @@ describe('JS API', function () {
     ]);
 
     assert(await outputFS.exists(path.join(distDir, 'bundle-buddy.json')));
+  });
+
+  describe('Reporter API', () => {
+    it('should pass the parcel version to plugins', async () => {
+      const dir = path.join(__dirname, 'plugin-parcel-version');
+      const versionFileLocation = path.join(dir, 'parcel-version.txt');
+
+      overlayFS.mkdirp(dir);
+
+      await fsFixture(overlayFS, dir)`
+      index.js:
+        export default 'Hi';
+      
+      .parcelrc:
+        {
+          extends: "@parcel/config-default",
+          reporters: ["./reporter-plugin.js", "..."],
+        }
+
+      package.json:
+        {
+          "version": "1234"
+        }
+
+      yarn.lock:
+      
+      reporter-plugin.js:
+        import {Reporter} from '@parcel/plugin';
+
+        export default new Reporter({
+          async report({event, options}) {
+            if (event.type === 'buildSuccess') {
+              await options.outputFS.writeFile("${versionFileLocation}", options.parcelVersion);
+            }
+          }
+        })
+      `;
+
+      await bundle(path.join(dir, 'index.js'), {
+        inputFS: overlayFS,
+        outputFS: overlayFS,
+      });
+
+      assert.equal(
+        await overlayFS.readFile(versionFileLocation),
+        PARCEL_VERSION,
+      );
+    });
   });
 });

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -62,7 +62,6 @@ describe('JS API', function () {
   describe('Reporter API', () => {
     it('should pass the parcel version to plugins', async () => {
       const dir = path.join(__dirname, 'plugin-parcel-version');
-      const versionFileLocation = path.join(dir, 'parcel-version.txt');
 
       overlayFS.mkdirp(dir);
 
@@ -85,11 +84,12 @@ describe('JS API', function () {
       
       reporter-plugin.js:
         import {Reporter} from '@parcel/plugin';
+        import path from 'node:path';
 
         export default new Reporter({
           async report({event, options}) {
             if (event.type === 'buildSuccess') {
-              await options.outputFS.writeFile("${versionFileLocation}", options.parcelVersion);
+              await options.outputFS.writeFile(path.join(options.projectRoot, 'parcel-version.txt'), options.parcelVersion);
             }
           }
         })
@@ -101,7 +101,7 @@ describe('JS API', function () {
       });
 
       assert.equal(
-        await overlayFS.readFile(versionFileLocation),
+        await overlayFS.readFile(path.join(dir, 'parcel-version.txt')),
         PARCEL_VERSION,
       );
     });

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -400,6 +400,7 @@ export type InitialServerOptions = {|
 
 export interface PluginOptions {
   +mode: BuildMode;
+  +parcelVersion: string;
   +env: EnvMap;
   +hmrOptions: ?HMROptions;
   +serveOptions: ServerOptions | false;

--- a/packages/reporters/cli/test/CLIReporter.test.js
+++ b/packages/reporters/cli/test/CLIReporter.test.js
@@ -14,6 +14,7 @@ import {DEFAULT_FEATURE_FLAGS} from '@parcel/feature-flags';
 
 const EMPTY_OPTIONS = {
   cacheDir: '.parcel-cache',
+  parcelVersion: '',
   entries: [],
   logLevel: 'info',
   targets: [],


### PR DESCRIPTION
To keep proper track of build metrics, we need to be able to link events to the version of Parcel that's running them.

We had been doing this by running a `yarn why` in the application repo, but that's not actually accurate if there are dependencies that are using their own versions of Parcel.

This PR takes the parcel version from `constants.js` and makes it available on PluginOptions, so that Reporters have access to it downstream.