### PR TITLE
Retry integration tests 2 times on CI

### DIFF
--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "cross-env NODE_ENV=test PARCEL_BUILD_ENV=test mocha --experimental-vm-modules",
-    "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json"
+    "test-ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=./test/mochareporters.json --retries 2"
   },
   "devDependencies": {
     "@babel/core": "^7.22.11",


### PR DESCRIPTION
As raised in #9689, integration tests are currently flaky. This makes the use of a merge queue harder since with merge queues individual builds can't be retried.

As a temporary work-around this commit adds retries to the integration tests' mocha invocation.

This is very subpar and we must come-up with a plan to address the tests' unreliability.
