### PR TITLE
Use debian bullseye to support GLIBC 2.31

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     name: linux-gnu-x64
     runs-on: ubuntu-20.04
     container:
-      image: node:22.4-bookworm
+      image: node:22.4-bullseye
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
@@ -290,6 +290,10 @@ jobs:
         with:
           name: debug-symbols
           path: debug-symbols/**
+      - name: Build node packages
+        run: yarn build
+      - name: Build TypeScript types
+        run: yarn build-ts
       - name: Debug
         run: |
           ls -l packages/*/*/*.node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,10 +290,6 @@ jobs:
         with:
           name: debug-symbols
           path: debug-symbols/**
-      - name: Build node packages
-        run: yarn build
-      - name: Build TypeScript types
-        run: yarn build-ts
       - name: Debug
         run: |
           ls -l packages/*/*/*.node

--- a/docs/Continuous Integration/Native Binary Builds.md
+++ b/docs/Continuous Integration/Native Binary Builds.md
@@ -23,3 +23,7 @@ Run the desired GitHub actions job:
 ```
 gh act --input profile=release --job "build-linux-gnu-x64"
 ```
+
+## GLIBC Versions
+
+- x86 builds rely on minimum GLIBC 2.31 in Debian 11 - bullseye https://packages.debian.org/bullseye/libc6


### PR DESCRIPTION
Use older debian version to support slightly older GLIBC base version.

Follow-up on https://github.com/parcel-bundler/parcel/pull/9841