### PR TITLE
Hide random cache keys under feature-flag

### DIFF
--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -8,6 +8,7 @@ import stream from 'stream';
 import path from 'path';
 import {promisify} from 'util';
 import {serialize, deserialize, registerSerializableClass} from '@parcel/core';
+import {getFeatureFlag} from '@parcel/feature-flags';
 import {NodeFS} from '@parcel/fs';
 // flowlint-next-line untyped-import:off
 import packageJson from '../package.json';
@@ -148,7 +149,9 @@ export class LMDBCache implements Cache {
     }
 
     // $FlowFixMe flow libs are outdated but we only support node>16 so randomUUID is present
-    const largeBlobKey = `${key}_${crypto.randomUUID()}`;
+    const largeBlobKey = getFeatureFlag('randomLargeBlobKeys')
+      ? `${key}_${crypto.randomUUID()}`
+      : key;
     await this.fsCache.setLargeBlob(largeBlobKey, contents, options);
     const entry: LargeBlobEntry = {type: 'LARGE_BLOB', largeBlobKey};
     await this.set(key, entry);

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -148,9 +148,9 @@ export class LMDBCache implements Cache {
       await this.fsCache.deleteLargeBlob(previousEntry.largeBlobKey);
     }
 
-    // $FlowFixMe flow libs are outdated but we only support node>16 so randomUUID is present
     const largeBlobKey = getFeatureFlag('randomLargeBlobKeys')
-      ? `${key}_${crypto.randomUUID()}`
+      ? // $FlowFixMe flow libs are outdated but we only support node>16 so randomUUID is present
+        `${key}_${crypto.randomUUID()}`
       : key;
     await this.fsCache.setLargeBlob(largeBlobKey, contents, options);
     const entry: LargeBlobEntry = {type: 'LARGE_BLOB', largeBlobKey};

--- a/packages/core/cache/test/LMDBCache.test.js
+++ b/packages/core/cache/test/LMDBCache.test.js
@@ -1,5 +1,6 @@
 // @flow
 
+import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '@parcel/feature-flags';
 import * as mkdirp from 'mkdirp';
 import * as tempy from 'tempy';
 import fs from 'fs';
@@ -15,6 +16,17 @@ describe('LMDBCache', () => {
     mkdirp.sync(tmpDir);
     lmdbCache = new LMDBCache(tmpDir);
     await lmdbCache.ensure();
+
+    setFeatureFlags({
+      ...DEFAULT_FEATURE_FLAGS,
+      randomLargeBlobKeys: true,
+    });
+  });
+
+  afterEach(() => {
+    setFeatureFlags({
+      ...DEFAULT_FEATURE_FLAGS,
+    });
   });
 
   it('LMDBCache::get / set will return key values', async () => {

--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -6,6 +6,7 @@ import {FSCache} from '@parcel/cache';
 import tempy from 'tempy';
 import path from 'path';
 import {inputFS, outputFS} from '@parcel/test-utils';
+import {DEFAULT_FEATURE_FLAGS} from '@parcel/feature-flags';
 import {relativePath} from '@parcel/utils';
 import {NodePackageManager} from '@parcel/package-manager';
 import {createEnvironment} from '../src/Environment';
@@ -53,9 +54,7 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
     sourceMaps: false,
   },
   featureFlags: {
-    exampleFeature: false,
-    configKeyInvalidation: false,
-    parcelV3: false,
+    ...DEFAULT_FEATURE_FLAGS,
   },
 };
 

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -9,6 +9,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   exampleFeature: false,
   configKeyInvalidation: false,
   parcelV3: false,
+  randomLargeBlobKeys: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -13,4 +13,8 @@ export type FeatureFlags = {|
    * Rust backed requests
    */
   +parcelV3: boolean,
+  /**
+   * Store large blobs on randomly generated keys
+   */
+  +randomLargeBlobKeys: boolean,
 |};


### PR DESCRIPTION
The idea of this change is to make it safer to bump parcel to the latest version without risking leaving too many dangling cache files in case the clean-up mechanisms do not work.

