### PR TITLE
Fix rust sentry errors having double quotes

### DIFF
--- a/crates/node-bindings/src/init_sentry/sentry.rs
+++ b/crates/node-bindings/src/init_sentry/sentry.rs
@@ -18,11 +18,6 @@ static SENTRY_GUARD: Lazy<Arc<Mutex<Option<ClientInitGuard>>>> =
   Lazy::new(|| Arc::new(Mutex::new(None)));
 const TIMEOUT: Duration = Duration::from_secs(2);
 
-fn get_tag(sentry_tags: HashMap<String, Value>, tag: String) -> Option<&Value> {
-  let tag_ref = &tag;
-  return sentry_tags.get(tag_ref);
-}
-
 fn value_to_string(value: &serde_json::Value) -> String {
   match value {
     serde_json::Value::String(inner) => inner.clone(),
@@ -63,11 +58,16 @@ fn init_sentry() -> Result<(), Status> {
     ..Default::default()
   };
 
-  if let Some(release) = value_to_string(sentry_tags.get("release")) {
-    sentry_client_options.release = Some(release.as_str().unwrap().into());
+  let sentry_tags: HashMap<String, String> = sentry_tags
+    .iter()
+    .map(|(k, v)| (k.clone(), value_to_string(v)))
+    .collect::<HashMap<String, String>>();
+
+  if let Some(release) = sentry_tags.get("release") {
+    sentry_client_options.release = Some(release.to_string().into());
   }
-  if let Some(environment) = value_to_string(sentry_tags.get("environment")) {
-    sentry_client_options.environment = Some(environment.as_str().unwrap().into());
+  if let Some(environment) = sentry_tags.get("environment") {
+    sentry_client_options.environment = Some(environment.to_string().into());
   }
   if let Some(debug) = sentry_tags.get("debug") {
     sentry_client_options.debug = debug.to_string() == "true";
@@ -85,11 +85,11 @@ fn init_sentry() -> Result<(), Status> {
   });
 
   for (key, val) in sentry_tags {
-    configure_scope(|scope| scope.set_tag(&key, value_to_string(&val)));
+    configure_scope(|scope| scope.set_tag(&key, val));
   }
   log::info!("Parcel Sentry for rust setup done!");
   panic!("test, please ignore");
-  return Ok(());
+  // return Ok(());
 }
 
 #[napi]

--- a/crates/node-bindings/src/init_sentry/sentry.rs
+++ b/crates/node-bindings/src/init_sentry/sentry.rs
@@ -88,8 +88,7 @@ fn init_sentry() -> Result<(), Status> {
     configure_scope(|scope| scope.set_tag(&key, val));
   }
   log::info!("Parcel Sentry for rust setup done!");
-  panic!("test, please ignore");
-  // return Ok(());
+  return Ok(());
 }
 
 #[napi]


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request
Finally implemented @marcins' solution.
<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
