### PR TITLE
Ensure const modules in async bundles are wrapped

### DIFF
--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -1247,6 +1247,14 @@ describe('bundler', function () {
 
     // This will fail when the async bundle does not export it's constant
     await run(b);
+
+    // Asset should not be inlined
+    const index = b.getBundles().find(b => b.name.startsWith('index'));
+    const contents = overlayFS.readFileSync(index.filePath, 'utf8');
+    assert(
+      !contents.includes('async value'),
+      'async value should not be inlined',
+    );
   });
   describe('manual shared bundles', () => {
     const dir = path.join(__dirname, 'manual-bundle');

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -1214,6 +1214,40 @@ describe('bundler', function () {
     ]);
   });
 
+  it('should support inline constants in async bundles', async () => {
+    await fsFixture(overlayFS, __dirname)`
+    inline-constants-async
+      index.js:
+        import('./async').then(m => console.log(m.value));
+
+      async.js:
+        export const value = 'async value';
+
+      package.json:
+        {
+          "@parcel/transformer-js": {
+            "unstable_inlineConstants": true
+          }
+        }
+
+      yarn.lock:`;
+
+    let b = await bundle(
+      path.join(__dirname, 'inline-constants-async/index.js'),
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+          sourceMaps: false,
+          shouldOptimize: false,
+        },
+        inputFS: overlayFS,
+      },
+    );
+
+    // This will fail when the async bundle does not export it's constant
+    await run(b);
+  });
   describe('manual shared bundles', () => {
     const dir = path.join(__dirname, 'manual-bundle');
 

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -317,7 +317,13 @@ export class ScopeHoistingPackager {
           .getIncomingDependencies(asset)
           .some(dep => dep.meta.shouldWrap && dep.specifierType !== 'url')
       ) {
-        if (!asset.meta.isConstantModule) {
+        // Don't wrap constant "entry" modules _except_ if they are referenced by any lazy dependency
+        if (
+          !asset.meta.isConstantModule ||
+          this.bundleGraph
+            .getIncomingDependencies(asset)
+            .some(dep => dep.priority === 'lazy')
+        ) {
           this.wrappedAssets.add(asset.id);
           wrapped.push(asset);
         }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This fixes a case where an async module only exports a constant, and it doesn't end up getting registered.

We had a use case where there were lots of async bundles containing just string exports for a PDF renderer, and a big switch case that would dynamically import fonts on demand. These small async bundles weren't registering their exports.

Pseudo example based on the real pattern - where the real values could vary in size between several hundred bytes and 60KB+, hence deferred loading:

```js
// fonts.ts
export const fonts = {
   'abc': () => import('./abc'),
   'def': () => import('./def')
}

// abc.ts
export const value = "abc";


// consumer.ts
import { fonts } from './fonts';

const { value } = await fonts['abc']();
```

## 🚨 Test instructions

* Added new integration test that was failing before the fix.
* Verified internally that the affected async bundles correctly register their assets

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
