### PR TITLE
chore: switch from `browserslist-rs` to `oxc-browserslist`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f222829ae9293e33a9f5e9f440c6760a3d450a64affe1846486b140db81c1f4"
 
 [[package]]
+name = "oxc-browserslist"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d96b978cbca7d108283a10fcfe79e0dc5b2ecaa99e610b5b5488c3c9321295"
+dependencies = [
+ "nom",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "oxipng"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,9 +1889,9 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "anyhow",
- "browserslist-rs",
  "dyn-hash",
  "nodejs-semver",
+ "oxc-browserslist",
  "parcel-resolver",
  "parcel_filesystem",
  "petgraph",
@@ -3805,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3826,9 +3840,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
-use swc_core::ecma::utils::stack_size::maybe_grow_default;
 
 use indexmap::IndexMap;
 use swc_core::common::util::take::Take;
@@ -15,6 +14,7 @@ use swc_core::ecma::parser::error::Error;
 use swc_core::ecma::parser::lexer::Lexer;
 use swc_core::ecma::parser::Parser;
 use swc_core::ecma::parser::StringInput;
+use swc_core::ecma::utils::stack_size::maybe_grow_default;
 use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 

--- a/crates/node-bindings/src/init_sentry/sentry.rs
+++ b/crates/node-bindings/src/init_sentry/sentry.rs
@@ -1,4 +1,3 @@
-use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -8,6 +7,7 @@ use napi::Result;
 use napi::Status;
 use napi_derive::napi;
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use sentry::configure_scope;
 use sentry::init;
 use sentry::ClientInitGuard;

--- a/crates/parcel_core/Cargo.toml
+++ b/crates/parcel_core/Cargo.toml
@@ -12,7 +12,7 @@ parcel_filesystem = { path = "../parcel_filesystem" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 
 ahash = "0.8.11"
-browserslist-rs = "0.15.0"
+oxc-browserslist = "0.17.0"
 nodejs-semver = "4.0.0"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = { version = "1.0.116", features = ["preserve_order"] }

--- a/crates/parcel_core/src/request_tracker/request_tracker.rs
+++ b/crates/parcel_core/src/request_tracker/request_tracker.rs
@@ -1,14 +1,16 @@
-use anyhow::anyhow;
 use std::collections::HashMap;
 
+use anyhow::anyhow;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableDiGraph;
 
+use super::Request;
 use super::RequestEdgeType;
 use super::RequestGraph;
 use super::RequestNode;
 use super::RequestResult;
-use super::{Request, RunRequestContext, RunRequestError};
+use super::RunRequestContext;
+use super::RunRequestError;
 
 pub struct RequestTracker<T> {
   graph: RequestGraph<T>,

--- a/crates/parcel_core/src/types/environment/browsers.rs
+++ b/crates/parcel_core/src/types/environment/browsers.rs
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for Browsers {
       serde_value::Value::String(s) => vec![s],
       value => Vec::<String>::deserialize(serde_value::ValueDeserializer::new(value))?,
     };
-    let distribs = browserslist::resolve(browsers, &Default::default()).unwrap_or(Vec::new());
+    let distribs = browserslist::resolve(&browsers, &Default::default()).unwrap_or(Vec::new());
     Ok(distribs.into())
   }
 }

--- a/crates/parcel_core/src/types/environment/engines.rs
+++ b/crates/parcel_core/src/types/environment/engines.rs
@@ -90,11 +90,11 @@ impl Engines {
       // If the output format is esmodule, exclude browsers
       // that support them natively so that we transpile less.
       browserslist::resolve(
-        std::iter::once(browserslist).chain(ESMODULE_BROWSERS.iter().map(|s| *s)),
+        &[&[browserslist], ESMODULE_BROWSERS].concat(),
         &Default::default(),
       )
     } else {
-      browserslist::resolve(std::iter::once(browserslist), &Default::default())
+      browserslist::resolve(&[browserslist], &Default::default())
     };
 
     Engines {

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::path::Path;
-use swc_core::ecma::utils::stack_size::maybe_grow_default;
 
 use path_slash::PathBufExt;
 use serde::Deserialize;
@@ -18,6 +17,7 @@ use swc_core::ecma::ast::MemberProp;
 use swc_core::ecma::ast::{self};
 use swc_core::ecma::atoms::js_word;
 use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::utils::stack_size::maybe_grow_default;
 use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -8,7 +8,8 @@ use swc_core::common::DUMMY_SP;
 use swc_core::ecma::ast;
 use swc_core::ecma::atoms::JsWord;
 use swc_core::ecma::utils::stack_size::maybe_grow;
-use swc_core::ecma::visit::{Fold, FoldWith};
+use swc_core::ecma::visit::Fold;
+use swc_core::ecma::visit::FoldWith;
 
 use crate::utils::*;
 

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use swc_core::ecma::utils::stack_size::maybe_grow_default;
 
 use indexmap::IndexMap;
 use path_slash::PathBufExt;
@@ -11,6 +10,7 @@ use swc_core::ecma::ast::ComputedPropName;
 use swc_core::ecma::ast::{self};
 use swc_core::ecma::atoms::js_word;
 use swc_core::ecma::atoms::JsWord;
+use swc_core::ecma::utils::stack_size::maybe_grow_default;
 use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

[oxc-browserslist](https://github.com/oxc-project/oxc-browserslist?tab=readme-ov-file) is a fork of [browserslist-rs](https://github.com/browserslist/browserslist-rs) with improved performance, actively maintained by [oxc-project](https://github.com/oxc-project). The following are the changes made to it after the fork:

> * reduced compilation speed from one minute to a few seconds
> * removed all unnecessary, heavy or slow dependencies: `ahash`, `chrono`, `either`, `indexmap`, `itertools`, `once_cell`, `string_cache`
> * improved some runtime performance, e.g. [improve sort method](https://github.com/oxc-project/oxc-browserslist/pull/28), [precompute versions](https://github.com/oxc-project/oxc-browserslist/pull/10)

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
