### PR TITLE
Rename plugin files and add debug constraint

### DIFF
--- a/crates/parcel_core/src/lib.rs
+++ b/crates/parcel_core/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(unused_crate_dependencies)]
 //! Core re-implementation in Rust
 
 pub mod bundle_graph;

--- a/crates/parcel_core/src/plugin.rs
+++ b/crates/parcel_core/src/plugin.rs
@@ -1,38 +1,37 @@
-mod bundler;
+mod bundler_plugin;
 
-pub use bundler::*;
+pub use bundler_plugin::*;
 
-mod compressor;
-pub use compressor::*;
+mod compressor_plugin;
+pub use compressor_plugin::*;
 
-mod namer;
-pub use namer::*;
+mod namer_plugin;
+pub use namer_plugin::*;
 
-mod optimizer;
-pub use optimizer::*;
+mod optimizer_plugin;
+pub use optimizer_plugin::*;
 
-mod packager;
-pub use packager::*;
+mod packager_plugin;
+pub use packager_plugin::*;
 
 mod plugin_config;
 pub use plugin_config::*;
 
-mod reporter;
-pub use reporter::*;
+mod reporter_plugin;
+pub use reporter_plugin::*;
 
-mod resolver;
-pub use resolver::*;
+mod resolver_plugin;
+pub use resolver_plugin::*;
 
-mod runtime;
-pub use runtime::*;
+mod runtime_plugin;
+pub use runtime_plugin::*;
 
-mod transformer;
-pub use transformer::*;
+mod transformer_plugin;
+pub use transformer_plugin::*;
 
-mod validator;
-pub use validator::*;
+mod validator_plugin;
+pub use validator_plugin::*;
 
