### PR TITLE
Native resolver plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "anyhow",
  "parcel-resolver",
  "parcel_core",
+ "parcel_filesystem",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,7 +1899,6 @@ dependencies = [
  "anyhow",
  "parcel-resolver",
  "parcel_core",
- "parcel_filesystem",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,9 @@ name = "parcel_plugin_resolver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "parcel-resolver",
  "parcel_core",
+ "parcel_filesystem",
 ]
 
 [[package]]

--- a/crates/parcel/src/plugins.rs
+++ b/crates/parcel/src/plugins.rs
@@ -188,6 +188,7 @@ impl<'a> Plugins<'a> {
 mod tests {
   use std::path::PathBuf;
   use std::rc::Rc;
+  use std::sync::Arc;
 
   use parcel_config::parcel_config_fixtures::default_config;
   use parcel_core::plugin::PluginConfig;
@@ -200,7 +201,7 @@ mod tests {
   fn ctx() -> PluginContext {
     PluginContext {
       config: PluginConfig::new(
-        Rc::new(InMemoryFileSystem::default()),
+        Arc::new(InMemoryFileSystem::default()),
         PathBuf::default(),
         PathBuf::default(),
       ),
@@ -267,10 +268,10 @@ mod tests {
 
   #[test]
   fn returns_reporters() {
-    let resolvers = plugins(&ctx()).reporters();
+    let reporters = plugins(&ctx()).reporters();
 
     assert_eq!(
-      format!("{:?}", resolvers),
+      format!("{:?}", reporters),
       "[NapiReporterPlugin { name: \"@parcel/reporter-dev-server\" }]"
     )
   }
@@ -279,7 +280,10 @@ mod tests {
   fn returns_resolvers() {
     let resolvers = plugins(&ctx()).resolvers();
 
-    assert_eq!(format!("{:?}", resolvers), "Ok([ParcelResolver])")
+    assert_eq!(
+      format!("{:?}", resolvers),
+      "Ok([ParcelResolver { cache: Cache, project_root: \"\", mode: Development }])"
+    )
   }
 
   #[test]

--- a/crates/parcel_core/src/plugin.rs
+++ b/crates/parcel_core/src/plugin.rs
@@ -42,4 +42,6 @@ pub struct PluginContext {
 pub struct PluginLogger {}
 
 #[derive(Default)]
-pub struct PluginOptions {}
+pub struct PluginOptions {
+  pub mode: crate::types::BuildMode,
+}

--- a/crates/parcel_core/src/plugin/plugin_config.rs
+++ b/crates/parcel_core/src/plugin/plugin_config.rs
@@ -9,9 +9,9 @@ use crate::types::JSONObject;
 
 /// Enables plugins to load config in various formats
 pub struct PluginConfig {
-  fs: Rc<dyn FileSystem>,
-  project_root: PathBuf,
-  search_path: PathBuf,
+  pub fs: Rc<dyn FileSystem>,
+  pub project_root: PathBuf,
+  pub search_path: PathBuf,
 }
 
 // TODO JavaScript configs, invalidations, dev deps, etc

--- a/crates/parcel_core/src/plugin/plugin_config.rs
+++ b/crates/parcel_core/src/plugin/plugin_config.rs
@@ -1,22 +1,21 @@
 use std::path::PathBuf;
-use std::rc::Rc;
 
 use parcel_filesystem::search::find_ancestor_file;
-use parcel_filesystem::FileSystem;
+use parcel_filesystem::FileSystemRef;
 use serde::de::DeserializeOwned;
 
 use crate::types::JSONObject;
 
 /// Enables plugins to load config in various formats
 pub struct PluginConfig {
-  pub fs: Rc<dyn FileSystem>,
+  pub fs: FileSystemRef,
   pub project_root: PathBuf,
   pub search_path: PathBuf,
 }
 
 // TODO JavaScript configs, invalidations, dev deps, etc
 impl PluginConfig {
-  pub fn new(fs: Rc<dyn FileSystem>, project_root: PathBuf, search_path: PathBuf) -> Self {
+  pub fn new(fs: FileSystemRef, project_root: PathBuf, search_path: PathBuf) -> Self {
     Self {
       fs,
       project_root,
@@ -68,6 +67,8 @@ mod tests {
   use super::*;
 
   mod load_json_config {
+    use std::sync::Arc;
+
     use serde::Deserialize;
 
     use super::*;
@@ -81,7 +82,7 @@ mod tests {
       let search_path = project_root.join("index");
 
       let config = PluginConfig {
-        fs: Rc::new(InMemoryFileSystem::default()),
+        fs: Arc::new(InMemoryFileSystem::default()),
         project_root,
         search_path: search_path.clone(),
       };
@@ -99,7 +100,7 @@ mod tests {
 
     #[test]
     fn returns_an_error_when_the_config_is_outside_the_search_path() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
 
@@ -127,7 +128,7 @@ mod tests {
 
     #[test]
     fn returns_an_error_when_the_config_is_outside_the_project_root() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
 
@@ -152,7 +153,7 @@ mod tests {
 
     #[test]
     fn returns_json_config_at_search_path() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
       let config_path = search_path.join("config.json");
@@ -175,7 +176,7 @@ mod tests {
 
     #[test]
     fn returns_json_config_at_project_root() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
       let config_path = project_root.join("config.json");
@@ -198,6 +199,8 @@ mod tests {
   }
 
   mod load_package_json_config {
+    use std::sync::Arc;
+
     use serde_json::Map;
     use serde_json::Value;
 
@@ -229,7 +232,7 @@ mod tests {
       let search_path = project_root.join("index");
 
       let config = PluginConfig {
-        fs: Rc::new(InMemoryFileSystem::default()),
+        fs: Arc::new(InMemoryFileSystem::default()),
         project_root,
         search_path: search_path.clone(),
       };
@@ -247,7 +250,7 @@ mod tests {
 
     #[test]
     fn returns_an_error_when_config_key_does_not_exist_at_search_path() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
       let package_path = search_path.join("package.json");
@@ -274,7 +277,7 @@ mod tests {
 
     #[test]
     fn returns_an_error_when_config_key_does_not_exist_at_project_root() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
       let package_path = project_root.join("package.json");
@@ -300,7 +303,7 @@ mod tests {
 
     #[test]
     fn returns_package_config_at_search_path() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
       let package_path = search_path.join("package.json");
@@ -323,7 +326,7 @@ mod tests {
 
     #[test]
     fn returns_package_config_at_project_root() {
-      let fs = Rc::new(InMemoryFileSystem::default());
+      let fs = Arc::new(InMemoryFileSystem::default());
       let project_root = PathBuf::from("/project-root");
       let search_path = project_root.join("index");
       let package_path = project_root.join("package.json");

--- a/crates/parcel_core/src/plugin/resolver_plugin.rs
+++ b/crates/parcel_core/src/plugin/resolver_plugin.rs
@@ -13,7 +13,7 @@ pub struct ResolveContext {
   pub pipeline: Option<String>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Resolution {
   /// Whether this dependency can be deferred by Parcel itself
   pub can_defer: bool,

--- a/crates/parcel_core/src/plugin/resolver_plugin.rs
+++ b/crates/parcel_core/src/plugin/resolver_plugin.rs
@@ -31,7 +31,7 @@ pub struct Resolution {
   pub is_excluded: bool,
 
   /// Is spread (shallowly merged) onto the request's dependency.meta
-  pub meta: Option<JSONObject>,
+  pub meta: JSONObject,
 
   /// An optional named pipeline to use to compile the resolved file
   pub pipeline: Option<String>,

--- a/crates/parcel_core/src/plugin/resolver_plugin.rs
+++ b/crates/parcel_core/src/plugin/resolver_plugin.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use crate::types::Dependency;
 use crate::types::JSONObject;
-use crate::types::ParcelOptions;
 use crate::types::Priority;
 
 // TODO Diagnostics and invalidations
@@ -12,7 +11,6 @@ pub struct ResolveContext {
   pub specifier: String,
   pub dependency: Dependency,
   pub pipeline: Option<String>,
-  pub options: ParcelOptions,
 }
 
 #[derive(Debug, Default)]

--- a/crates/parcel_core/src/plugin/resolver_plugin.rs
+++ b/crates/parcel_core/src/plugin/resolver_plugin.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use super::PluginConfig;
 use crate::types::Dependency;
 use crate::types::JSONObject;
+use crate::types::ParcelOptions;
 use crate::types::Priority;
 
 // TODO Diagnostics and invalidations
@@ -12,6 +13,7 @@ pub struct ResolveContext {
   pub specifier: String,
   pub dependency: Dependency,
   pub pipeline: Option<String>,
+  pub options: ParcelOptions,
 }
 
 #[derive(Debug, Default)]
@@ -32,7 +34,7 @@ pub struct Resolution {
   pub is_excluded: bool,
 
   /// Is spread (shallowly merged) onto the request's dependency.meta
-  pub meta: JSONObject,
+  pub meta: Option<JSONObject>,
 
   /// An optional named pipeline to use to compile the resolved file
   pub pipeline: Option<String>,

--- a/crates/parcel_core/src/types/parcel_options.rs
+++ b/crates/parcel_core/src/types/parcel_options.rs
@@ -16,8 +16,9 @@ pub struct ParcelOptions {
   pub project_root: PathBuf,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub enum BuildMode {
+  #[default]
   Development,
   Production,
   Other(String),

--- a/crates/parcel_filesystem/src/in_memory_file_system.rs
+++ b/crates/parcel_filesystem/src/in_memory_file_system.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::Component;
 use std::path::Path;

--- a/crates/parcel_plugin_resolver/Cargo.toml
+++ b/crates/parcel_plugin_resolver/Cargo.toml
@@ -11,3 +11,6 @@ path = "./src/lib.rs"
 parcel_core = { path = "../parcel_core" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 anyhow = "1"
+
+[dev-dependencies]
+parcel_filesystem = { path = "../parcel_filesystem" }

--- a/crates/parcel_plugin_resolver/Cargo.toml
+++ b/crates/parcel_plugin_resolver/Cargo.toml
@@ -9,6 +9,5 @@ path = "./src/lib.rs"
 
 [dependencies]
 parcel_core = { path = "../parcel_core" }
-parcel_filesystem = { path = "../parcel_filesystem" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 anyhow = "1"

--- a/crates/parcel_plugin_resolver/Cargo.toml
+++ b/crates/parcel_plugin_resolver/Cargo.toml
@@ -9,4 +9,6 @@ path = "./src/lib.rs"
 
 [dependencies]
 parcel_core = { path = "../parcel_core" }
+parcel_filesystem = { path = "../parcel_filesystem" }
+parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 anyhow = "1"

--- a/crates/parcel_plugin_resolver/src/resolver.rs
+++ b/crates/parcel_plugin_resolver/src/resolver.rs
@@ -233,7 +233,7 @@ fn excluded_resolution() -> Resolution {
     side_effects: true,
     can_defer: false,
     code: None,
-    meta: None,
+    meta: JSONObject::default(),
     pipeline: None,
     priority: None,
     query: None,

--- a/crates/parcel_plugin_resolver/src/resolver.rs
+++ b/crates/parcel_plugin_resolver/src/resolver.rs
@@ -317,7 +317,7 @@ mod test {
         can_defer: false,
         code: None,
         is_excluded: false,
-        meta: None,
+        meta: JSONObject::default(),
         pipeline: None,
         priority: None,
         side_effects: true,

--- a/crates/parcel_plugin_resolver/src/resolver.rs
+++ b/crates/parcel_plugin_resolver/src/resolver.rs
@@ -21,7 +21,7 @@ use parcel_resolver::Resolver;
 #[derive(Debug)]
 pub struct ParcelResolver {
   cache: Cache,
-  // TODO: Should these be references instead?
+  // TODO: These should probably be references instead?
   project_root: PathBuf,
   mode: BuildMode,
 }

--- a/crates/parcel_plugin_resolver/src/resolver.rs
+++ b/crates/parcel_plugin_resolver/src/resolver.rs
@@ -1,16 +1,91 @@
+use std::borrow::Cow;
 use std::path::Path;
+use std::path::PathBuf;
 
 use parcel_core::plugin::PluginConfig;
 use parcel_core::plugin::Resolution;
 use parcel_core::plugin::ResolveContext;
 use parcel_core::plugin::ResolverPlugin;
+use parcel_core::types::BuildMode;
+use parcel_core::types::EnvironmentContext;
+use parcel_core::types::SpecifierType;
+use parcel_filesystem::FileSystemRef;
+use parcel_resolver::Cache;
+use parcel_resolver::CacheCow;
+use parcel_resolver::ExportsCondition;
+use parcel_resolver::Fields;
+use parcel_resolver::IncludeNodeModules;
+use parcel_resolver::ResolveOptions;
+use parcel_resolver::Resolver;
 
 #[derive(Debug)]
-pub struct ParcelResolver {}
+pub struct ParcelResolver {
+  cache: Cache,
+}
 
 impl ParcelResolver {
+  pub fn new(fs: FileSystemRef) -> Self {
+    Self {
+      cache: Cache::new(fs),
+    }
+  }
+
   pub fn resolve_simple<S: AsRef<str>>(_from: &Path, _specifier: S) {
     todo!()
+  }
+
+  fn resolve_builtin(
+    &mut self,
+    config: &PluginConfig,
+    ctx: &ResolveContext,
+    builtin: String,
+  ) -> anyhow::Result<Resolution> {
+    let dep = &ctx.dependency;
+    if dep.env.context.is_node() {
+      return Ok(excluded_resolution());
+    }
+
+    if dep.env.is_library && should_include_node_module(&dep.env.include_node_modules, &builtin) {
+      return Ok(excluded_resolution());
+    }
+
+    let browser_module = match builtin.as_str() {
+      "assert" => "assert/",
+      "buffer" => "buffer/",
+      "console" => "console-browserify",
+      "constants" => "constants-browserify",
+      "crypto" => "crypto-browserify",
+      "domain" => "domain-browser",
+      "events" => "events/",
+      "http" => "stream-http",
+      "https" => "https-browserify",
+      "os" => "os-browserify",
+      "path" => "path-browserify",
+      "process" => "process/",
+      "punycode" => "punycode/",
+      "querystring" => "querystring-es3",
+      "stream" => "stream-browserify",
+      "string_decoder" => "string_decoder",
+      "sys" => "util/",
+      "timers" => "timers-browserify",
+      "tty" => "tty-browserify",
+      "url" => "url/",
+      "util" => "util/",
+      "vm" => "vm-browserify",
+      "zlib" => "browserify-zlib",
+      _ => return Ok(excluded_resolution()),
+    };
+
+    self.resolve(
+      config,
+      &ResolveContext {
+        // TODO: Can we get rid of the clones?
+        options: ctx.options.clone(),
+        dependency: ctx.dependency.clone(),
+        pipeline: ctx.pipeline.clone(),
+        specifier: browser_module.to_owned(),
+      },
+    )
   }
 }
 
@@ -19,11 +94,177 @@ impl ResolverPlugin for ParcelResolver {
     todo!()
   }
 
-  fn resolve(
-    &mut self,
-    _config: &PluginConfig,
-    _ctx: &ResolveContext,
-  ) -> Result<Resolution, anyhow::Error> {
-    todo!()
+  fn resolve(&mut self, config: &PluginConfig, ctx: &ResolveContext) -> anyhow::Result<Resolution> {
+    let ResolveContext {
+      specifier,
+      dependency: dep,
+      options,
+      pipeline: _pipeline,
+    } = ctx;
+    let mut resolver = Resolver::parcel(
+      Cow::Borrowed(&options.project_root),
+      CacheCow::Borrowed(&self.cache),
+    );
+
+    resolver
+      .conditions
+      .set(ExportsCondition::BROWSER, dep.env.context.is_browser());
+    resolver
+      .conditions
+      .set(ExportsCondition::WORKER, dep.env.context.is_worker());
+    resolver.conditions.set(
+      ExportsCondition::WORKLET,
+      dep.env.context == EnvironmentContext::Worklet,
+    );
+    resolver
+      .conditions
+      .set(ExportsCondition::ELECTRON, dep.env.context.is_electron());
+    resolver
+      .conditions
+      .set(ExportsCondition::NODE, dep.env.context.is_node());
+    resolver.conditions.set(
+      ExportsCondition::PRODUCTION,
+      options.mode == BuildMode::Production,
+    );
+    resolver.conditions.set(
+      ExportsCondition::DEVELOPMENT,
+      options.mode == BuildMode::Development,
+    );
+
+    resolver.entries = Fields::MAIN | Fields::MODULE | Fields::SOURCE;
+    if dep.env.context.is_browser() {
+      resolver.entries |= Fields::BROWSER;
+    }
+
+    resolver.include_node_modules = Cow::Borrowed(&dep.env.include_node_modules);
+
+    let resolver_options = ResolveOptions {
+      conditions: dep.package_conditions,
+      custom_conditions: vec![],
+      // TODO: Do we need custom condition?
+      // custom_conditions: dep.custom_package_conditions.clone(),
+    };
+
+    let resolve_from = dep
+      .resolve_from
+      .as_ref()
+      .or(dep.source_path.as_ref())
+      .as_ref()
+      .map(|p| Cow::Borrowed(p.as_path()))
+      .unwrap_or_else(|| Cow::Owned(options.project_root.join("index")));
+
+    let mut res = resolver.resolve_with_options(
+      specifier,
+      &resolve_from,
+      match dep.specifier_type {
+        SpecifierType::CommonJS => parcel_resolver::SpecifierType::Cjs,
+        SpecifierType::Esm => parcel_resolver::SpecifierType::Esm,
+        SpecifierType::Url => parcel_resolver::SpecifierType::Url,
+        // TODO: what should specifier custom map to?
+        SpecifierType::Custom => parcel_resolver::SpecifierType::Esm,
+      },
+      resolver_options,
+    );
+
+    let side_effects = if let Ok((parcel_resolver::Resolution::Path(p), _)) = &res.result {
+      match resolver.resolve_side_effects(p, &res.invalidations) {
+        Ok(side_effects) => side_effects,
+        Err(err) => {
+          res.result = Err(err);
+          true
+        }
+      }
+    } else {
+      true
+    };
+
+    // TODO: Create diagnostics from errors
+    // TODO: Handle invalidations
+
+    match res.result? {
+      (parcel_resolver::Resolution::Path(path), _invalidations) => Ok(Resolution {
+        file_path: path,
+        side_effects,
+        can_defer: false,
+        code: None,
+        is_excluded: false,
+        meta: None,
+        pipeline: None,
+        priority: None,
+        query: None,
+      }),
+      (parcel_resolver::Resolution::Builtin(builtin), _invalidations) => {
+        self.resolve_builtin(config, ctx, builtin)
+      }
+      (parcel_resolver::Resolution::Empty, _invalidations) => Ok(Resolution {
+        file_path: options
+          .project_root
+          .join("/packages/utils/node-resolver-core/src/_empty.js"),
+        side_effects,
+        can_defer: false,
+        code: None,
+        is_excluded: false,
+        meta: None,
+        pipeline: None,
+        priority: None,
+        query: None,
+      }),
+      (parcel_resolver::Resolution::External, _invalidations) => {
+        if let Some(_source_path) = &dep.source_path {
+          if dep.env.is_library && dep.specifier_type != SpecifierType::Url {
+            todo!("check excluded dependency for libraries");
+          }
+        }
+
+        Ok(excluded_resolution())
+      }
+      (parcel_resolver::Resolution::Global(global), _invalidations) => Ok(Resolution {
+        file_path: format!("{}.js", global).into(),
+        // TODO: Should this be a string or bytes?
+        code: Some(format!("module.exports={};", global)),
+        pipeline: None,
+        side_effects,
+        can_defer: false,
+        is_excluded: false,
+        meta: None,
+        priority: None,
+        query: None,
+      }),
+    }
+  }
+}
+
+fn excluded_resolution() -> Resolution {
+  Resolution {
+    is_excluded: true,
+    // TODO: Make resolution type an enum and remove the below fields
+    file_path: PathBuf::new(),
+    side_effects: true,
+    can_defer: false,
+    code: None,
+    meta: None,
+    pipeline: None,
+    priority: None,
+    query: None,
+  }
+}
+
+fn should_include_node_module(include_node_modules: &IncludeNodeModules, name: &str) -> bool {
+  match include_node_modules {
+    IncludeNodeModules::Bool(b) => *b,
+    IncludeNodeModules::Array(arr) => {
+      let Ok((module, _)) = parcel_resolver::parse_package_specifier(name) else {
+        return true;
+      };
+
+      arr.iter().any(|m| m.as_str() == module)
+    }
+    IncludeNodeModules::Map(map) => {
+      let Ok((module, _)) = parcel_resolver::parse_package_specifier(name) else {
+        return true;
+      };
+
+      map.contains_key(module)
+    }
   }
 }

--- a/crates/parcel_plugin_resolver/src/resolver.rs
+++ b/crates/parcel_plugin_resolver/src/resolver.rs
@@ -8,6 +8,7 @@ use parcel_core::plugin::ResolveContext;
 use parcel_core::plugin::ResolverPlugin;
 use parcel_core::types::BuildMode;
 use parcel_core::types::EnvironmentContext;
+use parcel_core::types::JSONObject;
 use parcel_core::types::SpecifierType;
 use parcel_resolver::Cache;
 use parcel_resolver::CacheCow;
@@ -178,7 +179,7 @@ impl ResolverPlugin for ParcelResolver {
         can_defer: false,
         code: None,
         is_excluded: false,
-        meta: None,
+        meta: JSONObject::default(),
         pipeline: None,
         priority: None,
         query: None,
@@ -194,7 +195,7 @@ impl ResolverPlugin for ParcelResolver {
         can_defer: false,
         code: None,
         is_excluded: false,
-        meta: None,
+        meta: JSONObject::default(),
         pipeline: None,
         priority: None,
         query: None,
@@ -216,7 +217,7 @@ impl ResolverPlugin for ParcelResolver {
         side_effects,
         can_defer: false,
         is_excluded: false,
-        meta: None,
+        meta: JSONObject::default(),
         priority: None,
         query: None,
       }),

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt;
 use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
@@ -28,6 +29,12 @@ pub struct Cache {
   is_file_cache: DashMap<PathBuf, bool>,
   is_dir_cache: DashMap<PathBuf, bool>,
   realpath_cache: DashMap<PathBuf, Option<PathBuf>>,
+}
+
+impl fmt::Debug for Cache {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("Cache").finish()
+  }
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -11,7 +11,6 @@ use package_json::ExportsResolution;
 use package_json::PackageJson;
 use serde::Deserialize;
 use serde::Serialize;
-use specifier::parse_package_specifier;
 use specifier::parse_scheme;
 use tsconfig::TsConfig;
 
@@ -36,6 +35,7 @@ pub use package_json::PackageJsonError;
 #[cfg(not(target_arch = "wasm32"))]
 pub use parcel_filesystem::os_file_system::OsFileSystem;
 pub use parcel_filesystem::FileSystem;
+pub use specifier::parse_package_specifier;
 pub use specifier::Specifier;
 pub use specifier::SpecifierError;
 pub use specifier::SpecifierType;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR implements the default resolver for the rust core. The actual resolver code was ported from @devongovett's [core-rs2 branch](https://github.com/parcel-bundler/parcel/blob/core-rs2/crates/core/src/requests/path_request.rs#L276). I've left a bunch of `TODO` comments in the code with open questions or things we'll need to address later like invalidations. I think there's also some opportunities to improve the `Resolutions` type and change it to be an enum for things like externals.

I've also updated the `InMemoryFileSystem` to use `RwLock`, allowing it to be used inside an `Arc`. This is required for testing against the `FileSystemRef` type.

