### PR TITLE
Expand plugin traits and plugin config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "dyn-hash",
  "nodejs-semver",
  "parcel-resolver",
+ "parcel_filesystem",
  "petgraph",
  "serde",
  "serde-value",

--- a/crates/parcel_core/Cargo.toml
+++ b/crates/parcel_core/Cargo.toml
@@ -8,6 +8,7 @@ description = "Core logic for the parcel bundler"
 default = []
 
 [dependencies]
+parcel_filesystem = { path = "../parcel_filesystem" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 
 ahash = "0.8.11"

--- a/crates/parcel_core/src/bundle_graph.rs
+++ b/crates/parcel_core/src/bundle_graph.rs
@@ -1,0 +1,1 @@
+pub struct BundleGraph {}

--- a/crates/parcel_core/src/lib.rs
+++ b/crates/parcel_core/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(unused_crate_dependencies)]
 //! Core re-implementation in Rust
 
+pub mod bundle_graph;
 pub mod hash;
 pub mod plugin;
 pub mod request_tracker;

--- a/crates/parcel_core/src/plugin.rs
+++ b/crates/parcel_core/src/plugin.rs
@@ -1,4 +1,5 @@
 mod bundler;
+
 pub use bundler::*;
 
 mod compressor;
@@ -12,6 +13,9 @@ pub use optimizer::*;
 
 mod packager;
 pub use packager::*;
+
+mod plugin_config;
+pub use plugin_config::*;
 
 mod reporter;
 pub use reporter::*;
@@ -28,11 +32,14 @@ pub use transformer::*;
 mod validator;
 pub use validator::*;
 
+#[derive(Default)]
 pub struct PluginContext {
   pub options: PluginOptions,
   pub logger: PluginLogger,
 }
 
+#[derive(Default)]
 pub struct PluginLogger {}
 
+#[derive(Default)]
 pub struct PluginOptions {}

--- a/crates/parcel_core/src/plugin/bundler.rs
+++ b/crates/parcel_core/src/plugin/bundler.rs
@@ -1,5 +1,3 @@
-use parcel_resolver::FileSystem;
-
 use super::PluginConfig;
 use crate::bundle_graph::BundleGraph;
 
@@ -10,12 +8,12 @@ use crate::bundle_graph::BundleGraph;
 ///
 /// Bundle and optimize run in series and are functionally identitical.
 ///
