### PR TITLE
Clean-up cache info when starting to write request tracker

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -55,7 +55,10 @@ import {report} from './ReporterRunner';
 import {PromiseQueue} from '@parcel/utils';
 import type {Cache} from '@parcel/cache';
 import {getConfigKeyContentHash} from './requests/ConfigRequest';
-import {storeRequestTrackerCacheInfo} from './RequestTrackerCacheInfo';
+import {
+  storeRequestTrackerCacheInfo,
+  clearRequestTrackerCacheInfo,
+} from './RequestTrackerCacheInfo';
 
 export const requestGraphEdgeTypes = {
   subrequest: 2,
@@ -1361,6 +1364,7 @@ export default class RequestTracker {
     let serialisedGraph = this.graph.serialize();
 
     // Delete an existing request graph cache, to prevent invalid states
+    await clearRequestTrackerCacheInfo(this.options.cache);
     await this.options.cache.deleteLargeBlob(requestGraphKey);
 
     let total = 0;

--- a/packages/core/core/src/RequestTrackerCacheInfo.js
+++ b/packages/core/core/src/RequestTrackerCacheInfo.js
@@ -58,3 +58,12 @@ export async function storeRequestTrackerCacheInfo(
     requestTrackerCacheInfo,
   );
 }
+
+/**
+ * When starting a build the request tracker cache keys are cleared.
+ * This prevents dangling references from being present if the process exits
+ * while writing the cache.
+ */
+export async function clearRequestTrackerCacheInfo(cache: Cache) {
+  await cache.set(toFsCacheKey('RequestTrackerCacheInfo'), null);
+}

--- a/packages/core/core/test/RequestTrackerCacheInfo.test.js
+++ b/packages/core/core/test/RequestTrackerCacheInfo.test.js
@@ -1,0 +1,74 @@
+// @flow strict-local
+
+import type {Cache} from '@parcel/types';
+import {FSCache, LMDBCache} from '@parcel/cache';
+import * as tempy from 'tempy';
+import {
+  clearRequestTrackerCacheInfo,
+  getRequestTrackerCacheInfo,
+  storeRequestTrackerCacheInfo,
+} from '../src/RequestTrackerCacheInfo';
+import assert from 'assert';
+import {NodeFS} from '@parcel/fs';
+
+type CacheImplementation = {|
+  name: string,
+  build: () => Cache,
+|};
+
+const cacheImplementations: CacheImplementation[] = [
+  {
+    name: 'FSCache',
+    build: () => new FSCache(new NodeFS(), tempy.directory()),
+  },
+  {
+    name: 'LMDBCache',
+    build: () => new LMDBCache(tempy.directory()),
+  },
+];
+
+describe('RequestTrackerCacheInfo', () => {
+  cacheImplementations.forEach(cacheImplementation => {
+    describe(`When using ${cacheImplementation.name}`, () => {
+      let cache: Cache;
+      beforeEach(async () => {
+        cache = cacheImplementation.build();
+        await cache.ensure();
+      });
+
+      it('getRequestTrackerCacheInfo - returns null if the cache entry is missing', async () => {
+        const entry = await getRequestTrackerCacheInfo(cache);
+        assert(entry === null);
+      });
+
+      it("getRequestTrackerCacheInfo - returns an entry if it's set with the store method", async () => {
+        {
+          const entry = await getRequestTrackerCacheInfo(cache);
+          assert(entry === null);
+        }
+        const expectedEntry = {
+          snapshotKey: 'snapshot-key',
+          timestamp: Date.now(),
+          requestGraphKey: 'request-graph-key',
+        };
+        await storeRequestTrackerCacheInfo(cache, expectedEntry);
+        {
+          const entry = await getRequestTrackerCacheInfo(cache);
+          assert.deepEqual(entry, expectedEntry);
+        }
+      });
+
+      it('entries can be cleared with clearRequestTrackerCacheInfo', async () => {
+        const expectedEntry = {
+          snapshotKey: 'snapshot-key',
+          timestamp: Date.now(),
+          requestGraphKey: 'request-graph-key',
+        };
+        await storeRequestTrackerCacheInfo(cache, expectedEntry);
+        await clearRequestTrackerCacheInfo(cache);
+        const entry = await getRequestTrackerCacheInfo(cache);
+        assert(entry === null);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This prevents the cache info entry from pointing at dangling references if the blobs are removed but the process exists before updating them.