### PR TITLE
Add serde to config types

### DIFF
--- a/crates/parcel_config/Cargo.toml
+++ b/crates/parcel_config/Cargo.toml
@@ -11,7 +11,7 @@ indexmap = { version = "2.2.6", features = ["serde", "std"] }
 parcel_filesystem = { path = "../parcel_filesystem" }
 parcel_package_manager = { path = "../parcel_package_manager" }
 pathdiff = "0.2.1"
-serde = { version = "1.0.123", features = ["derive"] }
+serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_json5 = "0.1.0"
 thiserror = "1.0.59"
 

--- a/crates/parcel_config/src/parcel_config.rs
+++ b/crates/parcel_config/src/parcel_config.rs
@@ -3,20 +3,23 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use indexmap::IndexMap;
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::config_error::ConfigError;
 use super::partial_parcel_config::PartialParcelConfig;
 use super::pipeline::is_match;
 use super::pipeline::PipelineMap;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PluginNode {
   pub package_name: String,
   pub resolve_from: Rc<PathBuf>,
 }
 
 /// Represents a fully merged and validated .parcel_rc config
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ParcelConfig {
   pub(crate) bundler: PluginNode,
   pub(crate) compressors: PipelineMap,


### PR DESCRIPTION
# ↪️ Pull Request

Makes the config crate types de/serializable, and removes `.map` in favour of `.0` so that it has the same representation as JavaScript when de/serialized.

## 🚨 Test instructions

`cargo test -p parcel_config`