### PR TITLE
Update resolver plugin types

### DIFF
--- a/crates/parcel/src/plugins.rs
+++ b/crates/parcel/src/plugins.rs
@@ -204,7 +204,7 @@ mod tests {
         PathBuf::default(),
         PathBuf::default(),
       ),
-      options: PluginOptions::default(),
+      options: Arc::new(PluginOptions::default()),
       logger: PluginLogger::default(),
     }
   }

--- a/crates/parcel_core/src/plugin.rs
+++ b/crates/parcel_core/src/plugin.rs
@@ -1,5 +1,7 @@
-mod bundler_plugin;
+use std::path::PathBuf;
+use std::sync::Arc;
 
+mod bundler_plugin;
 pub use bundler_plugin::*;
 
 mod compressor_plugin;
@@ -32,16 +34,19 @@ pub use transformer_plugin::*;
 mod validator_plugin;
 pub use validator_plugin::*;
 
+use crate::types::BuildMode;
+
 pub struct PluginContext {
   pub config: PluginConfig,
-  pub options: PluginOptions,
+  pub options: Arc<PluginOptions>,
   pub logger: PluginLogger,
 }
 
 #[derive(Default)]
 pub struct PluginLogger {}
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct PluginOptions {
-  pub mode: crate::types::BuildMode,
+  pub mode: BuildMode,
+  pub project_root: PathBuf,
 }

--- a/crates/parcel_core/src/request_tracker/request.rs
+++ b/crates/parcel_core/src/request_tracker/request.rs
@@ -58,5 +58,5 @@ pub enum RequestError {
   Impossible,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Invalidation {}

--- a/crates/parcel_core/src/types/dependency.rs
+++ b/crates/parcel_core/src/types/dependency.rs
@@ -17,7 +17,7 @@ use super::symbol::Symbol;
 use super::target::Target;
 
 /// A dependency denotes a connection between two assets
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dependency {
   /// Controls the behavior of the bundle the resolved asset is placed into
@@ -124,19 +124,22 @@ impl Dependency {
   }
 
   pub fn id(&self) -> u64 {
-    // Compute hashed dependency id
     let mut hasher = AHasher::default();
-
-    self.bundle_behavior.hash(&mut hasher);
-    self.env.hash(&mut hasher);
-    self.package_conditions.hash(&mut hasher);
-    self.pipeline.hash(&mut hasher);
-    self.priority.hash(&mut hasher);
-    self.source_path.hash(&mut hasher);
-    self.specifier.hash(&mut hasher);
-    self.specifier_type.hash(&mut hasher);
-
+    self.hash(&mut hasher);
     hasher.finish()
+  }
+}
+
+impl Hash for Dependency {
+  fn hash<H: Hasher>(&self, state: &mut H) {
+    self.bundle_behavior.hash(state);
+    self.env.hash(state);
+    self.package_conditions.hash(state);
+    self.pipeline.hash(state);
+    self.priority.hash(state);
+    self.source_path.hash(state);
+    self.specifier.hash(state);
+    self.specifier_type.hash(state);
   }
 }
 

--- a/crates/parcel_core/src/types/parcel_options.rs
+++ b/crates/parcel_core/src/types/parcel_options.rs
@@ -16,7 +16,7 @@ pub struct ParcelOptions {
   pub project_root: PathBuf,
 }
 
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, Default, Hash, PartialEq)]
 pub enum BuildMode {
   #[default]
   Development,

--- a/crates/parcel_plugin_resolver/Cargo.toml
+++ b/crates/parcel_plugin_resolver/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 description = "Resolver Plugin for the Parcel Bundler"
 
-[lib]
-path = "./src/lib.rs"
-
 [dependencies]
 parcel_core = { path = "../parcel_core" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }

--- a/crates/parcel_plugin_rpc/src/plugin/resolver.rs
+++ b/crates/parcel_plugin_rpc/src/plugin/resolver.rs
@@ -3,10 +3,11 @@ use std::fmt::Debug;
 
 use parcel_config::PluginNode;
 use parcel_core::plugin::PluginContext;
-use parcel_core::plugin::Resolution;
 use parcel_core::plugin::ResolveContext;
+use parcel_core::plugin::Resolved;
 use parcel_core::plugin::ResolverPlugin;
 
+#[derive(Hash)]
 pub struct RpcResolverPlugin {}
 
 impl Debug for RpcResolverPlugin {
@@ -22,7 +23,7 @@ impl RpcResolverPlugin {
 }
 
 impl ResolverPlugin for RpcResolverPlugin {
-  fn resolve(&self, _ctx: &ResolveContext) -> Result<Resolution, anyhow::Error> {
+  fn resolve(&self, _ctx: ResolveContext) -> Result<Resolved, anyhow::Error> {
     todo!()
   }
 }


### PR DESCRIPTION
# ↪️ Pull Request

These changes update the resolver plugin and types to prepare for the path request implementation
- Update `options` and `Dependency` to an arc
- Add `project_root` to `PluginOptions`
- Use enum for `resolve` return type to better reflect possibilities and update default resolver impl
- Use defaults where applicable to simplify code
- Add hashing to structures to prepare for request tracker constraints

## 🚨 Test instructions

`yarn build-native && cargo test`
