### PR TITLE
Remove nightly rustfmt options

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,1 @@
 tab_spaces = 2
-imports_granularity = "Item"
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
We shouldn't be keeping nightly rustfmt options in the repository. This PR removes them to avoid having multiple toolchains as a requirement for development.