### PR TITLE
Enable producing native debug symbols in canary/dev releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,11 +273,24 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: artifacts
-      - name: Move artifacts
-        run: for d in artifacts/*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+      - name: Move bindings
+        run: for d in artifacts/bindings-*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+      - name: Move debug symbols
+        run: |
+          mkdir debug-symbols
+          find artifacts -name "*.debug" -exec cp {} debug-symbols/ \;
+          find artifacts -name "*.node" -path "**/DWARF" -exec cp {} debug-symbols/ \;
+      - name: Upload combined debug symbols artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.profile == 'canary' }}
+        with:
+          name: debug-symbols
+          path: debug-symbols/**
       - name: Debug
-        run: ls -l packages/*/*/*.node
+        run: |
+          ls -l packages/*/*/*.node
+          ls -l debug-symbols
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: ${{ inputs.release-command }}
+      #- run: ${{ inputs.release-command }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,10 +136,12 @@ jobs:
           - target: arm-unknown-linux-gnueabihf
             arch: armhf
             strip: arm-linux-gnueabihf-strip
+            objcopy: arm-linux-gnueabihf-objcopy
             cflags: -mfpu=neon
           - target: aarch64-unknown-linux-gnu
             arch: arm64
             strip: aarch64-linux-gnu-strip
+            objcopy: aarch64-linux-gnu-objcopy
             cflags: ''
     name: ${{ matrix.target }}
     runs-on: ubuntu-20.04
@@ -167,9 +169,9 @@ jobs:
       - name: Extract debug symbols
         if: ${{ inputs.profile == 'canary' }}
         run: |
-          find packages -name "*.node" -type f -exec objcopy --only-keep-debug {} {}.debug \;
-          find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
-          find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --strip-debug --strip-unneeded {} \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
         uses: actions/upload-artifact@v3
         if: ${{ inputs.profile == 'canary' }}
@@ -201,10 +203,12 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             strip: strip
+            objcopy: objcopy
             cflags: -msse4.2
             arch: x86_64
           - target: aarch64-unknown-linux-musl
             strip: aarch64-linux-musl-strip
+            objcopy: aarch64-linux-musl-objcopy
             cflags: ''
             arch: aarch64
     name: ${{ matrix.target }}
@@ -232,9 +236,9 @@ jobs:
       - name: Extract debug symbols
         if: ${{ inputs.profile == 'canary' }}
         run: |
-          find packages -name "*.node" -type f -exec objcopy --only-keep-debug {} {}.debug \;
-          find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
-          find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --strip-debug --strip-unneeded {} \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
         uses: actions/upload-artifact@v3
         if: ${{ inputs.profile == 'canary' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ inputs.profile == 'canary' }}
         with:
-          name: debug-symbols-${{ matrix.name }}
+          name: debug-symbols-linux-gnu-x64
           path: packages/*/*/*.node.debug
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: strip packages/*/*/*.node
@@ -174,7 +174,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ inputs.profile == 'canary' }}
         with:
-          name: debug-symbols-${{ matrix.name }}
+          name: debug-symbols-${{ matrix.target }}
           path: packages/*/*/*.node.debug
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
@@ -239,7 +239,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ inputs.profile == 'canary' }}
         with:
-          name: debug-symbols-${{ matrix.name }}
+          name: debug-symbols-linux-musl-${{ matrix.arch }}
           path: packages/*/*/*.node.debug
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,15 @@ jobs:
         run: yarn build-native-${{ inputs.profile }}
         env:
           RUST_TARGET: ${{ matrix.target }}
+      - name: Extract debug symbols
+        if: ${{ runner.os == 'macOS' && inputs.profile == 'canary' }}
+        run: dsymutil packages/*/*/*.node
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.profile == 'canary' }}
+        with:
+          name: debug-symbols-${{ matrix.name }}
+          path: packages/*/*/*.node.dSYM/Contents/Resources/DWARF/*.node
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         if: ${{ runner.os == 'macOS' }}
         run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
@@ -95,6 +104,18 @@ jobs:
       - uses: bahmutov/npm-install@v1.8.35
       - name: Build native packages
         run: yarn build-native-${{ inputs.profile }}
+      - name: Extract debug symbols
+        if: ${{ inputs.profile == 'canary' }}
+        run: |
+          find packages -name "*.node" -type f -exec objcopy --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
+          find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.profile == 'canary' }}
+        with:
+          name: debug-symbols-${{ matrix.name }}
+          path: packages/*/*/*.node.debug
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: strip packages/*/*/*.node
       - name: Upload artifacts
@@ -143,6 +164,18 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.target }}
           CFLAGS: ${{ matrix.cflags }}
+      - name: Extract debug symbols
+        if: ${{ inputs.profile == 'canary' }}
+        run: |
+          find packages -name "*.node" -type f -exec objcopy --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
+          find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.profile == 'canary' }}
+        with:
+          name: debug-symbols-${{ matrix.name }}
+          path: packages/*/*/*.node.debug
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts
@@ -196,6 +229,18 @@ jobs:
         env:
           RUST_TARGET: ${{ matrix.target }}
           CFLAGS: ${{ matrix.cflags }}
+      - name: Extract debug symbols
+        if: ${{ inputs.profile == 'canary' }}
+        run: |
+          find packages -name "*.node" -type f -exec objcopy --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
+          find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
+      - name: Upload debug symbols
+        uses: actions/upload-artifact@v3
+        if: ${{ inputs.profile == 'canary' }}
+        with:
+          name: debug-symbols-${{ matrix.name }}
+          path: packages/*/*/*.node.debug
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Extract debug symbols
         if: ${{ inputs.profile == 'canary' }}
         run: |
-          find packages -name "*.node" -type f -exec objcopy --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec objcopy --only-keep-debug --compress-debug-sections=zlib {} {}.debug \;
           find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
           find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
@@ -169,7 +169,7 @@ jobs:
       - name: Extract debug symbols
         if: ${{ inputs.profile == 'canary' }}
         run: |
-          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --only-keep-debug --compress-debug-sections=zlib {} {}.debug \;
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --strip-debug --strip-unneeded {} \;
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
@@ -236,7 +236,7 @@ jobs:
       - name: Extract debug symbols
         if: ${{ inputs.profile == 'canary' }}
         run: |
-          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --only-keep-debug {} {}.debug \;
+          find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --only-keep-debug --compress-debug-sections=zlib {} {}.debug \;
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --strip-debug --strip-unneeded {} \;
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
             os: macos-latest
             target: aarch64-apple-darwin
 
-          - name: macos-latest
+          - name: x86_64-apple-darwin
             os: macos-latest
             target: x86_64-apple-darwin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,10 +276,12 @@ jobs:
       - name: Move bindings
         run: for d in artifacts/bindings-*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
       - name: Move debug symbols
+        if: ${{ inputs.profile == 'canary' }}
         run: |
           mkdir debug-symbols
           find artifacts -name "*.debug" -exec cp {} debug-symbols/ \;
-          find artifacts -name "*.node" -path "**/DWARF" -exec cp {} debug-symbols/ \;
+          find artifacts -name "*.node" -path "**/DWARF/**" -exec cp {} debug-symbols/ \;
+          ls -l debug-symbols
       - name: Upload combined debug symbols artifact
         uses: actions/upload-artifact@v3
         if: ${{ inputs.profile == 'canary' }}
@@ -289,8 +291,7 @@ jobs:
       - name: Debug
         run: |
           ls -l packages/*/*/*.node
-          ls -l debug-symbols
       - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #- run: ${{ inputs.release-command }}
+      - run: ${{ inputs.release-command }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ members = [
 
 [profile.canary]
 inherits = "release"
+debug = true


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Added `debug = true` to the canary release profile, this produces binaries with symbol debug information included. Existing `strip` operations take care of stripping these back out for the `@parcel/rust` package itself, however before we `strip` we now use platform specific tools to extract debug symbols out to a separate file / artifact.

At "build and release" time these are combined into a single `debug-symbols` artifact for ease of use. Any additional work is gated to only the dev/canary releases - there's a minor impact to build time, especially uploading the combined artifact, but it's pretty minor.

This has no impact on final `@parcel/rust` binary size (as the debug info is stripped), and it will be on our end when we bump to a canary to download  the debug symbols artifact and upload it to Sentry.

Example dev-release with these changes: https://github.com/parcel-bundler/parcel/actions/runs/8902598798
