### PR TITLE
Fix import usage tracking for destructure defaulting

### DIFF
--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -642,6 +642,8 @@ impl Visit for Collect {
         .or_default()
         .push(node.key.span);
     }
+
+    node.value.visit_with(self);
   }
 
   fn visit_member_expr(&mut self, node: &MemberExpr) {

--- a/packages/transformers/js/core/src/hoist.rs
+++ b/packages/transformers/js/core/src/hoist.rs
@@ -1669,6 +1669,25 @@ mod tests {
   }
 
   #[test]
+  fn collect_destructure_default() {
+    let (collect, _code, _hoist) = parse(
+      r#"
+    import {bar} from 'source';
+
+    export function thing(props) {
+      const {something = bar} = props;
+      return something;
+    }
+    "#,
+    );
+    assert_eq_imports!(
+      collect.imports,
+      map! { w!("bar") => (w!("source"), w!("bar"), false) }
+    );
+    assert_eq_set!(collect.used_imports, set! { w!("bar") });
+  }
+
+  #[test]
   fn collect_cjs_reassign() {
     let (collect, _code, _hoist) = parse(
       r#"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

This PR resolves an issue where imports used exclusively inside destructure defaulting are not marked as used. 

This fix is just to ensure we visit the defaulting node if it's present inside the destructure. 

## 🚨 Test instructions

Rust unit test added.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
