### PR TITLE
Update fs and package manager types in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,7 @@ dependencies = [
  "mockall",
  "parcel-resolver",
  "parcel_filesystem",
- "thiserror",
+ "serde",
 ]
 
 [[package]]

--- a/crates/parcel/src/parcel.rs
+++ b/crates/parcel/src/parcel.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use parcel_filesystem::os_file_system::OsFileSystem;
@@ -37,7 +38,7 @@ impl Parcel {
       .fs
       .unwrap_or_else(|| Arc::new(OsFileSystem::default()));
 
-    let _node_package_manager = NodePackageManager::new("project_root", fs.clone());
+    let _node_package_manager = NodePackageManager::new(PathBuf::default(), fs.clone());
 
     Self {
       fs,

--- a/crates/parcel_filesystem/src/lib.rs
+++ b/crates/parcel_filesystem/src/lib.rs
@@ -14,9 +14,9 @@ pub mod search;
 /// File-system implementation using std::fs and a canonicalize cache
 pub mod os_file_system;
 
-/// FileSystem abstraction instance.
-/// This should be `OsFileSystem` for non-testing environments and `InMemoryFileSystem` for
-/// testing.
+/// FileSystem abstraction instance
+///
+/// This should be `OsFileSystem` for non-testing environments and `InMemoryFileSystem` for testing.
 pub type FileSystemRef = Arc<dyn FileSystem + Send + Sync>;
 
 /// Trait abstracting file-system operations

--- a/crates/parcel_package_manager/Cargo.toml
+++ b/crates/parcel_package_manager/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0.82"
 mockall = "0.12.1"
-thiserror = "1.0.59"
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
 parcel_filesystem = { path = "../parcel_filesystem" }
-anyhow = "1.0.82"
+serde = { version = "1.0.200", features = ["derive"] }

--- a/crates/parcel_package_manager/src/lib.rs
+++ b/crates/parcel_package_manager/src/lib.rs
@@ -1,7 +1,5 @@
-pub mod node_package_manager;
-pub mod package_manager;
+pub use node_package_manager::*;
+pub use package_manager::*;
 
-pub use node_package_manager::NodePackageManager;
-pub use package_manager::MockPackageManager;
-pub use package_manager::PackageManager;
-pub use package_manager::Resolution;
+mod node_package_manager;
+mod package_manager;

--- a/crates/parcel_package_manager/src/node_package_manager.rs
+++ b/crates/parcel_package_manager/src/node_package_manager.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, path::PathBuf};
 
 use anyhow::anyhow;
 use parcel_filesystem::FileSystemRef;
@@ -11,10 +11,10 @@ pub struct NodePackageManager<'a> {
 }
 
 impl<'a> NodePackageManager<'a> {
-  pub fn new(project_root: &str, fs: FileSystemRef) -> Self {
+  pub fn new(project_root: PathBuf, fs: FileSystemRef) -> Self {
     Self {
       resolver: parcel_resolver::Resolver::node(
-        Cow::Owned(project_root.into()),
+        Cow::Owned(project_root),
         parcel_resolver::CacheCow::Owned(parcel_resolver::Cache::new(fs)),
       ),
     }

--- a/crates/parcel_package_manager/src/package_manager.rs
+++ b/crates/parcel_package_manager/src/package_manager.rs
@@ -1,8 +1,15 @@
+use std::fmt::Debug;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use mockall::automock;
+use serde::Deserialize;
 
+/// PackageManager abstraction instance
+pub type PackageManagerRef = Arc<dyn PackageManager + Send + Sync>;
+
+#[derive(Debug, Deserialize)]
 pub struct Resolution {
   pub resolved: PathBuf,
 }


### PR DESCRIPTION
# ↪️ Pull Request

These changes update the config crate to use the existing `FileSystemRef` and a new `PackageManagerRef` to better support the E2E state and improve consistency

## 🚨 Test instructions

`cargo test`