### PR TITLE
Fix dev packager global reference

### DIFF
--- a/packages/core/integration-tests/test/globals.js
+++ b/packages/core/integration-tests/test/globals.js
@@ -1,8 +1,10 @@
 import assert from 'assert';
 import path from 'path';
-import {bundle, run} from '@parcel/test-utils';
 
-describe('global alias', function () {
+import {bundle, fsFixture, overlayFS, run} from '@parcel/test-utils';
+import sinon from 'sinon';
+
+describe('globals', function () {
   it('should support global alias syntax', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/global-alias/index.js'),
@@ -18,5 +20,82 @@ describe('global alias', function () {
       }),
       'ok',
     );
+  });
+
+  describe('supports global in imported modules', () => {
+    const dir = path.join(__dirname, 'global-var');
+
+    beforeEach(async () => {
+      await overlayFS.mkdirp(dir);
+      await fsFixture(overlayFS, dir)`
+        index.js:
+          import { main } from './main';
+
+          onGlobal(main());
+
+        main.js:
+          export function main() {
+            let _global = typeof global !== 'undefined' ? global : 'missing global';
+
+            return _global;
+          }
+
+        yarn.lock: {}
+      `;
+    });
+
+    afterEach(async () => {
+      await overlayFS.rimraf(dir);
+    });
+
+    it('when scope hoisting is disabled', async function () {
+      let bundleGraph = await bundle(path.join(dir, 'index.js'), {
+        defaultTargetOptions: {
+          context: 'browser',
+          shouldScopeHoist: false,
+        },
+        inputFS: overlayFS,
+      });
+
+      let bundles = await Promise.all(
+        bundleGraph
+          .getBundles()
+          .map(b => overlayFS.readFile(b.filePath, 'utf8')),
+      );
+
+      let onGlobal = sinon.spy();
+      await run(bundleGraph, {globalThis: 'global', onGlobal});
+
+      assert(bundles.some(b => b.includes('var global = arguments[3]')));
+      assert(
+        bundles.every(b => !b.includes('var $parcel$global = globalThis')),
+      );
+      assert.equal(onGlobal.callCount, 1);
+      assert.deepEqual(onGlobal.firstCall.args, ['global']);
+    });
+
+    it('when scope hoisting is enabled', async function () {
+      let bundleGraph = await bundle(path.join(dir, 'index.js'), {
+        defaultTargetOptions: {
+          context: 'browser',
+          shouldScopeHoist: true,
+        },
+        inputFS: overlayFS,
+      });
+
+      let bundles = await Promise.all(
+        bundleGraph
+          .getBundles()
+          .map(b => overlayFS.readFile(b.filePath, 'utf8')),
+      );
+
+      let onGlobal = sinon.spy();
+      await run(bundleGraph, {globalThis: 'global', onGlobal});
+
+      assert(bundles.some(b => b.includes('var $parcel$global = globalThis')));
+      assert(bundles.every(b => !b.includes('var global = arguments[3]')));
+      assert.equal(onGlobal.callCount, 1);
+      assert.deepEqual(onGlobal.firstCall.args, ['global']);
+    });
   });
 });

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -448,7 +448,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'const local',
-      generatedStr: 'let o',
+      generatedStr: 'let r',
       sourcePath: 'index.js',
     });
 
@@ -457,7 +457,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'local.a',
-      generatedStr: 'o.a',
+      generatedStr: 'r.a',
       sourcePath: 'index.js',
     });
 
@@ -466,7 +466,7 @@ describe('sourcemaps', function () {
       source: inputs[1],
       generated: raw,
       str: 'exports.a',
-      generatedStr: 't.a',
+      generatedStr: 'o.a',
       sourcePath: 'local.js',
     });
 
@@ -475,7 +475,7 @@ describe('sourcemaps', function () {
       source: inputs[2],
       generated: raw,
       str: 'exports.count = function(a, b) {',
-      generatedStr: 't.count=function(e,n){',
+      generatedStr: 'o.count=function(e,n){',
       sourcePath: 'utils/util.js',
     });
   });

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -116,7 +116,7 @@ export class DevPackager {
         let output = code || '';
         wrapped +=
           JSON.stringify(this.bundleGraph.getAssetPublicId(asset)) +
-          ':[function(require,module,exports) {\n' +
+          ':[function(require,module,exports,__globalThis) {\n' +
           output +
           '\n},';
         wrapped += JSON.stringify(deps);

--- a/packages/packagers/js/src/dev-prelude.js
+++ b/packages/packagers/js/src/dev-prelude.js
@@ -73,7 +73,7 @@
         localRequire,
         module,
         module.exports,
-        this
+        globalObject
       );
     }
 


### PR DESCRIPTION
# ↪️ Pull Request

When running parcel without scope hoisting, `global` references are not passed through correctly in the `DevPackager` module. This results in runtime errors when any code directly uses `global.` without any checks of its existence since `var global = arguments[3]` is always undefined. These changes amend the pass through of the global object, so that `arguments[3]` exists under a privately namespaced variable to prevent collisions with other constants named global.

## 🚨 Test instructions

`yarn test:integration`