### PR TITLE
Fix rustup toolchain version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: yarn
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
           components: rustfmt
       # use `--frozen-lockfile` to fail immediately if the committed yarn.lock needs updates
       # https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile
@@ -74,7 +74,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.os }}
@@ -112,7 +112,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.os }}
@@ -139,7 +139,7 @@ jobs:
           node-version: 20
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
           targets: wasm32-unknown-unknown
       - name: Install wasm-opt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
           target: ${{ matrix.target }}
       - uses: bahmutov/npm-install@v1.8.35
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.77
           profile: minimal
           override: true
       - uses: bahmutov/npm-install@v1.8.35
@@ -150,7 +150,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
           target: ${{ matrix.target }}
       - name: Install cross compile toolchains
         run: |
@@ -225,7 +225,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
           target: ${{ matrix.target }}
       - uses: bahmutov/npm-install@v1.8.35
       - name: Build native packages

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.77
           targets: wasm32-unknown-unknown
       - name: Install wasm-opt
         run: |


### PR DESCRIPTION
This is a follow-up to #9696

It should fix this failure to build releases - https://github.com/parcel-bundler/parcel/actions/runs/8962384055/job/24611186421
