### PR TITLE
Improve constant module bundling error message

### DIFF
--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -924,7 +924,13 @@ ${code}
     if (resolved.meta.isConstantModule) {
       invariant(
         this.bundle.hasAsset(resolved),
-        'Constant module not found in bundle',
+        `Constant module ${path.relative(
+          this.options.projectRoot,
+          resolved.filePath,
+        )} referenced from ${path.relative(
+          this.options.projectRoot,
+          parentAsset.filePath,
+        )} not found in bundle ${this.bundle.name}`,
       );
       return false;
     }

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -17,7 +17,7 @@ import {
 } from '@parcel/utils';
 import SourceMap from '@parcel/source-map';
 import nullthrows from 'nullthrows';
-import invariant from 'assert';
+import invariant, {AssertionError} from 'assert';
 import ThrowableDiagnostic, {
   convertSourceLocationToHighlight,
 } from '@parcel/diagnostic';
@@ -922,16 +922,17 @@ ${code}
 
   isWrapped(resolved: Asset, parentAsset: Asset): boolean {
     if (resolved.meta.isConstantModule) {
-      invariant(
-        this.bundle.hasAsset(resolved),
-        `Constant module ${path.relative(
-          this.options.projectRoot,
-          resolved.filePath,
-        )} referenced from ${path.relative(
-          this.options.projectRoot,
-          parentAsset.filePath,
-        )} not found in bundle ${this.bundle.name}`,
-      );
+      if (!this.bundle.hasAsset(resolved)) {
+        throw new AssertionError({
+          message: `Constant module ${path.relative(
+            this.options.projectRoot,
+            resolved.filePath,
+          )} referenced from ${path.relative(
+            this.options.projectRoot,
+            parentAsset.filePath,
+          )} not found in bundle ${this.bundle.name}`,
+        });
+      }
       return false;
     }
     return (


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Improves the error message when a constant module cannot be found during packaging.

Before:
```
@parcel/packager-js: Constant module not found in bundle
```

After:
```
@parcel/packager-js: Constant module ../platform/packages/analytics/analytics-gas-types/src/index.ts referenced from
../platform/packages/analytics/analytics-listeners/src/fabric/process-event-payload.tsx not found in bundle
shared~vendor~atlaskit.HASH_REF_bb77a59655d528f0.js
```