### PR TITLE
quick fix for HTTPS port from env not working properly by allowing env `HMR_PORT` alongside env `PORT`

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -146,6 +146,7 @@ export default async function resolveOptions(
   };
 
   let port = determinePort(initialOptions.serveOptions, env.PORT);
+  let hmrPort = determinePort(initialOptions.hmrOptions, env.HMR_PORT);
 
   return {
     config: getRelativeConfigSpecifier(
@@ -162,7 +163,13 @@ export default async function resolveOptions(
     env,
     mode,
     shouldAutoInstall: initialOptions.shouldAutoInstall ?? false,
-    hmrOptions: initialOptions.hmrOptions ?? null,
+    hmrOptions:
+      initialOptions.hmrOptions != null
+        ? {
+            ...initialOptions.hmrOptions,
+            port: hmrPort,
+          }
+        : null,
     shouldBuildLazily,
     lazyIncludes,
     lazyExcludes,


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
quick fix for #9345

However, I do not like the fact that `normalizeOptions` is a) responsible for invoking `getPort` as a fallback & b) unaware of `env.PORT`.

This will at least solve the immediate issue #9345 and maybe a better refactor of the sequence of these checks can be done later.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

Steps to repro: (from `v2` branch)

run two parcel projects, both with `PORT=` and `HMR_PORT=` in the `.env` **and** the `--https` option (no `--port` option)
the two parcel projects you start up should have different non-conflicting port numbers in their `.env`

You will notice that the 2nd one givs an error about port 1234 being taken despite the fact that you have `PORT` specified in env. The reason for this is the first project, while it respects `PORT` for the https server, is silently running and HMR server on port 1234.

So what you will find is the 2nd parcel project you start up is picking a port number randomly with `getPort`.

However, if you use this PR, you will see that you can run multiple `--https` parcel projects with no port conflicts by relying only on `.env` configuration and no need to set `--port` (which in our case we are trying to avoid)







<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
