### PR TITLE
Minor transformer plugin changes

### DIFF
--- a/crates/parcel_core/src/plugin/transformer_plugin.rs
+++ b/crates/parcel_core/src/plugin/transformer_plugin.rs
@@ -1,14 +1,13 @@
+use parcel_filesystem::FileSystemRef;
 use std::fmt::Debug;
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
 
 use parcel_resolver::SpecifierType;
 
-use super::PluginConfig;
-use crate::types::Asset;
-use crate::types::SourceMap;
-
-pub struct AST {}
+use crate::types::{Asset, SourceCode};
+use crate::types::{Dependency, SourceMap};
 
 pub struct GenerateOutput {
   pub content: File,
@@ -26,103 +25,70 @@ pub struct ResolveOptions {
 /// A function that enables transformers to resolve a dependency specifier
 pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, anyhow::Error>;
 
+/// Transformers may run against:
+///
+/// * File-paths that have just been discovered
+/// * Outputs of previous transformation steps, which are in-place modified
+/// * These two scenarios are distinguished
+pub enum TransformationInput {
+  FilePath(PathBuf),
+  Asset(Asset),
+}
+
+impl TransformationInput {
+  pub fn file_path(&self) -> &Path {
+    match self {
+      TransformationInput::FilePath(path) => path,
+      TransformationInput::Asset(asset) => asset.file_path(),
+    }
+  }
+
+  pub fn read_source_code(&self, fs: FileSystemRef) -> anyhow::Result<Rc<SourceCode>> {
+    match self {
+      TransformationInput::FilePath(file_path) => {
+        let code = fs.read_to_string(&file_path)?;
+        let code = SourceCode::from(code);
+        Ok(Rc::new(code))
+      }
+      TransformationInput::Asset(asset) => Ok(asset.source_code.clone()),
+    }
+  }
+}
+
+/// Context parameters for the transformer, other than the input.
+pub struct RunTransformContext {
+  file_system: FileSystemRef,
+}
+
+impl RunTransformContext {
+  pub fn new(file_system: FileSystemRef) -> Self {
+    Self { file_system }
+  }
+
+  pub fn file_system(&self) -> FileSystemRef {
+    self.file_system.clone()
+  }
+}
+
+#[derive(Debug)]
+pub struct TransformResult {
+  pub asset: Asset,
+  pub dependencies: Vec<Dependency>,
+  /// The transformer signals through this field that its result should be invalidated
+  /// if these paths change.
+  pub invalidate_on_file_change: Vec<PathBuf>,
+}
+
 /// Compile a single asset, discover dependencies, or convert the asset to a different format
 ///
 /// Many transformers are wrappers around other tools such as compilers and preprocessors, and are
 /// designed to integrate with Parcel.
 ///
 pub trait TransformerPlugin: Debug + Send + Sync {
-  /// Whether an AST from a previous transformer can be reused to prevent double-parsing
-  ///
-  /// This function should inspect the type and version of the AST to determine if it can be
-  /// reused. When the AST is reused, parsing is skipped. Otherwise the previous transformer
-  /// generate function is called, and the next transformer will parse that result.
-  ///
-  fn can_reuse_ast(&self, ast: AST) -> bool;
-
-  /// Parse the asset code into an AST
-  ///
-  /// This function is called when an AST is not available and can_reuse_ast returns false.
-  ///
-  fn parse(
-    &mut self,
-    config: &PluginConfig,
-    asset: &Asset,
-    resolve: &Resolve,
-  ) -> Result<AST, anyhow::Error>;
-
   /// Transform the asset and/or add new assets
   fn transform(
     &mut self,
-    config: &PluginConfig,
-    asset: &mut Asset,
-    resolve: &Resolve,
-  ) -> Result<Vec<Asset>, anyhow::Error>;
-
-  // Perform processing after the transformation
-  fn post_process(
-    &mut self,
-    config: &PluginConfig,
-    assets: Vec<&Asset>,
-  ) -> Result<Vec<Asset>, anyhow::Error>;
-
-  /// Stringify the AST
-  ///
-  /// This function is called when the next transformer AST cannot be reused, or this is the last
-  /// transformer in a pipeline.
-  ///
-  fn generate(&self, asset: Asset, ast: AST) -> Result<GenerateOutput, anyhow::Error>;
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  #[derive(Debug)]
-  struct TestTransformerPlugin {}
-
-  impl TransformerPlugin for TestTransformerPlugin {
-    fn can_reuse_ast(&self, _ast: AST) -> bool {
-      todo!()
-    }
-
-    fn parse(
-      &mut self,
-      _config: &PluginConfig,
-      _asset: &Asset,
-      _resolve: &Resolve,
-    ) -> Result<AST, anyhow::Error> {
-      todo!()
-    }
-
-    fn transform(
-      &mut self,
-      _config: &PluginConfig,
-      _asset: &mut Asset,
-      _resolve: &Resolve,
-    ) -> Result<Vec<Asset>, anyhow::Error> {
-      todo!()
-    }
-
-    fn post_process(
-      &mut self,
-      _config: &PluginConfig,
-      _assets: Vec<&Asset>,
-    ) -> Result<Vec<Asset>, anyhow::Error> {
-      todo!()
-    }
-
-    fn generate(&self, _asset: Asset, _ast: AST) -> Result<GenerateOutput, anyhow::Error> {
-      todo!()
-    }
-  }
-
-  #[test]
-  fn can_be_defined_in_dyn_vec() {
-    let mut transformers = Vec::<Box<dyn TransformerPlugin>>::new();
-
-    transformers.push(Box::new(TestTransformerPlugin {}));
-
-    assert_eq!(transformers.len(), 1);
-  }
+    context: &mut RunTransformContext,
+    input: TransformationInput,
+  ) -> Result<TransformResult, anyhow::Error>;
 }

--- a/crates/parcel_core/src/types/symbol.rs
+++ b/crates/parcel_core/src/types/symbol.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use super::source::SourceLocation;
 
 /// A map of export names to the corresponding local variable names
-#[derive(Clone, Debug, Deserialize, Hash, Serialize)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Hash, Serialize)]
 pub struct Symbol {
   pub exported: String,
   pub loc: Option<SourceLocation>,

--- a/crates/parcel_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/parcel_plugin_rpc/src/plugin/transformer.rs
@@ -1,14 +1,12 @@
 use std::fmt;
 use std::fmt::Debug;
 
+use anyhow::Error;
+
 use parcel_config::PluginNode;
-use parcel_core::plugin::GenerateOutput;
-use parcel_core::plugin::PluginConfig;
 use parcel_core::plugin::PluginContext;
-use parcel_core::plugin::Resolve;
 use parcel_core::plugin::TransformerPlugin;
-use parcel_core::plugin::AST;
-use parcel_core::types::Asset;
+use parcel_core::plugin::{RunTransformContext, TransformResult, TransformationInput};
 
 pub struct RpcTransformerPlugin {
   _name: String,
@@ -29,37 +27,11 @@ impl RpcTransformerPlugin {
 }
 
 impl TransformerPlugin for RpcTransformerPlugin {
-  fn can_reuse_ast(&self, _ast: AST) -> bool {
-    todo!()
-  }
-
-  fn parse(
-    &mut self,
-    _config: &PluginConfig,
-    _asset: &Asset,
-    _resolve: &Resolve,
-  ) -> Result<AST, anyhow::Error> {
-    todo!()
-  }
-
   fn transform(
     &mut self,
-    _config: &PluginConfig,
-    _asset: &mut Asset,
-    _resolve: &Resolve,
-  ) -> Result<Vec<Asset>, anyhow::Error> {
-    todo!()
-  }
-
-  fn post_process(
-    &mut self,
-    _config: &PluginConfig,
-    _assets: Vec<&Asset>,
-  ) -> Result<Vec<Asset>, anyhow::Error> {
-    todo!()
-  }
-
-  fn generate(&self, _asset: Asset, _ast: AST) -> Result<GenerateOutput, anyhow::Error> {
+    _context: &mut RunTransformContext,
+    _asset: TransformationInput,
+  ) -> Result<TransformResult, Error> {
     todo!()
   }
 }

--- a/crates/parcel_plugin_transformer_js/src/transformer.rs
+++ b/crates/parcel_plugin_transformer_js/src/transformer.rs
@@ -1,10 +1,8 @@
-use parcel_core::plugin::GenerateOutput;
-use parcel_core::plugin::PluginConfig;
 use parcel_core::plugin::PluginContext;
-use parcel_core::plugin::Resolve;
+use parcel_core::plugin::RunTransformContext;
+use parcel_core::plugin::TransformResult;
+use parcel_core::plugin::TransformationInput;
 use parcel_core::plugin::TransformerPlugin;
-use parcel_core::plugin::AST;
-use parcel_core::types::Asset;
 
 #[derive(Debug)]
 pub struct ParcelTransformerJs {}
@@ -16,37 +14,11 @@ impl ParcelTransformerJs {
 }
 
 impl TransformerPlugin for ParcelTransformerJs {
-  fn can_reuse_ast(&self, _ast: AST) -> bool {
-    todo!()
-  }
-
-  fn parse(
-    &mut self,
-    _config: &PluginConfig,
-    _asset: &Asset,
-    _resolve: &Resolve,
-  ) -> Result<AST, anyhow::Error> {
-    todo!()
-  }
-
   fn transform(
     &mut self,
-    _config: &PluginConfig,
-    _asset: &mut Asset,
-    _resolve: &Resolve,
-  ) -> Result<Vec<Asset>, anyhow::Error> {
-    todo!()
-  }
-
-  fn post_process(
-    &mut self,
-    _config: &PluginConfig,
-    _assets: Vec<&Asset>,
-  ) -> Result<Vec<Asset>, anyhow::Error> {
-    todo!()
-  }
-
-  fn generate(&self, _asset: Asset, _ast: AST) -> Result<GenerateOutput, anyhow::Error> {
+    _context: &mut RunTransformContext,
+    _asset: TransformationInput,
+  ) -> Result<TransformResult, anyhow::Error> {
     todo!()
   }
 }


### PR DESCRIPTION
Minor changes to transformer API in preparation for https://github.com/parcel-bundler/parcel/tree/issue/rust-transformer

This removes unnecessary methods from transformer trait & makes minor changes so we get a context type passed in, separate to an input type. This context type will be used to interact with the request API.