### PR TITLE
Add changes required for AssetGraphRequest

### DIFF
--- a/crates/parcel/src/plugins.rs
+++ b/crates/parcel/src/plugins.rs
@@ -85,6 +85,11 @@ impl Plugins {
   }
 
   #[allow(unused)]
+  pub fn named_pipelines(&self) -> Vec<String> {
+    self.config.transformers.named_pipelines()
+  }
+
+  #[allow(unused)]
   pub fn namers(&self) -> Result<Vec<Box<dyn NamerPlugin>>, anyhow::Error> {
     let mut namers: Vec<Box<dyn NamerPlugin>> = Vec::new();
 

--- a/crates/parcel/src/requests.rs
+++ b/crates/parcel/src/requests.rs
@@ -3,6 +3,7 @@ use path_request::PathRequestOutput;
 use target_request::TargetRequestOutput;
 
 mod asset_request;
+mod entry_request;
 mod path_request;
 mod target_request;
 

--- a/crates/parcel/src/requests/entry_request.rs
+++ b/crates/parcel/src/requests/entry_request.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+/// A resolved entry file for the build
+#[derive(Clone, Debug, Default, Hash, PartialEq)]
+pub struct Entry {
+  pub file_path: PathBuf,
+  pub target: Option<String>,
+}

--- a/crates/parcel_config/src/map/named_pipelines_map.rs
+++ b/crates/parcel_config/src/map/named_pipelines_map.rs
@@ -144,11 +144,15 @@ impl NamedPipelinesMap {
       .any(|glob| glob.starts_with(&named_pipeline))
   }
 
-  pub fn named_pipelines(&self) -> Vec<&str> {
+  pub fn named_pipelines(&self) -> Vec<String> {
     self
       .inner
       .keys()
-      .filter_map(|glob| glob.split_once(':').map(|g| g.0))
+      .filter_map(|glob| {
+        glob
+          .split_once(':')
+          .map(|(named_pipeline, _pattern)| String::from(named_pipeline))
+      })
       .collect()
   }
 }


### PR DESCRIPTION
# ↪️ Pull Request

These minor changes better enable the asset graph request:
* Add `Entry` type to `EntryRequest`
* Add `named_pipelines` method to `Plugins` and update the internal `named_pipelines` to return a `Vec<String>` to avoid specifying lifetimes
* Return `entry` from `TargetRequest`, as this is the easiest way to create the connection in the AssetGraph, without async / await or storing requests in a complicated way
* Update `TargetRequest` to take in an `Entry` type
* Use dedicated `SourceField` type for `package.json` definition so there are less conflicts with Entry types

## 🚨 Test instructions

`cargo test`