### PR TITLE
Reenable REPL deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,35 +162,35 @@ jobs:
       #   with:
       #     name: REPL
       #     path: 'packages/dev/repl/dist'
-#      - name: Start Deployment
-#        uses: bobheadxi/deployments@v1
-#        id: deployment
-#        with:
-#          step: start
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          ref: ${{ github.head_ref }}
-#          env: Preview
-#          override: false
-#      - name: Deploy to Vercel
-#        uses: amondnet/vercel-action@v25
-#        id: vercel-action
-#        with:
-#          vercel-token: ${{ secrets.REPL_VERCEL_TOKEN }}
-#          vercel-org-id: ${{ secrets.REPL_VERCEL_ORG_ID }}
-#          vercel-project-id: ${{ secrets.REPL_VERCEL_PROJECT_ID }}
-#          github-comment: false
-#          working-directory: packages/dev/repl
-#          # vercel-args: '--prod'
-#          alias-domains: |
-#            pr-{{PR_NUMBER}}.repl.parceljs.org
-#      - name: Update Deployment Status
-#        uses: bobheadxi/deployments@v1
-#        if: always()
-#        with:
-#          step: finish
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          env: Preview
-#          override: false
-#          status: ${{ job.status }}
-#          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-#          env_url: ${{ steps.vercel-action.outputs.preview-url }}
+      - name: Start Deployment
+        uses: bobheadxi/deployments@v1
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.head_ref }}
+          env: Preview
+          override: false
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        id: vercel-action
+        with:
+          vercel-token: ${{ secrets.REPL_VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.REPL_VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.REPL_VERCEL_PROJECT_ID }}
+          github-comment: false
+          working-directory: packages/dev/repl
+          # vercel-args: '--prod'
+          alias-domains: |
+            pr-{{PR_NUMBER}}.repl.parceljs.org
+      - name: Update Deployment Status
+        uses: bobheadxi/deployments@v1
+        if: always()
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: Preview
+          override: false
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ steps.vercel-action.outputs.preview-url }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
           github-comment: false
           working-directory: packages/dev/repl
           # vercel-args: '--prod'
+          scope: parcel
           alias-domains: |
             pr-{{PR_NUMBER}}.repl.parceljs.org
       - name: Update Deployment Status

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -71,6 +71,7 @@ jobs:
           github-comment: false
           working-directory: packages/dev/repl
           vercel-args: '--prod'
+          scope: parcel
       - name: Update Deployment Status
         uses: bobheadxi/deployments@v1
         if: always()


### PR DESCRIPTION
Let's see if adding `scope: parcel` fixes it.

My guess is that this somehow broke when Vercel migrated all personal projects into a team a few months back.