### PR TITLE
Fix canary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     name: linux-gnu-x64
     runs-on: ubuntu-20.04
     container:
-      image: docker.io/mischnic/centos7-node16
+      image: node:22.4-bookworm
     steps:
       - uses: actions/checkout@v3
       - name: Install yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,6 @@ jobs:
       image: node:22.4-bookworm
     steps:
       - uses: actions/checkout@v3
-      - name: Install yarn
-        run: npm install --global yarn@1
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/docs/Continuous Integration/Native Binary Builds.md
+++ b/docs/Continuous Integration/Native Binary Builds.md
@@ -1,0 +1,25 @@
+# Parcel • Continuous Integration • Native Binary Builds
+
+Parcel relies on a few native artifacts that need to be built for multiple target platforms and architectures.
+
+To support this, there are a number of different runner jobs running on different images/os:
+
+- macos-latest is used for arm / x86 builds of the macOS targets
+- windows-latest is used for windows builds
+- linux builds
+  - Debian bookworm is used for x86 builds
+  - Ubuntu 20.04 is used for armhf 32-bit, arm64
+  - What looks like Alpine linux in napi-rs/napi-rs/nodejs-rust is used for MUSL x86 64-bit and MUSL arm64
+
+## Testing builds locally
+
+We can use `act` to test CI jobs locally:
+
+- [Install the GitHub CLI](https://cli.github.com/)
+- [Install `act` - `gh extension install https://github.com/nektos/gh-act`](https://nektosact.com/installation/gh.html)
+
+Run the desired GitHub actions job:
+
+```
+gh act --input profile=release --job "build-linux-gnu-x64"
+```


### PR DESCRIPTION
This PR switches just one runner image to use `node:...debian` docker image to test it out.

Long-term we'd want all linux builds to run in debian, but this PR is just switching the x86 build to try to fix the canary release - https://github.com/parcel-bundler/parcel/actions/runs/9864446097/job/27296209033

- - -

## Context

Currently the GitHub actions configuration is complex due to supporting building the native add-ons for many target OSs and architectures.

To support this, there are a number of different runner jobs running on different images/os:

* macos-latest is used for arm / x86 builds of the macOS targets
* windows-latest is used for windows builds
* linux builds
  * CentOS 7 is used for a x64 build
  * Ubuntu 20.04 is used for armhf 32-bit, arm64
  * What looks like Alpine linux in napi-rs/napi-rs/nodejs-rust is used for MUSL x86 64-bit and MUSL arm64

While this is currently set-up and working, maintaining this set-up becomes hard. When adding new native libraries for example that need to be linked dynamically against the main binary, this becomes an issue.

## Trying debian

Rather than using multiple OSes we could strive for having a single Linux distribution cross compile for all targets. For example, debian has good support for cross-compilation with popular libraries being distributed as binary for many architectures:

* https://wiki.debian.org/Multiarch/HOWTO

## OpenSSL

* To avoid having to cross-compile OpenSSL at the moment we're using rustls - SSL is needed for the sentry client used only on canary releases and was added on https://github.com/parcel-bundler/parcel/pull/9667