### PR TITLE
Improve request graph cache reading

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1430,11 +1430,10 @@ export default class RequestTracker {
       i += 1
     ) {
       let nodesStartIndex = i * this.graph.nodesPerBlob;
-      let nodesEndIndex = (i + 1) * this.graph.nodesPerBlob;
-
-      if (nodesEndIndex > cacheableNodes.length) {
-        nodesEndIndex = cacheableNodes.length;
-      }
+      let nodesEndIndex = Math.min(
+        (i + 1) * this.graph.nodesPerBlob,
+        cacheableNodes.length,
+      );
 
       nodeCountsPerBlob.push(nodesEndIndex - nodesStartIndex);
 

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1503,7 +1503,7 @@ export function getWatcherOptions({
   watchBackend,
 }: ParcelOptions): WatcherOptions {
   const vcsDirs = ['.git', '.hg'];
-  const uniqueDirs = [...new Set([...watchIgnore, cacheDir, ...vcsDirs])];
+  const uniqueDirs = [...new Set([...watchIgnore, ...vcsDirs, cacheDir])];
   const ignore = uniqueDirs.map(dir => path.resolve(watchDir, dir));
 
   return {ignore, backend: watchBackend};

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -307,4 +307,26 @@ describe('RequestTracker', () => {
     assert.strictEqual(cachedResult, 'b');
     assert.strictEqual(called, false);
   });
+
+  it.only('should use the request graph ID when writing nodes to cache', async () => {
+    let tracker = new RequestTracker({farm, options});
+
+    // Set the nodes per blob low so we can ensure multiple files without
+    // creating 17,000 nodes
+    tracker.graph.nodesPerBlob = 2;
+
+    tracker.graph.addNode({type: 0, id: 'some-file-node-1'});
+    tracker.graph.addNode({type: 0, id: 'some-file-node-2'});
+    tracker.graph.addNode({type: 0, id: 'some-file-node-3'});
+
+    await tracker.writeToCache();
+
+    tracker = new RequestTracker({farm, options});
+    assert.equal(tracker.graph.nodes.length, 0);
+
+    await tracker.writeToCache();
+
+    tracker = await RequestTracker.init({farm, options});
+    assert.equal(tracker.graph.nodes.length, 0);
+  });
 });


### PR DESCRIPTION
One of the issues that we think might be causing the cache related bugs we've been getting is that when reading the nodes files back in, the read and deserialise logic just reads in however many there happen to be on disk.

Since it's possible for two different instances of a RequestTracker to have the same cache key, and that one may contain fewer nodes, a number of incorrect nodes are being read in when we hydrate from cache.

To work around this, we're adding some information to the cache to store how many node chunk files there are and how many nodes are in each one. This avoids overreading from cache, and means we can validate that the right number of nodes are being read in (since the last file in a cache won't be full).

Also to allow for testing of multiple chunks, we've made the number of nodes that go in each blob a property on the class, so it can be overridden in testing (without having to create 2**16 test nodes to force a second chunk).