### PR TITLE
Skip vercel REPL deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,15 +162,15 @@ jobs:
       #   with:
       #     name: REPL
       #     path: 'packages/dev/repl/dist'
-      - name: Start Deployment
-        uses: bobheadxi/deployments@v1
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ref: ${{ github.head_ref }}
-          env: Preview
-          override: false
+#      - name: Start Deployment
+#        uses: bobheadxi/deployments@v1
+#        id: deployment
+#        with:
+#          step: start
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          ref: ${{ github.head_ref }}
+#          env: Preview
+#          override: false
 #      - name: Deploy to Vercel
 #        uses: amondnet/vercel-action@v25
 #        id: vercel-action

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,26 +171,26 @@ jobs:
           ref: ${{ github.head_ref }}
           env: Preview
           override: false
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        id: vercel-action
-        with:
-          vercel-token: ${{ secrets.REPL_VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.REPL_VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.REPL_VERCEL_PROJECT_ID }}
-          github-comment: false
-          working-directory: packages/dev/repl
-          # vercel-args: '--prod'
-          alias-domains: |
-            pr-{{PR_NUMBER}}.repl.parceljs.org
-      - name: Update Deployment Status
-        uses: bobheadxi/deployments@v1
-        if: always()
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: Preview
-          override: false
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.vercel-action.outputs.preview-url }}
+#      - name: Deploy to Vercel
+#        uses: amondnet/vercel-action@v25
+#        id: vercel-action
+#        with:
+#          vercel-token: ${{ secrets.REPL_VERCEL_TOKEN }}
+#          vercel-org-id: ${{ secrets.REPL_VERCEL_ORG_ID }}
+#          vercel-project-id: ${{ secrets.REPL_VERCEL_PROJECT_ID }}
+#          github-comment: false
+#          working-directory: packages/dev/repl
+#          # vercel-args: '--prod'
+#          alias-domains: |
+#            pr-{{PR_NUMBER}}.repl.parceljs.org
+#      - name: Update Deployment Status
+#        uses: bobheadxi/deployments@v1
+#        if: always()
+#        with:
+#          step: finish
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          env: Preview
+#          override: false
+#          status: ${{ job.status }}
+#          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+#          env_url: ${{ steps.vercel-action.outputs.preview-url }}


### PR DESCRIPTION
The vercel REPL deployment is broken, so this diff skips it. 

It can be added back once it's fixed.