### PR TITLE
Add resolver plugin diagnostics

### DIFF
--- a/crates/parcel/src/requests/target_request.rs
+++ b/crates/parcel/src/requests/target_request.rs
@@ -21,7 +21,6 @@ use parcel_core::types::DiagnosticBuilder;
 use parcel_core::types::Entry;
 use parcel_core::types::Environment;
 use parcel_core::types::EnvironmentContext;
-use parcel_core::types::File;
 use parcel_core::types::OutputFormat;
 use parcel_core::types::SourceType;
 use parcel_core::types::Target;
@@ -440,7 +439,7 @@ impl TargetRequest {
     {
       return Err(diagnostic_error!(DiagnosticBuilder::default()
         .code_frames(vec![CodeFrame::from(package_json)])
-        .message(String::from("Output format \"esmodule\" cannot be used in the \"main\" target without a .mjs extension or \"type\": \"module\" field"))));
+        .message("Output format \"esmodule\" cannot be used in the \"main\" target without a .mjs extension or \"type\": \"module\" field")));
     }
 
     let is_library = target_descriptor

--- a/crates/parcel_core/src/types/file.rs
+++ b/crates/parcel_core/src/types/file.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct File {
   pub contents: String,
   pub path: PathBuf,

--- a/crates/parcel_filesystem/src/in_memory_file_system.rs
+++ b/crates/parcel_filesystem/src/in_memory_file_system.rs
@@ -37,6 +37,12 @@ impl InMemoryFileSystem {
   pub fn write_file(&self, path: &Path, contents: String) {
     let mut files = self.files.write().unwrap();
     files.insert(path.into(), InMemoryFileSystemEntry::File { contents });
+
+    let mut dir = path.parent();
+    while let Some(path) = dir {
+      files.insert(path.to_path_buf(), InMemoryFileSystemEntry::Directory);
+      dir = path.parent();
+    }
   }
 }
 

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -489,14 +489,13 @@ export default class NodeResolver {
         };
       }
       case 'JsonError': {
-        let pkgContent = await this.options.fs.readFile(error.path, 'utf8');
         return {
           message: 'Error parsing JSON',
           codeFrames: [
             {
-              filePath: error.path,
+              filePath: error.file.path,
               language: 'json',
-              code: pkgContent,
+              code: error.file.contents,
               // TODO
               codeHighlights: [
                 {

--- a/packages/utils/node-resolver-rs/src/error.rs
+++ b/packages/utils/node-resolver-rs/src/error.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -37,9 +38,9 @@ pub enum ResolverError {
   IOError(IOError),
   #[error("Package JSON error. Module {module} at path {path}")]
   PackageJsonError {
+    error: PackageJsonError,
     module: String,
     path: PathBuf,
-    error: PackageJsonError,
   },
   #[error("Package JSON not found from {from}")]
   PackageJsonNotFound { from: PathBuf },
@@ -70,6 +71,12 @@ impl serde::Serialize for IOError {
     };
 
     msg.serialize(serializer)
+  }
+}
+
+impl Display for IOError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.0.to_string())
   }
 }
 

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -481,10 +481,10 @@ impl<'a> ResolveRequest<'a> {
           if let Some(package) = package {
             let res = package
               .resolve_package_imports(hash, self.conditions, self.custom_conditions)
-              .map_err(|e| ResolverError::PackageJsonError {
+              .map_err(|error| ResolverError::PackageJsonError {
+                error,
                 module: package.name.to_owned(),
                 path: package.path.clone(),
-                error: e,
               })?;
             match res {
               ExportsResolution::Path(path) => {


### PR DESCRIPTION
# ↪️ Pull Request

These changes map resolver errors in the rust resolver plugin to diagnostic errors:

* Add `to_diagnostic_error` in the resolver plugin to map resolver errors
* Add `CodeFrame` from helper when only the file path is known
* Add  `#[builder(setter(into))]` to the diagnostic message, so string slices can be passed in
* Fix `diagnostic_error!` handling of simple messages, so that a diagnostic is actually returns instead of a plain anyhow error
* Update memory file system to write directories when files are written, so that the resolver checks work as expected in the resolver plugin tests
* Return `File` in `JsonError` to avoid additional fs reading

Note that hints and alternative modules have not been implemented

## 🚨 Test instructions

`cargo test`