### PR TITLE
Avoid boxing RequestTracker parameters

### DIFF
--- a/crates/parcel/src/request_tracker/request.rs
+++ b/crates/parcel/src/request_tracker/request.rs
@@ -29,8 +29,7 @@ impl<'a, T: Clone> RunRequestContext<'a, T> {
     // TODO
   }
 
-  // TODO: Why is this boxed?
-  pub fn run_request(&mut self, request: Box<&dyn Request<T>>) -> anyhow::Result<T> {
+  pub fn run_request(&mut self, request: &impl Request<T>) -> anyhow::Result<T> {
     self
       .request_tracker
       .run_child_request(request, self.parent_request_hash)

--- a/crates/parcel/src/request_tracker/request_tracker.rs
+++ b/crates/parcel/src/request_tracker/request_tracker.rs
@@ -27,13 +27,13 @@ impl<T: Clone> RequestTracker<T> {
     }
   }
 
-  pub fn run_request(&mut self, request: Box<&dyn Request<T>>) -> anyhow::Result<T> {
+  pub fn run_request(&mut self, request: &impl Request<T>) -> anyhow::Result<T> {
     self.run_child_request(request, None)
   }
 
   pub fn run_child_request(
     &mut self,
-    request: Box<&dyn Request<T>>,
+    request: &impl Request<T>,
     parent_request_hash: Option<u64>,
   ) -> anyhow::Result<T> {
     let request_id = request.id();

--- a/crates/parcel/src/request_tracker/test.rs
+++ b/crates/parcel/src/request_tracker/test.rs
@@ -13,7 +13,7 @@ fn should_run_request() {
   let request_b = TestRequest::new("B", &[&request_c]);
   let request_a = TestRequest::new("A", &[&request_b]);
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
 
   assert_eq!(result[0], "A");
   assert_eq!(result[1], "B");
@@ -28,13 +28,13 @@ fn should_reuse_previously_run_request() {
   let request_b = TestRequest::new("B", &[&request_c]);
   let request_a = TestRequest::new("A", &[&request_b]);
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
 
   assert_eq!(result[0], "A");
   assert_eq!(result[1], "B");
   assert_eq!(result[2], "C");
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
   assert_eq!(result[0], "A");
   assert_eq!(result[1], "B");
   assert_eq!(result[2], "C");
@@ -46,12 +46,12 @@ fn should_run_request_once() {
 
   let request_a = TestRequest::new("A", &[]);
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
 
   assert_eq!(result[0], "A");
   assert_eq!(request_a.run_count(), 1);
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
   assert_eq!(result[0], "A");
   assert_eq!(request_a.run_count(), 1);
 }
@@ -63,14 +63,14 @@ fn should_run_request_once_2() {
   let request_b = TestRequest::new("B", &[]);
   let request_a = TestRequest::new("A", &[&request_b]);
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
 
   assert_eq!(result[0], "A");
   assert_eq!(result[1], "B");
   assert_eq!(request_a.run_count(), 1);
   assert_eq!(request_b.run_count(), 1);
 
-  let result = rt.run_request(Box::new(&request_a)).unwrap();
+  let result = rt.run_request(&request_a).unwrap();
   assert_eq!(result[0], "A");
   assert_eq!(result[1], "B");
   assert_eq!(request_a.run_count(), 1);
@@ -127,7 +127,7 @@ impl<'a> Request<Vec<String>> for TestRequest<'a> {
 
     while let Some(subrequest) = subrequets.pop() {
       let req = subrequest.clone();
-      let subrequest_result = context.run_request(Box::new(&req))?;
+      let subrequest_result = context.run_request(&req)?;
       result.extend(subrequest_result);
     }
 


### PR DESCRIPTION
We only need to box these types when they are consumed.

This is related to https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-smart and makes the APIs more flexible most of the time.

We can change back if these APIs will take ownership of the requests.