### PR TITLE
Alsh added multiple Nodejs workers and workers RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,6 +1797,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "num_cpus",
  "once_cell",
  "oxipng",
  "parcel",
@@ -1912,8 +1913,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "napi",
+ "once_cell",
  "parcel_config",
  "parcel_core",
+ "parking_lot",
  "serde",
 ]
 

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -31,6 +31,7 @@ toml = "0.8.12"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
+num_cpus = "1.16.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 parcel = { path = "../parcel", features = ["nodejs"] }

--- a/crates/node-bindings/src/parcel/mod.rs
+++ b/crates/node-bindings/src/parcel/mod.rs
@@ -1,1 +1,2 @@
 pub mod parcel;
+pub mod worker;

--- a/crates/node-bindings/src/parcel/worker.rs
+++ b/crates/node-bindings/src/parcel/worker.rs
@@ -1,0 +1,10 @@
+use napi::{Env, JsFunction, JsUndefined};
+use napi_derive::napi;
+
+use parcel::rpc::nodejs::RpcConnectionNodejs;
+
+#[napi]
+pub fn worker_callback(env: Env, callback: JsFunction) -> napi::Result<JsUndefined> {
+  RpcConnectionNodejs::create_worker_callback(&env, callback)?;
+  env.get_undefined()
+}

--- a/crates/parcel/src/parcel.rs
+++ b/crates/parcel/src/parcel.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
+use anyhow;
 use parcel_filesystem::os_file_system::OsFileSystem;
 use parcel_filesystem::FileSystemRef;
 use parcel_package_manager::NodePackageManager;
+use parcel_plugin_rpc::RpcConnectionRef;
 use parcel_plugin_rpc::RpcHostRef;
 
 pub struct Parcel {
@@ -27,5 +29,15 @@ impl Parcel {
       fs,
       rpc: options.rpc,
     }
+  }
+
+  pub fn build(&self) -> anyhow::Result<()> {
+    let mut _rpc_connection = None::<RpcConnectionRef>;
+
+    if let Some(rpc_host) = &self.rpc {
+      _rpc_connection = Some(rpc_host.start()?);
+    }
+
+    Ok(())
   }
 }

--- a/crates/parcel_plugin_rpc/Cargo.toml
+++ b/crates/parcel_plugin_rpc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Parcel Bundler"
 
 [features]
-nodejs = ["dep:napi", "dep:serde"]
+nodejs = ["dep:napi", "dep:serde", "dep:parking_lot", "dep:once_cell"]
 
 [dependencies]
 parcel_config = { path = "../parcel_config" }
@@ -14,5 +14,5 @@ parcel_core = { path = "../parcel_core" }
 anyhow = "1.0.82"
 napi = { version = "2.16.4", features = ["serde"], optional = true }
 serde = { version = "1.0.198", optional = true }
-parking_lot = "0.12"
-once_cell = { version = "1.19.0" }
+parking_lot = { version = "0.12", optional = true }
+once_cell = { version = "1.19.0", optional = true }

--- a/crates/parcel_plugin_rpc/Cargo.toml
+++ b/crates/parcel_plugin_rpc/Cargo.toml
@@ -14,3 +14,5 @@ parcel_core = { path = "../parcel_core" }
 anyhow = "1.0.82"
 napi = { version = "2.16.4", features = ["serde"], optional = true }
 serde = { version = "1.0.198", optional = true }
+parking_lot = "0.12"
+once_cell = { version = "1.19.0" }

--- a/crates/parcel_plugin_rpc/src/lib.rs
+++ b/crates/parcel_plugin_rpc/src/lib.rs
@@ -2,8 +2,10 @@
 pub mod nodejs;
 
 pub mod plugin;
+mod rpc_conn_message;
 mod rpc_host;
 mod rpc_host_message;
 
+pub use rpc_conn_message::*;
 pub use rpc_host::*;
 pub use rpc_host_message::*;

--- a/crates/parcel_plugin_rpc/src/lib.rs
+++ b/crates/parcel_plugin_rpc/src/lib.rs
@@ -2,10 +2,6 @@
 pub mod nodejs;
 
 pub mod plugin;
-mod rpc_conn_message;
 mod rpc_host;
-mod rpc_host_message;
 
-pub use rpc_conn_message::*;
 pub use rpc_host::*;
-pub use rpc_host_message::*;

--- a/crates/parcel_plugin_rpc/src/nodejs/mod.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/mod.rs
@@ -1,3 +1,9 @@
+mod napi;
+mod rpc_conn_nodejs;
+mod rpc_conns_nodejs;
 mod rpc_host_nodejs;
