### PR TITLE
Fix possible race condition in the caching of request graph

### DIFF
--- a/packages/core/cache/src/FSCache.js
+++ b/packages/core/cache/src/FSCache.js
@@ -151,6 +151,21 @@ export class FSCache implements Cache {
     await Promise.all(writePromises);
   }
 
+  async deleteLargeBlob(key: string): Promise<void> {
+    const deletePromises: Promise<void>[] = [];
+
+    let i = 0;
+    let filePath = this.#getFilePath(key, i);
+
+    while (await this.fs.exists(filePath)) {
+      deletePromises.push(this.fs.rimraf(filePath));
+      i += 1;
+      filePath = this.#getFilePath(key, i);
+    }
+
+    await Promise.all(deletePromises);
+  }
+
   async get<T>(key: string): Promise<?T> {
     try {
       let data = await this.fs.readFile(this._getCachePath(key));

--- a/packages/core/cache/src/IDBCache.browser.js
+++ b/packages/core/cache/src/IDBCache.browser.js
@@ -133,6 +133,10 @@ export class IDBCache implements Cache {
     return this.setBlob(key, contents);
   }
 
+  async deleteLargeBlob(key: string): Promise<void> {
+    await (await this.store).delete(STORE_NAME, key);
+  }
+
   refresh(): void {
     // NOOP
   }

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -117,6 +117,10 @@ export class LMDBCache implements Cache {
     return this.fsCache.setLargeBlob(key, contents, options);
   }
 
+  deleteLargeBlob(key: string): Promise<void> {
+    return this.fsCache.deleteLargeBlob(key);
+  }
+
   refresh(): void {
     // Reset the read transaction for the store. This guarantees that
     // the next read will see the latest changes to the store.

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1352,6 +1352,9 @@ export default class RequestTracker {
 
     let serialisedGraph = this.graph.serialize();
 
+    // Delete an existing request graph cache, to prevent invalid states
+    await this.options.cache.deleteLargeBlob(requestGraphKey);
+
     let total = 0;
     const serialiseAndSet = async (
       key: string,

--- a/packages/core/types-internal/src/Cache.js
+++ b/packages/core/types-internal/src/Cache.js
@@ -18,6 +18,7 @@ export interface Cache {
     contents: Buffer | string,
     options?: {|signal?: AbortSignal|},
   ): Promise<void>;
+  deleteLargeBlob(key: string): Promise<void>;
   getBuffer(key: string): Promise<?Buffer>;
   /**
    * In a multi-threaded environment, where there are potentially multiple Cache


### PR DESCRIPTION
**TL;DR**: To fix some existing race conditions in the way the request graph is cached, the old cached graph is now deleted from disk at the start of the process to prevent stale references, and the cache/snapshot write has been moved until after the node-blobs processing rather than being queued.

---

As part of the incremental cache write system, we add all the nodes to be cached on to the queue, and then the request graph itself and the cache snapshot.

We're currently having some problems with "hanging builds" in our application, which means that a number of users are killing the Parcel process through more drastic means once their `ctrl C` has taken too long.

There are two possible scenarios that we think are causing issues in our application at the moment.

## Problems

### 1. Missing nodes

The process is force quit _before_ the nodes are finished being written, but _after_ the request graph cache has been written.

Given the promise queue used in the cache system has concurrency inbuilt, it's possible that the request graph write would finish before the last couple of node-blob writes.

This means that the request graph written to cache would contain references to nodes that don't actually exist in the cache. Since the node IDs are index based, this is causing the graph to look up the wrong nodes.

### 2. Old request graph cache

The process is force quit _after_ the nodes are finished being written, but _before_ the request graph cache has been written.

This would result in all the new node-blobs being written to disk, but the _old_ request graph remaining in place. This means that all its index-based IDs now, again, point to different nodes than it was expecting.

## Solutions

This PR contains fixes for both of these issues.

To fix problem number 1, the write of the request graph and snapshot file have been removed from the queue system, and now wait until after the queue has been flushed. This means that the request graph cache file won't be written until all of the node-blobs are in place.

To fix problem number 2, the cached request graph is deleted once we start writing a new cache. To achieve this, a new `deleteLargeBlob` method has been added to the parent `Cache` type, and implemented for each different cache variant. This means that if a user force-quits the process before the new request graph cache has been written, there will be no cached graph at all, eliminating the stale references problem.