### PR TITLE
Add simple reporting to request tracker

### DIFF
--- a/crates/parcel/src/request_tracker/request.rs
+++ b/crates/parcel/src/request_tracker/request.rs
@@ -26,8 +26,8 @@ impl<'a, T: Clone> RunRequestContext<'a, T> {
     }
   }
 
-  pub fn report(&self, _event: ReporterEvent) {
-    // TODO
+  pub fn report(&self, event: ReporterEvent) {
+    self.request_tracker.report(event);
   }
 
   pub fn run_request(&mut self, request: &impl Request<T>) -> anyhow::Result<T> {

--- a/crates/parcel/src/request_tracker/request_tracker.rs
+++ b/crates/parcel/src/request_tracker/request_tracker.rs
@@ -1,5 +1,8 @@
 use anyhow::anyhow;
+use parcel_core::plugin::ReporterEvent;
+use parcel_core::plugin::ReporterPlugin;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableDiGraph;
@@ -14,16 +17,31 @@ use super::RunRequestError;
 
 pub struct RequestTracker<T> {
   graph: RequestGraph<T>,
+  reporters: Vec<Box<dyn ReporterPlugin>>,
   request_index: HashMap<u64, NodeIndex>,
 }
 
+impl<T: Clone> Default for RequestTracker<T> {
+  fn default() -> Self {
+    RequestTracker::new(Vec::new())
+  }
+}
+
 impl<T: Clone> RequestTracker<T> {
-  pub fn new() -> Self {
+  pub fn new(reporters: Vec<Box<dyn ReporterPlugin>>) -> Self {
     let mut graph = StableDiGraph::<RequestNode<T>, RequestEdgeType>::new();
     graph.add_node(RequestNode::Root);
     RequestTracker {
       graph,
+      reporters,
       request_index: HashMap::new(),
+    }
+  }
+
+  pub fn report(&self, event: ReporterEvent) {
+    for reporter in self.reporters.iter() {
+      // TODO Decide how to handle errors
+      let _ = reporter.report(&event);
     }
   }
 

--- a/crates/parcel/src/request_tracker/test.rs
+++ b/crates/parcel/src/request_tracker/test.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test]
 fn should_run_request() {
-  let mut rt = RequestTracker::<Vec<String>>::new();
+  let mut rt = RequestTracker::<Vec<String>>::default();
 
   let request_c = TestRequest::new("C", &[]);
   let request_b = TestRequest::new("B", &[&request_c]);
@@ -22,7 +22,7 @@ fn should_run_request() {
 
 #[test]
 fn should_reuse_previously_run_request() {
-  let mut rt = RequestTracker::<Vec<String>>::new();
+  let mut rt = RequestTracker::<Vec<String>>::default();
 
   let request_c = TestRequest::new("C", &[]);
   let request_b = TestRequest::new("B", &[&request_c]);
@@ -42,7 +42,7 @@ fn should_reuse_previously_run_request() {
 
 #[test]
 fn should_run_request_once() {
-  let mut rt = RequestTracker::<Vec<String>>::new();
+  let mut rt = RequestTracker::<Vec<String>>::default();
 
   let request_a = TestRequest::new("A", &[]);
 
@@ -58,7 +58,7 @@ fn should_run_request_once() {
 
 #[test]
 fn should_run_request_once_2() {
-  let mut rt = RequestTracker::<Vec<String>>::new();
+  let mut rt = RequestTracker::<Vec<String>>::default();
 
   let request_b = TestRequest::new("B", &[]);
   let request_a = TestRequest::new("A", &[&request_b]);

--- a/crates/parcel/src/requests/path_request.rs
+++ b/crates/parcel/src/requests/path_request.rs
@@ -222,7 +222,7 @@ mod tests {
       resolvers: Arc::new(vec![Box::new(ExcludedResolverPlugin {})]),
     };
 
-    let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::new()));
+    let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::default()));
 
     assert_eq!(
       resolution.map_err(|e| e.to_string()),
@@ -246,7 +246,7 @@ mod tests {
       })]),
     };
 
-    let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::new()));
+    let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::default()));
 
     assert_eq!(
       resolution.map_err(|e| e.to_string()),
@@ -284,7 +284,7 @@ mod tests {
       ]),
     };
 
-    let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::new()));
+    let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::default()));
 
     assert_eq!(
       resolution.map_err(|e| e.to_string()),
@@ -317,7 +317,7 @@ mod tests {
         resolvers: Arc::new(vec![Box::new(UnresolvedResolverPlugin {})]),
       };
 
-      let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::new()));
+      let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::default()));
 
       assert_eq!(
         resolution.map_err(|e| e.to_string()),
@@ -340,7 +340,7 @@ mod tests {
           resolvers: Arc::new(vec![Box::new(UnresolvedResolverPlugin {})]),
         };
 
-        let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::new()));
+        let resolution = request.run(RunRequestContext::new(None, &mut RequestTracker::default()));
 
         assert_eq!(
           resolution.map_err(|e| e.to_string()),

--- a/crates/parcel_core/src/plugin/reporter_plugin.rs
+++ b/crates/parcel_core/src/plugin/reporter_plugin.rs
@@ -35,7 +35,7 @@ pub enum ReporterEvent {
 ///
 pub trait ReporterPlugin: Debug {
   /// Processes the event from Parcel
-  fn report(&self, event: ReporterEvent) -> Result<(), anyhow::Error>;
+  fn report(&self, event: &ReporterEvent) -> Result<(), anyhow::Error>;
 }
 
 #[cfg(test)]
@@ -46,7 +46,7 @@ mod tests {
   struct TestReporterPlugin {}
 
   impl ReporterPlugin for TestReporterPlugin {
-    fn report(&self, _event: ReporterEvent) -> Result<(), anyhow::Error> {
+    fn report(&self, _event: &ReporterEvent) -> Result<(), anyhow::Error> {
       todo!()
     }
   }

--- a/crates/parcel_plugin_rpc/src/plugin/reporter.rs
+++ b/crates/parcel_plugin_rpc/src/plugin/reporter.rs
@@ -25,7 +25,7 @@ impl RpcReporterPlugin {
 }
 
 impl ReporterPlugin for RpcReporterPlugin {
-  fn report(&self, _event: ReporterEvent) -> Result<(), anyhow::Error> {
+  fn report(&self, _event: &ReporterEvent) -> Result<(), anyhow::Error> {
     todo!()
   }
 }


### PR DESCRIPTION
# ↪️ Pull Request

These changes fill out the `report` fn on the request context using a naive implementation to flesh out the empty placeholder. Later on we should decide if we need the equivalent of the `ReporterRunner` from JavaScript, and determine if all / certain events should be run sync / async.

## 🚨 Test instructions

`yarn build-native && cargo test`