### PR TITLE
Pass through includeInline

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1600,7 +1600,7 @@ export default class BundleGraph {
       }
 
       for (let referencedBundle of this.getReferencedBundles(bundle, {
-        includeInline: true,
+        includeInline: opts?.includeInline,
       })) {
         bundles.add(referencedBundle);
       }


### PR DESCRIPTION
# ↪️ Pull Request

This change passes through the `includeInline` option from `getBundlesInBundleGroup` into `getReferencedBundles` so that the default of false and `includeInline: false` function as expected.

## 🚨 Test instructions

`yarn test:integration`

## ✔️ PR Todo

- [x] Validate changes through a dev release

