### PR TITLE
V3: Added default thread count and build options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dyn-hash",
+ "num_cpus",
  "parcel-resolver",
  "parcel_config",
  "parcel_core",
@@ -1797,7 +1798,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "num_cpus",
  "once_cell",
  "oxipng",
  "parcel",

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -31,7 +31,6 @@ toml = "0.8.12"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
-num_cpus = "1.16.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 parcel = { path = "../parcel", features = ["nodejs"] }

--- a/crates/node-bindings/src/file_system/file_system_napi.rs
+++ b/crates/node-bindings/src/file_system/file_system_napi.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use napi::bindgen_prelude::FromNapiValue;
 use napi::threadsafe_function::ThreadsafeFunctionCallMode;
@@ -8,7 +7,6 @@ use napi::Env;
 use napi::JsFunction;
 use napi::JsObject;
 use parcel::file_system::FileSystem;
-use parcel::file_system::FileSystemRef;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -39,15 +37,6 @@ impl FileSystemNapi {
         "isDir",
       )?),
     })
-  }
-
-  pub fn from_options(env: &Env, options: &JsObject) -> napi::Result<Option<FileSystemRef>> {
-    let mut fs = None::<FileSystemRef>;
-    if options.has_named_property("fs")? {
-      let fs_raw: JsObject = options.get_named_property("fs")?;
-      fs.replace(Arc::new(FileSystemNapi::new(&env, &fs_raw)?));
-    }
-    Ok(fs)
   }
 }
 

--- a/crates/parcel/Cargo.toml
+++ b/crates/parcel/Cargo.toml
@@ -21,3 +21,4 @@ anyhow = "1.0.82"
 dyn-hash = "0.x"
 petgraph = "0.x"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
+num_cpus = "1.16.0"

--- a/crates/parcel/src/parcel.rs
+++ b/crates/parcel/src/parcel.rs
@@ -10,12 +10,27 @@ use parcel_plugin_rpc::RpcHostRef;
 pub struct Parcel {
   pub fs: FileSystemRef,
   pub rpc: Option<RpcHostRef>,
+  pub threads: usize,
 }
 
 pub struct ParcelOptions {
   pub fs: Option<FileSystemRef>,
   pub rpc: Option<RpcHostRef>,
+  pub threads: usize,
 }
+
+impl Default for ParcelOptions {
+  fn default() -> Self {
+    Self {
+      fs: Some(Arc::new(OsFileSystem::default())),
+      rpc: Default::default(),
+      threads: num_cpus::get(),
+    }
+  }
+}
+
+pub struct BuildOptions;
+pub struct BuildResult;
 
 impl Parcel {
   pub fn new(options: ParcelOptions) -> Self {
@@ -28,16 +43,17 @@ impl Parcel {
     Self {
       fs,
       rpc: options.rpc,
+      threads: options.threads,
     }
   }
 
-  pub fn build(&self) -> anyhow::Result<()> {
+  pub fn build(&self, options: BuildOptions) -> anyhow::Result<BuildResult> {
     let mut _rpc_connection = None::<RpcConnectionRef>;
 
     if let Some(rpc_host) = &self.rpc {
       _rpc_connection = Some(rpc_host.start()?);
     }
 
-    Ok(())
+    Ok(BuildResult {})
   }
 }

--- a/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
+++ b/crates/parcel_plugin_rpc/src/nodejs/rpc_host_nodejs.rs
@@ -21,11 +21,11 @@ use super::RpcConnectionNodejsMulti;
 // the lazy initialization of Nodejs worker threads.
 pub struct RpcHostNodejs {
   threadsafe_function: ThreadsafeFunction<RpcHostMessage>,
-  node_workers: u32,
+  node_workers: usize,
 }
 
 impl RpcHostNodejs {
-  pub fn new(env: &Env, callback: JsFunction, node_workers: u32) -> napi::Result<Self> {
+  pub fn new(env: &Env, callback: JsFunction, node_workers: usize) -> napi::Result<Self> {
     // Create a threadsafe function that casts the incoming message data to something
     // accessible in JavaScript. The function accepts a return value from a JS callback
     let mut threadsafe_function: ThreadsafeFunction<RpcHostMessage> = env

--- a/packages/core/core/src/parcel-v3/Parcel.js
+++ b/packages/core/core/src/parcel-v3/Parcel.js
@@ -16,10 +16,11 @@ export type ParcelV3BuildOptions = {||};
 export class ParcelV3 {
   _internal: napi.ParcelNapi;
 
-  constructor({threads, nodeWorkers}: ParcelV3Options) {
+  constructor({threads, nodeWorkers, fs}: ParcelV3Options) {
     this._internal = new napi.ParcelNapi({
       threads,
       nodeWorkers,
+      fs,
       rpc: async (err, id, data, done) => {
         try {
           if (err) {

--- a/packages/core/core/src/parcel-v3/Parcel.js
+++ b/packages/core/core/src/parcel-v3/Parcel.js
@@ -11,15 +11,12 @@ export type ParcelV3Options = {|
   fs?: FileSystem,
 |};
 
+export type ParcelV3BuildOptions = {||};
+
 export class ParcelV3 {
   _internal: napi.ParcelNapi;
-  #nodeWorkerCount: number;
 
-  constructor({
-    threads = napi.ParcelNapi.defaultThreadCount(),
-    nodeWorkers,
-  }: ParcelV3Options) {
-    this.#nodeWorkerCount = nodeWorkers || threads;
+  constructor({threads, nodeWorkers}: ParcelV3Options) {
     this._internal = new napi.ParcelNapi({
       threads,
       nodeWorkers,
@@ -49,12 +46,12 @@ export class ParcelV3 {
     }
   }
 
-  async build(): Promise<any> {
+  async build(options: ParcelV3BuildOptions): Promise<any> {
     // initialize workers lazily
     const workers = this.#startWorkers();
 
     // Run the Parcel build
-    let result = await this._internal.build();
+    let result = await this._internal.build(options);
 
     // Stop workers
     this.#stopWorkers(await workers);
@@ -65,7 +62,7 @@ export class ParcelV3 {
     const workersOnLoad = [];
     const workers = [];
 
-    for (let i = 0; i < this.#nodeWorkerCount; i++) {
+    for (let i = 0; i < this._internal.nodeWorkerCount; i++) {
       let worker = new Worker(path.join(__dirname, 'worker', 'index.js'));
       workers.push(worker);
       workersOnLoad.push(

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -44,6 +44,6 @@ describe('parcel-v3', function () {
     assert(await parcel._internal.testingTempFsIsFile(__filename));
     await parcel._internal.testingRpcPing();
 
-    await parcel.build();
+    await parcel.build({});
   });
 });

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -25,8 +25,9 @@ export interface ParcelNapiOptions {
 }
 
 declare export class ParcelNapi {
+  nodeWorkerCount: number,
   constructor(options: ParcelNapiOptions): ParcelNapi;
-  build(): Promise<void>;
+  build(options: {||}): Promise<void>;
   static defaultThreadCount(): number;
   testingTempFsReadToString(path: string): string;
   testingTempFsIsDir(path: string): boolean;


### PR DESCRIPTION
- Moved setting the default `nodeWorkers` option to Rust
- Setting default Rust `threads` count to be available CPUs
- Setting default `node_worker_count` to be the value set for the Rust `threads`
- Updated `build` to run asynchronously without blocking + parsing the options/return values
- Added `BuildOptions` and `BuildResult` to `Parcel.build()`