+mod worker_init;
 
+pub use rpc_conn_nodejs::*;
+pub use rpc_conns_nodejs::*;
 pub use rpc_host_nodejs::*;

--- a/crates/parcel_plugin_rpc/src/nodejs/mod.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/mod.rs
@@ -1,6 +1,8 @@
 mod napi;
+mod rpc_conn_message;
 mod rpc_conn_nodejs;
 mod rpc_conns_nodejs;
+mod rpc_host_message;
 mod rpc_host_nodejs;
 mod worker_init;
 

--- a/crates/parcel_plugin_rpc/src/nodejs/napi.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/napi.rs
@@ -1,0 +1,49 @@
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use napi::threadsafe_function::ThreadsafeFunction;
+use napi::threadsafe_function::ThreadsafeFunctionCallMode;
+use napi::Env;
+use napi::JsUnknown;
+use napi::Status;
+use serde::de::DeserializeOwned;
+
+// Generic method to create a "resolve" javascript function to
+// return the value from the thread safe function
+pub fn create_callback<Returns: DeserializeOwned + 'static>(
+  env: &Env,
+  reply: Sender<Returns>,
+) -> napi::Result<JsUnknown> {
+  let callback = env
+    .create_function_from_closure("callback", move |ctx| {
+      let response = ctx
+        .env
+        .from_js_value::<Returns, JsUnknown>(ctx.get::<JsUnknown>(0)?)?;
+
+      if reply.send(response).is_err() {
+        return Err(napi::Error::from_reason("Unable to send rpc response"));
+      }
+
+      ctx.env.get_undefined()
+    })?
+    .into_unknown();
+
+  Ok(callback)
+}
+
+pub fn wrap_threadsafe_function<T: Send>(
+  threadsafe_function: ThreadsafeFunction<T>,
+  rx: Receiver<T>,
+) {
+  thread::spawn(move || {
+    while let Ok(msg) = rx.recv() {
+      if !matches!(
+        threadsafe_function.call(Ok(msg), ThreadsafeFunctionCallMode::NonBlocking),
+        Status::Ok
+      ) {
+        return;
+      };
+    }
+  });
+}

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_conn_message.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_conn_message.rs
@@ -1,19 +1,16 @@
 use std::sync::mpsc::Sender;
 
