### PR TITLE
Fix assets outside project root with Manual Shared Bundles.

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -476,9 +476,9 @@ function createIdealGraph(
           node.type === 'asset' &&
           (!Array.isArray(c.types) || c.types.includes(node.value.type))
         ) {
-          // +1 accounts for leading slash
-          let projectRelativePath = node.value.filePath.slice(
-            config.projectRoot.length + 1,
+          let projectRelativePath = path.relative(
+            config.projectRoot,
+            node.value.filePath,
           );
           if (!assetRegexes.some(regex => regex.test(projectRelativePath))) {
             return;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Where assets in a manual shared bundle are outside the project root, the code that matches assets against globs is not correctly calculating the relative path to those assets. This results in a likely malformed path being compared.

This change replaces that code with a `path.relative` to ensure proper relative paths are produced.

## 🚨 Test instructions

New integration test has been added (tested failing first).

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
