### PR TITLE
Make filesystem object safe

### DIFF
--- a/crates/node-bindings/src/core/requests/config_request/mod.rs
+++ b/crates/node-bindings/src/core/requests/config_request/mod.rs
@@ -354,7 +354,7 @@ mod test {
 
   #[test]
   fn test_read_json_config() {
-    let mut file_system = InMemoryFileSystem::default();
+    let file_system = InMemoryFileSystem::default();
     let config_path = Path::new("/config.json");
     file_system.write_file(config_path, String::from(r#"{"key": "value"}"#));
 
@@ -364,7 +364,7 @@ mod test {
 
   #[test]
   fn test_read_toml_config() {
-    let mut file_system = InMemoryFileSystem::default();
+    let file_system = InMemoryFileSystem::default();
     let config_path = Path::new("/config.toml");
     file_system.write_file(config_path, String::from(r#"key = "value""#));
 

--- a/crates/node-bindings/src/core/requests/entry_request/mod.rs
+++ b/crates/node-bindings/src/core/requests/entry_request/mod.rs
@@ -215,7 +215,7 @@ mod test {
 
   #[test]
   fn test_resolve_entry_file() {
-    let mut fs = InMemoryFileSystem::default();
+    let fs = InMemoryFileSystem::default();
     fs.set_current_working_directory("/project".into());
     let project_root = Path::new("/project");
     let path = Path::new("/project/file");

--- a/crates/node-bindings/src/resolver.rs
+++ b/crates/node-bindings/src/resolver.rs
@@ -93,13 +93,13 @@ pub struct JsFileSystem {
 }
 
 impl FileSystem for JsFileSystem {
-  fn canonicalize<P: AsRef<Path>>(
+  fn canonicalize(
     &self,
-    path: P,
+    path: &Path,
     _cache: &DashMap<PathBuf, Option<PathBuf>>,
   ) -> std::io::Result<std::path::PathBuf> {
     let canonicalize = || -> napi::Result<_> {
-      let path = path.as_ref().to_string_lossy();
+      let path = path.to_string_lossy();
       let path = self.canonicalize.env.create_string(path.as_ref())?;
       let res: JsString = self.canonicalize.get()?.call(None, &[path])?.try_into()?;
       let utf8 = res.into_utf8()?;
@@ -109,9 +109,9 @@ impl FileSystem for JsFileSystem {
     canonicalize().map_err(|err| std::io::Error::new(std::io::ErrorKind::NotFound, err.to_string()))
   }
 
-  fn read_to_string<P: AsRef<Path>>(&self, path: P) -> std::io::Result<String> {
+  fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     let read = || -> napi::Result<_> {
-      let path = path.as_ref().to_string_lossy();
+      let path = path.to_string_lossy();
       let path = self.read.env.create_string(path.as_ref())?;
       let res: JsBuffer = self.read.get()?.call(None, &[path])?.try_into()?;
       let value = res.into_value()?;
@@ -121,9 +121,9 @@ impl FileSystem for JsFileSystem {
     read().map_err(|err| std::io::Error::new(std::io::ErrorKind::NotFound, err.to_string()))
   }
 
-  fn is_file<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_file(&self, path: &Path) -> bool {
     let is_file = || -> napi::Result<_> {
-      let path = path.as_ref().to_string_lossy();
+      let path = path.to_string_lossy();
       let p = self.is_file.env.create_string(path.as_ref())?;
       let res: JsBoolean = self.is_file.get()?.call(None, &[p])?.try_into()?;
       res.get_value()
@@ -132,9 +132,9 @@ impl FileSystem for JsFileSystem {
     is_file().unwrap_or(false)
   }
 
-  fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_dir(&self, path: &Path) -> bool {
     let is_dir = || -> napi::Result<_> {
-      let path = path.as_ref().to_string_lossy();
+      let path = path.to_string_lossy();
       let path = self.is_dir.env.create_string(path.as_ref())?;
       let res: JsBoolean = self.is_dir.get()?.call(None, &[path])?.try_into()?;
       res.get_value()
@@ -153,9 +153,9 @@ enum EitherFs<A, B> {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<A: FileSystem, B: FileSystem> FileSystem for EitherFs<A, B> {
-  fn canonicalize<P: AsRef<Path>>(
+  fn canonicalize(
     &self,
-    path: P,
+    path: &Path,
     cache: &DashMap<PathBuf, Option<PathBuf>>,
   ) -> std::io::Result<std::path::PathBuf> {
     match self {
@@ -164,21 +164,21 @@ impl<A: FileSystem, B: FileSystem> FileSystem for EitherFs<A, B> {
     }
   }
 
-  fn read_to_string<P: AsRef<Path>>(&self, path: P) -> std::io::Result<String> {
+  fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     match self {
       EitherFs::A(a) => a.read_to_string(path),
       EitherFs::B(b) => b.read_to_string(path),
     }
   }
 
-  fn is_file<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_file(&self, path: &Path) -> bool {
     match self {
       EitherFs::A(a) => a.is_file(path),
       EitherFs::B(b) => b.is_file(path),
     }
   }
 
-  fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_dir(&self, path: &Path) -> bool {
     match self {
       EitherFs::A(a) => a.is_dir(path),
       EitherFs::B(b) => b.is_dir(path),

--- a/crates/parcel_config/src/parcel_rc_config_loader.rs
+++ b/crates/parcel_config/src/parcel_rc_config_loader.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use parcel_filesystem::search::find_ancestor_file;
 use parcel_filesystem::FileSystem;
@@ -25,13 +26,13 @@ pub struct LoadConfigOptions<'a> {
 }
 
 /// Loads and validates .parcel_rc config
-pub struct ParcelRcConfigLoader<'a, T, U> {
-  fs: &'a T,
-  package_manager: &'a U,
+pub struct ParcelRcConfigLoader {
+  fs: Rc<dyn FileSystem>,
+  package_manager: Rc<dyn PackageManager>,
 }
 
-impl<'a, T: FileSystem, U: PackageManager> ParcelRcConfigLoader<'a, T, U> {
-  pub fn new(fs: &'a T, package_manager: &'a U) -> Self {
+impl ParcelRcConfigLoader {
+  pub fn new(fs: Rc<dyn FileSystem>, package_manager: Rc<dyn PackageManager>) -> Self {
     ParcelRcConfigLoader {
       fs,
       package_manager,
@@ -41,8 +42,13 @@ impl<'a, T: FileSystem, U: PackageManager> ParcelRcConfigLoader<'a, T, U> {
   fn find_config(&self, project_root: &Path, path: &PathBuf) -> Result<PathBuf, ConfigError> {
     let from = path.parent().unwrap_or(path);
 
-    find_ancestor_file(self.fs, vec![String::from(".parcelrc")], from, project_root)
-      .ok_or(ConfigError::MissingParcelRc(PathBuf::from(from)))
+    find_ancestor_file(
+      Rc::clone(&self.fs),
+      vec![String::from(".parcelrc")],
+      from,
+      project_root,
+    )
+    .ok_or(ConfigError::MissingParcelRc(PathBuf::from(from)))
   }
 
   fn resolve_from(&self, project_root: &PathBuf) -> PathBuf {
@@ -101,7 +107,7 @@ impl<'a, T: FileSystem, U: PackageManager> ParcelRcConfigLoader<'a, T, U> {
 
     self
       .fs
-      .canonicalize_base(path.clone())
+      .canonicalize_base(&path)
       .map_err(|source| ConfigError::UnresolvedConfig {
         config_type: String::from("extended config"),
         from: path,
@@ -166,7 +172,7 @@ impl<'a, T: FileSystem, U: PackageManager> ParcelRcConfigLoader<'a, T, U> {
   pub fn load(
     &self,
     project_root: &PathBuf,
-    options: LoadConfigOptions<'a>,
+    options: LoadConfigOptions,
   ) -> Result<(ParcelConfig, Vec<PathBuf>), ConfigError> {
     let resolve_from = self.resolve_from(project_root);
     let mut config_path = match options.config {
@@ -232,17 +238,17 @@ mod tests {
       });
   }
 
-  struct InMemoryPackageManager<'a> {
-    fs: &'a InMemoryFileSystem,
+  struct TestPackageManager {
+    fs: Rc<dyn FileSystem>,
   }
 
-  impl<'a> InMemoryPackageManager<'a> {
-    pub fn new(fs: &'a InMemoryFileSystem) -> Self {
+  impl TestPackageManager {
+    pub fn new(fs: Rc<dyn FileSystem>) -> Self {
       Self { fs }
     }
   }
 
-  impl<'a> PackageManager for InMemoryPackageManager<'a> {
+  impl PackageManager for TestPackageManager {
     fn resolve(&self, specifier: &str, from: &Path) -> Result<Resolution, ResolveError> {
       let path = match "true" {
         _s if specifier.starts_with(".") => from.join(specifier),
@@ -301,10 +307,10 @@ mod tests {
 
     #[test]
     fn errors_on_missing_parcelrc_file() {
-      let fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
-      let err = ParcelRcConfigLoader::new(&fs, &MockPackageManager::new())
+      let err = ParcelRcConfigLoader::new(fs, Rc::new(MockPackageManager::new()))
         .load(&project_root, LoadConfigOptions::default())
         .map_err(|e| e.to_string());
 
@@ -316,17 +322,17 @@ mod tests {
 
     #[test]
     fn errors_on_failed_extended_parcelrc_resolution() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let config = default_extended_config(&project_root);
 
-      fs.write_file(
-        config.base_config.path.clone(),
-        config.base_config.parcel_rc,
-      );
+      fs.write_file(&config.base_config.path, config.base_config.parcel_rc);
 
-      let err = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let err = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(&project_root, LoadConfigOptions::default())
         .map_err(|e| e.to_string());
 
@@ -346,15 +352,15 @@ mod tests {
 
     #[test]
     fn returns_default_parcel_config() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let default_config = default_config(&Rc::new(project_root.join(".parcelrc")));
       let files = vec![default_config.path.clone()];
 
-      fs.write_file(default_config.path, default_config.parcel_rc);
+      fs.write_file(&default_config.path, default_config.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &MockPackageManager::default())
+      let parcel_config = ParcelRcConfigLoader::new(fs, Rc::new(MockPackageManager::default()))
         .load(&project_root, LoadConfigOptions::default())
         .map_err(|e| e.to_string());
 
@@ -363,15 +369,15 @@ mod tests {
 
     #[test]
     fn returns_default_parcel_config_from_project_root() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap().join("src").join("packages").join("root");
 
       let default_config = default_config(&Rc::new(project_root.join(".parcelrc")));
       let files = vec![default_config.path.clone()];
 
-      fs.write_file(default_config.path, default_config.parcel_rc);
+      fs.write_file(&default_config.path, default_config.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &MockPackageManager::default())
+      let parcel_config = ParcelRcConfigLoader::new(fs, Rc::new(MockPackageManager::default()))
         .load(&project_root, LoadConfigOptions::default())
         .map_err(|e| e.to_string());
 
@@ -380,15 +386,16 @@ mod tests {
 
     #[test]
     fn returns_default_parcel_config_from_project_root_when_outside_cwd() {
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/root");
+
       let default_config = default_config(&Rc::new(project_root.join(".parcelrc")));
       let files = vec![default_config.path.clone()];
-      let mut fs = InMemoryFileSystem::default();
 
       fs.set_current_working_directory(PathBuf::from("/cwd"));
-      fs.write_file(default_config.path, default_config.parcel_rc);
+      fs.write_file(&default_config.path, default_config.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &MockPackageManager::default())
+      let parcel_config = ParcelRcConfigLoader::new(fs, Rc::new(MockPackageManager::default()))
         .load(&project_root, LoadConfigOptions::default())
         .map_err(|e| e.to_string());
 
@@ -397,7 +404,7 @@ mod tests {
 
     #[test]
     fn returns_merged_default_parcel_config() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let default_config = default_extended_config(&project_root);
@@ -407,16 +414,19 @@ mod tests {
       ];
 
       fs.write_file(
-        default_config.base_config.path,
+        &default_config.base_config.path,
         default_config.base_config.parcel_rc,
       );
 
       fs.write_file(
-        default_config.extended_config.path,
+        &default_config.extended_config.path,
         default_config.extended_config.parcel_rc,
       );
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let parcel_config = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(&project_root, LoadConfigOptions::default())
         .map_err(|e| e.to_string());
 
@@ -431,13 +441,15 @@ mod tests {
 
     #[test]
     fn errors_on_failed_config_resolution() {
-      let fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let mut package_manager = MockPackageManager::new();
       let project_root = fs.cwd().unwrap();
 
       fail_package_manager_resolution(&mut package_manager);
 
-      let err = ParcelRcConfigLoader::new(&fs, &package_manager)
+      let package_manager = Rc::new(package_manager);
+
+      let err = ParcelRcConfigLoader::new(fs, package_manager)
         .load(
           &&project_root,
           LoadConfigOptions {
@@ -464,17 +476,17 @@ mod tests {
 
     #[test]
     fn errors_on_failed_extended_config_resolution() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (specifier, config) = extended_config(&project_root);
 
-      fs.write_file(
-        config.base_config.path.clone(),
-        config.base_config.parcel_rc,
-      );
+      fs.write_file(&config.base_config.path, config.base_config.parcel_rc);
 
-      let err = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let err = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -501,11 +513,11 @@ mod tests {
 
     #[test]
     fn errors_on_missing_config_file() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let mut package_manager = MockPackageManager::new();
       let project_root = fs.cwd().unwrap();
 
-      fs.write_file(project_root.join(".parcelrc"), String::from("{}"));
+      fs.write_file(&project_root.join(".parcelrc"), String::from("{}"));
 
       let config_path = package_manager_resolution(
         &mut package_manager,
@@ -513,7 +525,10 @@ mod tests {
         project_root.join("index"),
       );
 
-      let err = ParcelRcConfigLoader::new(&fs, &package_manager)
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(package_manager);
+
+      let err = ParcelRcConfigLoader::new(fs, package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -538,16 +553,19 @@ mod tests {
 
     #[test]
     fn returns_specified_config() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (specifier, specified_config) = config(&project_root);
       let files = vec![specified_config.path.clone()];
 
-      fs.write_file(project_root.join(".parcelrc"), String::from("{}"));
-      fs.write_file(specified_config.path, specified_config.parcel_rc);
+      fs.write_file(&project_root.join(".parcelrc"), String::from("{}"));
+      fs.write_file(&specified_config.path, specified_config.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let parcel_config = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -572,13 +590,15 @@ mod tests {
 
     #[test]
     fn errors_on_failed_fallback_resolution() {
-      let fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let mut package_manager = MockPackageManager::new();
       let project_root = fs.cwd().unwrap();
 
       fail_package_manager_resolution(&mut package_manager);
 
-      let err = ParcelRcConfigLoader::new(&fs, &package_manager)
+      let package_manager = Rc::new(package_manager);
+
+      let err = ParcelRcConfigLoader::new(fs, package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -605,17 +625,17 @@ mod tests {
 
     #[test]
     fn errors_on_failed_extended_fallback_config_resolution() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (fallback_specifier, fallback) = extended_config(&project_root);
 
-      fs.write_file(
-        fallback.base_config.path.clone(),
-        fallback.base_config.parcel_rc,
-      );
+      fs.write_file(&fallback.base_config.path, fallback.base_config.parcel_rc);
 
-      let err = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let err = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -642,7 +662,7 @@ mod tests {
 
     #[test]
     fn errors_on_missing_fallback_config_file() {
-      let fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let mut package_manager = MockPackageManager::new();
       let project_root = fs.cwd().unwrap();
 
@@ -652,7 +672,9 @@ mod tests {
         project_root.join("index"),
       );
 
-      let err = ParcelRcConfigLoader::new(&InMemoryFileSystem::default(), &package_manager)
+      let package_manager = Rc::new(package_manager);
+
+      let err = ParcelRcConfigLoader::new(fs, package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -677,20 +699,19 @@ mod tests {
 
     #[test]
     fn returns_project_root_parcel_rc() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (fallback_specifier, fallback) = fallback_config(&project_root);
       let project_root_config = default_config(&Rc::new(project_root.join(".parcelrc")));
 
-      fs.write_file(
-        project_root_config.path.clone(),
-        project_root_config.parcel_rc,
-      );
+      fs.write_file(&project_root_config.path, project_root_config.parcel_rc);
+      fs.write_file(&fallback.path, String::from("{}"));
 
-      fs.write_file(fallback.path, String::from("{}"));
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let parcel_config = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -712,15 +733,18 @@ mod tests {
 
     #[test]
     fn returns_fallback_config_when_parcel_rc_is_missing() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (fallback_specifier, fallback) = fallback_config(&project_root);
       let files = vec![fallback.path.clone()];
 
-      fs.write_file(fallback.path, fallback.parcel_rc);
+      fs.write_file(&fallback.path, fallback.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let parcel_config = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -742,7 +766,7 @@ mod tests {
 
     #[test]
     fn returns_specified_config() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (config_specifier, config) = config(&project_root);
@@ -750,10 +774,13 @@ mod tests {
 
       let files = vec![config.path.clone()];
 
-      fs.write_file(config.path, config.parcel_rc);
-      fs.write_file(fallback_config.path, fallback_config.parcel_rc);
+      fs.write_file(&config.path, config.parcel_rc);
+      fs.write_file(&fallback_config.path, fallback_config.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let parcel_config = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {
@@ -769,7 +796,7 @@ mod tests {
 
     #[test]
     fn returns_fallback_config_when_config_file_missing() {
-      let mut fs = InMemoryFileSystem::default();
+      let fs = Rc::new(InMemoryFileSystem::default());
       let project_root = fs.cwd().unwrap();
 
       let (config_specifier, _config) = config(&project_root);
@@ -777,9 +804,12 @@ mod tests {
 
       let files = vec![fallback.path.clone()];
 
-      fs.write_file(fallback.path, fallback.parcel_rc);
+      fs.write_file(&fallback.path, fallback.parcel_rc);
 
-      let parcel_config = ParcelRcConfigLoader::new(&fs, &InMemoryPackageManager::new(&fs))
+      let fs: Rc<dyn FileSystem> = fs;
+      let package_manager = Rc::new(TestPackageManager::new(Rc::clone(&fs)));
+
+      let parcel_config = ParcelRcConfigLoader::new(Rc::clone(&fs), package_manager)
         .load(
           &project_root,
           LoadConfigOptions {

--- a/crates/parcel_filesystem/src/js_delegate_file_system.rs
+++ b/crates/parcel_filesystem/src/js_delegate_file_system.rs
@@ -46,9 +46,9 @@ impl FileSystem for JSDelegateFileSystem {
     })
   }
 
-  fn canonicalize_base<P: AsRef<Path>>(&self, path: P) -> std::io::Result<PathBuf> {
+  fn canonicalize_base(&self, path: &Path) -> std::io::Result<PathBuf> {
     run_with_errors(|| {
-      let path = path.as_ref().to_str().unwrap();
+      let path = path.to_str().unwrap();
       let js_path = self.env.create_string(path)?;
       let result = call_method(
         &self.env,
@@ -60,9 +60,9 @@ impl FileSystem for JSDelegateFileSystem {
     })
   }
 
-  fn read_to_string<P: AsRef<Path>>(&self, path: P) -> std::io::Result<String> {
+  fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     run_with_errors(|| {
-      let path = path.as_ref().to_str().unwrap();
+      let path = path.to_str().unwrap();
       let js_path = self.env.create_string(path)?;
       let result = call_method(
         &self.env,
@@ -79,9 +79,9 @@ impl FileSystem for JSDelegateFileSystem {
     })
   }
 
-  fn is_file<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_file(&self, path: &Path) -> bool {
     run_with_errors(|| {
-      let path = path.as_ref().to_str().unwrap();
+      let path = path.to_str().unwrap();
       let js_path = self.env.create_string(path)?;
       let result = call_method(
         &self.env,
@@ -96,9 +96,9 @@ impl FileSystem for JSDelegateFileSystem {
     .unwrap_or(false)
   }
 
-  fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_dir(&self, path: &Path) -> bool {
     run_with_errors(|| {
-      let path = path.as_ref().to_str().unwrap();
+      let path = path.to_str().unwrap();
       let js_path = self.env.create_string(path)?;
       let result = call_method(
         &self.env,

--- a/crates/parcel_filesystem/src/lib.rs
+++ b/crates/parcel_filesystem/src/lib.rs
@@ -32,20 +32,20 @@ pub trait FileSystem {
       "Not implemented",
     ))
   }
-  fn canonicalize_base<P: AsRef<Path>>(&self, _path: P) -> Result<PathBuf> {
+  fn canonicalize_base(&self, _path: &Path) -> Result<PathBuf> {
     Err(std::io::Error::new(
       std::io::ErrorKind::Other,
       "Not implemented",
     ))
   }
-  fn canonicalize<P: AsRef<Path>>(
+  fn canonicalize(
     &self,
-    path: P,
+    path: &Path,
     _cache: &DashMap<PathBuf, Option<PathBuf>>,
   ) -> Result<PathBuf> {
     self.canonicalize_base(path)
   }
-  fn read_to_string<P: AsRef<Path>>(&self, path: P) -> Result<String>;
-  fn is_file<P: AsRef<Path>>(&self, path: P) -> bool;
-  fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool;
+  fn read_to_string(&self, path: &Path) -> Result<String>;
+  fn is_file(&self, path: &Path) -> bool;
+  fn is_dir(&self, path: &Path) -> bool;
 }

--- a/crates/parcel_filesystem/src/os_file_system.rs
+++ b/crates/parcel_filesystem/src/os_file_system.rs
@@ -16,24 +16,24 @@ impl FileSystem for OsFileSystem {
     std::env::current_dir()
   }
 
-  fn canonicalize<P: AsRef<Path>>(
+  fn canonicalize(
     &self,
-    path: P,
+    path: &Path,
     cache: &DashMap<PathBuf, Option<PathBuf>>,
   ) -> std::io::Result<PathBuf> {
-    canonicalize(path.as_ref(), cache)
+    canonicalize(path, cache)
   }
 
-  fn read_to_string<P: AsRef<Path>>(&self, path: P) -> std::io::Result<String> {
+  fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     std::fs::read_to_string(path)
   }
 
-  fn is_file<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_file(&self, path: &Path) -> bool {
     let path: &Path = path.as_ref();
     path.is_file()
   }
 
-  fn is_dir<P: AsRef<Path>>(&self, path: P) -> bool {
+  fn is_dir(&self, path: &Path) -> bool {
     let path: &Path = path.as_ref();
     path.is_dir()
   }

--- a/crates/parcel_filesystem/src/search.rs
+++ b/crates/parcel_filesystem/src/search.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use crate::FileSystem;
 
 pub fn find_ancestor_file<P: AsRef<Path>>(
-  fs: &impl FileSystem,
+  fs: Rc<dyn FileSystem>,
   filenames: Vec<String>,
   from: P,
   root: P,


### PR DESCRIPTION
# ↪️ Pull Request

This change is necessary to remove the filesystem generics in https://github.com/parcel-bundler/parcel/pull/9744 and the existing config crate

## 🚨 Test instructions

`yarn build native && cargo test`
