### PR TITLE
Add resolver plugin trait

### DIFF
--- a/crates/parcel_core/src/bundle_graph.rs
+++ b/crates/parcel_core/src/bundle_graph.rs
@@ -1,0 +1,1 @@
+pub struct BundleGraph {}

--- a/crates/parcel_core/src/lib.rs
+++ b/crates/parcel_core/src/lib.rs
@@ -1,6 +1,8 @@
 //! Core re-implementation in Rust
 
+pub mod bundle_graph;
 pub mod hash;
+pub mod plugin;
 pub mod types;
 
 /// New-type for paths relative to a project-root

--- a/crates/parcel_core/src/plugin.rs
+++ b/crates/parcel_core/src/plugin.rs
@@ -1,0 +1,38 @@
+mod bundler;
+pub use bundler::*;
+
+mod compressor;
+pub use compressor::*;
+
+mod namer;
+pub use namer::*;
+
+mod optimizer;
+pub use optimizer::*;
+
+mod packager;
+pub use packager::*;
+
+mod reporter;
+pub use reporter::*;
+
+mod resolver;
+pub use resolver::*;
+
+mod runtime;
+pub use runtime::*;
+
+mod transformer;
+pub use transformer::*;
+
+mod validator;
+pub use validator::*;
+
+pub struct PluginContext {
+  pub options: PluginOptions,
+  pub logger: PluginLogger,
+}
+
+pub struct PluginLogger {}
+
+pub struct PluginOptions {}

--- a/crates/parcel_core/src/plugin/bundler.rs
+++ b/crates/parcel_core/src/plugin/bundler.rs
@@ -1,0 +1,8 @@
+/// Converts an asset graph into a BundleGraph
+///
+/// Bundlers accept the entire asset graph and modify it to add bundle nodes that group the assets
+/// into output bundles.
+///
+/// Bundle and optimize run in series and are functionally identitical.
+///
+pub trait BundlerPlugin {}

--- a/crates/parcel_core/src/plugin/compressor.rs
+++ b/crates/parcel_core/src/plugin/compressor.rs
@@ -1,0 +1,2 @@
+/// Compresses the input file stream
+pub trait CompressorPlugin {}

--- a/crates/parcel_core/src/plugin/namer.rs
+++ b/crates/parcel_core/src/plugin/namer.rs
@@ -1,0 +1,5 @@
+/// Determines the output filename for a bundle
+///
+/// Namers run in a pipeline until one returns a result.
+///
+pub trait NamerPlugin {}

--- a/crates/parcel_core/src/plugin/optimizer.rs
+++ b/crates/parcel_core/src/plugin/optimizer.rs
@@ -1,0 +1,11 @@
+/// Optimises a bundle
+///
+/// Optimizers are commonly used to implement minification, tree shaking, dead code elimination,
+/// and other size reduction techniques that need a full bundle to be effective. However,
+/// optimizers can also be used for any type of bundle transformation, such as prepending license
+/// headers, converting inline bundles to base 64, etc.
+///
+/// Multiple optimizer plugins may run in series, and the result of each optimizer is passed to
+/// the next.
+///
+pub trait OptimizerPlugin: Send + Sync {}

--- a/crates/parcel_core/src/plugin/packager.rs
+++ b/crates/parcel_core/src/plugin/packager.rs
@@ -1,0 +1,6 @@
+/// Combines all the assets in a bundle together into an output file
+///
+/// Packagers are also responsible for resolving URL references, bundle inlining, and generating
+/// source maps.
+///
+pub trait PackagerPlugin: Send + Sync {}

--- a/crates/parcel_core/src/plugin/reporter.rs
+++ b/crates/parcel_core/src/plugin/reporter.rs
@@ -1,0 +1,6 @@
+/// Receives events from Parcel as they occur throughout the build process
+///
+/// For example, reporters may write status information to stdout, run a dev server, or generate a
+/// bundle analysis report at the end of a build.
+///
+pub trait ReporterPlugin {}

