### PR TITLE
Fix bugs in cache writes

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1516,18 +1516,31 @@ export default class RequestTracker {
         snapshotPath,
         opts,
       );
+
+      await storeRequestTrackerCacheInfo(this.options.cache, {
+        allLargeBlobKeys: Array.from(allLargeBlobKeys),
+        requestGraphKey,
+        snapshotKey,
+        timestamp: Date.now(),
+      });
+      report({
+        type: 'cache',
+        phase: 'end',
+        total,
+        size: this.graph.nodes.length,
+      });
     } catch (err) {
       // If we have aborted, ignore the error and continue
       if (!signal?.aborted) throw err;
+      logger.warn({
+        origin: '@parcel/core',
+        message: 'Aborted writing to cache, ignoring error',
+        meta: {
+          errorMessage: err.message,
+          errorStack: err.stack,
+        },
+      });
     }
-
-    await storeRequestTrackerCacheInfo(this.options.cache, {
-      allLargeBlobKeys: Array.from(allLargeBlobKeys),
-      requestGraphKey,
-      snapshotKey,
-      timestamp: Date.now(),
-    });
-    report({type: 'cache', phase: 'end', total, size: this.graph.nodes.length});
   }
 
   static async init({

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1161,12 +1161,14 @@ export default class RequestTracker {
       return result;
     } else if (node.resultCacheKey != null && ifMatch == null) {
       let key = node.resultCacheKey;
-      invariant(this.options.cache.hasLargeBlob(key));
-      let cachedResult: T = deserialize(
-        await this.options.cache.getLargeBlob(key),
-      );
-      node.result = cachedResult;
-      return cachedResult;
+      try {
+        const cachedBlob = await this.options.cache.getLargeBlob(key);
+        let cachedResult: T = deserialize(cachedBlob);
+        node.result = cachedResult;
+        return cachedResult;
+      } catch (_error) {
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
* Fix bug where cache info entries would be written even if write was aborted
* Clean-up entries partially written if we're aborting
* Prevent concurrent cache writes
* Degrade gracefully on missing entries (which is sort of what previously happened)