### PR TITLE
Clean-up dfsFast feature-flag

### DIFF
--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -56,7 +56,6 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
     exampleFeature: false,
     configKeyInvalidation: false,
     parcelV3: false,
-    dfsFasterRefactor: false,
   },
 };
 

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -9,7 +9,6 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   exampleFeature: false,
   configKeyInvalidation: false,
   parcelV3: false,
-  dfsFasterRefactor: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -10,10 +10,6 @@ export type FeatureFlags = {|
    */
   +configKeyInvalidation: boolean,
   /**
-   * Refactors dfsNew to use an iterative approach.
-   */
-  +dfsFasterRefactor: boolean,
-  /**
    * Rust backed requests
    */
   +parcelV3: boolean,

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -3,7 +3,6 @@
 import {fromNodeId} from './types';
 import AdjacencyList, {type SerializedAdjacencyList} from './AdjacencyList';
 import type {Edge, NodeId} from './types';
-import {getFeatureFlag} from '@parcel/feature-flags';
 import type {
   TraversalActions,
   GraphVisitor,

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -335,17 +335,11 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     ) {
       return this.dfsFast(enter, startNodeId);
     } else {
-      return getFeatureFlag('dfsFasterRefactor')
-        ? this.dfsNew({
-            visit,
-            startNodeId,
-            getChildren: nodeId => this.getNodeIdsConnectedFrom(nodeId, type),
-          })
-        : this.dfs({
-            visit,
-            startNodeId,
-            getChildren: nodeId => this.getNodeIdsConnectedFrom(nodeId, type),
-          });
+      return this.dfs({
+        visit,
+        startNodeId,
+        getChildren: nodeId => this.getNodeIdsConnectedFrom(nodeId, type),
+      });
     }
   }
 
@@ -506,7 +500,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
    *
    * This replaces `dfs` and will replace `dfsFast`.
    */
