### PR TITLE
Fix building parcel with a debug build of itself

### DIFF
--- a/crates/parcel/src/requests/target_request.rs
+++ b/crates/parcel/src/requests/target_request.rs
@@ -10,7 +10,6 @@ use package_json::ModuleFormat;
 use package_json::PackageJson;
 use package_json::SourceMapField;
 use package_json::TargetDescriptor;
-
 use parcel_core::config_loader::ConfigFile;
 use parcel_core::diagnostic_error;
 use parcel_core::types::engines::Engines;
@@ -21,7 +20,6 @@ use parcel_core::types::DiagnosticBuilder;
 use parcel_core::types::Entry;
 use parcel_core::types::Environment;
 use parcel_core::types::EnvironmentContext;
-use parcel_core::types::File;
 use parcel_core::types::OutputFormat;
 use parcel_core::types::SourceType;
 use parcel_core::types::Target;
@@ -573,9 +571,10 @@ impl Request for TargetRequest {
 mod tests {
   use std::{num::NonZeroU16, sync::Arc};
 
+  use regex::Regex;
+
   use parcel_core::types::{browsers::Browsers, version::Version};
   use parcel_filesystem::in_memory_file_system::InMemoryFileSystem;
-  use regex::Regex;
 
   use crate::test_utils::{request_tracker, RequestTrackerTestOptions};
 

--- a/packages/transformers/js/core/src/constant_module.rs
+++ b/packages/transformers/js/core/src/constant_module.rs
@@ -19,6 +19,29 @@ fn is_safe_literal(lit: &Lit) -> bool {
   )
 }
 
+/// Run analysis over a module to return whether it is a 'constant module'. A constant module is one
+/// which only consists of constant variable declaration export statements and is safe to inline
+/// at its usage site. Declarations are safe if they refer to value type literals (string, bool,
+/// null, big-int, numbers, certain template strings).
+///
+/// For example, this is a constant module:
+/// ```skip
+/// export const ANGLE = 30;
+/// export const COLOR = 'red';
+/// ```
+///
+/// For example, this is not a constant module:
+/// ```skip
+/// bail-out due to non-decl statement:
+/// import {writeFileSync, readFileSync} from 'fs';
+///
+/// // bail-out due to non-decl statement:
+/// writeFileSync('test', 'file');
+///
+/// // bail-out to non constant declarator RHS (only value type literals are supported):
+/// export const COLOR = readFileSync('test');
+///
+/// ```
 pub struct ConstantModule {
   pub is_constant_module: bool,
   constants: HashSet<JsWord>,

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -78,7 +78,7 @@ use swc_core::ecma::transforms::proposal::decorators;
 use swc_core::ecma::transforms::react;
 use swc_core::ecma::transforms::typescript;
 use swc_core::ecma::visit::VisitWith;
-use swc_core::ecma::visit::{FoldWith, VisitMutWith};
+use swc_core::ecma::visit::{as_folder, FoldWith};
 use typeof_replacer::*;
 use utils::error_buffer_to_diagnostics;
 use utils::CodeHighlight;
@@ -349,13 +349,13 @@ pub fn transform(
                 result.is_constant_module = constant_module.is_constant_module;
               }
 
-              if config.source_type != SourceType::Script {
-                module.visit_mut_with(&mut TypeofReplacer::new(unresolved_mark));
-              }
-
               let module = {
                 let mut passes = chain!(
-                  // Inline process.env and process.browser
+                  Optional::new(
+                    as_folder(TypeofReplacer::new(unresolved_mark)),
+                    config.source_type != SourceType::Script,
+                  ),
+                  // Inline process.env and process.browser,
                   Optional::new(
                     EnvReplacer {
                       replace_env: config.replace_env,

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -388,7 +388,7 @@ pub fn transform(
                   ),
                 );
 
-                module
+                module.fold_with(&mut passes)
               };
 
               let module = module.fold_with(

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -351,10 +351,6 @@ pub fn transform(
 
               let module = {
                 let mut passes = chain!(
-                  // Optional::new(
-                  //   TypeofReplacer { unresolved_mark },
-                  //   config.source_type != SourceType::Script
-                  // ),
                   // Inline process.env and process.browser
                   Optional::new(
                     EnvReplacer {

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -349,6 +349,10 @@ pub fn transform(
                 result.is_constant_module = constant_module.is_constant_module;
               }
 
+              if config.source_type != SourceType::Script {
+                module.visit_mut_with(&mut TypeofReplacer::new(unresolved_mark));
+              }
+
               let module = {
                 let mut passes = chain!(
                   // Inline process.env and process.browser
@@ -383,11 +387,6 @@ pub fn transform(
                     should_inline_fs
                   ),
                 );
-
-                let mut module = module.fold_with(&mut passes);
-                if config.source_type != SourceType::Script {
-                  module.visit_mut_with(&mut TypeofReplacer { unresolved_mark });
-                }
 
                 module
               };

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -20,6 +20,8 @@ use crate::utils::is_unresolved;
 use crate::utils::SourceLocation;
 use crate::utils::SourceType;
 
+/// Replaces __filename and __dirname with globals that reference to string literals for the
+/// file-path of this file.
 pub struct NodeReplacer<'a> {
   pub source_map: &'a SourceMap,
   pub items: &'a mut Vec<DependencyDescriptor>,

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -4,9 +4,7 @@ use swc_core::ecma::ast::Lit;
 use swc_core::ecma::ast::Str;
 use swc_core::ecma::ast::UnaryOp;
 use swc_core::ecma::atoms::js_word;
-use swc_core::ecma::utils::stack_size::maybe_grow_default;
-use swc_core::ecma::visit::FoldWith;
-use swc_core::ecma::visit::{Fold, VisitMut};
+use swc_core::ecma::visit::VisitMut;
 
 use crate::utils::is_unresolved;
 
@@ -73,16 +71,6 @@ impl VisitMut for TypeofReplacer {
   }
 }
 
-impl Fold for TypeofReplacer {
-  fn fold_expr(&mut self, node: Expr) -> Expr {
-    if let Some(replacement) = self.get_replacement(&node) {
-      return replacement;
-    }
-
-    maybe_grow_default(|| node.fold_children_with(self))
-  }
-}
-
 #[cfg(test)]
 mod test {
   use swc_core::common::input::StringInput;
@@ -92,7 +80,7 @@ mod test {
   use swc_core::ecma::parser::lexer::Lexer;
   use swc_core::ecma::parser::Parser;
   use swc_core::ecma::transforms::base::resolver;
-  use swc_core::ecma::visit::VisitMutWith;
+  use swc_core::ecma::visit::{FoldWith, VisitMutWith};
 
   use super::*;
 
@@ -142,96 +130,10 @@ function wrapper({ require, module, exports }) {
     assert_eq!(output_code, expected_code);
   }
 
-  #[test]
-  fn test_typeof_replacer_without_shadowing() {
-    let code = r#"
-const x = typeof require;
-const m = typeof module;
-const e = typeof exports;
-"#;
-
-    let output_code = run_fold(code, |context| TypeofReplacer {
-      unresolved_mark: context.unresolved_mark,
-    });
-
-    let expected_code = r#"
-const x = "function";
-const m = "object";
-const e = "object";
-"#
-    .trim_start();
-    assert_eq!(output_code, expected_code);
-  }
-
-  #[test]
-  fn test_typeof_replacer_with_shadowing() {
-    let code = r#"
-function wrapper({ require, module, exports }) {
-    const x = typeof require;
-    const m = typeof module;
-    const e = typeof exports;
-}
-    "#;
-
-    let output_code = run_fold(code, |context| TypeofReplacer {
-      unresolved_mark: context.unresolved_mark,
-    });
-
-    let expected_code = r#"
-function wrapper({ require, module, exports }) {
-    const x = typeof require;
-    const m = typeof module;
-    const e = typeof exports;
-}
-"#
-    .trim_start();
-    assert_eq!(output_code, expected_code);
-  }
-
   struct RunTestContext {
     #[allow(unused)]
     global_mark: Mark,
     unresolved_mark: Mark,
-  }
-
-  fn run_fold<F: Fold>(code: &str, make_fold: impl FnOnce(RunTestContext) -> F) -> String {
-    let source_map = Lrc::new(SourceMap::default());
-    let source_file = source_map.new_source_file(FileName::Anon, code.into());
-
-    let lexer = Lexer::new(
-      Default::default(),
-      Default::default(),
-      StringInput::from(&*source_file),
-      None,
-    );
-
-    let mut parser = Parser::new_from(lexer);
-    let module = parser.parse_module().unwrap();
-
-    let output_code = GLOBALS.set(&Globals::new(), || {
-      let global_mark = Mark::new();
-      let unresolved_mark = Mark::new();
-      let module = module.fold_with(&mut resolver(unresolved_mark, global_mark, false));
-
-      let mut fold = make_fold(RunTestContext {
-        global_mark,
-        unresolved_mark,
-      });
-      let module = module.fold_with(&mut fold);
-
-      let mut output_buffer = vec![];
-      let writer = JsWriter::new(source_map.clone(), "\n", &mut output_buffer, None);
-      let mut emitter = swc_core::ecma::codegen::Emitter {
-        cfg: Default::default(),
-        cm: source_map,
-        comments: None,
-        wr: writer,
-      };
-      emitter.emit_module(&module).unwrap();
-      let output_code = String::from_utf8(output_buffer).unwrap();
-      output_code
-    });
-    output_code
   }
 
   fn run_visit<V: VisitMut>(code: &str, make_visit: impl FnOnce(RunTestContext) -> V) -> String {

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -5,48 +5,272 @@ use swc_core::ecma::ast::Str;
 use swc_core::ecma::ast::UnaryOp;
 use swc_core::ecma::atoms::js_word;
 use swc_core::ecma::utils::stack_size::maybe_grow_default;
-use swc_core::ecma::visit::Fold;
 use swc_core::ecma::visit::FoldWith;
+use swc_core::ecma::visit::{Fold, VisitMut};
 
 use crate::utils::is_unresolved;
 
+/// Replaces `typeof module`, `typeof exports` and `typeof require` unary operator expressions
+/// with the resulting string literals.
+///
+/// Requires `unresolved_mark` as passed into `swc_ecma_transform_base::resolver`, which is a mark
+/// the SWC transformer will add into variables that are NOT shadowed. This means the `typeof`
+/// expression will be replaced at build time with the resulting literal only if it's referring to
+/// the global `module`, `exports` and `require` symbols.
 pub struct TypeofReplacer {
   pub unresolved_mark: Mark,
 }
 
+impl TypeofReplacer {
+  fn get_replacement(&mut self, node: &Expr) -> Option<Expr> {
+    let Expr::Unary(ref unary) = node else {
+      return None;
+    };
+    if unary.op != UnaryOp::TypeOf {
+      return None;
+    }
+    // typeof require -> "function"
+    // typeof module -> "object"
+    let Expr::Ident(ident) = &*unary.arg else {
+      return None;
+    };
+
+    if ident.sym == js_word!("require") && is_unresolved(&ident, self.unresolved_mark) {
+      return Some(Expr::Lit(Lit::Str(Str {
+        span: unary.span,
+        value: js_word!("function"),
+        raw: None,
+      })));
+    }
+
+    if &*ident.sym == "exports" && is_unresolved(&ident, self.unresolved_mark) {
+      return Some(Expr::Lit(Lit::Str(Str {
+        span: unary.span,
+        value: js_word!("object"),
+        raw: None,
+      })));
+    }
+
+    if ident.sym == js_word!("module") && is_unresolved(&ident, self.unresolved_mark) {
+      return Some(Expr::Lit(Lit::Str(Str {
+        span: unary.span,
+        value: js_word!("object"),
+        raw: None,
+      })));
+    }
+
+    None
+  }
+}
+
+impl VisitMut for TypeofReplacer {
+  fn visit_mut_expr(&mut self, node: &mut Expr) {
+    let Some(replacement) = self.get_replacement(node) else {
+      return;
+    };
+
+    *node = replacement;
+  }
+}
+
 impl Fold for TypeofReplacer {
   fn fold_expr(&mut self, node: Expr) -> Expr {
-    if let Expr::Unary(ref unary) = node {
-      // typeof require -> "function"
-      // typeof module -> "object"
-      if unary.op == UnaryOp::TypeOf {
-        if let Expr::Ident(ident) = &*unary.arg {
-          if ident.sym == js_word!("require") && is_unresolved(&ident, self.unresolved_mark) {
-            return Expr::Lit(Lit::Str(Str {
-              span: unary.span,
-              value: js_word!("function"),
-              raw: None,
-            }));
-          }
-          if &*ident.sym == "exports" && is_unresolved(&ident, self.unresolved_mark) {
-            return Expr::Lit(Lit::Str(Str {
-              span: unary.span,
-              value: js_word!("object"),
-              raw: None,
-            }));
-          }
-
-          if ident.sym == js_word!("module") && is_unresolved(&ident, self.unresolved_mark) {
-            return Expr::Lit(Lit::Str(Str {
-              span: unary.span,
-              value: js_word!("object"),
-              raw: None,
-            }));
-          }
-        }
-      }
+    if let Some(replacement) = self.get_replacement(&node) {
+      return replacement;
     }
 
     maybe_grow_default(|| node.fold_children_with(self))
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use swc_core::common::input::StringInput;
+  use swc_core::common::sync::Lrc;
+  use swc_core::common::{FileName, Globals, SourceMap, GLOBALS};
+  use swc_core::ecma::codegen::text_writer::JsWriter;
+  use swc_core::ecma::parser::lexer::Lexer;
+  use swc_core::ecma::parser::Parser;
+  use swc_core::ecma::transforms::base::resolver;
+  use swc_core::ecma::visit::VisitMutWith;
+
+  use super::*;
+
+  #[test]
+  fn test_visitor_typeof_replacer_without_shadowing() {
+    let code = r#"
+const x = typeof require;
+const m = typeof module;
+const e = typeof exports;
+"#;
+
+    let output_code = run_visit(code, |context| TypeofReplacer {
+      unresolved_mark: context.unresolved_mark,
+    });
+
+    let expected_code = r#"
+const x = "function";
+const m = "object";
+const e = "object";
+"#
+    .trim_start();
+    assert_eq!(output_code, expected_code);
+  }
+
+  #[test]
+  fn test_visitor_typeof_replacer_with_shadowing() {
+    let code = r#"
+function wrapper({ require, module, exports }) {
+    const x = typeof require;
+    const m = typeof module;
+    const e = typeof exports;
+}
+    "#;
+
+    let output_code = run_visit(code, |context| TypeofReplacer {
+      unresolved_mark: context.unresolved_mark,
+    });
+
+    let expected_code = r#"
+function wrapper({ require, module, exports }) {
+    const x = typeof require;
+    const m = typeof module;
+    const e = typeof exports;
+}
+"#
+    .trim_start();
+    assert_eq!(output_code, expected_code);
+  }
+
+  #[test]
+  fn test_typeof_replacer_without_shadowing() {
+    let code = r#"
+const x = typeof require;
+const m = typeof module;
+const e = typeof exports;
+"#;
+
+    let output_code = run_fold(code, |context| TypeofReplacer {
+      unresolved_mark: context.unresolved_mark,
+    });
+
+    let expected_code = r#"
+const x = "function";
+const m = "object";
+const e = "object";
+"#
+    .trim_start();
+    assert_eq!(output_code, expected_code);
+  }
+
+  #[test]
+  fn test_typeof_replacer_with_shadowing() {
+    let code = r#"
+function wrapper({ require, module, exports }) {
+    const x = typeof require;
+    const m = typeof module;
+    const e = typeof exports;
+}
+    "#;
+
+    let output_code = run_fold(code, |context| TypeofReplacer {
+      unresolved_mark: context.unresolved_mark,
+    });
+
+    let expected_code = r#"
+function wrapper({ require, module, exports }) {
+    const x = typeof require;
+    const m = typeof module;
+    const e = typeof exports;
+}
+"#
+    .trim_start();
+    assert_eq!(output_code, expected_code);
+  }
+
+  struct RunTestContext {
+    #[allow(unused)]
+    global_mark: Mark,
+    unresolved_mark: Mark,
+  }
+
+  fn run_fold<F: Fold>(code: &str, make_fold: impl FnOnce(RunTestContext) -> F) -> String {
+    let source_map = Lrc::new(SourceMap::default());
+    let source_file = source_map.new_source_file(FileName::Anon, code.into());
+
+    let lexer = Lexer::new(
+      Default::default(),
+      Default::default(),
+      StringInput::from(&*source_file),
+      None,
+    );
+
+    let mut parser = Parser::new_from(lexer);
+    let module = parser.parse_module().unwrap();
+
+    let output_code = GLOBALS.set(&Globals::new(), || {
+      let global_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+      let module = module.fold_with(&mut resolver(unresolved_mark, global_mark, false));
+
+      let mut fold = make_fold(RunTestContext {
+        global_mark,
+        unresolved_mark,
+      });
+      let module = module.fold_with(&mut fold);
+
+      let mut output_buffer = vec![];
+      let writer = JsWriter::new(source_map.clone(), "\n", &mut output_buffer, None);
+      let mut emitter = swc_core::ecma::codegen::Emitter {
+        cfg: Default::default(),
+        cm: source_map,
+        comments: None,
+        wr: writer,
+      };
+      emitter.emit_module(&module).unwrap();
+      let output_code = String::from_utf8(output_buffer).unwrap();
+      output_code
+    });
+    output_code
+  }
+
+  fn run_visit<V: VisitMut>(code: &str, make_visit: impl FnOnce(RunTestContext) -> V) -> String {
+    let source_map = Lrc::new(SourceMap::default());
+    let source_file = source_map.new_source_file(FileName::Anon, code.into());
+
+    let lexer = Lexer::new(
+      Default::default(),
+      Default::default(),
+      StringInput::from(&*source_file),
+      None,
+    );
+
+    let mut parser = Parser::new_from(lexer);
+    let module = parser.parse_module().unwrap();
+
+    let output_code = GLOBALS.set(&Globals::new(), || {
+      let global_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+      let mut module = module.fold_with(&mut resolver(unresolved_mark, global_mark, false));
+
+      let mut visit = make_visit(RunTestContext {
+        global_mark,
+        unresolved_mark,
+      });
+      module.visit_mut_with(&mut visit);
+
+      let mut output_buffer = vec![];
+      let writer = JsWriter::new(source_map.clone(), "\n", &mut output_buffer, None);
+      let mut emitter = swc_core::ecma::codegen::Emitter {
+        cfg: Default::default(),
+        cm: source_map,
+        comments: None,
+        wr: writer,
+      };
+      emitter.emit_module(&module).unwrap();
+      let output_code = String::from_utf8(output_buffer).unwrap();
+      output_code
+    });
+    output_code
   }
 }

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -26,6 +26,8 @@ impl TypeofReplacer {
 }
 
 impl TypeofReplacer {
+  /// Given an expression, optionally return a replacement if it happens to be `typeof $symbol` for
+  /// the constants supported in this transformation step (`require`, `exports` and `module`).
   fn get_replacement(&mut self, node: &Expr) -> Option<Expr> {
     let Expr::Unary(ref unary) = node else {
       return None;
@@ -114,7 +116,7 @@ const e = "object";
   #[test]
   fn test_visitor_typeof_replacer_with_shadowing() {
     let code = r#"
-function wrapper({ require, module, exports }) {
+function wrapper({ require, exports }) {
     const x = typeof require;
     const m = typeof module;
     const e = typeof exports;
@@ -126,9 +128,9 @@ function wrapper({ require, module, exports }) {
     });
 
     let expected_code = r#"
-function wrapper({ require, module, exports }) {
+function wrapper({ require, exports }) {
     const x = typeof require;
-    const m = typeof module;
+    const m = "object";
     const e = typeof exports;
 }
 "#

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -16,7 +16,13 @@ use crate::utils::is_unresolved;
 /// expression will be replaced at build time with the resulting literal only if it's referring to
 /// the global `module`, `exports` and `require` symbols.
 pub struct TypeofReplacer {
-  pub unresolved_mark: Mark,
+  unresolved_mark: Mark,
+}
+
+impl TypeofReplacer {
+  pub fn new(unresolved_mark: Mark) -> Self {
+    Self { unresolved_mark }
+  }
 }
 
 impl TypeofReplacer {


### PR DESCRIPTION
This commit fixes a segmentation fault in parcel when building itself using a debug build of its native extensions.

This would previously crash due to usage of `Fold` and its recursive nature.

All expressions will recurse in the typeof replacer code, so SWC will crash if a module has large enough expressions, which is a case that does happen within parcel own dependencies.

This should improve performance and is the recommended usage by SWC
* https://github.com/parcel-bundler/parcel/discussions/9828 We should replace all SWC transformations from `Fold` to `VisitMut`.

parcel-bundler/parcel/discussions/9828