-pub trait BundlerPlugin<Fs: FileSystem> {
+pub trait BundlerPlugin {
   /// A hook designed to load config necessary for the bundler to operate
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   // TODO: Should BundleGraph be AssetGraph or something that contains AssetGraph in the name?
   fn bundle(&self, bundle_graph: &mut BundleGraph) -> Result<(), anyhow::Error>;
@@ -25,15 +23,13 @@ pub trait BundlerPlugin<Fs: FileSystem> {
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   #[derive(Debug)]
   struct TestBundlerPlugin {}
 
-  impl<Fs: FileSystem> BundlerPlugin<Fs> for TestBundlerPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl BundlerPlugin for TestBundlerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
@@ -48,6 +44,6 @@ mod tests {
 
   #[test]
   fn can_be_dyn() {
-    let _bundler: Box<dyn BundlerPlugin<InMemoryFileSystem>> = Box::new(TestBundlerPlugin {});
+    let _bundler: Box<dyn BundlerPlugin> = Box::new(TestBundlerPlugin {});
   }
 }

--- a/crates/parcel_core/src/plugin/bundler.rs
+++ b/crates/parcel_core/src/plugin/bundler.rs
@@ -1,3 +1,8 @@
+use parcel_resolver::FileSystem;
+
+use super::PluginConfig;
+use crate::bundle_graph::BundleGraph;
+
 /// Converts an asset graph into a BundleGraph
 ///
 /// Bundlers accept the entire asset graph and modify it to add bundle nodes that group the assets
@@ -5,4 +10,44 @@
 ///
 /// Bundle and optimize run in series and are functionally identitical.
 ///
-pub trait BundlerPlugin {}
+pub trait BundlerPlugin<Fs: FileSystem> {
+  /// A hook designed to load config necessary for the bundler to operate
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  ///
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
+  // TODO: Should BundleGraph be AssetGraph or something that contains AssetGraph in the name?
+  fn bundle(&self, bundle_graph: &mut BundleGraph) -> Result<(), anyhow::Error>;
+
+  fn optimize(&self, bundle_graph: &mut BundleGraph) -> Result<(), anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  #[derive(Debug)]
+  struct TestBundlerPlugin {}
+
+  impl<Fs: FileSystem> BundlerPlugin<Fs> for TestBundlerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn bundle(&self, _bundle_graph: &mut BundleGraph) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn optimize(&self, _bundle_graph: &mut BundleGraph) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_dyn() {
+    let _bundler: Box<dyn BundlerPlugin<InMemoryFileSystem>> = Box::new(TestBundlerPlugin {});
+  }
+}

--- a/crates/parcel_core/src/plugin/compressor.rs
+++ b/crates/parcel_core/src/plugin/compressor.rs
@@ -1,2 +1,44 @@
+use std::fs::File;
+
+pub struct CompressedFile {
+  /// An optional file extension appended to the output file
+  ///
+  /// When no extension is returned, then the returned stream replaces the original file.
+  ///
+  pub extension: Option<String>,
+
+  /// The compressed file
+  pub file: File,
+}
+
 /// Compresses the input file stream
-pub trait CompressorPlugin {}
+pub trait CompressorPlugin {
+  /// Compress the given file
+  ///
+  /// The file contains the final contents of bundles and sourcemaps as they are being written.
+  /// A new stream can be returned, or None to forward compression onto the next plugin.
+  ///
+  fn compress(&self, file: &File) -> Result<Option<CompressedFile>, String>;
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  struct TestCompressorPlugin {}
+
+  impl CompressorPlugin for TestCompressorPlugin {
+    fn compress(&self, _file: &File) -> Result<Option<CompressedFile>, String> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut compressors = Vec::<Box<dyn CompressorPlugin>>::new();
+
+    compressors.push(Box::new(TestCompressorPlugin {}));
+
+    assert_eq!(compressors.len(), 1);
+  }
+}

--- a/crates/parcel_core/src/plugin/namer.rs
+++ b/crates/parcel_core/src/plugin/namer.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use parcel_resolver::FileSystem;
-
 use super::PluginConfig;
 use crate::bundle_graph::BundleGraph;
 use crate::types::Bundle;
@@ -10,12 +8,12 @@ use crate::types::Bundle;
 ///
 /// Namers run in a pipeline until one returns a result.
 ///
-pub trait NamerPlugin<Fs: FileSystem> {
+pub trait NamerPlugin {
   /// A hook designed to setup config needed for naming bundles
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Names the given bundle
   ///
@@ -24,7 +22,7 @@ pub trait NamerPlugin<Fs: FileSystem> {
   ///
   fn name(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     bundle: &Bundle,
     bundle_graph: &BundleGraph,
   ) -> Result<Option<PathBuf>, anyhow::Error>;
@@ -32,20 +30,18 @@ pub trait NamerPlugin<Fs: FileSystem> {
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestNamerPlugin {}
 
-  impl<Fs: FileSystem> NamerPlugin<Fs> for TestNamerPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl NamerPlugin for TestNamerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
     fn name(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _bundle: &Bundle,
       _bundle_graph: &BundleGraph,
     ) -> Result<Option<PathBuf>, anyhow::Error> {
@@ -55,7 +51,7 @@ mod tests {
 
   #[test]
   fn can_be_defined_in_dyn_vec() {
-    let mut namers = Vec::<Box<dyn NamerPlugin<InMemoryFileSystem>>>::new();
+    let mut namers = Vec::<Box<dyn NamerPlugin>>::new();
 
     namers.push(Box::new(TestNamerPlugin {}));
 

--- a/crates/parcel_core/src/plugin/namer.rs
+++ b/crates/parcel_core/src/plugin/namer.rs
@@ -1,5 +1,64 @@
+use std::path::PathBuf;
+
+use parcel_resolver::FileSystem;
+
+use super::PluginConfig;
+use crate::bundle_graph::BundleGraph;
+use crate::types::Bundle;
+
 /// Determines the output filename for a bundle
 ///
 /// Namers run in a pipeline until one returns a result.
 ///
-pub trait NamerPlugin {}
+pub trait NamerPlugin<Fs: FileSystem> {
+  /// A hook designed to setup config needed for naming bundles
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  ///
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
+  /// Names the given bundle
+  ///
+  /// The returned file path should be relative to the target dist directory, and will be used to
+  /// name the bundle. Naming can be forwarded onto the next plugin by returning None.
+  ///
+  fn name(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    bundle: &Bundle,
+    bundle_graph: &BundleGraph,
+  ) -> Result<Option<PathBuf>, anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  struct TestNamerPlugin {}
+
+  impl<Fs: FileSystem> NamerPlugin<Fs> for TestNamerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn name(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _bundle: &Bundle,
+      _bundle_graph: &BundleGraph,
+    ) -> Result<Option<PathBuf>, anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut namers = Vec::<Box<dyn NamerPlugin<InMemoryFileSystem>>>::new();
+
+    namers.push(Box::new(TestNamerPlugin {}));
+
+    assert_eq!(namers.len(), 1);
+  }
+}

--- a/crates/parcel_core/src/plugin/optimizer.rs
+++ b/crates/parcel_core/src/plugin/optimizer.rs
@@ -1,3 +1,25 @@
+use std::fs::File;
+
+use parcel_resolver::FileSystem;
+
+use super::PluginConfig;
+use crate::bundle_graph::BundleGraph;
+use crate::types::Bundle;
+use crate::types::SourceMap;
+
+pub struct OptimizeContext<'a> {
+  pub bundle: &'a Bundle,
+  pub bundle_graph: &'a BundleGraph,
+  pub contents: &'a File, // TODO We may want this to be a String or File later
+  pub map: Option<&'a SourceMap>,
+  // TODO getSourceMapReference?
+}
+
+pub struct OptimizedBundle {
+  pub contents: File,
+  // TODO ast, map, type
+}
+
 /// Optimises a bundle
 ///
 /// Optimizers are commonly used to implement minification, tree shaking, dead code elimination,
@@ -8,4 +30,49 @@
 /// Multiple optimizer plugins may run in series, and the result of each optimizer is passed to
 /// the next.
 ///
-pub trait OptimizerPlugin: Send + Sync {}
+pub trait OptimizerPlugin<Fs: FileSystem>: Send + Sync {
+  /// A hook designed to setup config needed for optimizing bundles
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  ///
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
+  /// Transforms the contents of a bundle and its source map
+  fn optimize(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    optimize_context: OptimizeContext,
+  ) -> Result<OptimizedBundle, anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  struct TestOptimizerPlugin {}
+
+  impl<Fs: FileSystem> OptimizerPlugin<Fs> for TestOptimizerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn optimize(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _optimize_context: OptimizeContext,
+    ) -> Result<OptimizedBundle, anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut optimizers = Vec::<Box<dyn OptimizerPlugin<InMemoryFileSystem>>>::new();
+
+    optimizers.push(Box::new(TestOptimizerPlugin {}));
+
+    assert_eq!(optimizers.len(), 1);
+  }
+}

--- a/crates/parcel_core/src/plugin/optimizer.rs
+++ b/crates/parcel_core/src/plugin/optimizer.rs
@@ -1,7 +1,5 @@
 use std::fs::File;
 
-use parcel_resolver::FileSystem;
-
 use super::PluginConfig;
 use crate::bundle_graph::BundleGraph;
 use crate::types::Bundle;
@@ -30,38 +28,36 @@ pub struct OptimizedBundle {
 /// Multiple optimizer plugins may run in series, and the result of each optimizer is passed to
 /// the next.
 ///
-pub trait OptimizerPlugin<Fs: FileSystem>: Send + Sync {
+pub trait OptimizerPlugin: Send + Sync {
   /// A hook designed to setup config needed for optimizing bundles
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Transforms the contents of a bundle and its source map
   fn optimize(
     &mut self,
-    config: &PluginConfig<Fs>,
-    optimize_context: OptimizeContext,
+    config: &PluginConfig,
+    ctx: OptimizeContext,
   ) -> Result<OptimizedBundle, anyhow::Error>;
 }
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestOptimizerPlugin {}
 
-  impl<Fs: FileSystem> OptimizerPlugin<Fs> for TestOptimizerPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl OptimizerPlugin for TestOptimizerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
     fn optimize(
       &mut self,
-      _config: &PluginConfig<Fs>,
-      _optimize_context: OptimizeContext,
+      _config: &PluginConfig,
+      _ctx: OptimizeContext,
     ) -> Result<OptimizedBundle, anyhow::Error> {
       todo!()
     }
@@ -69,7 +65,7 @@ mod tests {
 
   #[test]
   fn can_be_defined_in_dyn_vec() {
-    let mut optimizers = Vec::<Box<dyn OptimizerPlugin<InMemoryFileSystem>>>::new();
+    let mut optimizers = Vec::<Box<dyn OptimizerPlugin>>::new();
 
     optimizers.push(Box::new(TestOptimizerPlugin {}));
 

--- a/crates/parcel_core/src/plugin/packager.rs
+++ b/crates/parcel_core/src/plugin/packager.rs
@@ -1,6 +1,69 @@
+use std::fs::File;
+
+use parcel_resolver::FileSystem;
+
+use super::PluginConfig;
+use crate::bundle_graph::BundleGraph;
+use crate::types::Bundle;
+use crate::types::SourceMap;
+
+pub struct PackageContext<'a> {
+  pub bundle: &'a Bundle,
+  pub bundle_graph: &'a BundleGraph,
+  pub contents: &'a File, // TODO We may want this to be a String or File later
+  pub map: Option<&'a SourceMap>,
+  // TODO getSourceMapReference?
+}
+
+pub struct PackagedBundle {
+  pub contents: File,
+  // TODO ast, map, type
+}
+
 /// Combines all the assets in a bundle together into an output file
 ///
 /// Packagers are also responsible for resolving URL references, bundle inlining, and generating
 /// source maps.
 ///
-pub trait PackagerPlugin: Send + Sync {}
+pub trait PackagerPlugin<Fs: FileSystem>: Send + Sync {
+  /// A hook designed to setup config needed for packaging
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  ///
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
+  /// Combines assets in a bundle
+  fn package(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    package_context: PackageContext,
+  ) -> Result<PackagedBundle, anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  struct TestPackagerPlugin {}
+
+  impl<Fs: FileSystem> PackagerPlugin<Fs> for TestPackagerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn package(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _package_context: PackageContext,
+    ) -> Result<PackagedBundle, anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_dyn() {
+    let _packager: Box<dyn PackagerPlugin<InMemoryFileSystem>> = Box::new(TestPackagerPlugin {});
+  }
+}

--- a/crates/parcel_core/src/plugin/packager.rs
+++ b/crates/parcel_core/src/plugin/packager.rs
@@ -1,7 +1,5 @@
 use std::fs::File;
 
-use parcel_resolver::FileSystem;
-
 use super::PluginConfig;
 use crate::bundle_graph::BundleGraph;
 use crate::types::Bundle;
@@ -25,38 +23,36 @@ pub struct PackagedBundle {
 /// Packagers are also responsible for resolving URL references, bundle inlining, and generating
 /// source maps.
 ///
-pub trait PackagerPlugin<Fs: FileSystem>: Send + Sync {
+pub trait PackagerPlugin: Send + Sync {
   /// A hook designed to setup config needed for packaging
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Combines assets in a bundle
   fn package(
     &mut self,
-    config: &PluginConfig<Fs>,
-    package_context: PackageContext,
+    config: &PluginConfig,
+    ctx: PackageContext,
   ) -> Result<PackagedBundle, anyhow::Error>;
 }
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestPackagerPlugin {}
 
-  impl<Fs: FileSystem> PackagerPlugin<Fs> for TestPackagerPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl PackagerPlugin for TestPackagerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
     fn package(
       &mut self,
-      _config: &PluginConfig<Fs>,
-      _package_context: PackageContext,
+      _config: &PluginConfig,
+      _ctx: PackageContext,
     ) -> Result<PackagedBundle, anyhow::Error> {
       todo!()
     }
@@ -64,6 +60,6 @@ mod tests {
 
   #[test]
   fn can_be_dyn() {
-    let _packager: Box<dyn PackagerPlugin<InMemoryFileSystem>> = Box::new(TestPackagerPlugin {});
+    let _packager: Box<dyn PackagerPlugin> = Box::new(TestPackagerPlugin {});
   }
 }

--- a/crates/parcel_core/src/plugin/plugin_config.rs
+++ b/crates/parcel_core/src/plugin/plugin_config.rs
@@ -1,0 +1,340 @@
+use std::path::PathBuf;
+
+use parcel_filesystem::search::find_ancestor_file;
+use parcel_filesystem::FileSystem;
+use serde::de::DeserializeOwned;
+
+use crate::types::JSONObject;
+
+/// Enables plugins to load config in various formats
+pub struct PluginConfig<'a, Fs: FileSystem> {
+  fs: &'a Fs,
+  project_root: PathBuf,
+  search_path: PathBuf,
+}
+
+// TODO JavaScript configs, invalidations, dev deps, etc
+impl<'a, Fs: FileSystem> PluginConfig<'a, Fs> {
+  pub fn new(fs: &'a Fs, project_root: PathBuf, search_path: PathBuf) -> Self {
+    Self {
+      fs,
+      project_root,
+      search_path,
+    }
+  }
+
+  pub fn load_json_config<Config: DeserializeOwned>(
+    &self,
+    filename: &str,
+  ) -> Result<(PathBuf, Config), anyhow::Error> {
+    let config_path = find_ancestor_file(
+      self.fs,
+      vec![String::from(filename)],
+      &self.search_path,
+      &self.project_root,
+    )
+    .ok_or(anyhow::Error::msg(format!(
+      "Unable to locate {} config file from {}",
+      filename,
+      self.search_path.display()
+    )))?;
+
+    let config = self.fs.read_to_string(config_path.clone())?;
+    let config = serde_json::from_str::<Config>(&config)?;
+
+    Ok((config_path, config))
+  }
+
+  pub fn load_package_json_config(
+    &self,
+    key: &str,
+  ) -> Result<(PathBuf, serde_json::Value), anyhow::Error> {
+    let (config_path, config) = self.load_json_config::<JSONObject>("package.json")?;
+    let config = config.get(key).ok_or(anyhow::Error::msg(format!(
+      "Unable to locate {} config key in {}",
+      key,
+      config_path.display()
+    )))?;
+
+    Ok((config_path, config.clone()))
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  mod load_json_config {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct JsonConfig {}
+
+    #[test]
+    fn returns_an_error_when_the_config_does_not_exist() {
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      let config = PluginConfig {
+        fs: &InMemoryFileSystem::default(),
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_json_config::<JsonConfig>("config.json")
+          .map_err(|err| err.to_string()),
+        Err(String::from(
+          "Unable to locate config.json config file from /project-root/index"
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_an_error_when_the_config_is_outside_the_search_path() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(
+        search_path.join("packages").join("config.json"),
+        String::from("{}"),
+      );
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root: PathBuf::default(),
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_json_config::<JsonConfig>("config.json")
+          .map_err(|err| err.to_string()),
+        Err(String::from(
+          "Unable to locate config.json config file from /project-root/index"
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_an_error_when_the_config_is_outside_the_project_root() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file("config.json", String::from("{}"));
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_json_config::<JsonConfig>("config.json")
+          .map_err(|err| err.to_string()),
+        Err(String::from(
+          "Unable to locate config.json config file from /project-root/index"
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_json_config_at_search_path() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(search_path.join("config.json"), String::from("{}"));
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_json_config::<JsonConfig>("config.json")
+          .map_err(|err| err.to_string()),
+        Ok((
+          PathBuf::from("/project-root/index/config.json"),
+          JsonConfig {}
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_json_config_at_project_root() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(project_root.join("config.json"), String::from("{}"));
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_json_config::<JsonConfig>("config.json")
+          .map_err(|err| err.to_string()),
+        Ok((PathBuf::from("/project-root/config.json"), JsonConfig {}))
+      )
+    }
+  }
+
+  mod load_package_json_config {
+    use serde_json::Map;
+    use serde_json::Value;
+
+    use super::*;
+
+    fn package_json() -> String {
+      String::from(
+        r#"
+        {
+          "plugin": {
+            "enabled": true
+          }
+        }
+      "#,
+      )
+    }
+
+    fn plugin_config() -> Value {
+      let mut map = Map::new();
+
+      map.insert(String::from("enabled"), Value::Bool(true));
+
+      Value::Object(map)
+    }
+
+    #[test]
+    fn returns_an_error_when_package_json_does_not_exist() {
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      let config = PluginConfig {
+        fs: &InMemoryFileSystem::default(),
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_package_json_config("plugin")
+          .map_err(|err| err.to_string()),
+        Err(String::from(
+          "Unable to locate package.json config file from /project-root/index"
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_an_error_when_config_key_does_not_exist_at_search_path() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(search_path.join("package.json"), String::from("{}"));
+      fs.write_file(project_root.join("package.json"), package_json());
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_package_json_config("plugin")
+          .map_err(|err| err.to_string()),
+        Err(String::from(
+          "Unable to locate plugin config key in /project-root/index/package.json"
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_an_error_when_config_key_does_not_exist_at_project_root() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(project_root.join("package.json"), String::from("{}"));
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_package_json_config("plugin")
+          .map_err(|err| err.to_string()),
+        Err(String::from(
+          "Unable to locate plugin config key in /project-root/package.json"
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_package_config_at_search_path() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(search_path.join("package.json"), package_json());
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_package_json_config("plugin")
+          .map_err(|err| err.to_string()),
+        Ok((
+          PathBuf::from("/project-root/index/package.json"),
+          plugin_config()
+        ))
+      )
+    }
+
+    #[test]
+    fn returns_package_config_at_project_root() {
+      let mut fs = InMemoryFileSystem::default();
+      let project_root = PathBuf::from("/project-root");
+      let search_path = project_root.join("index");
+
+      fs.write_file(project_root.join("package.json"), package_json());
+
+      let config = PluginConfig {
+        fs: &fs,
+        project_root,
+        search_path,
+      };
+
+      assert_eq!(
+        config
+          .load_package_json_config("plugin")
+          .map_err(|err| err.to_string()),
+        Ok((PathBuf::from("/project-root/package.json"), plugin_config()))
+      )
+    }
+  }
+}

--- a/crates/parcel_core/src/plugin/reporter.rs
+++ b/crates/parcel_core/src/plugin/reporter.rs
@@ -1,6 +1,43 @@
+// TODO Flesh these out
+pub enum ReporterEvent {
+  BuildStart,
+  BuildProgress,
+  BuildFailure,
+  BuildSuccess,
+  Log,
+  Validation,
+  WatchStart,
+  WatchEnd,
+}
+
 /// Receives events from Parcel as they occur throughout the build process
 ///
 /// For example, reporters may write status information to stdout, run a dev server, or generate a
 /// bundle analysis report at the end of a build.
 ///
-pub trait ReporterPlugin {}
+pub trait ReporterPlugin {
+  /// Processes the event from Parcel
+  fn report(&self, event: ReporterEvent) -> Result<(), anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  struct TestReporterPlugin {}
+
+  impl ReporterPlugin for TestReporterPlugin {
+    fn report(&self, _event: ReporterEvent) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut reporters = Vec::<Box<dyn ReporterPlugin>>::new();
+
+    reporters.push(Box::new(TestReporterPlugin {}));
+
+    assert_eq!(reporters.len(), 1);
+  }
+}

--- a/crates/parcel_core/src/plugin/resolver.rs
+++ b/crates/parcel_core/src/plugin/resolver.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use parcel_filesystem::FileSystem;
-
 use super::PluginConfig;
 use crate::types::Dependency;
 use crate::types::JSONObject;
@@ -52,38 +50,36 @@ pub struct Resolution {
 ///
 /// Resolvers run in a pipeline until one of them return a result.
 ///
-pub trait ResolverPlugin<Fs: FileSystem>: Send + Sync {
+pub trait ResolverPlugin: Send + Sync {
   /// A hook designed to setup any config needed to resolve dependencies
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Determines what the dependency specifier resolves to
   fn resolve(
     &mut self,
-    config: &mut PluginConfig<Fs>,
-    resolve_context: &ResolveContext,
+    config: &PluginConfig,
+    ctx: &ResolveContext,
   ) -> Result<Resolution, anyhow::Error>;
 }
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestResolverPlugin {}
 
-  impl<Fs: FileSystem> ResolverPlugin<Fs> for TestResolverPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl ResolverPlugin for TestResolverPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
     fn resolve(
       &mut self,
-      _config: &mut PluginConfig<Fs>,
-      _resolve_context: &ResolveContext,
+      _config: &PluginConfig,
+      _ctx: &ResolveContext,
     ) -> Result<Resolution, anyhow::Error> {
       todo!()
     }
@@ -91,7 +87,7 @@ mod tests {
 
   #[test]
   fn can_be_defined_in_dyn_vec() {
-    let mut resolvers = Vec::<Box<dyn ResolverPlugin<InMemoryFileSystem>>>::new();
+    let mut resolvers = Vec::<Box<dyn ResolverPlugin>>::new();
 
     resolvers.push(Box::new(TestResolverPlugin {}));
 

--- a/crates/parcel_core/src/plugin/resolver.rs
+++ b/crates/parcel_core/src/plugin/resolver.rs
@@ -1,12 +1,21 @@
 use std::path::PathBuf;
 
-use super::PluginContext;
+use parcel_filesystem::FileSystem;
+
+use super::PluginConfig;
 use crate::types::Dependency;
 use crate::types::JSONObject;
 use crate::types::Priority;
 
 // TODO Diagnostics and invalidations
 
+pub struct ResolveContext {
+  pub specifier: String,
+  pub dependency: Dependency,
+  pub pipeline: Option<String>,
+}
+
+#[derive(Debug, Default)]
 pub struct Resolution {
   /// Whether this dependency can be deferred by Parcel itself
   pub can_defer: bool,
@@ -43,13 +52,49 @@ pub struct Resolution {
 ///
 /// Resolvers run in a pipeline until one of them return a result.
 ///
-pub trait ResolverPlugin: Send + Sync {
+pub trait ResolverPlugin<Fs: FileSystem>: Send + Sync {
+  /// A hook designed to setup any config needed to resolve dependencies
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  ///
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
   /// Determines what the dependency specifier resolves to
   fn resolve(
-    &self,
-    specifier: &str,
-    dependency: &Dependency,
-    pipeline: Option<&str>,
-    context: &PluginContext,
+    &mut self,
+    config: &mut PluginConfig<Fs>,
+    resolve_context: &ResolveContext,
   ) -> Result<Resolution, anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  struct TestResolverPlugin {}
+
+  impl<Fs: FileSystem> ResolverPlugin<Fs> for TestResolverPlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn resolve(
+      &mut self,
+      _config: &mut PluginConfig<Fs>,
+      _resolve_context: &ResolveContext,
+    ) -> Result<Resolution, anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut resolvers = Vec::<Box<dyn ResolverPlugin<InMemoryFileSystem>>>::new();
+
+    resolvers.push(Box::new(TestResolverPlugin {}));
+
+    assert_eq!(resolvers.len(), 1);
+  }
 }

--- a/crates/parcel_core/src/plugin/runtime.rs
+++ b/crates/parcel_core/src/plugin/runtime.rs
@@ -1,2 +1,73 @@
+use std::path::PathBuf;
+
+use parcel_resolver::FileSystem;
+
+use super::PluginConfig;
+use crate::bundle_graph::BundleGraph;
+use crate::types::Bundle;
+use crate::types::Dependency;
+
+pub enum RuntimeAssetPriority {
+  Sync,
+  Parallel,
+}
+
+/// A "synthetic" asset that will be inserted into the bundle graph
+pub struct RuntimeAsset {
+  pub code: String,
+  pub dependency: Option<Dependency>,
+  pub file_path: PathBuf,
+  pub is_entry: Option<bool>,
+  pub priority: Option<RuntimeAssetPriority>,
+  // TODO env: Option<EnvironmentOptions>
+}
+
 /// Programmatically insert assets into bundles
-pub trait RuntimePlugin {}
+pub trait RuntimePlugin<Fs: FileSystem> {
+  /// A hook designed to setup config needed to create runtime assets
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  ///
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
+  /// Generates runtime assets to insert into bundles
+  fn apply(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    bundle: Bundle,
+    bundle_graph: BundleGraph,
+  ) -> Result<Option<Vec<RuntimeAsset>>, anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  struct TestRuntimePlugin {}
+
+  impl<Fs: FileSystem> RuntimePlugin<Fs> for TestRuntimePlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn apply(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _bundle: Bundle,
+      _bundle_graph: BundleGraph,
+    ) -> Result<Option<Vec<RuntimeAsset>>, anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut runtimes = Vec::<Box<dyn RuntimePlugin<InMemoryFileSystem>>>::new();
+
+    runtimes.push(Box::new(TestRuntimePlugin {}));
+
+    assert_eq!(runtimes.len(), 1);
+  }
+}

--- a/crates/parcel_core/src/plugin/runtime.rs
+++ b/crates/parcel_core/src/plugin/runtime.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use parcel_resolver::FileSystem;
-
 use super::PluginConfig;
 use crate::bundle_graph::BundleGraph;
 use crate::types::Bundle;
@@ -23,17 +21,17 @@ pub struct RuntimeAsset {
 }
 
 /// Programmatically insert assets into bundles
-pub trait RuntimePlugin<Fs: FileSystem> {
+pub trait RuntimePlugin {
   /// A hook designed to setup config needed to create runtime assets
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Generates runtime assets to insert into bundles
   fn apply(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     bundle: Bundle,
     bundle_graph: BundleGraph,
   ) -> Result<Option<Vec<RuntimeAsset>>, anyhow::Error>;
@@ -41,20 +39,18 @@ pub trait RuntimePlugin<Fs: FileSystem> {
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestRuntimePlugin {}
 
-  impl<Fs: FileSystem> RuntimePlugin<Fs> for TestRuntimePlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl RuntimePlugin for TestRuntimePlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
     fn apply(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _bundle: Bundle,
       _bundle_graph: BundleGraph,
     ) -> Result<Option<Vec<RuntimeAsset>>, anyhow::Error> {
@@ -64,7 +60,7 @@ mod tests {
 
   #[test]
   fn can_be_defined_in_dyn_vec() {
-    let mut runtimes = Vec::<Box<dyn RuntimePlugin<InMemoryFileSystem>>>::new();
+    let mut runtimes = Vec::<Box<dyn RuntimePlugin>>::new();
 
     runtimes.push(Box::new(TestRuntimePlugin {}));
 

--- a/crates/parcel_core/src/plugin/transformer.rs
+++ b/crates/parcel_core/src/plugin/transformer.rs
@@ -1,6 +1,138 @@
+use std::fs::File;
+use std::path::PathBuf;
+
+use parcel_resolver::FileSystem;
+use parcel_resolver::SpecifierType;
+
+use super::PluginConfig;
+use crate::types::Asset;
+use crate::types::SourceMap;
+
+pub struct AST {}
+
+pub struct GenerateOutput {
+  pub content: File,
+  pub map: Option<SourceMap>,
+}
+
+pub struct ResolveOptions {
+  /// A list of custom conditions to use when resolving package.json "exports" and "imports"
+  pub package_conditions: Vec<String>,
+
+  /// How the specifier should be interpreted
+  pub specifier_type: SpecifierType,
+}
+
+/// A function that enables transformers to resolve a dependency specifier
+pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, anyhow::Error>;
+
 /// Compile a single asset, discover dependencies, or convert the asset to a different format
 ///
 /// Many transformers are wrappers around other tools such as compilers and preprocessors, and are
 /// designed to integrate with Parcel.
 ///
-pub trait TransformerPlugin: Send + Sync {}
+pub trait TransformerPlugin<Fs: FileSystem>: Send + Sync {
+  /// A hook designed to setup config needed to transform assets
+  ///
+  /// This function will run once, shortly after the plugin is initialised.
+  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+
+  /// Whether an AST from a previous transformer can be reused to prevent double-parsing
+  ///
+  /// This function should inspect the type and version of the AST to determine if it can be
+  /// reused. When the AST is reused, parsing is skipped. Otherwise the previous transformer
+  /// generate function is called, and the next transformer will parse that result.
+  ///
+  fn can_reuse_ast(&self, ast: AST) -> bool;
+
+  /// Parse the asset code into an AST
+  ///
+  /// This function is called when an AST is not available and can_reuse_ast returns false.
+  ///
+  fn parse(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    asset: &Asset,
+    resolve: &Resolve,
+  ) -> Result<AST, anyhow::Error>;
+
+  /// Transform the asset and/or add new assets
+  fn transform(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    asset: &mut Asset,
+    resolve: &Resolve,
+  ) -> Result<Vec<Asset>, anyhow::Error>;
+
+  // Perform processing after the transformation
+  fn post_process(
+    &mut self,
+    config: &PluginConfig<Fs>,
+    assets: Vec<&Asset>,
+  ) -> Result<Vec<Asset>, anyhow::Error>;
+
+  /// Stringify the AST
+  ///
+  /// This function is called when the next transformer AST cannot be reused, or this is the last
+  /// transformer in a pipeline.
+  ///
+  fn generate(&self, asset: Asset, ast: AST) -> Result<GenerateOutput, anyhow::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  struct TestTransformerPlugin {}
+
+  impl<Fs: FileSystem> TransformerPlugin<Fs> for TestTransformerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+      todo!()
+    }
+
+    fn can_reuse_ast(&self, _ast: AST) -> bool {
+      todo!()
+    }
+
+    fn parse(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _asset: &Asset,
+      _resolve: &Resolve,
+    ) -> Result<AST, anyhow::Error> {
+      todo!()
+    }
+
+    fn transform(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _asset: &mut Asset,
+      _resolve: &Resolve,
+    ) -> Result<Vec<Asset>, anyhow::Error> {
+      todo!()
+    }
+
+    fn post_process(
+      &mut self,
+      _config: &PluginConfig<Fs>,
+      _assets: Vec<&Asset>,
+    ) -> Result<Vec<Asset>, anyhow::Error> {
+      todo!()
+    }
+
+    fn generate(&self, _asset: Asset, _ast: AST) -> Result<GenerateOutput, anyhow::Error> {
+      todo!()
+    }
+  }
+
+  #[test]
+  fn can_be_defined_in_dyn_vec() {
+    let mut transformers = Vec::<Box<dyn TransformerPlugin<InMemoryFileSystem>>>::new();
+
+    transformers.push(Box::new(TestTransformerPlugin {}));
+
+    assert_eq!(transformers.len(), 1);
+  }
+}

--- a/crates/parcel_core/src/plugin/transformer.rs
+++ b/crates/parcel_core/src/plugin/transformer.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::path::PathBuf;
 
-use parcel_resolver::FileSystem;
 use parcel_resolver::SpecifierType;
 
 use super::PluginConfig;
@@ -31,11 +30,11 @@ pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, an
 /// Many transformers are wrappers around other tools such as compilers and preprocessors, and are
 /// designed to integrate with Parcel.
 ///
-pub trait TransformerPlugin<Fs: FileSystem>: Send + Sync {
+pub trait TransformerPlugin: Send + Sync {
   /// A hook designed to setup config needed to transform assets
   ///
   /// This function will run once, shortly after the plugin is initialised.
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Whether an AST from a previous transformer can be reused to prevent double-parsing
   ///
@@ -51,7 +50,7 @@ pub trait TransformerPlugin<Fs: FileSystem>: Send + Sync {
   ///
   fn parse(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     asset: &Asset,
     resolve: &Resolve,
   ) -> Result<AST, anyhow::Error>;
@@ -59,7 +58,7 @@ pub trait TransformerPlugin<Fs: FileSystem>: Send + Sync {
   /// Transform the asset and/or add new assets
   fn transform(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     asset: &mut Asset,
     resolve: &Resolve,
   ) -> Result<Vec<Asset>, anyhow::Error>;
@@ -67,7 +66,7 @@ pub trait TransformerPlugin<Fs: FileSystem>: Send + Sync {
   // Perform processing after the transformation
   fn post_process(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     assets: Vec<&Asset>,
   ) -> Result<Vec<Asset>, anyhow::Error>;
 
@@ -81,14 +80,12 @@ pub trait TransformerPlugin<Fs: FileSystem>: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestTransformerPlugin {}
 
-  impl<Fs: FileSystem> TransformerPlugin<Fs> for TestTransformerPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl TransformerPlugin for TestTransformerPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
@@ -98,7 +95,7 @@ mod tests {
 
     fn parse(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _asset: &Asset,
       _resolve: &Resolve,
     ) -> Result<AST, anyhow::Error> {
@@ -107,7 +104,7 @@ mod tests {
 
     fn transform(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _asset: &mut Asset,
       _resolve: &Resolve,
     ) -> Result<Vec<Asset>, anyhow::Error> {
@@ -116,7 +113,7 @@ mod tests {
 
     fn post_process(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _assets: Vec<&Asset>,
     ) -> Result<Vec<Asset>, anyhow::Error> {
       todo!()
@@ -129,7 +126,7 @@ mod tests {
 
   #[test]
   fn can_be_defined_in_dyn_vec() {
-    let mut transformers = Vec::<Box<dyn TransformerPlugin<InMemoryFileSystem>>>::new();
+    let mut transformers = Vec::<Box<dyn TransformerPlugin>>::new();
 
     transformers.push(Box::new(TestTransformerPlugin {}));
 

--- a/crates/parcel_core/src/plugin/validator.rs
+++ b/crates/parcel_core/src/plugin/validator.rs
@@ -1,5 +1,3 @@
-use parcel_resolver::FileSystem;
-
 use super::PluginConfig;
 use crate::types::Asset;
 
@@ -20,12 +18,12 @@ pub struct Validation {
 /// remain productive, and do not have to worry about every small typing or linting issue while
 /// trying to solve a problem.
 ///
-pub trait ValidatorPlugin<Fs: FileSystem> {
+pub trait ValidatorPlugin {
   /// A hook designed to setup config needed to validate assets
   ///
   /// This function will run once, shortly after the plugin is initialised.
   ///
-  fn load_config(&mut self, config: &PluginConfig<Fs>) -> Result<(), anyhow::Error>;
+  fn load_config(&mut self, config: &PluginConfig) -> Result<(), anyhow::Error>;
 
   /// Validates a single asset at a time
   ///
@@ -33,7 +31,7 @@ pub trait ValidatorPlugin<Fs: FileSystem> {
   ///
   fn validate_asset(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     asset: &Asset,
   ) -> Result<Validation, anyhow::Error>;
 
@@ -49,27 +47,25 @@ pub trait ValidatorPlugin<Fs: FileSystem> {
   ///
   fn validate_assets(
     &mut self,
-    config: &PluginConfig<Fs>,
+    config: &PluginConfig,
     assets: Vec<&Asset>,
   ) -> Result<Validation, anyhow::Error>;
 }
 
 #[cfg(test)]
 mod tests {
-  use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-
   use super::*;
 
   struct TestValidatorPlugin {}
 
-  impl<Fs: FileSystem> ValidatorPlugin<Fs> for TestValidatorPlugin {
-    fn load_config(&mut self, _config: &PluginConfig<Fs>) -> Result<(), anyhow::Error> {
+  impl ValidatorPlugin for TestValidatorPlugin {
+    fn load_config(&mut self, _config: &PluginConfig) -> Result<(), anyhow::Error> {
       todo!()
     }
 
     fn validate_asset(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _asset: &Asset,
     ) -> Result<Validation, anyhow::Error> {
       todo!()
@@ -77,7 +73,7 @@ mod tests {
 
     fn validate_assets(
       &mut self,
-      _config: &PluginConfig<Fs>,
+      _config: &PluginConfig,
       _assets: Vec<&Asset>,
     ) -> Result<Validation, anyhow::Error> {
       todo!()
@@ -86,7 +82,7 @@ mod tests {
 
   #[test]
   fn can_be_defined_in_dyn_vec() {
-    let mut validators = Vec::<Box<dyn ValidatorPlugin<InMemoryFileSystem>>>::new();
+    let mut validators = Vec::<Box<dyn ValidatorPlugin>>::new();
 
     validators.push(Box::new(TestValidatorPlugin {}));
 

--- a/crates/parcel_core/src/types/environment.rs
+++ b/crates/parcel_core/src/types/environment.rs
@@ -23,7 +23,7 @@ pub struct EnvironmentId(pub NonZeroU32);
 ///
 /// This influences how Parcel compiles your code, including what syntax to transpile.
 ///
-#[derive(Clone, Debug, Deserialize, Eq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Environment {
   /// The environment the output should run in
@@ -102,9 +102,10 @@ impl PartialEq for Environment {
 ///
 /// This informs Parcel what environment-specific APIs are available.
 ///
-#[derive(Clone, Copy, Debug, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Default, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum EnvironmentContext {
+  #[default]
   Browser = 0,
   ElectronMain = 1,
   ElectronRenderer = 2,
@@ -139,9 +140,10 @@ impl EnvironmentContext {
   }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Hash, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Default, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum SourceType {
+  #[default]
   Module = 0,
   Script = 1,
 }

--- a/crates/parcel_core/src/types/environment/output_format.rs
+++ b/crates/parcel_core/src/types/environment/output_format.rs
@@ -2,7 +2,7 @@ use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 
 /// The JavaScript bundle output format
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Deserialize_repr, Hash, Serialize_repr)]
+#[derive(Clone, Copy, Debug, Default, Deserialize_repr, Eq, Hash, PartialEq, Serialize_repr)]
 #[repr(u8)]
 pub enum OutputFormat {
   /// A classic script that can be loaded in a <script> tag in the browser
@@ -21,5 +21,6 @@ pub enum OutputFormat {
   ///
   /// ES Modules are often loaded using a <script type="module"> tag in the browser.
   ///
+  #[default]
   EsModule = 2,
 }


### PR DESCRIPTION
# ↪️ Pull Request

These changes expand on the empty plugin traits and introduce plugin config that can be loaded once off or is dependent on input parameters such as assets, bundles, etc. These traits are [object safe](https://doc.rust-lang.org/beta/reference/items/traits.html#object-safety) and adhere to those limitations. Secondly, the trait APIs are subject to change as more work is completed towards loading plugins.

The `load_config` fn roughly matches the current plugin API. If possible, each plugin will later be constructed with its config (provided it's a one time setup) in the parcel core lib rather than being part of the trait.

## 🚨 Test instructions

`cargo test -p parcel_core`