--- a/crates/parcel_core/src/plugin/resolver.rs
+++ b/crates/parcel_core/src/plugin/resolver.rs
@@ -1,0 +1,55 @@
+use std::path::PathBuf;
+
+use super::PluginContext;
+use crate::types::Dependency;
+use crate::types::JSONObject;
+use crate::types::Priority;
+
+// TODO Diagnostics and invalidations
+
+pub struct Resolution {
+  /// Whether this dependency can be deferred by Parcel itself
+  pub can_defer: bool,
+
+  /// The code of the resolved asset
+  ///
+  /// If provided, this is used rather than reading the file from disk.
+  ///
+  pub code: Option<String>,
+
+  /// An absolute path to the resolved file
+  pub file_path: PathBuf,
+
+  /// Whether the resolved file should be excluded from the build
+  pub is_excluded: bool,
+
+  /// Is spread (shallowly merged) onto the request's dependency.meta
+  pub meta: JSONObject,
+
+  /// An optional named pipeline to use to compile the resolved file
+  pub pipeline: Option<String>,
+
+  /// Overrides the priority set on the dependency
+  pub priority: Option<Priority>,
+
+  /// Corresponds to the asset side effects
+  pub side_effects: bool,
+
+  /// Query parameters to be used by transformers when compiling the resolved file
+  pub query: Option<String>,
+}
+
+/// Converts a dependency specifier into a file path that will be processed by transformers
+///
+/// Resolvers run in a pipeline until one of them return a result.
+///
+pub trait ResolverPlugin: Send + Sync {
+  /// Determines what the dependency specifier resolves to
+  fn resolve(
+    &self,
+    specifier: &str,
+    dependency: &Dependency,
+    pipeline: Option<&str>,
+    context: &PluginContext,
+  ) -> Result<Resolution, anyhow::Error>;
+}

--- a/crates/parcel_core/src/plugin/runtime.rs
+++ b/crates/parcel_core/src/plugin/runtime.rs
@@ -1,0 +1,2 @@
+/// Programmatically insert assets into bundles
+pub trait RuntimePlugin {}

--- a/crates/parcel_core/src/plugin/transformer.rs
+++ b/crates/parcel_core/src/plugin/transformer.rs
@@ -1,0 +1,6 @@
+/// Compile a single asset, discover dependencies, or convert the asset to a different format
+///
+/// Many transformers are wrappers around other tools such as compilers and preprocessors, and are
+/// designed to integrate with Parcel.
+///
+pub trait TransformerPlugin: Send + Sync {}

--- a/crates/parcel_core/src/plugin/validator.rs
+++ b/crates/parcel_core/src/plugin/validator.rs
@@ -1,0 +1,13 @@
+/// Analyzes assets to ensure they are in a valid state
+///
+/// Validators may throw errors or log warnings to indicate an asset is invalid. They can be used
+/// to verify linting, type safety, etc and are run after a build has completed. This enables more
+/// important compilation errors to occur first.
+///
+/// When Parcel runs in watch mode, the built bundles are served even if a validator throws an
+/// error. But when running a build, Parcel exits with a failure and status code to ensure code is
+/// not deployed for assets that do not meet the validation criteria. This ensures developers
+/// remain productive, and do not have to worry about every small typing or linting issue while
+/// trying to solve a problem.
+///
+pub trait ValidatorPlugin {}

--- a/crates/parcel_core/src/types/source.rs
+++ b/crates/parcel_core/src/types/source.rs
@@ -25,3 +25,5 @@ pub struct SourceLocation {
   /// The final location in the source code
   pub end: Location,
 }
+
+pub struct SourceMap {}


### PR DESCRIPTION
# ↪️ Pull Request

Adds the resolver plugin trait and empty placeholders for the remaining plugins. This is because the config is difficult to implement, and will be tackled in the near future.

**Note:** https://github.com/parcel-bundler/parcel/tree/molejniczak/plugin-types was the initial implementation with all the types, that needs to be revisited.

## 🚨 Test instructions

```
cargo build -p parcel_core
```