### PR TITLE
Fix request tracker incremental cache write for new nodes

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -328,6 +328,8 @@ export class RequestGraph extends ContentGraph<
       this.optionNodeIds.add(nodeId);
     }
 
+    this.removeCachedRequestChunkForNode(nodeId);
+
     return nodeId;
   }
 

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -308,7 +308,7 @@ describe('RequestTracker', () => {
     assert.strictEqual(called, false);
   });
 
-  it.only('should write new nodes to cache', async () => {
+  it('should write new nodes to cache', async () => {
     let tracker = new RequestTracker({farm, options});
 
     tracker.graph.addNode({
@@ -332,7 +332,7 @@ describe('RequestTracker', () => {
     assert.equal(tracker.graph.nodes.length, 2);
   });
 
-  it.only('should write updated nodes to cache', async () => {
+  it('should write updated nodes to cache', async () => {
     let tracker = new RequestTracker({farm, options});
 
     let contentKey = 'abc';
@@ -368,7 +368,7 @@ describe('RequestTracker', () => {
     assert.equal(await tracker.getRequestResult(contentKey), 'b');
   });
 
-  it.only('should write invalidated nodes to cache', async () => {
+  it('should write invalidated nodes to cache', async () => {
     let tracker = new RequestTracker({farm, options});
 
     let contentKey = 'abc';

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -340,11 +340,11 @@ describe('RequestTracker', () => {
       id: contentKey,
       type: 7,
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
-        api.storeResult('a');
+        let result = await Promise.resolve('a');
+        api.storeResult(result);
       },
       input: null,
     });
-    let nodeId = tracker.graph.getNodeIdByContentKey(contentKey);
     assert.equal(await tracker.getRequestResult(contentKey), 'a');
     await tracker.writeToCache();
 
@@ -353,7 +353,8 @@ describe('RequestTracker', () => {
         id: contentKey,
         type: 7,
         run: async ({api}: {api: RunAPI<string | void>, ...}) => {
-          api.storeResult('b');
+          let result = await Promise.resolve('b');
+          api.storeResult(result);
         },
         input: null,
       },


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This PR adds a fix for the RequestTracker incremental cache writing where node chunks are skipped being written even if they're not yet full. This can cause the nodes to become out of sync with their content keys. This fix is to ensure node chunks are marked as needing re-write when they are appended to. 

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
