### PR TITLE
Specifically target x86_64 for macos builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
 
           - name: macos-latest
             os: macos-latest
+            target: x86_64-apple-darwin
 
           - name: windows-latest
             os: windows-latest


### PR DESCRIPTION
At the beginning of this month, MacOS 14 [became generally available] in GitHub Actions. This means that the M1/Apple Silicon versions came out of beta, and (trickily for us) became the default image for `macos-latest`.

This switchover seems to have happened for us [a few days ago] in an entirely unrelated PR (I hope, it was mine 😅).

This means that our `macos-latest` build is now spitting out arm64 bindings, _as well as_ our `aarch64-apple-darwin` build. Two Arms, no Intel.

This means that the canary @parcel/rust package has been [published without x64 bindings] since v3197.

I've added a specific target for `x86_64-apple-darwin` to our `macos-latest` build to force it back to outputting Intel binding.

[became generally available]: https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/
[a few days ago]: https://github.com/parcel-bundler/parcel/actions/runs/8843791578/job/24284998218#step:1:8
[published without x64 bindings]: https://www.npmjs.com/package/@parcel/rust/v/2.12.1-canary.3197?activeTab=code