### PR TITLE
Statically type all request results

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -71,7 +71,7 @@ type Opts = {|
   previousInvalidations: Array<RequestInvalidation>,
 |};
 
-export type PackageRequestResult = {|
+export type RunPackagerRunnerResult = {|
   bundleInfo: BundleInfo,
   configRequests: Array<ConfigRequest>,
   devDepRequests: Array<DevDepRequest>,
@@ -142,7 +142,7 @@ export default class PackagerRunner {
     bundleGraph: InternalBundleGraph,
     bundle: InternalBundle,
     invalidDevDeps: Array<DevDepSpecifier>,
-  ): Promise<PackageRequestResult> {
+  ): Promise<RunPackagerRunnerResult> {
     invalidateDevDeps(invalidDevDeps, this.options, this.config);
 
     let {configs, bundleConfigs} = await this.loadConfigs(bundleGraph, bundle);

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -59,6 +59,19 @@ import {
   storeRequestTrackerCacheInfo,
   clearRequestTrackerCacheInfo,
 } from './RequestTrackerCacheInfo';
+import type {AssetGraphRequestResult} from './requests/AssetGraphRequest';
+import type {PackageRequestResult} from './requests/PackageRequest';
+import type {ConfigRequestResult} from './requests/ConfigRequest';
+import type {DevDepRequestResult} from './requests/DevDepRequest';
+import type {WriteBundlesRequestResult} from './requests/WriteBundlesRequest';
+import type {WriteBundleRequestResult} from './requests/WriteBundleRequest';
+import type {TargetRequestResult} from './requests/TargetRequest';
+import type {PathRequestResult} from './requests/PathRequest';
+import type {ParcelConfigRequestResult} from './requests/ParcelConfigRequest';
+import type {ParcelBuildRequestResult} from './requests/ParcelBuildRequest';
+import type {EntryRequestResult} from './requests/EntryRequest';
+import type {BundleGraphResult} from './requests/BundleGraphRequest';
+import type {AssetRequestResult} from './types';
 
 export const requestGraphEdgeTypes = {
   subrequest: 2,
@@ -144,13 +157,28 @@ type Request<TInput, TResult> = {|
   run: ({|input: TInput, ...StaticRunOpts<TResult>|}) => Async<TResult>,
 |};
 
+export type RequestResult =
+  | AssetGraphRequestResult
+  | PackageRequestResult
+  | ConfigRequestResult
+  | DevDepRequestResult
+  | WriteBundlesRequestResult
+  | WriteBundleRequestResult
+  | TargetRequestResult
+  | PathRequestResult
+  | ParcelConfigRequestResult
+  | ParcelBuildRequestResult
+  | EntryRequestResult
+  | BundleGraphResult
+  | AssetRequestResult;
+
 type InvalidateReason = number;
 type RequestNode = {|
   id: ContentKey,
   +type: typeof REQUEST,
   +requestType: RequestType,
   invalidateReason: InvalidateReason,
-  result?: mixed,
+  result?: RequestResult,
   resultCacheKey?: ?string,
   hash?: string,
 |};
@@ -184,7 +212,7 @@ type RequestGraphNode =
   | OptionNode
   | ConfigKeyNode;
 
-export type RunAPI<TResult> = {|
+export type RunAPI<TResult: RequestResult> = {|
   invalidateOnFileCreate: InternalFileCreateInvalidation => void,
   invalidateOnFileDelete: ProjectPath => void,
   invalidateOnFileUpdate: ProjectPath => void,
@@ -199,12 +227,12 @@ export type RunAPI<TResult> = {|
   invalidateOnOptionChange: string => void,
   getInvalidations(): Array<RequestInvalidation>,
   storeResult(result: TResult, cacheKey?: string): void,
-  getRequestResult<T>(contentKey: ContentKey): Async<?T>,
-  getPreviousResult<T>(ifMatch?: string): Async<?T>,
+  getRequestResult<T: RequestResult>(contentKey: ContentKey): Async<?T>,
+  getPreviousResult<T: RequestResult>(ifMatch?: string): Async<?T>,
   getSubRequests(): Array<RequestNode>,
   getInvalidSubRequests(): Array<RequestNode>,
   canSkipSubrequest(ContentKey): boolean,
-  runRequest: <TInput, TResult>(
+  runRequest: <TInput, TResult: RequestResult>(
     subRequest: Request<TInput, TResult>,
     opts?: RunRequestOpts,
   ) => Promise<TResult>,
@@ -1096,7 +1124,7 @@ export default class RequestTracker {
   }
 
   // If a cache key is provided, the result will be removed from the node and stored in a separate cache entry
-  storeResult(nodeId: NodeId, result: mixed, cacheKey: ?string) {
+  storeResult(nodeId: NodeId, result: RequestResult, cacheKey: ?string) {
     let node = this.graph.getNode(nodeId);
     if (node && node.type === REQUEST) {
       node.result = result;
@@ -1112,7 +1140,7 @@ export default class RequestTracker {
     );
   }
 
-  async getRequestResult<T>(
+  async getRequestResult<T: RequestResult>(
     contentKey: ContentKey,
     ifMatch?: string,
   ): Promise<?T> {
@@ -1184,7 +1212,7 @@ export default class RequestTracker {
     this.graph.replaceSubrequests(requestNodeId, subrequestContextKeys);
   }
 
-  async runRequest<TInput, TResult>(
+  async runRequest<TInput, TResult: RequestResult>(
     request: Request<TInput, TResult>,
     opts?: ?RunRequestOpts,
   ): Promise<TResult> {
@@ -1289,7 +1317,7 @@ export default class RequestTracker {
     return formattedStats;
   }
 
-  createAPI<TResult>(
+  createAPI<TResult: RequestResult>(
     requestId: NodeId,
     previousInvalidations: Array<RequestInvalidation>,
   ): {|api: RunAPI<TResult>, subRequestContentKeys: Set<ContentKey>|} {
@@ -1324,11 +1352,12 @@ export default class RequestTracker {
       },
       getSubRequests: () => this.graph.getSubRequests(requestId),
       getInvalidSubRequests: () => this.graph.getInvalidSubRequests(requestId),
-      getPreviousResult: <T>(ifMatch?: string): Async<?T> => {
+      getPreviousResult: <T: RequestResult>(ifMatch?: string): Async<?T> => {
         let contentKey = nullthrows(this.graph.getNode(requestId)?.id);
         return this.getRequestResult<T>(contentKey, ifMatch);
       },
-      getRequestResult: <T>(id): Async<?T> => this.getRequestResult<T>(id),
+      getRequestResult: <T: RequestResult>(id): Async<?T> =>
+        this.getRequestResult<T>(id),
       canSkipSubrequest: contentKey => {
         if (
           this.graph.hasContentKey(contentKey) &&
@@ -1340,7 +1369,7 @@ export default class RequestTracker {
 
         return false;
       },
-      runRequest: <TInput, TResult>(
+      runRequest: <TInput, TResult: RequestResult>(
         subRequest: Request<TInput, TResult>,
         opts?: RunRequestOpts,
       ): Promise<TResult> => {

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -13,7 +13,7 @@ import type {
 } from './types';
 import type ParcelConfig from './ParcelConfig';
 import type PluginOptions from './public/PluginOptions';
-import type {RunAPI} from './RequestTracker';
+import type {RequestResult, RunAPI} from './RequestTracker';
 
 import path from 'path';
 import assert from 'assert';
@@ -60,7 +60,7 @@ function nameRuntimeBundle(
   bundle.displayName = name.replace(hashReference, '[hash]');
 }
 
-export default async function applyRuntimes<TResult>({
+export default async function applyRuntimes<TResult: RequestResult>({
   bundleGraph,
   config,
   options,
@@ -324,7 +324,7 @@ export default async function applyRuntimes<TResult>({
   return changedAssets;
 }
 
-function reconcileNewRuntimes<TResult>(
+function reconcileNewRuntimes<TResult: RequestResult>(
   api: RunAPI<TResult>,
   connections: Array<RuntimeConnection>,
   optionsRef: SharedReference,

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -13,7 +13,7 @@ import type {
   Target,
 } from '../types';
 import type {StaticRunOpts, RunAPI} from '../RequestTracker';
-import type {EntryResult} from './EntryRequest';
+import type {EntryRequestResult} from './EntryRequest';
 import type {PathRequestInput} from './PathRequest';
 import type {Diagnostic} from '@parcel/diagnostic';
 import logger from '@parcel/logger';
@@ -46,7 +46,7 @@ type AssetGraphRequestInput = {|
   requestedAssetIds?: Set<string>,
 |};
 
-type AssetGraphRequestResult = {|
+export type AssetGraphRequestResult = {|
   assetGraph: AssetGraph,
   /** Assets added/modified since the last successful build. */
   changedAssets: Map<string, Asset>,
@@ -468,9 +468,12 @@ export class AssetGraphBuilder {
       : [];
 
     let request = createEntryRequest(input);
-    let result = await this.api.runRequest<ProjectPath, EntryResult>(request, {
-      force: true,
-    });
+    let result = await this.api.runRequest<ProjectPath, EntryRequestResult>(
+      request,
+      {
+        force: true,
+      },
+    );
     this.assetGraph.resolveEntry(request.input, result.entries, request.id);
 
     if (this.assetGraph.safeToIncrementallyBundle) {

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -6,7 +6,6 @@ import type {StaticRunOpts} from '../RequestTracker';
 import type {
   AssetRequestInput,
   AssetRequestResult,
-  DevDepRequest,
   TransformationRequest,
 } from '../types';
 import type {ConfigAndCachePath} from './ParcelConfigRequest';

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -71,6 +71,7 @@ type RunInput = {|
   ...StaticRunOpts<BundleGraphResult>,
 |};
 
+// TODO: Rename to BundleGraphRequestResult
 export type BundleGraphResult = {|
   bundleGraph: InternalBundleGraph,
   changedAssets: Map<string, Asset>,

--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -15,7 +15,7 @@ import type {
   InternalFileCreateInvalidation,
 } from '../types';
 import type {LoadedPlugin} from '../ParcelConfig';
-import type {RunAPI} from '../RequestTracker';
+import type {RequestResult, RunAPI} from '../RequestTracker';
 import type {ProjectPath} from '../projectPath';
 import {napiRunConfigRequest} from '@parcel/rust';
 
@@ -75,6 +75,8 @@ export type ConfigRequest = {
   invalidateOnBuild: boolean,
   ...
 };
+
+export type ConfigRequestResult = void;
 
 export async function loadPluginConfig<T: PluginWithLoadConfig>(
   loadedPlugin: LoadedPlugin<T>,
@@ -143,7 +145,7 @@ export async function getConfigKeyContentHash(
   return contentHash;
 }
 
-export async function runConfigRequest<TResult>(
+export async function runConfigRequest<TResult: RequestResult>(
   api: RunAPI<TResult>,
   configRequest: ConfigRequest,
 ) {

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -34,11 +34,11 @@ type RunOpts<TResult> = {|
 export type EntryRequest = {|
   id: string,
   +type: typeof requestTypes.entry_request,
-  run: (RunOpts<EntryResult>) => Async<EntryResult>,
+  run: (RunOpts<EntryRequestResult>) => Async<EntryRequestResult>,
   input: ProjectPath,
 |};
 
-export type EntryResult = {|
+export type EntryRequestResult = {|
   entries: Array<Entry>,
   files: Array<InternalFile>,
   globs: Array<Glob>,
@@ -55,7 +55,7 @@ export default function createEntryRequest(input: ProjectPath): EntryRequest {
   };
 }
 
-async function run({input, api, options}): Promise<EntryResult> {
+async function run({input, api, options}): Promise<EntryRequestResult> {
   let entryResolver = new EntryResolver(options);
   let filePath = fromProjectPath(options.projectRoot, input);
   let result = await entryResolver.resolveEntry(filePath);
@@ -157,7 +157,7 @@ export class EntryResolver {
     this.options = options;
   }
 
-  async resolveEntry(entry: FilePath): Promise<EntryResult> {
+  async resolveEntry(entry: FilePath): Promise<EntryRequestResult> {
     let stat;
     try {
       stat = await this.options.inputFS.stat(entry);

--- a/packages/core/core/src/requests/PackageRequest.js
+++ b/packages/core/core/src/requests/PackageRequest.js
@@ -8,7 +8,7 @@ import type {StaticRunOpts} from '../RequestTracker';
 import {requestTypes} from '../RequestTracker';
 import type {Bundle} from '../types';
 import type BundleGraph from '../BundleGraph';
-import type {BundleInfo, PackageRequestResult} from '../PackagerRunner';
+import type {BundleInfo, RunPackagerRunnerResult} from '../PackagerRunner';
 import type {ConfigAndCachePath} from './ParcelConfigRequest';
 
 import nullthrows from 'nullthrows';
@@ -23,6 +23,8 @@ type PackageRequestInput = {|
   optionsRef: SharedReference,
   useMainThread?: boolean,
 |};
+
+export type PackageRequestResult = BundleInfo;
 
 type RunInput<TResult> = {|
   input: PackageRequestInput,
@@ -66,7 +68,7 @@ async function run({input, api, farm}) {
       previousDevDeps: devDeps,
       invalidDevDeps,
       previousInvalidations: api.getInvalidations(),
-    }): PackageRequestResult);
+    }): RunPackagerRunnerResult);
 
   for (let devDepRequest of devDepRequests) {
     await runDevDepRequest(api, devDepRequest);

--- a/packages/core/core/src/requests/ParcelBuildRequest.js
+++ b/packages/core/core/src/requests/ParcelBuildRequest.js
@@ -29,7 +29,7 @@ type ParcelBuildRequestInput = {|
   signal?: AbortSignal,
 |};
 
-type ParcelBuildRequestResult = {|
+export type ParcelBuildRequestResult = {|
   bundleGraph: BundleGraph,
   bundleInfo: Map<string, PackagedBundleInfo>,
   changedAssets: Map<string, Asset>,

--- a/packages/core/core/src/requests/ParcelConfigRequest.js
+++ b/packages/core/core/src/requests/ParcelConfigRequest.js
@@ -56,8 +56,10 @@ export type ParcelConfigRequest = {|
   id: string,
   type: typeof requestTypes.parcel_config_request,
   input: null,
-  run: (RunOpts<ConfigAndCachePath>) => Async<ConfigAndCachePath>,
+  run: (RunOpts<ParcelConfigRequestResult>) => Async<ParcelConfigRequestResult>,
 |};
+
+export type ParcelConfigRequestResult = ConfigAndCachePath;
 
 type ParcelConfigChain = {|
   config: ProcessedParcelConfig,

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -56,9 +56,11 @@ import {requestTypes} from '../RequestTracker';
 export type PathRequest = {|
   id: string,
   +type: typeof requestTypes.path_request,
-  run: (RunOpts<?AssetGroup>) => Async<?AssetGroup>,
+  run: (RunOpts<PathRequestResult>) => Async<PathRequestResult>,
   input: PathRequestInput,
 |};
+
+export type PathRequestResult = null | void | AssetGroup;
 
 export type PathRequestInput = {|
   dependency: Dependency,
@@ -83,7 +85,7 @@ export default function createPathRequest(
   };
 }
 
-async function run({input, api, options}) {
+async function run({input, api, options}): Promise<PathRequestResult> {
   let configResult = nullthrows(
     await api.runRequest<null, ConfigAndCachePath>(createParcelConfigRequest()),
   );

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -91,9 +91,11 @@ const DEFAULT_ENGINES = {
 export type TargetRequest = {|
   id: string,
   +type: typeof requestTypes.target_request,
-  run: (RunOpts<Array<Target>>) => Async<Array<Target>>,
+  run: (RunOpts<TargetRequestResult>) => Async<TargetRequestResult>,
   input: Entry,
 |};
+
+export type TargetRequestResult = Target[];
 
 const type = 'target_request';
 
@@ -125,7 +127,7 @@ async function run({input, api, options}) {
     api,
     optionsProxy(options, api.invalidateOnOptionChange),
   );
-  let targets: Array<Target> = await targetResolver.resolve(
+  let targets: TargetRequestResult = await targetResolver.resolve(
     fromProjectPath(options.projectRoot, input.packagePath),
     input.target,
   );

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -51,6 +51,8 @@ type WriteBundleRequestInput = {|
   hashRefToNameHash: Map<string, string>,
 |};
 
+export type WriteBundleRequestResult = PackagedBundleInfo;
+
 type RunInput<TResult> = {|
   input: WriteBundleRequestInput,
   ...StaticRunOpts<TResult>,

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -21,6 +21,8 @@ type WriteBundlesRequestInput = {|
   optionsRef: SharedReference,
 |};
 
+export type WriteBundlesRequestResult = Map<string, PackagedBundleInfo>;
+
 type RunInput<TResult> = {|
   input: WriteBundlesRequestInput,
   ...StaticRunOpts<TResult>,
@@ -30,8 +32,8 @@ export type WriteBundlesRequest = {|
   id: ContentKey,
   +type: typeof requestTypes.write_bundles_request,
   run: (
-    RunInput<Map<string, PackagedBundleInfo>>,
-  ) => Async<Map<string, PackagedBundleInfo>>,
+    RunInput<WriteBundlesRequestResult>,
+  ) => Async<WriteBundlesRequestResult>,
   input: WriteBundlesRequestInput,
 |};
 

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -18,7 +18,7 @@ import Transformation, {
   type TransformationResult,
 } from './Transformation';
 import {reportWorker, report} from './ReporterRunner';
-import PackagerRunner, {type PackageRequestResult} from './PackagerRunner';
+import PackagerRunner, {type RunPackagerRunnerResult} from './PackagerRunner';
 import Validation, {type ValidationOpts} from './Validation';
 import ParcelConfig from './ParcelConfig';
 import {registerCoreWithSerializer} from './registerCoreWithSerializer';
@@ -142,7 +142,7 @@ export async function runPackage(
     invalidDevDeps: Array<DevDepSpecifier>,
     previousInvalidations: Array<RequestInvalidation>,
   |},
-): Promise<PackageRequestResult> {
+): Promise<RunPackagerRunnerResult> {
   let bundleGraph = workerApi.getSharedReference(bundleGraphReference);
   invariant(bundleGraph instanceof BundleGraph);
   let options = loadOptions(optionsRef, workerApi);

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -144,6 +144,7 @@ describe('RequestTracker', () => {
     await tracker.runRequest({
       id: 'abc',
       type: 7,
+      // $FlowFixMe string isn't a valid result
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
         let result = await Promise.resolve('hello');
         api.storeResult(result);
@@ -190,6 +191,7 @@ describe('RequestTracker', () => {
     await tracker.runRequest({
       id: 'abc',
       type: 7,
+      // $FlowFixMe string isn't a valid result
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
         let result = await Promise.resolve();
         api.storeResult(result);
@@ -222,6 +224,7 @@ describe('RequestTracker', () => {
     let requestA = tracker.runRequest({
       id: 'abc',
       type: 7,
+      // $FlowFixMe string isn't a valid result
       run: async ({api}: {api: RunAPI<string>, ...}) => {
         await lockA.promise;
         api.storeResult('a');
@@ -234,6 +237,7 @@ describe('RequestTracker', () => {
     let requestB = tracker.runRequest({
       id: 'abc',
       type: 7,
+      // $FlowFixMe string isn't a valid result
       run: async ({api}: {api: RunAPI<string>, ...}) => {
         calledB = true;
         await lockB.promise;
@@ -283,6 +287,7 @@ describe('RequestTracker', () => {
     let requestB = tracker.runRequest({
       id: 'abc',
       type: 7,
+      // $FlowFixMe string isn't a valid result
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
         await lockB.promise;
         api.storeResult('b');
@@ -385,6 +390,7 @@ describe('RequestTracker', () => {
     await tracker.runRequest({
       id: contentKey,
       type: 7,
+      // $FlowFixMe string isn't a valid result
       run: async ({api}: {api: RunAPI<string | void>, ...}) => {
         let result = await Promise.resolve('a');
         api.storeResult(result);
@@ -398,6 +404,7 @@ describe('RequestTracker', () => {
       {
         id: contentKey,
         type: 7,
+        // $FlowFixMe string isn't a valid result
         run: async ({api}: {api: RunAPI<string | void>, ...}) => {
           let result = await Promise.resolve('b');
           api.storeResult(result);

--- a/packages/core/core/test/requests/ConfigRequest.test.js
+++ b/packages/core/core/test/requests/ConfigRequest.test.js
@@ -8,7 +8,10 @@ import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '@parcel/feature-flags';
 import {MemoryFS} from '@parcel/fs';
 import {hashString} from '@parcel/rust';
 
-import type {ConfigRequest} from '../../src/requests/ConfigRequest';
+import type {
+  ConfigRequest,
+  ConfigRequestResult,
+} from '../../src/requests/ConfigRequest';
 import type {RunAPI} from '../../src/RequestTracker';
 import {runConfigRequest} from '../../src/requests/ConfigRequest';
 import {toProjectPath} from '../../src/projectPath';
@@ -40,7 +43,7 @@ describe('ConfigRequest tests', () => {
 
   const getMockRunApi = (
     options: mixed = {projectRoot, inputFS: fs},
-  ): RunAPI<mixed> => {
+  ): RunAPI<ConfigRequestResult> => {
     const mockRunApi = {
       storeResult: sinon.spy(),
       canSkipSubrequest: sinon.spy(),


### PR DESCRIPTION
This PR adds a union type for all request results. It fixes a case which was mistyped and was caught by this change, in DevDepRequest.