-  dfsNew<TContext>({
+  dfs<TContext>({
     visit,
     startNodeId,
     getChildren,
@@ -607,103 +601,6 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     }
 
     this._visited = visited;
-  }
-
-  /**
-   * @deprecated Will be replaced by `dfsNew`
-   */
-  dfs<TContext>({
-    visit,
-    startNodeId,
-    getChildren,
-  }: DFSParams<TContext>): ?TContext {
-    let traversalStartNode = nullthrows(
-      startNodeId ?? this.rootNodeId,
-      'A start node is required to traverse',
-    );
-    this._assertHasNodeId(traversalStartNode);
-
-    let visited;
-    if (!this._visited || this._visited.capacity < this.nodes.length) {
-      this._visited = new BitSet(this.nodes.length);
-      visited = this._visited;
-    } else {
-      visited = this._visited;
-      visited.clear();
-    }
-    // Take shared instance to avoid re-entrancy issues.
-    this._visited = null;
-
-    let stopped = false;
-    let skipped = false;
-    let actions: TraversalActions = {
-      skipChildren() {
-        skipped = true;
-      },
-      stop() {
-        stopped = true;
-      },
-    };
-
-    let walk = (nodeId, context: ?TContext) => {
-      if (!this.hasNode(nodeId)) return;
-      visited.add(nodeId);
-
-      skipped = false;
-      let enter = typeof visit === 'function' ? visit : visit.enter;
-      if (enter) {
-        let newContext = enter(nodeId, context, actions);
-        if (typeof newContext !== 'undefined') {
-          // $FlowFixMe[reassign-const]
-          context = newContext;
-        }
-      }
-
-      if (skipped) {
-        return;
-      }
-
-      if (stopped) {
-        return context;
-      }
-
-      for (let child of getChildren(nodeId)) {
-        if (visited.has(child)) {
-          continue;
-        }
-
-        visited.add(child);
-        let result = walk(child, context);
-        if (stopped) {
-          return result;
-        }
-      }
-
-      if (
-        typeof visit !== 'function' &&
-        visit.exit &&
-        // Make sure the graph still has the node: it may have been removed between enter and exit
-        this.hasNode(nodeId)
-      ) {
-        let newContext = visit.exit(nodeId, context, actions);
-        if (typeof newContext !== 'undefined') {
-          // $FlowFixMe[reassign-const]
-          context = newContext;
-        }
-      }
-
-      if (skipped) {
-        return;
-      }
-
-      if (stopped) {
-        return context;
-      }
-    };
-
-    let result = walk(traversalStartNode);
-    this._visited = visited;
-    return result;
   }
 
   bfs(visit: (nodeId: NodeId) => ?boolean): ?NodeId {

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -4,7 +4,7 @@ import assert from 'assert';
 import sinon from 'sinon';
 import type {TraversalActions} from '@parcel/types-internal';
 
-import Graph, {type DFSParams} from '../src/Graph';
+import Graph from '../src/Graph';
 import {toNodeId, type NodeId} from '../src/types';
 
 describe('Graph', () => {

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -343,38 +343,62 @@ describe('Graph', () => {
   });
 
   describe('dfs(...)', () => {
-    function testSuite(
-      name: string,
-      dfsImpl: (graph: Graph<string>, DFSParams<mixed>) => mixed | null | void,
-    ) {
-      it(`${name} throws if the graph is empty`, () => {
-        const graph = new Graph();
-        const visit = sinon.stub();
-        const getChildren = sinon.stub();
-        assert.throws(() => {
-          dfsImpl(graph, {
-            visit,
-            startNodeId: 0,
-            getChildren,
-          });
-        }, /Does not have node 0/);
-      });
-
-      it(`${name} visits a single node`, () => {
-        const graph = new Graph();
-        graph.addNode('root');
-        const visit = sinon.stub();
-        const getChildren = () => [];
-        dfsImpl(graph, {
+    it(`throws if the graph is empty`, () => {
+      const graph = new Graph();
+      const visit = sinon.stub();
+      const getChildren = sinon.stub();
+      assert.throws(() => {
+        graph.dfs({
           visit,
           startNodeId: 0,
           getChildren,
         });
+      }, /Does not have node 0/);
+    });
 
-        assert(visit.calledOnce);
+    it(`visits a single node`, () => {
+      const graph = new Graph();
+      graph.addNode('root');
+      const visit = sinon.stub();
+      const getChildren = () => [];
+      graph.dfs({
+        visit,
+        startNodeId: 0,
+        getChildren,
       });
 
-      it(`${name} visits all connected nodes in DFS order`, () => {
+      assert(visit.calledOnce);
+    });
+
+    it(`visits all connected nodes in DFS order`, () => {
+      const graph = new Graph();
+      graph.addNode('0');
+      graph.addNode('1');
+      graph.addNode('2');
+      graph.addNode('3');
+      graph.addNode('disconnected-1');
+      graph.addNode('disconnected-2');
+      graph.addEdge(0, 1);
+      graph.addEdge(0, 2);
+      graph.addEdge(1, 3);
+      graph.addEdge(2, 3);
+
+      const order = [];
+      const visit = (node: NodeId) => {
+        order.push(node);
+      };
+      const getChildren = (node: NodeId) => graph.getNodeIdsConnectedFrom(node);
+      graph.dfs({
+        visit,
+        startNodeId: 0,
+        getChildren,
+      });
+
+      assert.deepEqual(order, [0, 1, 3, 2]);
+    });
+
+    describe(`actions tests`, () => {
+      it(`skips children if skip is called on a node`, () => {
         const graph = new Graph();
         graph.addNode('0');
         graph.addNode('1');
@@ -383,187 +407,153 @@ describe('Graph', () => {
         graph.addNode('disconnected-1');
         graph.addNode('disconnected-2');
         graph.addEdge(0, 1);
-        graph.addEdge(0, 2);
-        graph.addEdge(1, 3);
-        graph.addEdge(2, 3);
+        graph.addEdge(1, 2);
+        graph.addEdge(0, 3);
 
         const order = [];
-        const visit = (node: NodeId) => {
+        const visit = (
+          node: NodeId,
+          context: mixed | null,
+          actions: TraversalActions,
+        ) => {
+          if (node === 1) actions.skipChildren();
           order.push(node);
         };
         const getChildren = (node: NodeId) =>
           graph.getNodeIdsConnectedFrom(node);
-        dfsImpl(graph, {
+        graph.dfs({
           visit,
           startNodeId: 0,
           getChildren,
         });
 
-        assert.deepEqual(order, [0, 1, 3, 2]);
+        assert.deepEqual(order, [0, 1, 3]);
       });
 
-      describe(`${name} actions tests`, () => {
-        it(`${name} skips children if skip is called on a node`, () => {
-          const graph = new Graph();
-          graph.addNode('0');
-          graph.addNode('1');
-          graph.addNode('2');
-          graph.addNode('3');
-          graph.addNode('disconnected-1');
-          graph.addNode('disconnected-2');
-          graph.addEdge(0, 1);
-          graph.addEdge(1, 2);
-          graph.addEdge(0, 3);
+      it(`stops the traversal if stop is called`, () => {
+        const graph = new Graph();
+        graph.addNode('0');
+        graph.addNode('1');
+        graph.addNode('2');
+        graph.addNode('3');
+        graph.addNode('disconnected-1');
+        graph.addNode('disconnected-2');
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 2);
+        graph.addEdge(1, 3);
+        graph.addEdge(0, 2);
+        graph.addEdge(2, 3);
 
-          const order = [];
-          const visit = (
-            node: NodeId,
-            context: mixed | null,
-            actions: TraversalActions,
-          ) => {
-            if (node === 1) actions.skipChildren();
-            order.push(node);
-          };
-          const getChildren = (node: NodeId) =>
-            graph.getNodeIdsConnectedFrom(node);
-          dfsImpl(graph, {
-            visit,
-            startNodeId: 0,
-            getChildren,
-          });
-
-          assert.deepEqual(order, [0, 1, 3]);
+        const order = [];
+        const visit = (
+          node: NodeId,
+          context: mixed | null,
+          actions: TraversalActions,
+        ) => {
+          order.push(node);
+          if (node === 1) {
+            actions.stop();
+            return 'result';
+          }
+          return 'other';
+        };
+        const getChildren = (node: NodeId) =>
+          graph.getNodeIdsConnectedFrom(node);
+        const result = graph.dfs({
+          visit,
+          startNodeId: 0,
+          getChildren,
         });
 
-        it(`${name} stops the traversal if stop is called`, () => {
-          const graph = new Graph();
-          graph.addNode('0');
-          graph.addNode('1');
-          graph.addNode('2');
-          graph.addNode('3');
-          graph.addNode('disconnected-1');
-          graph.addNode('disconnected-2');
-          graph.addEdge(0, 1);
-          graph.addEdge(1, 2);
-          graph.addEdge(1, 3);
-          graph.addEdge(0, 2);
-          graph.addEdge(2, 3);
-
-          const order = [];
-          const visit = (
-            node: NodeId,
-            context: mixed | null,
-            actions: TraversalActions,
-          ) => {
-            order.push(node);
-            if (node === 1) {
-              actions.stop();
-              return 'result';
-            }
-            return 'other';
-          };
-          const getChildren = (node: NodeId) =>
-            graph.getNodeIdsConnectedFrom(node);
-          const result = dfsImpl(graph, {
-            visit,
-            startNodeId: 0,
-            getChildren,
-          });
-
-          assert.deepEqual(order, [0, 1]);
-          assert.equal(result, 'result');
-        });
+        assert.deepEqual(order, [0, 1]);
+        assert.equal(result, 'result');
       });
+    });
 
-      describe(`${name} context tests`, () => {
-        it(`${name} passes the context between visitors`, () => {
-          const graph = new Graph();
-          graph.addNode('0');
-          graph.addNode('1');
-          graph.addNode('2');
-          graph.addNode('3');
-          graph.addNode('disconnected-1');
-          graph.addNode('disconnected-2');
-          graph.addEdge(0, 1);
-          graph.addEdge(1, 2);
-          graph.addEdge(1, 3);
-          graph.addEdge(0, 2);
-          graph.addEdge(2, 3);
+    describe(`context tests`, () => {
+      it(`passes the context between visitors`, () => {
+        const graph = new Graph();
+        graph.addNode('0');
+        graph.addNode('1');
+        graph.addNode('2');
+        graph.addNode('3');
+        graph.addNode('disconnected-1');
+        graph.addNode('disconnected-2');
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 2);
+        graph.addEdge(1, 3);
+        graph.addEdge(0, 2);
+        graph.addEdge(2, 3);
 
-          const contexts = [];
-          const visit = (node: NodeId, context: mixed | null) => {
-            contexts.push([node, context]);
-            return `node-${node}-created-context`;
-          };
-          const getChildren = (node: NodeId) =>
-            graph.getNodeIdsConnectedFrom(node);
-          const result = dfsImpl(graph, {
-            visit,
-            startNodeId: 0,
-            getChildren,
-          });
-
-          assert.deepEqual(contexts, [
-            [0, undefined],
-            [1, 'node-0-created-context'],
-            [2, 'node-1-created-context'],
-            [3, 'node-2-created-context'],
-          ]);
-          assert.equal(result, undefined);
+        const contexts = [];
+        const visit = (node: NodeId, context: mixed | null) => {
+          contexts.push([node, context]);
+          return `node-${node}-created-context`;
+        };
+        const getChildren = (node: NodeId) =>
+          graph.getNodeIdsConnectedFrom(node);
+        const result = graph.dfs({
+          visit,
+          startNodeId: 0,
+          getChildren,
         });
+
+        assert.deepEqual(contexts, [
+          [0, undefined],
+          [1, 'node-0-created-context'],
+          [2, 'node-1-created-context'],
+          [3, 'node-2-created-context'],
+        ]);
+        assert.equal(result, undefined);
       });
+    });
 
-      describe(`${name} exit visitor tests`, () => {
-        it(`${name} calls the exit visitor`, () => {
-          const graph = new Graph();
-          graph.addNode('0');
-          graph.addNode('1');
-          graph.addNode('2');
-          graph.addNode('3');
-          graph.addNode('disconnected-1');
-          graph.addNode('disconnected-2');
-          graph.addEdge(0, 1);
-          graph.addEdge(1, 2);
-          graph.addEdge(1, 3);
-          graph.addEdge(0, 2);
+    describe(`exit visitor tests`, () => {
+      it(`calls the exit visitor`, () => {
+        const graph = new Graph();
+        graph.addNode('0');
+        graph.addNode('1');
+        graph.addNode('2');
+        graph.addNode('3');
+        graph.addNode('disconnected-1');
+        graph.addNode('disconnected-2');
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 2);
+        graph.addEdge(1, 3);
+        graph.addEdge(0, 2);
 
-          const contexts = [];
-          const visit = (node: NodeId, context: mixed | null) => {
-            contexts.push([node, context]);
-            return `node-${node}-created-context`;
-          };
-          const visitExit = (node: NodeId, context: mixed | null) => {
-            contexts.push(['exit', node, context]);
-            return `node-exit-${node}-created-context`;
-          };
-          const getChildren = (node: NodeId) =>
-            graph.getNodeIdsConnectedFrom(node);
-          const result = dfsImpl(graph, {
-            visit: {
-              enter: visit,
-              exit: visitExit,
-            },
-            startNodeId: 0,
-            getChildren,
-          });
-
-          assert.deepEqual(contexts, [
-            [0, undefined],
-            [1, 'node-0-created-context'],
-            [2, 'node-1-created-context'],
-            ['exit', 2, 'node-2-created-context'],
-            [3, 'node-1-created-context'],
-            ['exit', 3, 'node-3-created-context'],
-            ['exit', 1, 'node-1-created-context'],
-            ['exit', 0, 'node-0-created-context'],
-          ]);
-          assert.equal(result, undefined);
+        const contexts = [];
+        const visit = (node: NodeId, context: mixed | null) => {
+          contexts.push([node, context]);
+          return `node-${node}-created-context`;
+        };
+        const visitExit = (node: NodeId, context: mixed | null) => {
+          contexts.push(['exit', node, context]);
+          return `node-exit-${node}-created-context`;
+        };
+        const getChildren = (node: NodeId) =>
+          graph.getNodeIdsConnectedFrom(node);
+        const result = graph.dfs({
+          visit: {
+            enter: visit,
+            exit: visitExit,
+          },
+          startNodeId: 0,
+          getChildren,
         });
+
+        assert.deepEqual(contexts, [
+          [0, undefined],
+          [1, 'node-0-created-context'],
+          [2, 'node-1-created-context'],
+          ['exit', 2, 'node-2-created-context'],
+          [3, 'node-1-created-context'],
+          ['exit', 3, 'node-3-created-context'],
+          ['exit', 1, 'node-1-created-context'],
+          ['exit', 0, 'node-0-created-context'],
+        ]);
+        assert.equal(result, undefined);
       });
-    }
-
-    testSuite('dfs', (graph, params) => graph.dfs(params));
-
-    testSuite('dfsNew', (graph, params) => graph.dfsNew(params));
+    });
   });
 });

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -1320,7 +1320,6 @@ describe('cache', function () {
             exampleFeature: false,
             configKeyInvalidation: true,
             parcelV3: false,
-            dfsFasterRefactor: false,
           },
           async setup() {
             let pkgFile = path.join(inputDir, 'package.json');
@@ -1382,7 +1381,6 @@ describe('cache', function () {
             exampleFeature: false,
             configKeyInvalidation: true,
             parcelV3: false,
-            dfsFasterRefactor: false,
           },
           async setup() {
             let pkgFile = path.join(inputDir, 'package.json');
@@ -1444,7 +1442,6 @@ describe('cache', function () {
             exampleFeature: false,
             configKeyInvalidation: true,
             parcelV3: false,
-            dfsFasterRefactor: false,
           },
           async setup() {
             let pkgFile = path.join(inputDir, 'package.json');


### PR DESCRIPTION
Clean-up feature-flag controlling DFS refactor from recursive to iterative implementation. No significant performance difference has been observed in production.