-pub enum RpcHostMessage {
+#[derive(Debug)]
+pub enum RpcConnectionMessage {
   Ping {
-    response: Sender<Result<(), String>>,
-  },
-  Start {
     response: Sender<Result<(), String>>,
   },
 }
 
-impl RpcHostMessage {
+impl RpcConnectionMessage {
   pub fn get_id(&self) -> u32 {
     match self {
       Self::Ping { response: _ } => 0,
-      Self::Start { response: _ } => 1,
     }
   }
 }

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
@@ -15,6 +15,7 @@ use crate::RpcConnection;
 use super::napi::create_done_callback;
 use super::rpc_conn_message::RpcConnectionMessage;
 use super::worker_init::get_worker_rx;
+use super::worker_init::get_worker_tx;
 
 /// RpcConnectionNodejs wraps the communication with a
 /// single Nodejs worker thread
@@ -23,8 +24,10 @@ pub struct RpcConnectionNodejs {
 }
 
 impl RpcConnectionNodejs {
-  pub fn new(tx_rpc: Sender<RpcConnectionMessage>) -> Self {
-    Self { tx_rpc }
+  pub fn new() -> Self {
+    Self {
+      tx_rpc: get_worker_tx(),
+    }
   }
 
   pub fn create_worker_callback(env: &Env, callback: JsFunction) -> napi::Result<()> {

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
@@ -1,0 +1,70 @@
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Sender;
+
+use napi::threadsafe_function::ThreadSafeCallContext;
+use napi::threadsafe_function::ThreadsafeFunction;
+use napi::Env;
+use napi::JsFunction;
+use napi::JsUnknown;
+
+use super::napi::create_callback;
+use super::napi::wrap_threadsafe_function;
+use super::worker_init::on_worker_loaded;
+use super::worker_init::register_worker_loaded;
+
+use crate::RpcConnection;
+use crate::RpcConnectionMessage;
+
+/// Connection to a single Nodejs Worker
+pub struct RpcConnectionNodejs {
+  tx_rpc: Sender<RpcConnectionMessage>,
+}
+
+impl RpcConnectionNodejs {
+  pub fn new() -> Self {
+    Self {
+      tx_rpc: on_worker_loaded(),
+    }
+  }
+
+  pub fn create_worker_callback(env: &Env, callback: JsFunction) -> napi::Result<()> {
+    // Nodejs will not shutdown automatically. The threads
+    // need to be closed manually at the end of a build
+    let threadsafe_function: ThreadsafeFunction<RpcConnectionMessage> = env
+      .create_threadsafe_function(
+        &callback,
+        0,
+        |ctx: ThreadSafeCallContext<RpcConnectionMessage>| {
+          let id = ctx.env.create_uint32(ctx.value.get_id())?.into_unknown();
+          let (message, callback) = Self::map_rpc_message(&ctx.env, ctx.value)?;
+          Ok(vec![id, message, callback])
+        },
+      )?;
+
+    let rx_rpc = register_worker_loaded();
+    wrap_threadsafe_function(threadsafe_function, rx_rpc);
+
+    Ok(())
+  }
+
+  // Map the RPC message to a JavaScript type
+  fn map_rpc_message(env: &Env, msg: RpcConnectionMessage) -> napi::Result<(JsUnknown, JsUnknown)> {
+    Ok(match msg {
+      RpcConnectionMessage::Ping { response: reply } => {
+        let message = env.to_js_value(&())?;
+        let callback = create_callback(&env, reply)?;
+        (message, callback)
+      }
+    })
+  }
+}
+
+impl RpcConnection for RpcConnectionNodejs {
+  fn ping(&self) -> anyhow::Result<()> {
+    let (tx, rx) = channel();
+    self
+      .tx_rpc
+      .send(RpcConnectionMessage::Ping { response: tx })?;
+    Ok(rx.recv()?.map_err(|e| anyhow::anyhow!(e))?)
+  }
+}

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
@@ -6,12 +6,12 @@ use crate::RpcConnection;
 
 /// Connection to multiple Nodejs Workers
 /// Implements round robin messaging
-pub struct RpcConnectionsNodejs {
+pub struct RpcConnectionNodejsMulti {
   current_index: Mutex<usize>, // TODO use AtomicUsize
   conns: Vec<RpcConnectionNodejs>,
 }
 
-impl RpcConnectionsNodejs {
+impl RpcConnectionNodejsMulti {
   pub fn new(conns: Vec<RpcConnectionNodejs>) -> Self {
     Self {
       current_index: Default::default(),
@@ -30,7 +30,7 @@ impl RpcConnectionsNodejs {
   }
 }
 
-impl RpcConnection for RpcConnectionsNodejs {
+impl RpcConnection for RpcConnectionNodejsMulti {
   fn ping(&self) -> anyhow::Result<()> {
     let next = self.next_index();
     self.conns[next].ping()

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
@@ -1,0 +1,38 @@
+use parking_lot::Mutex;
+
+use super::RpcConnectionNodejs;
+
+use crate::RpcConnection;
+
+/// Connection to multiple Nodejs Workers
+/// Implements round robin messaging
+pub struct RpcConnectionsNodejs {
+  current_index: Mutex<usize>, // TODO use AtomicUsize
+  conns: Vec<RpcConnectionNodejs>,
+}
+
+impl RpcConnectionsNodejs {
+  pub fn new(conns: Vec<RpcConnectionNodejs>) -> Self {
+    Self {
+      current_index: Default::default(),
+      conns,
+    }
+  }
+
+  fn next_index(&self) -> usize {
+    let mut current_index = self.current_index.lock();
+    if *current_index >= self.conns.len() - 1 {
+      *current_index = 0;
+    } else {
+      *current_index = *current_index + 1;
+    }
+    current_index.clone()
+  }
+}
+
+impl RpcConnection for RpcConnectionsNodejs {
+  fn ping(&self) -> anyhow::Result<()> {
+    let next = self.next_index();
+    self.conns[next].ping()
+  }
+}

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_message.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_message.rs
@@ -1,12 +1,12 @@
 use std::sync::mpsc::Sender;
 
-pub enum RpcConnectionMessage {
+pub enum RpcHostMessage {
   Ping {
     response: Sender<Result<(), String>>,
   },
 }
 
-impl RpcConnectionMessage {
+impl RpcHostMessage {
   pub fn get_id(&self) -> u32 {
     match self {
       Self::Ping { response: _ } => 0,

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
@@ -15,7 +15,7 @@ use crate::RpcHost;
 use super::napi::create_done_callback;
 use super::rpc_host_message::RpcHostMessage;
 use super::RpcConnectionNodejs;
-use super::RpcConnectionsNodejs;
+use super::RpcConnectionNodejsMulti;
 
 // RpcHostNodejs has a connection to the main Nodejs thread and manages
 // the lazy initialization of Nodejs worker threads.
@@ -50,7 +50,7 @@ impl RpcHostNodejs {
     })
   }
 
-  fn call_threadsafe_function(&self, msg: RpcHostMessage) {
+  fn call_rpc(&self, msg: RpcHostMessage) {
     if !matches!(
       self
         .threadsafe_function
@@ -77,7 +77,7 @@ impl RpcHostNodejs {
 impl RpcHost for RpcHostNodejs {
   fn ping(&self) -> anyhow::Result<()> {
     let (tx, rx) = channel();
-    self.call_threadsafe_function(RpcHostMessage::Ping { response: tx });
+    self.call_rpc(RpcHostMessage::Ping { response: tx });
     Ok(rx.recv()?.map_err(|e| anyhow::anyhow!(e))?)
   }
 
@@ -88,6 +88,6 @@ impl RpcHost for RpcHostNodejs {
       connections.push(RpcConnectionNodejs::new())
     }
 
-    Ok(Arc::new(RpcConnectionsNodejs::new(connections)))
+    Ok(Arc::new(RpcConnectionNodejsMulti::new(connections)))
   }
 }

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
@@ -14,7 +14,6 @@ use crate::RpcHost;
 
 use super::napi::create_done_callback;
 use super::rpc_host_message::RpcHostMessage;
-use super::worker_init::register_worker_rx;
 use super::RpcConnectionNodejs;
 use super::RpcConnectionsNodejs;
 
@@ -86,9 +85,7 @@ impl RpcHost for RpcHostNodejs {
     let mut connections = vec![];
 
     for _ in 0..self.node_workers {
-      let (tx_rpc, rx_rpc) = channel();
-      register_worker_rx(rx_rpc);
-      connections.push(RpcConnectionNodejs::new(tx_rpc))
+      connections.push(RpcConnectionNodejs::new())
     }
 
     Ok(Arc::new(RpcConnectionsNodejs::new(connections)))

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
@@ -1,90 +1,67 @@
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
-use std::thread;
+use std::sync::Arc;
 
-use anyhow::anyhow;
-use napi;
 use napi::threadsafe_function::ThreadSafeCallContext;
 use napi::threadsafe_function::ThreadsafeFunction;
-use napi::threadsafe_function::ThreadsafeFunctionCallMode;
 use napi::Env;
 use napi::JsFunction;
 use napi::JsUnknown;
-use napi::Status;
-use serde::de::DeserializeOwned;
 
+use crate::RpcConnectionRef;
 use crate::RpcHost;
 use crate::RpcHostMessage;
 
+use super::napi::create_callback;
+use super::napi::wrap_threadsafe_function;
+use super::RpcConnectionNodejs;
+use super::RpcConnectionsNodejs;
+
 pub struct RpcHostNodejs {
   tx_rpc: Sender<RpcHostMessage>,
+  node_workers: u32,
 }
 
 impl RpcHostNodejs {
-  pub fn new(env: &Env, callback: JsFunction) -> napi::Result<Self> {
+  pub fn new(env: &Env, callback: JsFunction, node_workers: u32) -> napi::Result<Self> {
     // Create a threadsafe function that casts the incoming message data to something
     // accessible in JavaScript. The function accepts a return value from a JS callback
-    let threadsafe_function: ThreadsafeFunction<RpcHostMessage> = env.create_threadsafe_function(
-      &callback,
-      0,
-      |ctx: ThreadSafeCallContext<RpcHostMessage>| {
-        let id = Self::get_message_id(&ctx.value);
-        match ctx.value {
-          RpcHostMessage::Ping { response: reply } => {
-            let callback = Self::create_callback(&ctx.env, reply)?;
-            let id = ctx.env.create_uint32(id)?.into_unknown();
-            let message = ctx.env.to_js_value(&())?;
-            Ok(vec![id, message, callback])
-          }
-        }
-      },
-    )?;
+    let mut threadsafe_function: ThreadsafeFunction<RpcHostMessage> = env
+      .create_threadsafe_function(
+        &callback,
+        0,
+        |ctx: ThreadSafeCallContext<RpcHostMessage>| {
+          let id = ctx.env.create_uint32(ctx.value.get_id())?.into_unknown();
+          let (message, callback) = Self::map_rpc_message(&ctx.env, ctx.value)?;
+          Ok(vec![id, message, callback])
+        },
+      )?;
 
-    // Forward RPC events to the threadsafe function from a new thread
+    // Don't prevent Nodejs from shutting down
+    threadsafe_function.unref(&env)?;
+
+    // Forward RPC events to the threadsafe function
     let (tx_rpc, rx_rpc) = channel();
-    thread::spawn(move || {
-      while let Ok(msg) = rx_rpc.recv() {
-        if !matches!(
-          threadsafe_function.call(Ok(msg), ThreadsafeFunctionCallMode::NonBlocking),
-          Status::Ok
-        ) {
-          return;
-        };
+    wrap_threadsafe_function(threadsafe_function, rx_rpc);
+
+    Ok(Self {
+      node_workers,
+      tx_rpc,
+    })
+  }
+
+  // Map the RPC message to a JavaScript type
+  fn map_rpc_message(env: &Env, msg: RpcHostMessage) -> napi::Result<(JsUnknown, JsUnknown)> {
+    Ok(match msg {
+      RpcHostMessage::Ping { response: reply } => {
+        let message = env.to_js_value(&())?;
+        let callback = create_callback(&env, reply)?;
+        (message, callback)
       }
-    });
-
-    Ok(Self { tx_rpc })
-  }
-
-  // Generic method to create a "resolve" javascript function to
-  // return the value from the thread safe function
-  fn create_callback<Returns: DeserializeOwned + 'static>(
-    env: &Env,
-    reply: Sender<Returns>,
-  ) -> napi::Result<JsUnknown> {
-    let callback = env
-      .create_function_from_closure("callback", move |ctx| {
-        let response = ctx
-          .env
-          .from_js_value::<Returns, JsUnknown>(ctx.get::<JsUnknown>(0)?)?;
-
-        if reply.send(response).is_err() {
-          return Err(napi::Error::from_reason("Unable to send rpc response"));
-        }
-
-        ctx.env.get_undefined()
-      })?
-      .into_unknown();
-
-    Ok(callback)
-  }
-
-  // Map the RPC messages to numerical values to make matching
-  // easier from within JavaScript
-  fn get_message_id(message: &RpcHostMessage) -> u32 {
-    match message {
-      RpcHostMessage::Ping { response: _ } => 0,
-    }
+      RpcHostMessage::Start { response: _ } => {
+        unreachable!()
+      }
+    })
   }
 }
 
@@ -93,6 +70,17 @@ impl RpcHost for RpcHostNodejs {
   fn ping(&self) -> anyhow::Result<()> {
     let (tx, rx) = channel();
     self.tx_rpc.send(RpcHostMessage::Ping { response: tx })?;
-    Ok(rx.recv()?.map_err(|e| anyhow!(e))?)
+    Ok(rx.recv()?.map_err(|e| anyhow::anyhow!(e))?)
+  }
+
+  fn start(&self) -> anyhow::Result<RpcConnectionRef> {
+    // JavaScript workers will have already been created
+    // This waits for the workers to connect
+    let mut connections = vec![];
+    for _ in 0..self.node_workers {
+      connections.push(RpcConnectionNodejs::new())
+    }
+
+    Ok(Arc::new(RpcConnectionsNodejs::new(connections)))
   }
 }

--- a/crates/parcel_plugin_rpc/src/nodejs/worker_init.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/worker_init.rs
@@ -48,10 +48,12 @@ static WORKER_INIT: Lazy<Sender<WorkerInitMessage>> = Lazy::new(|| {
   tx_subscribe
 });
 
-pub fn register_worker_rx(rx_rpc: Receiver<RpcConnectionMessage>) {
+pub fn get_worker_tx() -> Sender<RpcConnectionMessage> {
+  let (tx_rpc, rx_rpc) = channel();
   WORKER_INIT
     .send(WorkerInitMessage::Register(rx_rpc))
     .unwrap();
+  tx_rpc
 }
 
 pub fn get_worker_rx() -> Receiver<RpcConnectionMessage> {

--- a/crates/parcel_plugin_rpc/src/nodejs/worker_init.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/worker_init.rs
@@ -1,0 +1,60 @@
+use std::sync::mpsc::channel;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use once_cell::sync::Lazy;
+
+use crate::RpcConnectionMessage;
+
+enum WorkerInitMessage {
+  Subscribe(Sender<Sender<RpcConnectionMessage>>),
+  Register(Sender<RpcConnectionMessage>),
+}
+
+// This allows for workers to notify RPC Connections that they are ready
+const WORKER_INIT: Lazy<Sender<WorkerInitMessage>> = Lazy::new(|| {
+  let (tx_subscribe, rx_subscribe) = channel::<WorkerInitMessage>();
+
+  thread::spawn(move || {
+    let mut subscribers = Vec::<Sender<Sender<RpcConnectionMessage>>>::new();
+    let mut workers = Vec::<Sender<RpcConnectionMessage>>::new();
+
+    while let Ok(msg) = rx_subscribe.recv() {
+      match msg {
+        WorkerInitMessage::Subscribe(subscriber) => {
+          if let Some(worker) = workers.pop() {
+            subscriber.send(worker).unwrap();
+          } else {
+            subscribers.push(subscriber);
+          }
+        }
+        WorkerInitMessage::Register(worker) => {
+          if let Some(subscriber) = subscribers.pop() {
+            subscriber.send(worker).unwrap();
+          } else {
+            workers.push(worker);
+          }
+        }
+      }
+    }
+  });
+
+  tx_subscribe
+});
+
+pub fn on_worker_loaded() -> Sender<RpcConnectionMessage> {
+  let (tx_rpc_subscribe, rx_rpc_subscribe) = channel();
+  WORKER_INIT
+    .send(WorkerInitMessage::Subscribe(tx_rpc_subscribe))
+    .unwrap();
+  rx_rpc_subscribe.recv().unwrap()
+}
+
+pub fn register_worker_loaded() -> Receiver<RpcConnectionMessage> {
+  let (tx_rpc, rx_rpc) = channel();
+  WORKER_INIT
+    .send(WorkerInitMessage::Register(tx_rpc))
+    .unwrap();
+  rx_rpc
+}

--- a/crates/parcel_plugin_rpc/src/nodejs/worker_init.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/worker_init.rs
@@ -13,7 +13,7 @@ enum WorkerInitMessage {
 }
 
 // This allows for workers to notify RPC Connections that they are ready
-const WORKER_INIT: Lazy<Sender<WorkerInitMessage>> = Lazy::new(|| {
+static WORKER_INIT: Lazy<Sender<WorkerInitMessage>> = Lazy::new(|| {
   let (tx_subscribe, rx_subscribe) = channel::<WorkerInitMessage>();
 
   thread::spawn(move || {

--- a/crates/parcel_plugin_rpc/src/rpc_conn_message.rs
+++ b/crates/parcel_plugin_rpc/src/rpc_conn_message.rs
@@ -1,19 +1,15 @@
 use std::sync::mpsc::Sender;
 
-pub enum RpcHostMessage {
+pub enum RpcConnectionMessage {
   Ping {
-    response: Sender<Result<(), String>>,
-  },
-  Start {
     response: Sender<Result<(), String>>,
   },
 }
 
-impl RpcHostMessage {
+impl RpcConnectionMessage {
   pub fn get_id(&self) -> u32 {
     match self {
       Self::Ping { response: _ } => 0,
-      Self::Start { response: _ } => 1,
     }
   }
 }

--- a/crates/parcel_plugin_rpc/src/rpc_host.rs
+++ b/crates/parcel_plugin_rpc/src/rpc_host.rs
@@ -3,7 +3,13 @@ use std::sync::Arc;
 use anyhow;
 
 pub type RpcHostRef = Arc<dyn RpcHost>;
+pub type RpcConnectionRef = Arc<dyn RpcConnection>;
 
 pub trait RpcHost: Send + Sync {
+  fn ping(&self) -> anyhow::Result<()>;
+  fn start(&self) -> anyhow::Result<RpcConnectionRef>;
+}
+
+pub trait RpcConnection: Send + Sync {
   fn ping(&self) -> anyhow::Result<()>;
 }

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -51,6 +51,8 @@
     "semver": "^7.5.2"
   },
   "devDependencies": {
+    "@parcel/babel-register": "2.12.0",
+    "@types/node": ">= 18",
     "graphviz": "^0.0.9",
     "tempy": "^0.2.1"
   },

--- a/packages/core/core/src/index.js
+++ b/packages/core/core/src/index.js
@@ -18,3 +18,5 @@ export {
   INTERNAL_RESOLVE,
   INTERNAL_TRANSFORM,
 } from './Parcel';
+
+export * from './parcel-v3';

--- a/packages/core/core/src/parcel-v3/Parcel.js
+++ b/packages/core/core/src/parcel-v3/Parcel.js
@@ -50,9 +50,14 @@ export class ParcelV3 {
   }
 
   async build(): Promise<any> {
-    const workers = await this.#startWorkers();
+    // initialize workers lazily
+    const workers = this.#startWorkers();
+
+    // Run the Parcel build
     let result = await this._internal.build();
-    this.#stopWorkers(workers);
+
+    // Stop workers
+    this.#stopWorkers(await workers);
     return result;
   }
 

--- a/packages/core/core/src/parcel-v3/Parcel.js
+++ b/packages/core/core/src/parcel-v3/Parcel.js
@@ -1,0 +1,79 @@
+// @flow
+
+import path from 'path';
+import {Worker} from 'worker_threads';
+import * as napi from '@parcel/rust';
+import type {FileSystem} from '@parcel/types';
+
+export type ParcelV3Options = {|
+  threads?: number,
+  nodeWorkers?: number,
+  fs?: FileSystem,
+|};
+
+export class ParcelV3 {
+  _internal: napi.ParcelNapi;
+  #nodeWorkerCount: number;
+
+  constructor({
+    threads = napi.ParcelNapi.defaultThreadCount(),
+    nodeWorkers,
+  }: ParcelV3Options) {
+    this.#nodeWorkerCount = nodeWorkers || threads;
+    this._internal = new napi.ParcelNapi({
+      threads,
+      nodeWorkers,
+      // eslint-disable-next-line no-unused-vars
+      rpc: async (err, id, data, done) => {
+        if (err) {
+          done({Err: err});
+          return;
+        }
+        try {
+          done({Ok: (await this.#on_event(id, data)) ?? undefined});
+        } catch (error) {
+          done({Err: error});
+        }
+      },
+    });
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  #on_event(id, data: any) {
+    switch (id) {
+      // Ping
+      case 0:
+        return undefined;
+      // Start workers
+      case 1:
+        return undefined;
+      default:
+        throw new Error('Unknown message');
+    }
+  }
+
+  async build(): Promise<any> {
+    const workers = await this.#startWorkers();
+    let result = await this._internal.build();
+    this.#stopWorkers(workers);
+    return result;
+  }
+
+  async #startWorkers() {
+    const workers = [];
+
+    for (let i = 0; i < this.#nodeWorkerCount; i++) {
+      let worker = new Worker(path.join(__dirname, 'worker', 'index.js'));
+      await new Promise(resolve => worker.once('message', resolve));
+      workers.push(worker);
+    }
+
+    return workers;
+  }
+
+  #stopWorkers(workers) {
+    for (const worker of workers) {
+      worker.terminate();
+    }
+  }
+}

--- a/packages/core/core/src/parcel-v3/Parcel.js
+++ b/packages/core/core/src/parcel-v3/Parcel.js
@@ -56,17 +56,20 @@ export class ParcelV3 {
     return result;
   }
 
-  #startWorkers() {
+  async #startWorkers() {
     const workersOnLoad = [];
+    const workers = [];
 
     for (let i = 0; i < this.#nodeWorkerCount; i++) {
       let worker = new Worker(path.join(__dirname, 'worker', 'index.js'));
+      workers.push(worker);
       workersOnLoad.push(
         new Promise(resolve => worker.once('message', resolve)),
       );
     }
 
-    return Promise.all(workersOnLoad);
+    await Promise.all(workersOnLoad);
+    return workers;
   }
 
   #stopWorkers(workers) {

--- a/packages/core/core/src/parcel-v3/ParcelWorker.js
+++ b/packages/core/core/src/parcel-v3/ParcelWorker.js
@@ -5,11 +5,11 @@ import * as napi from '@parcel/rust';
 export class ParcelWorker {
   constructor() {
     napi.workerCallback(async (err, id, data, done) => {
-      if (err) {
-        done({Err: err});
-        return;
-      }
       try {
+        if (err) {
+          done({Err: err});
+          return;
+        }
         done({Ok: (await this.#on_event(id, data)) ?? undefined});
       } catch (error) {
         done({Err: error});
@@ -23,7 +23,7 @@ export class ParcelWorker {
     switch (id) {
       // Ping
       case 0:
-        return undefined;
+        return;
       default:
         throw new Error('Unknown message');
     }

--- a/packages/core/core/src/parcel-v3/ParcelWorker.js
+++ b/packages/core/core/src/parcel-v3/ParcelWorker.js
@@ -1,0 +1,31 @@
+// @flow
+import {parentPort} from 'worker_threads';
+import * as napi from '@parcel/rust';
+
+export class ParcelWorker {
+  constructor() {
+    napi.workerCallback(async (err, id, data, done) => {
+      if (err) {
+        done({Err: err});
+        return;
+      }
+      try {
+        done({Ok: (await this.#on_event(id, data)) ?? undefined});
+      } catch (error) {
+        done({Err: error});
+      }
+    });
+    parentPort?.postMessage(null);
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  #on_event(id, data: any) {
+    switch (id) {
+      // Ping
+      case 0:
+        return undefined;
+      default:
+        throw new Error('Unknown message');
+    }
+  }
+}

--- a/packages/core/core/src/parcel-v3/index.js
+++ b/packages/core/core/src/parcel-v3/index.js
@@ -1,0 +1,4 @@
+// @flow
+
+export {ParcelV3} from './Parcel';
+export type * from './Parcel';

--- a/packages/core/core/src/parcel-v3/worker/index.js
+++ b/packages/core/core/src/parcel-v3/worker/index.js
@@ -1,0 +1,8 @@
+if (
+  process.env.PARCEL_BUILD_ENV !== 'production' ||
+  process.env.PARCEL_SELF_BUILD
+) {
+  require('@parcel/babel-register');
+}
+
+require('./worker');

--- a/packages/core/core/src/parcel-v3/worker/worker.js
+++ b/packages/core/core/src/parcel-v3/worker/worker.js
@@ -1,0 +1,4 @@
+// @flow
+import {ParcelWorker} from '../ParcelWorker';
+
+new ParcelWorker();

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -24,7 +24,7 @@ describe('parcel-v3', function () {
     assert.equal(output(), 3);
   });
 
-  it('should run the main-thread bootstrap function', async function () {
+  it.only('should run the main-thread bootstrap function', async function () {
     let fs: any = {
       readFileSync: (_, [...args]) => inputFS.readFileSync(...args),
       isFile: (_, path) => inputFS.statSync(path).isFile(),

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -24,7 +24,7 @@ describe('parcel-v3', function () {
     assert.equal(output(), 3);
   });
 
-  it.only('should run the main-thread bootstrap function', async function () {
+  it('should run the main-thread bootstrap function', async function () {
     let fs: any = {
       readFileSync: (_, [...args]) => inputFS.readFileSync(...args),
       isFile: (_, path) => inputFS.statSync(path).isFile(),

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -1,5 +1,5 @@
 // @flow
-import type {FileCreateInvalidation} from '@parcel/types';
+import type {FileCreateInvalidation, FileSystem as ParcelFileSystem} from '@parcel/types';
 
 declare export var init: void | (() => void);
 
@@ -16,19 +16,25 @@ export interface ConfigRequest {
 }
 export interface RequestOptions {}
 
+export type RpcCallback = (error: any, id: number, data: any, done: (value: {| Ok: any |} | {| Err: any |}) => any) => any | Promise<any>;
 
 export interface ParcelNapiOptions {
-  fs?: any;
-  rpc?: (error: any, id: number, data: any, done: (value: {| Ok: any |} | {| Err: any |}) => any) => any | Promise<any>;
+  fs?: ParcelFileSystem;
+  nodeWorkers?: number;
+  rpc?: RpcCallback;
 }
 
 declare export class ParcelNapi {
   constructor(options: ParcelNapiOptions): ParcelNapi;
+  build(): Promise<void>;
+  static defaultThreadCount(): number;
   testingTempFsReadToString(path: string): string;
   testingTempFsIsDir(path: string): boolean;
   testingTempFsIsFile(path: string): boolean;
   testingRpcPing(): void;
 }
+
+declare export function workerCallback(callback: RpcCallback): void
 
 declare export function initSentry(): void;
 declare export function closeSentry(): void;


### PR DESCRIPTION
- Added `RpcConnection` trait to describe an active worker (or worker pool the case of napi)
- Added `RpcHost` to act as a factory for creating an `RpcConnection`
- Added `RpcConnectionNodejs` to represent the connection to one Nodejs worker
- Added `RpcConnectionNodejsMulti` to load balance across multiple Nodejs workers
  - Currently uses round-robin to schedule work
- Added JavaScript class `ParcelV3` that adds the JS side of the bindings 
  - This will eventually replace `Parcel`, offloading everything to Rust
- Added JavaScript class `ParcelWorker` that handles the bindings for Nodejs workers
- Updated tests to use the new wrapper
  - Not sure how to tests threads in the integration tests, but I tested them in isolation and they work as expected