### PR TITLE
Added Ping/Pong RPC message circuit for Rust <-> Js plugin interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,7 +1800,6 @@ dependencies = [
  "parcel-js-swc-core",
  "parcel-macros",
  "parcel-resolver",
- "parcel_plugin_rpc",
  "parking_lot",
  "rayon",
  "sentry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,8 +1909,10 @@ name = "parcel_plugin_rpc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "napi",
  "parcel_config",
  "parcel_core",
+ "serde",
 ]
 
 [[package]]

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -14,63 +14,49 @@ rustls = ["sentry/rustls"]
 openssl = ["sentry/native-tls"]
 
 [dependencies]
-napi-derive = "2.16.3"
+parcel = { path = "../parcel" }
 parcel-js-swc-core = { path = "../../packages/transformers/js/core" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
-parcel_plugin_rpc = { path = "../parcel_plugin_rpc", features = ["nodejs"] }
-parcel = { path = "../parcel" }
-dashmap = "5.4.0"
-xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
-log = "0.4.21"
-tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
 
+anyhow = "1.0.82"
+dashmap = "5.4.0"
 glob = "0.3.1"
+log = "0.4.21"
+mockall = "0.12.1"
+napi-derive = "2.16.3"
+parking_lot = "0.12"
 serde = "1.0.198"
 serde_json = "1.0.116"
 toml = "0.8.12"
-anyhow = "1.0.82"
-mockall = "0.12.1"
-parking_lot = "0.12"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
+xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sentry = { version = "0.32.2", optional = true, default-features = false, features = [
-    "backtrace",
-    "contexts",
-    "panic",
-    "reqwest",
-    "debug-images",
-    "anyhow",
-] }
-whoami = { version = "1.5.1", optional = true }
-once_cell = { version = "1.19.0", optional = true }
-
-napi = { version = "2.16.4", features = [
-    "serde-json",
-    "napi4",
-    "napi5",
-    "async",
-] }
 parcel-dev-dep-resolver = { path = "../../packages/utils/dev-dep-resolver" }
 parcel-macros = { path = "../macros", features = ["napi"] }
-oxipng = "8.0.0"
-mozjpeg-sys = "1.0.0"
-libc = "0.2"
-rayon = "1.7.0"
+parcel_plugin_rpc = { path = "../parcel_plugin_rpc", features = ["nodejs"] }
+
 crossbeam-channel = "0.5.6"
 indexmap = "1.9.2"
+libc = "0.2"
+mozjpeg-sys = "1.0.0"
+napi = { version = "2.16.4", features = ["serde-json", "napi4", "napi5", "async"] }
+once_cell = { version = "1.19.0", optional = true }
+oxipng = "8.0.0"
+rayon = "1.7.0"
+sentry = { version = "0.32.2", optional = true, default-features = false, features = ["backtrace", "contexts", "panic", "reqwest", "debug-images", "anyhow"] }
+whoami = { version = "1.5.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-napi = { version = "2.16.4", features = ["serde-json"] }
 getrandom = { version = "0.2", features = ["custom"], default-features = false }
+napi = { version = "2.16.4", features = ["serde-json"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 
 [target.'cfg(windows)'.dependencies]
 mimalloc = { version = "0.1.25", default-features = false }
-
-[dev-dependencies]
 
 [build-dependencies]
 napi-build = "2.1.3"

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -33,9 +33,9 @@ tracing-subscriber = "0.3.18"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+parcel = { path = "../parcel", features = ["nodejs"] }
 parcel-dev-dep-resolver = { path = "../../packages/utils/dev-dep-resolver" }
 parcel-macros = { path = "../macros", features = ["napi"] }
-parcel_plugin_rpc = { path = "../parcel_plugin_rpc", features = ["nodejs"] }
 
 crossbeam-channel = "0.5.6"
 indexmap = "1.9.2"

--- a/crates/node-bindings/src/parcel/parcel.rs
+++ b/crates/node-bindings/src/parcel/parcel.rs
@@ -1,62 +1,138 @@
+use std::io;
 use std::path::PathBuf;
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Sender;
 use std::sync::Arc;
+use std::thread;
 
 use napi::Env;
 use napi::JsObject;
 use napi_derive::napi;
-use parcel::file_system::FileSystemRef;
 use parcel::Parcel;
 use parcel::ParcelOptions;
 use parcel_plugin_rpc::nodejs::RpcHostNodejs;
 
 use crate::file_system::FileSystemNapi;
 
+enum ParcelMessage {
+  RpcPing {
+    response: Sender<()>,
+  },
+  FsReadToString {
+    path: PathBuf,
+    response: Sender<io::Result<String>>,
+  },
+  FsIsFile {
+    path: PathBuf,
+    response: Sender<bool>,
+  },
+  FsIsDir {
+    path: PathBuf,
+    response: Sender<bool>,
+  },
+}
+
+enum ParcelResponse {}
+
 #[napi]
 pub struct ParcelNapi {
-  internal: Arc<Parcel>,
+  tx_parcel: Sender<ParcelMessage>,
 }
 
 #[napi]
 impl ParcelNapi {
   #[napi(constructor)]
   pub fn new(env: Env, options: JsObject) -> napi::Result<Self> {
+    // Debugging Instrumentation
     let _ = tracing_subscriber::fmt::try_init();
-
     let thread_id = std::thread::current().id();
     tracing::trace!(?thread_id, "parcel-napi initialize");
 
-    let rpc_host_nodejs = RpcHostNodejs::new();
+    // Wrap the JavaScript-supplied FileSystem
+    let fs = FileSystemNapi::from_options(&env, &options)?;
 
-    let mut fs = None::<FileSystemRef>;
+    // Set up Nodejs plugin bindings
+    let rpc_host_nodejs = RpcHostNodejs::new(&env, options.get_named_property("rpc")?)?;
 
-    if options.has_named_property("fs")? {
-      let fs_raw: JsObject = options.get_named_property("fs")?;
-      fs.replace(Arc::new(FileSystemNapi::new(&env, fs_raw)?));
-    }
-
+    // Initialize Parcel
     let parcel = Parcel::new(ParcelOptions {
       fs,
       rpc: Some(Arc::new(rpc_host_nodejs)),
     });
 
-    Ok(Self {
-      internal: Arc::new(parcel),
-    })
+    // Run Parcel within its own thread
+    let (tx_parcel, rx_parcel) = channel::<ParcelMessage>();
+    thread::spawn(move || {
+      while let Ok(msg) = rx_parcel.recv() {
+        if match msg {
+          ParcelMessage::FsReadToString { path, response } => {
+            response.send(parcel.fs.read_to_string(&path)).is_err()
+          }
+          ParcelMessage::FsIsFile { path, response } => {
+            response.send(parcel.fs.is_file(&path)).is_err()
+          }
+          ParcelMessage::FsIsDir { path, response } => {
+            response.send(parcel.fs.is_dir(&path)).is_err()
+          }
+          ParcelMessage::RpcPing { response } => response
+            .send(parcel.rpc.as_ref().unwrap().ping().unwrap())
+            .is_err(),
+        } {
+          return;
+        }
+      }
+    });
+
+    Ok(Self { tx_parcel })
   }
 
   // Temporary, for testing
   #[napi]
   pub async fn _testing_temp_fs_read_to_string(&self, path: String) -> napi::Result<String> {
-    Ok(self.internal.fs.read_to_string(&PathBuf::from(path))?)
+    let (tx, rx) = channel();
+    self
+      .tx_parcel
+      .send(ParcelMessage::FsReadToString {
+        path: PathBuf::from(path),
+        response: tx,
+      })
+      .unwrap();
+    Ok(rx.recv().unwrap()?)
   }
 
   #[napi]
   pub async fn _testing_temp_fs_is_file(&self, path: String) -> napi::Result<bool> {
-    Ok(self.internal.fs.is_file(&PathBuf::from(path)))
+    let (tx, rx) = channel();
+    self
+      .tx_parcel
+      .send(ParcelMessage::FsIsFile {
+        path: PathBuf::from(path),
+        response: tx,
+      })
+      .unwrap();
+    Ok(rx.recv().unwrap())
   }
 
   #[napi]
   pub async fn _testing_temp_fs_is_dir(&self, path: String) -> napi::Result<bool> {
-    Ok(self.internal.fs.is_dir(&PathBuf::from(path)))
+    let (tx, rx) = channel();
+    self
+      .tx_parcel
+      .send(ParcelMessage::FsIsDir {
+        path: PathBuf::from(path),
+        response: tx,
+      })
+      .unwrap();
+    Ok(rx.recv().unwrap())
+  }
+
+  #[napi]
+  pub async fn _testing_rpc_ping(&self) -> napi::Result<()> {
+    let (tx, rx) = channel();
+    self
+      .tx_parcel
+      .send(ParcelMessage::RpcPing { response: tx })
+      .unwrap();
+    Ok(rx.recv().unwrap())
   }
 }

--- a/crates/node-bindings/src/parcel/parcel.rs
+++ b/crates/node-bindings/src/parcel/parcel.rs
@@ -1,9 +1,5 @@
-use std::io;
 use std::path::PathBuf;
-use std::sync::mpsc::channel;
-use std::sync::mpsc::Sender;
 use std::sync::Arc;
-use std::thread;
 
 use napi::Env;
 use napi::JsObject;
@@ -14,29 +10,9 @@ use parcel::ParcelOptions;
 
 use crate::file_system::FileSystemNapi;
 
-enum ParcelMessage {
-  RpcPing {
-    response: Sender<()>,
-  },
-  FsReadToString {
-    path: PathBuf,
-    response: Sender<io::Result<String>>,
-  },
-  FsIsFile {
-    path: PathBuf,
-    response: Sender<bool>,
-  },
-  FsIsDir {
-    path: PathBuf,
-    response: Sender<bool>,
-  },
-}
-
-enum ParcelResponse {}
-
 #[napi]
 pub struct ParcelNapi {
-  tx_parcel: Sender<ParcelMessage>,
+  parcel: Arc<Parcel>,
 }
 
 #[napi]
@@ -60,79 +36,32 @@ impl ParcelNapi {
       rpc: Some(Arc::new(rpc_host_nodejs)),
     });
 
-    // Run Parcel within its own thread
-    let (tx_parcel, rx_parcel) = channel::<ParcelMessage>();
-    thread::spawn(move || {
-      while let Ok(msg) = rx_parcel.recv() {
-        if match msg {
-          ParcelMessage::FsReadToString { path, response } => {
-            response.send(parcel.fs.read_to_string(&path)).is_err()
-          }
-          ParcelMessage::FsIsFile { path, response } => {
-            response.send(parcel.fs.is_file(&path)).is_err()
-          }
-          ParcelMessage::FsIsDir { path, response } => {
-            response.send(parcel.fs.is_dir(&path)).is_err()
-          }
-          ParcelMessage::RpcPing { response } => response
-            .send(parcel.rpc.as_ref().unwrap().ping().unwrap())
-            .is_err(),
-        } {
-          return;
-        }
-      }
-    });
-
-    Ok(Self { tx_parcel })
+    Ok(Self {
+      parcel: Arc::new(parcel),
+    })
   }
 
   // Temporary, for testing
   #[napi]
   pub async fn _testing_temp_fs_read_to_string(&self, path: String) -> napi::Result<String> {
-    let (tx, rx) = channel();
-    self
-      .tx_parcel
-      .send(ParcelMessage::FsReadToString {
-        path: PathBuf::from(path),
-        response: tx,
-      })
-      .unwrap();
-    Ok(rx.recv().unwrap()?)
+    Ok(self.parcel.fs.read_to_string(&PathBuf::from(path))?)
   }
 
   #[napi]
   pub async fn _testing_temp_fs_is_file(&self, path: String) -> napi::Result<bool> {
-    let (tx, rx) = channel();
-    self
-      .tx_parcel
-      .send(ParcelMessage::FsIsFile {
-        path: PathBuf::from(path),
-        response: tx,
-      })
-      .unwrap();
-    Ok(rx.recv().unwrap())
+    Ok(self.parcel.fs.is_file(&PathBuf::from(path)))
   }
 
   #[napi]
   pub async fn _testing_temp_fs_is_dir(&self, path: String) -> napi::Result<bool> {
-    let (tx, rx) = channel();
-    self
-      .tx_parcel
-      .send(ParcelMessage::FsIsDir {
-        path: PathBuf::from(path),
-        response: tx,
-      })
-      .unwrap();
-    Ok(rx.recv().unwrap())
+    Ok(self.parcel.fs.is_dir(&PathBuf::from(path)))
   }
 
   #[napi]
   pub async fn _testing_rpc_ping(&self) -> napi::Result<()> {
-    let (tx, rx) = channel();
-    self
-      .tx_parcel
-      .send(ParcelMessage::RpcPing { response: tx })
-      .unwrap();
-    Ok(rx.recv().unwrap())
+    if self.parcel.rpc.as_ref().unwrap().ping().is_err() {
+      return Err(napi::Error::from_reason("Failed to run"));
+    }
+    Ok(())
   }
 }

--- a/crates/node-bindings/src/parcel/parcel.rs
+++ b/crates/node-bindings/src/parcel/parcel.rs
@@ -8,9 +8,9 @@ use std::thread;
 use napi::Env;
 use napi::JsObject;
 use napi_derive::napi;
+use parcel::rpc::nodejs::RpcHostNodejs;
 use parcel::Parcel;
 use parcel::ParcelOptions;
-use parcel_plugin_rpc::nodejs::RpcHostNodejs;
 
 use crate::file_system::FileSystemNapi;
 

--- a/crates/parcel/Cargo.toml
+++ b/crates/parcel/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2021"
 description = "Parcel Bundler"
 
+[features]
+nodejs = ["parcel_plugin_rpc/nodejs"]
+
 [lib]
 path = "./src/lib.rs"
 

--- a/crates/parcel/src/lib.rs
+++ b/crates/parcel/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod parcel;
 pub use parcel::*;
 pub use parcel_filesystem as file_system;
+pub use parcel_plugin_rpc as rpc;
 
 #[allow(dead_code)]
 mod plugins;

--- a/crates/parcel_plugin_rpc/Cargo.toml
+++ b/crates/parcel_plugin_rpc/Cargo.toml
@@ -5,10 +5,12 @@ edition = "2021"
 description = "Parcel Bundler"
 
 [features]
-nodejs = []
+nodejs = ["dep:napi"]
 
 [dependencies]
 parcel_config = { path = "../parcel_config" }
 parcel_core = { path = "../parcel_core" }
 
 anyhow = "1.0.82"
+napi = { version = "2.16.4", features = ["serde"], optional = true }
+serde = { version = "1.0.198" }

--- a/crates/parcel_plugin_rpc/Cargo.toml
+++ b/crates/parcel_plugin_rpc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Parcel Bundler"
 
 [features]
-nodejs = ["dep:napi"]
+nodejs = ["dep:napi", "dep:serde"]
 
 [dependencies]
 parcel_config = { path = "../parcel_config" }
@@ -13,4 +13,4 @@ parcel_core = { path = "../parcel_core" }
 
 anyhow = "1.0.82"
 napi = { version = "2.16.4", features = ["serde"], optional = true }
-serde = { version = "1.0.198" }
+serde = { version = "1.0.198", optional = true }

--- a/crates/parcel_plugin_rpc/src/lib.rs
+++ b/crates/parcel_plugin_rpc/src/lib.rs
@@ -4,8 +4,6 @@ pub mod nodejs;
 pub mod plugin;
 mod rpc_host;
 mod rpc_host_message;
-mod rpc_host_response;
 
 pub use rpc_host::*;
 pub use rpc_host_message::*;
-pub use rpc_host_response::*;

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
@@ -22,8 +22,8 @@ pub struct RpcHostNodejs {
 
 impl RpcHostNodejs {
   pub fn new(env: &Env, callback: JsFunction) -> napi::Result<Self> {
-    // Create a threadsafe function that casts the incoming message data to
-    // something accessible in JavaScript. The function accepts from a JS callback
+    // Create a threadsafe function that casts the incoming message data to something
+    // accessible in JavaScript. The function accepts a return value from a JS callback
     let threadsafe_function: ThreadsafeFunction<RpcHostMessage> = env.create_threadsafe_function(
       &callback,
       0,

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
@@ -1,15 +1,98 @@
-use crate::RpcHost;
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Sender;
+use std::thread;
 
-pub struct RpcHostNodejs {}
+use anyhow::anyhow;
+use napi;
+use napi::threadsafe_function::ThreadSafeCallContext;
+use napi::threadsafe_function::ThreadsafeFunction;
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
+use napi::Env;
+use napi::JsFunction;
+use napi::JsUnknown;
+use napi::Status;
+use serde::de::DeserializeOwned;
+
+use crate::RpcHost;
+use crate::RpcHostMessage;
+
+pub struct RpcHostNodejs {
+  tx_rpc: Sender<RpcHostMessage>,
+}
 
 impl RpcHostNodejs {
-  pub fn new() -> Self {
-    Self {}
+  pub fn new(env: &Env, callback: JsFunction) -> napi::Result<Self> {
+    // Create a threadsafe function that casts the incoming message data to
+    // something accessible in JavaScript. The function accepts from a JS callback
+    let threadsafe_function: ThreadsafeFunction<RpcHostMessage> = env.create_threadsafe_function(
+      &callback,
+      0,
+      |ctx: ThreadSafeCallContext<RpcHostMessage>| {
+        let id = Self::get_message_id(&ctx.value);
+        match ctx.value {
+          RpcHostMessage::Ping { response: reply } => {
+            let callback = Self::create_callback(&ctx.env, reply)?;
+            let id = ctx.env.create_uint32(id)?.into_unknown();
+            let message = ctx.env.to_js_value(&())?;
+            Ok(vec![id, message, callback])
+          }
+        }
+      },
+    )?;
+
+    // Forward RPC events to the threadsafe function from a new thread
+    let (tx_rpc, rx_rpc) = channel();
+    thread::spawn(move || {
+      while let Ok(msg) = rx_rpc.recv() {
+        if !matches!(
+          threadsafe_function.call(Ok(msg), ThreadsafeFunctionCallMode::NonBlocking),
+          Status::Ok
+        ) {
+          return;
+        };
+      }
+    });
+
+    Ok(Self { tx_rpc })
+  }
+
+  // Generic method to create a "resolve" javascript function to
+  // return the value from the thread safe function
+  fn create_callback<Returns: DeserializeOwned + 'static>(
+    env: &Env,
+    reply: Sender<Returns>,
+  ) -> napi::Result<JsUnknown> {
+    let callback = env
+      .create_function_from_closure("callback", move |ctx| {
+        let response = ctx
+          .env
+          .from_js_value::<Returns, JsUnknown>(ctx.get::<JsUnknown>(0)?)?;
+
+        if reply.send(response).is_err() {
+          return Err(napi::Error::from_reason("Unable to send rpc response"));
+        }
+
+        ctx.env.get_undefined()
+      })?
+      .into_unknown();
+
+    Ok(callback)
+  }
+
+  // Map the RPC messages to numerical values to make matching
+  // easier from within JavaScript
+  fn get_message_id(message: &RpcHostMessage) -> u32 {
+    match message {
+      RpcHostMessage::Ping { response: _ } => 0,
+    }
   }
 }
 
+// Forward events to Nodejs
 impl RpcHost for RpcHostNodejs {
-  fn send(&self, _message: crate::RpcHostMessage) -> crate::RpcHostResponse {
-    todo!()
+  fn ping(&self) -> anyhow::Result<()> {
+    let (tx, rx) = channel();
+    self.tx_rpc.send(RpcHostMessage::Ping { response: tx })?;
+    Ok(rx.recv()?.map_err(|e| anyhow!(e))?)
   }
 }

--- a/crates/parcel_plugin_rpc/src/rpc_host.rs
+++ b/crates/parcel_plugin_rpc/src/rpc_host.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
-use crate::RpcHostMessage;
-use crate::RpcHostResponse;
+use anyhow;
 
 pub type RpcHostRef = Arc<dyn RpcHost>;
 
 pub trait RpcHost: Send + Sync {
-  fn send(&self, message: RpcHostMessage) -> RpcHostResponse;
+  fn ping(&self) -> anyhow::Result<()>;
 }

--- a/crates/parcel_plugin_rpc/src/rpc_host_message.rs
+++ b/crates/parcel_plugin_rpc/src/rpc_host_message.rs
@@ -1,5 +1,7 @@
-pub enum RpcHostMessage {
-  Ping(RpcHostMessagePing),
-}
+use std::sync::mpsc::Sender;
 
-pub struct RpcHostMessagePing {}
+pub enum RpcHostMessage {
+  Ping {
+    response: Sender<Result<(), String>>,
+  },
+}

--- a/crates/parcel_plugin_rpc/src/rpc_host_response.rs
+++ b/crates/parcel_plugin_rpc/src/rpc_host_response.rs
@@ -1,5 +1,0 @@
-pub enum RpcHostResponse {
-  Ping(RpcHostResponsePing),
-}
-
-pub struct RpcHostResponsePing {}

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -31,10 +31,28 @@ describe('parcel-v3', function () {
         isFile: (_, path) => inputFS.statSync(path).isFile(),
         isDir: (_, path) => inputFS.statSync(path).isDirectory(),
       },
+      rpc: rpc_wrapper(async (id, data) => {
+        console.log(id, data);
+        return undefined;
+      }),
     });
 
     assert(typeof (await p.testingTempFsReadToString(__filename)) === 'string');
     assert(!(await p.testingTempFsIsDir(__filename)));
     assert(await p.testingTempFsIsFile(__filename));
+    assert.doesNotThrow(async () => await p.testingRpcPing());
   });
 });
+
+// shim for Rpc types
+const rpc_wrapper = callback => async (err, id, data, done) => {
+  if (err) {
+    done({Err: err});
+    return;
+  }
+  try {
+    done({Ok: (await callback(id, data)) ?? undefined});
+  } catch (error) {
+    done({Err: error});
+  }
+};

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -31,8 +31,8 @@ describe('parcel-v3', function () {
         isFile: (_, path) => inputFS.statSync(path).isFile(),
         isDir: (_, path) => inputFS.statSync(path).isDirectory(),
       },
-      rpc: rpc_wrapper(async (id, data) => {
-        console.log(id, data);
+      // eslint-disable-next-line no-unused-vars
+      rpc: rpc_wrapper((id, data) => {
         return undefined;
       }),
     });
@@ -40,19 +40,28 @@ describe('parcel-v3', function () {
     assert(typeof (await p.testingTempFsReadToString(__filename)) === 'string');
     assert(!(await p.testingTempFsIsDir(__filename)));
     assert(await p.testingTempFsIsFile(__filename));
-    assert.doesNotThrow(async () => await p.testingRpcPing());
+    assert.doesNotThrow(async () => {
+      await p.testingRpcPing();
+    });
   });
 });
 
 // shim for Rpc types
