### PR TITLE
Remove resolver dependency on core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1831,6 +1831,7 @@ dependencies = [
  "itertools 0.10.5",
  "json_comments",
  "once_cell",
+ "parcel_core",
  "parcel_filesystem",
  "parking_lot",
  "percent-encoding",
@@ -1864,10 +1865,10 @@ name = "parcel_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bitflags 1.3.2",
  "browserslist-rs",
  "dyn-hash",
  "nodejs-semver",
- "parcel-resolver",
  "parcel_filesystem",
  "serde",
  "serde-value",

--- a/crates/parcel_core/Cargo.toml
+++ b/crates/parcel_core/Cargo.toml
@@ -9,9 +9,9 @@ default = []
 
 [dependencies]
 parcel_filesystem = { path = "../parcel_filesystem" }
-parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 
 anyhow = "1.0.82"
+bitflags = "1.3.2"
 browserslist-rs = "0.15.0"
 dyn-hash = "0.x"
 nodejs-semver = "4.0.0"

--- a/crates/parcel_core/src/plugin/transformer_plugin.rs
+++ b/crates/parcel_core/src/plugin/transformer_plugin.rs
@@ -1,18 +1,10 @@
 use parcel_filesystem::FileSystemRef;
 use std::fmt::Debug;
-use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use parcel_resolver::SpecifierType;
-
 use crate::types::{Asset, SourceCode};
-use crate::types::{Dependency, SourceMap};
-
-pub struct GenerateOutput {
-  pub content: File,
-  pub map: Option<SourceMap>,
-}
+use crate::types::{Dependency, SpecifierType};
 
 pub struct ResolveOptions {
   /// A list of custom conditions to use when resolving package.json "exports" and "imports"
@@ -25,11 +17,12 @@ pub struct ResolveOptions {
 /// A function that enables transformers to resolve a dependency specifier
 pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, anyhow::Error>;
 
-/// Transformers may run against:
+/// The input to transform within the plugin
 ///
+/// Transformers may run against two distinguished scenarios:
 /// * File-paths that have just been discovered
 /// * Outputs of previous transformation steps, which are in-place modified
-/// * These two scenarios are distinguished
+///
 pub enum TransformationInput {
   FilePath(PathBuf),
   Asset(Asset),

--- a/crates/parcel_core/src/types.rs
+++ b/crates/parcel_core/src/types.rs
@@ -25,6 +25,8 @@ pub use self::json::*;
 mod parcel_options;
 pub use self::parcel_options::*;
 
+pub mod package_json;
+
 mod source;
 pub use self::source::*;
 

--- a/crates/parcel_core/src/types/dependency.rs
+++ b/crates/parcel_core/src/types/dependency.rs
@@ -2,7 +2,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::path::PathBuf;
 
-use parcel_resolver::ExportsCondition;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_repr::Deserialize_repr;
@@ -11,6 +10,7 @@ use serde_repr::Serialize_repr;
 use super::bundle::BundleBehavior;
 use super::environment::Environment;
 use super::json::JSONObject;
+use super::package_json::ExportsCondition;
 use super::source::SourceLocation;
 use super::symbol::Symbol;
 use super::target::Target;

--- a/crates/parcel_core/src/types/environment.rs
+++ b/crates/parcel_core/src/types/environment.rs
@@ -1,6 +1,6 @@
+use std::collections::HashMap;
 use std::num::NonZeroU32;
 
-use parcel_resolver::IncludeNodeModules;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_repr::Deserialize_repr;
@@ -137,6 +137,34 @@ impl EnvironmentContext {
   pub fn is_electron(&self) -> bool {
     use EnvironmentContext::*;
     matches!(self, ElectronMain | ElectronRenderer)
+  }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum IncludeNodeModules {
+  Bool(bool),
+  Array(Vec<String>),
+  Map(HashMap<String, bool>),
+}
+
+impl Default for IncludeNodeModules {
+  fn default() -> Self {
+    IncludeNodeModules::Bool(true)
+  }
+}
+
+impl std::hash::Hash for IncludeNodeModules {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    match self {
+      IncludeNodeModules::Bool(b) => b.hash(state),
+      IncludeNodeModules::Array(a) => a.hash(state),
+      IncludeNodeModules::Map(m) => {
+        for (k, v) in m {
+          k.hash(state);
+          v.hash(state);
+        }
+      }
+    }
   }
 }
 

--- a/crates/parcel_core/src/types/package_json.rs
+++ b/crates/parcel_core/src/types/package_json.rs
@@ -1,0 +1,75 @@
+use bitflags::bitflags;
+use serde::Deserialize;
+
+bitflags! {
+  /// Represents a condition name within the exports field of package.json
+  pub struct ExportsCondition: u16 {
+    const IMPORT = 1 << 0;
+    const REQUIRE = 1 << 1;
+    const MODULE = 1 << 2;
+    const NODE = 1 << 3;
+    const BROWSER = 1 << 4;
+    const WORKER = 1 << 5;
+    const WORKLET = 1 << 6;
+    const ELECTRON = 1 << 7;
+    const DEVELOPMENT = 1 << 8;
+    const PRODUCTION = 1 << 9;
+    const TYPES = 1 << 10;
+    const DEFAULT = 1 << 11;
+    const STYLE = 1 << 12;
+    const SASS = 1 << 13;
+    const LESS = 1 << 14;
+    const STYLUS = 1 << 15;
+  }
+}
+
+impl Default for ExportsCondition {
+  fn default() -> Self {
+    ExportsCondition::empty()
+  }
+}
+
+impl serde::Serialize for ExportsCondition {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    self.bits().serialize(serializer)
+  }
+}
+
+impl<'de> serde::Deserialize<'de> for ExportsCondition {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let bits = Deserialize::deserialize(deserializer)?;
+    Ok(ExportsCondition::from_bits_truncate(bits))
+  }
+}
+
+impl TryFrom<&str> for ExportsCondition {
+  type Error = ();
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    Ok(match value {
+      "import" => ExportsCondition::IMPORT,
+      "require" => ExportsCondition::REQUIRE,
+      "module" => ExportsCondition::MODULE,
+      "node" => ExportsCondition::NODE,
+      "browser" => ExportsCondition::BROWSER,
+      "worker" => ExportsCondition::WORKER,
+      "worklet" => ExportsCondition::WORKLET,
+      "electron" => ExportsCondition::ELECTRON,
+      "development" => ExportsCondition::DEVELOPMENT,
+      "production" => ExportsCondition::PRODUCTION,
+      "types" => ExportsCondition::TYPES,
+      "default" => ExportsCondition::DEFAULT,
+      "style" => ExportsCondition::STYLE,
+      "sass" => ExportsCondition::SASS,
+      "less" => ExportsCondition::LESS,
+      "stylus" => ExportsCondition::STYLUS,
+      _ => return Err(()),
+    })
+  }
+}

--- a/packages/utils/node-resolver-rs/Cargo.toml
+++ b/packages/utils/node-resolver-rs/Cargo.toml
@@ -5,23 +5,25 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
-url = "2.3.1"
-percent-encoding = "2.2.0"
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.91"
+parcel_core = { path = "../../../crates/parcel_core" }
+parcel_filesystem = { path = "../../../crates/parcel_filesystem" }
+
 bitflags = "1.3.2"
+dashmap = "5.4.0"
+elsa = "1.7.0"
+glob-match = "0.2.1"
 indexmap = { version = "1.9.2", features = ["serde"] }
 itertools = "0.10.5"
 json_comments = { path = "../../../crates/json-comments-rs" }
-parcel_filesystem = { path = "../../../crates/parcel_filesystem" }
-typed-arena = "2.0.2"
-elsa = "1.7.0"
 once_cell = "1.17.0"
-glob-match = "0.2.1"
-dashmap = "5.4.0"
 parking_lot = "0.12"
+percent-encoding = "2.2.0"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.91"
 thiserror = "1.0.59"
+typed-arena = "2.0.2"
+url = "2.3.1"
+xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 
 [dev-dependencies]
 assert_fs = "1.0"

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,8 +8,7 @@ use once_cell::unsync::OnceCell;
 use package_json::AliasValue;
 use package_json::ExportsResolution;
 use package_json::PackageJson;
-use serde::Deserialize;
-use serde::Serialize;
+pub use parcel_core::types::IncludeNodeModules;
 use tsconfig::TsConfig;
 
 mod builtins;
@@ -74,34 +72,6 @@ bitflags! {
     const NODE_ESM = Self::EXPORTS.bits;
     /// Default TypeScript settings.
     const TYPESCRIPT = Self::TSCONFIG.bits | Self::EXPORTS.bits | Self::DIR_INDEX.bits | Self::OPTIONAL_EXTENSIONS.bits | Self::TYPESCRIPT_EXTENSIONS.bits | Self::EXPORTS_OPTIONAL_EXTENSIONS.bits;
-  }
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub enum IncludeNodeModules {
-  Bool(bool),
-  Array(Vec<String>),
-  Map(HashMap<String, bool>),
-}
-
-impl Default for IncludeNodeModules {
-  fn default() -> Self {
-    IncludeNodeModules::Bool(true)
-  }
-}
-
-impl std::hash::Hash for IncludeNodeModules {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    match self {
-      IncludeNodeModules::Bool(b) => b.hash(state),
-      IncludeNodeModules::Array(a) => a.hash(state),
-      IncludeNodeModules::Map(m) => {
-        for (k, v) in m {
-          k.hash(state);
-          v.hash(state);
-        }
-      }
-    }
   }
 }
 
