### PR TITLE
Ensure Asset public ids are assigned deterministically

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -174,7 +174,9 @@ export default class BundleGraph {
         : null;
     invariant(assetGraphRootNode != null && assetGraphRootNode.type === 'root');
 
-    for (let [nodeId, node] of assetGraph.nodes.entries()) {
+    assetGraph.dfsFast(nodeId => {
+      let node = assetGraph.getNode(nodeId);
+
       if (node != null && node.type === 'asset') {
         let {id: assetId} = node.value;
         // Generate a new, short public id for this asset to use.
@@ -190,7 +192,7 @@ export default class BundleGraph {
       } else if (node != null && node.type === 'asset_group') {
         assetGroupIds.set(nodeId, assetGraph.getNodeIdsConnectedFrom(nodeId));
       }
-    }
+    });
 
     let walkVisited = new Set();
     function walk(nodeId) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

We've been seeing issues internally where public Ids are not deterministic between two builds on the same commit and options. I believe this is related to how we iterate over the nodes array directly to assign the public Ids rather than using a DFS. As Assets are transformed off-thread, it's possible Assets are added to the graph in different order between builds, therefore the node Array is not deterministic. 

This PR instead uses a dfs to ensure the nodes are visited in order. In the full Jira AssetGraph I measured a 100ms performance loss using DFS instead which I think is acceptable in this case. 