-const rpc_wrapper = callback => async (err, id, data, done) => {
-  if (err) {
-    done({Err: err});
-    return;
-  }
-  try {
-    done({Ok: (await callback(id, data)) ?? undefined});
-  } catch (error) {
-    done({Err: error});
-  }
-};
+const rpc_wrapper =
+  (callback: (id: number, data: any) => any | Promise<any>) =>
+  async (
+    err: any,
+    id: number,
+    data: any,
+    done: (value: {|Ok: any|} | {|Err: any|}) => null,
+  ) => {
+    if (err) {
+      done({Err: err});
+      return;
+    }
+    try {
+      done({Ok: (await callback(id, data)) ?? undefined});
+    } catch (error) {
+      done({Err: error});
+    }
+  };

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -16,8 +16,10 @@ export interface ConfigRequest {
 }
 export interface RequestOptions {}
 
+
 export interface ParcelNapiOptions {
   fs?: any;
+  rpc?: (error: any, id: number, data: any, done: (value: {| Ok: any |} | {| Err: any |}) => any) => any | Promise<any>;
 }
 
 declare export class ParcelNapi {
@@ -25,6 +27,7 @@ declare export class ParcelNapi {
   testingTempFsReadToString(path: string): string;
   testingTempFsIsDir(path: string): boolean;
   testingTempFsIsFile(path: string): boolean;
+  testingRpcPing(): void;
 }
 
 declare export function initSentry(): void;


### PR DESCRIPTION
# ↪️ Pull Request

- Tidied up the `ParcelNapi` constructor a little
- Moved `Parcel` (within `ParcelNapi`) into its own thread
  - Interactions with `Parcel` now occur over a channel
- Added `rpc` callback to `ParcelNapi` Js options object
- Added `napi` to `parcel_plugin_rpc` behind `nodejs` feature
- Added `Ping`/`Pong` circuit to prove a round trip works
- Added napi bindings to `RpcHostNodejs` (not an `unsafe` in sight :rofl:)
- Updated the `RpcHostMessage` enum to reflect changes
- Updated `parcel-v3` test to test the `Ping/Pong` circuit

## 🚨 Test instructions

```
yarn build-native && yarn test:integration
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