@@ -1230,7 +1200,7 @@ impl<'a> ResolveRequest<'a> {
 
 #[cfg(test)]
 mod tests {
-  use std::collections::HashSet;
+  use std::collections::{HashMap, HashSet};
 
   use super::cache::Cache;
   use super::*;

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -9,6 +9,7 @@ use bitflags::bitflags;
 use glob_match::glob_match;
 use glob_match::glob_match_with_captures;
 use indexmap::IndexMap;
+pub use parcel_core::types::package_json::ExportsCondition;
 use serde::Deserialize;
 
 use crate::path::resolve_path;
@@ -97,77 +98,6 @@ pub enum ExportsField<'a> {
   String(&'a str),
   Array(Vec<ExportsField<'a>>),
   Map(IndexMap<ExportsKey<'a>, ExportsField<'a>>),
-}
-
-bitflags! {
-  pub struct ExportsCondition: u16 {
-    const IMPORT = 1 << 0;
-    const REQUIRE = 1 << 1;
-    const MODULE = 1 << 2;
-    const NODE = 1 << 3;
-    const BROWSER = 1 << 4;
-    const WORKER = 1 << 5;
-    const WORKLET = 1 << 6;
-    const ELECTRON = 1 << 7;
-    const DEVELOPMENT = 1 << 8;
-    const PRODUCTION = 1 << 9;
-    const TYPES = 1 << 10;
-    const DEFAULT = 1 << 11;
-    const STYLE = 1 << 12;
-    const SASS = 1 << 13;
-    const LESS = 1 << 14;
-    const STYLUS = 1 << 15;
-  }
-}
-
-impl Default for ExportsCondition {
-  fn default() -> Self {
-    ExportsCondition::empty()
-  }
-}
-
-impl serde::Serialize for ExportsCondition {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: serde::Serializer,
-  {
-    self.bits().serialize(serializer)
-  }
-}
-
-impl<'de> serde::Deserialize<'de> for ExportsCondition {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: serde::Deserializer<'de>,
-  {
-    let bits = Deserialize::deserialize(deserializer)?;
-    Ok(ExportsCondition::from_bits_truncate(bits))
-  }
-}
-
-impl TryFrom<&str> for ExportsCondition {
-  type Error = ();
-  fn try_from(value: &str) -> Result<Self, Self::Error> {
-    Ok(match value {
-      "import" => ExportsCondition::IMPORT,
-      "require" => ExportsCondition::REQUIRE,
-      "module" => ExportsCondition::MODULE,
-      "node" => ExportsCondition::NODE,
-      "browser" => ExportsCondition::BROWSER,
-      "worker" => ExportsCondition::WORKER,
-      "worklet" => ExportsCondition::WORKLET,
-      "electron" => ExportsCondition::ELECTRON,
-      "development" => ExportsCondition::DEVELOPMENT,
-      "production" => ExportsCondition::PRODUCTION,
-      "types" => ExportsCondition::TYPES,
-      "default" => ExportsCondition::DEFAULT,
-      "style" => ExportsCondition::STYLE,
-      "sass" => ExportsCondition::SASS,
-      "less" => ExportsCondition::LESS,
-      "stylus" => ExportsCondition::STYLUS,
-      _ => return Err(()),
-    })
-  }
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
# ↪️ Pull Request

These changes remove the `parcel-resolver` dependency in the `parcel_core` crate. This will prevent circular dependencies down the line, when types within the resolver need to reference the core types. To reduce the resolver crate size in future, we may want to further split up the core crate into a dedicated `environment` or `package_json` crate but this is unnecessary at the moment.

## 🚨 Test instructions

`yarn build-native && cargo test`