-#[derive(Default)]
 pub struct PluginContext {
   pub options: PluginOptions,
   pub logger: PluginLogger,

--- a/crates/parcel_core/src/plugin/bundler_plugin.rs
+++ b/crates/parcel_core/src/plugin/bundler_plugin.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use super::PluginConfig;
 use crate::bundle_graph::BundleGraph;
 
@@ -8,7 +10,7 @@ use crate::bundle_graph::BundleGraph;
 ///
 /// Bundle and optimize run in series and are functionally identitical.
 ///
-pub trait BundlerPlugin {
+pub trait BundlerPlugin: Debug {
   /// A hook designed to load config necessary for the bundler to operate
   ///
   /// This function will run once, shortly after the plugin is initialised.

--- a/crates/parcel_core/src/plugin/compressor_plugin.rs
+++ b/crates/parcel_core/src/plugin/compressor_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::fs::File;
 
 pub struct CompressedFile {
@@ -12,7 +13,7 @@ pub struct CompressedFile {
 }
 
 /// Compresses the input file stream
-pub trait CompressorPlugin {
+pub trait CompressorPlugin: Debug {
   /// Compress the given file
   ///
   /// The file contains the final contents of bundles and sourcemaps as they are being written.
@@ -25,6 +26,7 @@ pub trait CompressorPlugin {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestCompressorPlugin {}
 
   impl CompressorPlugin for TestCompressorPlugin {

--- a/crates/parcel_core/src/plugin/namer_plugin.rs
+++ b/crates/parcel_core/src/plugin/namer_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::path::PathBuf;
 
 use super::PluginConfig;
@@ -8,7 +9,7 @@ use crate::types::Bundle;
 ///
 /// Namers run in a pipeline until one returns a result.
 ///
-pub trait NamerPlugin {
+pub trait NamerPlugin: Debug {
   /// A hook designed to setup config needed for naming bundles
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -32,6 +33,7 @@ pub trait NamerPlugin {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestNamerPlugin {}
 
   impl NamerPlugin for TestNamerPlugin {

--- a/crates/parcel_core/src/plugin/optimizer_plugin.rs
+++ b/crates/parcel_core/src/plugin/optimizer_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::fs::File;
 
 use super::PluginConfig;
@@ -28,7 +29,7 @@ pub struct OptimizedBundle {
 /// Multiple optimizer plugins may run in series, and the result of each optimizer is passed to
 /// the next.
 ///
-pub trait OptimizerPlugin: Send + Sync {
+pub trait OptimizerPlugin: Debug + Send + Sync {
   /// A hook designed to setup config needed for optimizing bundles
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -47,6 +48,7 @@ pub trait OptimizerPlugin: Send + Sync {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestOptimizerPlugin {}
 
   impl OptimizerPlugin for TestOptimizerPlugin {

--- a/crates/parcel_core/src/plugin/packager_plugin.rs
+++ b/crates/parcel_core/src/plugin/packager_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::fs::File;
 
 use super::PluginConfig;
@@ -23,7 +24,7 @@ pub struct PackagedBundle {
 /// Packagers are also responsible for resolving URL references, bundle inlining, and generating
 /// source maps.
 ///
-pub trait PackagerPlugin: Send + Sync {
+pub trait PackagerPlugin: Debug + Send + Sync {
   /// A hook designed to setup config needed for packaging
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -42,6 +43,7 @@ pub trait PackagerPlugin: Send + Sync {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestPackagerPlugin {}
 
   impl PackagerPlugin for TestPackagerPlugin {

--- a/crates/parcel_core/src/plugin/reporter_plugin.rs
+++ b/crates/parcel_core/src/plugin/reporter_plugin.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 // TODO Flesh these out
 pub enum ReporterEvent {
   BuildStart,
@@ -15,7 +17,7 @@ pub enum ReporterEvent {
 /// For example, reporters may write status information to stdout, run a dev server, or generate a
 /// bundle analysis report at the end of a build.
 ///
-pub trait ReporterPlugin {
+pub trait ReporterPlugin: Debug {
   /// Processes the event from Parcel
   fn report(&self, event: ReporterEvent) -> Result<(), anyhow::Error>;
 }
@@ -24,6 +26,7 @@ pub trait ReporterPlugin {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestReporterPlugin {}
 
   impl ReporterPlugin for TestReporterPlugin {

--- a/crates/parcel_core/src/plugin/resolver_plugin.rs
+++ b/crates/parcel_core/src/plugin/resolver_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::path::PathBuf;
 
 use super::PluginConfig;
@@ -50,7 +51,7 @@ pub struct Resolution {
 ///
 /// Resolvers run in a pipeline until one of them return a result.
 ///
-pub trait ResolverPlugin: Send + Sync {
+pub trait ResolverPlugin: Debug + Send + Sync {
   /// A hook designed to setup any config needed to resolve dependencies
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -69,6 +70,7 @@ pub trait ResolverPlugin: Send + Sync {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestResolverPlugin {}
 
   impl ResolverPlugin for TestResolverPlugin {

--- a/crates/parcel_core/src/plugin/runtime_plugin.rs
+++ b/crates/parcel_core/src/plugin/runtime_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::path::PathBuf;
 
 use super::PluginConfig;
@@ -21,7 +22,7 @@ pub struct RuntimeAsset {
 }
 
 /// Programmatically insert assets into bundles
-pub trait RuntimePlugin {
+pub trait RuntimePlugin: Debug {
   /// A hook designed to setup config needed to create runtime assets
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -41,6 +42,7 @@ pub trait RuntimePlugin {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestRuntimePlugin {}
 
   impl RuntimePlugin for TestRuntimePlugin {

--- a/crates/parcel_core/src/plugin/transformer_plugin.rs
+++ b/crates/parcel_core/src/plugin/transformer_plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -30,7 +31,7 @@ pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, an
 /// Many transformers are wrappers around other tools such as compilers and preprocessors, and are
 /// designed to integrate with Parcel.
 ///
-pub trait TransformerPlugin: Send + Sync {
+pub trait TransformerPlugin: Debug + Send + Sync {
   /// A hook designed to setup config needed to transform assets
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -82,6 +83,7 @@ pub trait TransformerPlugin: Send + Sync {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestTransformerPlugin {}
 
   impl TransformerPlugin for TestTransformerPlugin {

--- a/crates/parcel_core/src/plugin/validator_plugin.rs
+++ b/crates/parcel_core/src/plugin/validator_plugin.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use super::PluginConfig;
 use crate::types::Asset;
 
@@ -18,7 +20,7 @@ pub struct Validation {
 /// remain productive, and do not have to worry about every small typing or linting issue while
 /// trying to solve a problem.
 ///
-pub trait ValidatorPlugin {
+pub trait ValidatorPlugin: Debug {
   /// A hook designed to setup config needed to validate assets
   ///
   /// This function will run once, shortly after the plugin is initialised.
@@ -56,6 +58,7 @@ pub trait ValidatorPlugin {
 mod tests {
   use super::*;
 
+  #[derive(Debug)]
   struct TestValidatorPlugin {}
 
   impl ValidatorPlugin for TestValidatorPlugin {


### PR DESCRIPTION
# ↪️ Pull Request

This is a straightforward change that:
* Adds `Debug` to all plugin traits, that will be used later primarily for testing
* Renames all `{plugin_type}.rs` files to `{plugin_type}_plugin.rs` specifically so that it is easier to locate in IDEs when searching all files (note that the exports remain the same via reexports)

## 🚨 Test instructions

`yarn build-native && cargo test`