### PR TITLE
Ensure empty extended config throws a diagnostic

### DIFF
--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -16,7 +16,6 @@ import {
 import {validatePackageName} from '../src/ParcelConfig.schema';
 import {DEFAULT_OPTIONS, relative} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
-import ThrowableDiagnostic from '@parcel/diagnostic';
 
 describe('ParcelConfigRequest', () => {
   describe('validatePackageName', () => {

--- a/packages/core/core/test/ParcelConfigRequest.test.js
+++ b/packages/core/core/test/ParcelConfigRequest.test.js
@@ -16,6 +16,7 @@ import {
 import {validatePackageName} from '../src/ParcelConfig.schema';
 import {DEFAULT_OPTIONS, relative} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
+import ThrowableDiagnostic from '@parcel/diagnostic';
 
 describe('ParcelConfigRequest', () => {
   describe('validatePackageName', () => {
@@ -309,9 +310,12 @@ describe('ParcelConfigRequest', () => {
     });
 
     it('should throw error on empty config file', () => {
-      assert.throws(() => {
-        validateConfigFile({}, '.parcelrc');
-      }, /.parcelrc can't be empty/);
+      assert.throws(
+        () => {
+          validateConfigFile({}, '.parcelrc');
+        },
+        {name: 'Error', message: ".parcelrc can't be empty"},
+      );
     });
   });
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Small fix for a bug where an empty extended config file would result in an error message that didn't point to the root cause, this was because the error was an `AssertionError` and the error handling tried to process it as a `Diagnostic`.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
Before:

```
❯ parcel build
TypeError: Cannot read properties of undefined (reading 'message')
    at new ThrowableDiagnostic (/Users/mszczepanski/Work/atlassian/data-playground/node_modules/@parcel/diagnostic/lib/diagnostic.js:124:26)
[...]
```

After:
```
❯ parcel build
@parcel/core: packages/parcel-config-broken/index.json can't be empty
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->
Extend an "empty" config file (i.e. `index.json` contains `{}`)

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
