### PR TITLE
Fix issue in async bundle runtime where it would not always add the runtime code

### DIFF
--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -120,6 +120,12 @@ export default class BundleGraph<TBundle: IBundle>
       .map(bundle => this.#createBundle(bundle, this.#graph, this.#options));
   }
 
+  getReferencingBundles(bundle: IBundle): Array<TBundle> {
+    return this.#graph
+      .getReferencingBundles(bundleToInternalBundle(bundle))
+      .map(bundle => this.#createBundle(bundle, this.#graph, this.#options));
+  }
+
   resolveAsyncDependency(
     dependency: IDependency,
     bundle: ?IBundle,

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.html
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.html
@@ -1,1 +1,0 @@
-<script type="module" src="./a.js"></script>

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/a.js
@@ -1,1 +1,0 @@
-export default 'a';

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/b.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/b.js
@@ -1,1 +1,0 @@
-export default 'b';

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/c.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/c.js
@@ -1,1 +1,0 @@
-export default 'c';

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/empty.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/empty.js
@@ -1,1 +1,0 @@
-// Just a comment

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.html
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.html
@@ -1,1 +1,0 @@
-<script type="module" src="./index.js"></script>

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.js
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/index.js
@@ -1,5 +1,0 @@
-import a from './a';
-import b from './b';
-import c from './c';
-
-result([a, b, c]);

--- a/packages/core/integration-tests/test/integration/bundle-queue-runtime/package.json
+++ b/packages/core/integration-tests/test/integration/bundle-queue-runtime/package.json
@@ -1,8 +1,0 @@
-{
-    "@parcel/bundler-default": {
-        "minBundleSize": 0
-    },
-    "@parcel/packager-js": {
-        "unstable_asyncBundleRuntime": true
-    }
-}

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -6043,18 +6043,56 @@ describe('scope hoisting', function () {
   });
 
   it('should add experimental bundle queue runtime for out of order bundle execution', async function () {
+    await fsFixture(overlayFS, __dirname)`
+      bundle-queue-runtime
+        a.html:
+          <script type="module" src="./a.js"></script>
+        a.js:
+          export default 'a';
+          
+        b.js:
+          export default 'b';
+          
+        c.js:
+          export default 'c';
+          
+        empty.js:
+          // Just a comment
+        index.html:
+          <script type="module" src="./index.js"></script>
+        index.js:
+          import a from './a';
+          import b from './b';
+          import c from './c';
+          
+          result([a, b, c]);
+          
+        package.json:
+          {
+              "@parcel/bundler-default": {
+                  "minBundleSize": 0
+              },
+              "@parcel/packager-js": {
+                  "unstable_asyncBundleRuntime": true
+              }
+          }
+        yarn.lock:`;
+
     let b = await bundle(
       [
-        path.join(__dirname, 'integration/bundle-queue-runtime/index.html'),
-        path.join(__dirname, 'integration/bundle-queue-runtime/a.html'),
+        path.join(__dirname, 'bundle-queue-runtime/index.html'),
+        path.join(__dirname, 'bundle-queue-runtime/a.html'),
       ],
       {
         mode: 'production',
+
         defaultTargetOptions: {
           shouldScopeHoist: true,
           shouldOptimize: false,
           outputFormat: 'esmodule',
         },
+
+        inputFS: overlayFS,
       },
     );
 
@@ -6075,15 +6113,53 @@ describe('scope hoisting', function () {
   });
 
   it('should not add experimental bundle queue runtime to empty bundles', async function () {
+    await fsFixture(overlayFS, __dirname)`
+      bundle-queue-runtime
+        a.html:
+          <script type="module" src="./a.js"></script>
+        a.js:
+          export default 'a';
+          
+        b.js:
+          export default 'b';
+          
+        c.js:
+          export default 'c';
+          
+        empty.js:
+          // Just a comment
+        index.html:
+          <script type="module" src="./index.js"></script>
+        index.js:
+          import a from './a';
+          import b from './b';
+          import c from './c';
+          
+          result([a, b, c]);
+          
+        package.json:
+          {
+              "@parcel/bundler-default": {
+                  "minBundleSize": 0
+              },
+              "@parcel/packager-js": {
+                  "unstable_asyncBundleRuntime": true
+              }
+          }
+        yarn.lock:`;
+
     let b = await bundle(
-      [path.join(__dirname, 'integration/bundle-queue-runtime/empty.js')],
+      [path.join(__dirname, 'bundle-queue-runtime/empty.js')],
       {
         mode: 'production',
+
         defaultTargetOptions: {
           shouldScopeHoist: true,
           shouldOptimize: false,
           outputFormat: 'esmodule',
         },
+
+        inputFS: overlayFS,
       },
     );
 

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -6056,8 +6056,6 @@ describe('scope hoisting', function () {
         c.js:
           export default 'c';
 
-        empty.js:
-          // Just a comment
         index.html:
           <script type="module" src="./index.js"></script>
         index.js:
@@ -6198,34 +6196,11 @@ describe('scope hoisting', function () {
   it('should not add experimental bundle queue runtime to empty bundles', async function () {
     await fsFixture(overlayFS, __dirname)`
       bundle-queue-runtime
-        a.html:
-          <script type="module" src="./a.js"></script>
-        a.js:
-          export default 'a';
-
-        b.js:
-          export default 'b';
-
-        c.js:
-          export default 'c';
-
         empty.js:
           // Just a comment
-        index.html:
-          <script type="module" src="./index.js"></script>
-        index.js:
-          import a from './a';
-          import b from './b';
-          import c from './c';
-
-          result([a, b, c]);
-
         package.json:
           {
-              "@parcel/bundler-default": {
-                  "minBundleSize": 0
-              },
-              "@parcel/packager-js": {
+             "@parcel/packager-js": {
                   "unstable_asyncBundleRuntime": true
               }
           }

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1,4 +1,3 @@
-// @flow
 import assert from 'assert';
 import path from 'path';
 import nullthrows from 'nullthrows';

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1542,6 +1542,8 @@ export interface BundleGraph<TBundle: Bundle> {
     bundle: Bundle,
     opts?: {|recursive?: boolean, includeInline?: boolean|},
   ): Array<TBundle>;
+  /** Returns a list of bundles that reference this bundle. */
+  getReferencingBundles(bundle: Bundle): Array<TBundle>;
   /** Get the dependencies that the asset requires */
   getDependencies(asset: Asset): Array<Dependency>;
   /** Get the dependencies that require the asset */

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -24,7 +24,6 @@ import ThrowableDiagnostic, {
 import globals from 'globals';
 import path from 'path';
 
-import logger from '@parcel/logger';
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
 import {GlobalOutputFormat} from './GlobalOutputFormat';

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -35,7 +35,6 @@ import {
   isValidIdentifier,
   makeValidIdentifier,
 } from './utils';
-
 // General regex used to replace imports with the resolved code, references with resolutions,
 // and count the number of newlines in the file for source maps.
 const REPLACEMENT_RE =
@@ -264,20 +263,10 @@ export class ScopeHoistingPackager {
     };
   }
 
-  shouldBundleQueue(bundle: NamedBundle, debug?: boolean): boolean {
+  shouldBundleQueue(bundle: NamedBundle): boolean {
     let referencingBundles = this.bundleGraph.getReferencingBundles(bundle);
-    let hasHtmlReferernce = referencingBundles.some(b =>
-      bundle.name.endsWith('.html'),
-    );
+    let hasHtmlReference = referencingBundles.some(b => b.type === 'html');
 
-    if (bundle.name.includes('shared')) {
-      logger.verbose({
-        message: 'shouldBundleQueue',
-        bundle: bundle.name,
-        hasHtmlReferernce,
-        referencingBundles: referencingBundles.map(b => b.name),
-      });
-    }
     return (
       this.useAsyncBundleRuntime &&
       bundle.type === 'js' &&
@@ -285,12 +274,7 @@ export class ScopeHoistingPackager {
       bundle.env.outputFormat === 'esmodule' &&
       !bundle.env.isIsolated() &&
       bundle.bundleBehavior !== 'isolated' &&
-      hasHtmlReferernce
-      // !this.bundleGraph.hasParentBundleOfType(
-      //   bundle,
-      //   'js',
-      //   bundle.name.includes('shared'),
-      // )
+      hasHtmlReference
     );
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This fixes an issue with the `unstable_asyncBundleRuntime` feature that unlocks usage of `<script type=module async>` by allowing those bundles to be executed out of order. The current expectation is any bundle loaded by an HTML file should contain the extra runtime code, however we were seeing some manual shared bundles that had left out the extra runtime code. 

Previously we were relying on `BundleGraph.hasParentBundleOfType` to return false when one of it's parents bundles were of type `html`. However, in practice this doesn't always seem to be true when you have a complex manual shared bundle setup. 

I have now moved the check to use `BundleGraph.getReferencingBundles` which models this problem more accurately. This API instead reads the `reference` type edges in the bundle graph which models the following:

https://github.com/parcel-bundler/parcel/blob/d988abeb1c666ad2649d4c2b43a108eba0d7a226/packages/core/core/src/BundleGraph.js#L56-L65

This edge type is also the point of truth used by the `HTMLPackager` for which files to include which is exactly our use case.

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
