### PR TITLE
Add error data into cache bailout logs

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1693,6 +1693,8 @@ function logErrorOnBailout(
       origin: '@parcel/core',
       message: `Unexpected error loading cache from disk, building with clean cache.`,
       meta: {
+        errorMessage: e.message,
+        errorStack: e.stack,
         trackableEvent: 'cache_load_error',
       },
     });


### PR DESCRIPTION
Adds missing error reason data into cache bail-out logs.