### PR TITLE
Add an error message to nullthrows in WriteBundlesRequest

### DIFF
--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -67,7 +67,10 @@ async function run({input, api, farm, options}) {
     if (bundle.isPlaceholder) {
       let hash = bundle.id.slice(-8);
       hashRefToNameHash.set(bundle.hashReference, hash);
-      let name = nullthrows(bundle.name).replace(bundle.hashReference, hash);
+      let name = nullthrows(
+        bundle.name,
+        `Expected ${bundle.type} bundle to have a name`,
+      ).replace(bundle.hashReference, hash);
       res.set(bundle.id, {
         filePath: joinProjectPath(bundle.target.distDir, name),
         type: bundle.type, // FIXME: this is wrong if the packager changes the type...


### PR DESCRIPTION
Now that we've Solved* mismatched node types (#9721), the next biggest source of errors in our application is a number of `nullthrows` errors, coming from a `.filter` in `WriteBundlesRequest`.

I'm moderately sure this is the source, and for some reason we're getting bundles that have no name, but to be sure I'd like to add an error message to the nullthrows so we know for certain.