### PR TITLE
Refactor node replacer to use VisitMut

### DIFF
--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -397,7 +397,7 @@ pub fn transform(
                 // Replace __dirname and __filename with placeholders in Node env
                 &mut Optional::new(
                   NodeReplacer {
-                    source_map: &source_map,
+                    source_map: source_map.clone(),
                     items: &mut global_deps,
                     global_mark,
                     globals: HashMap::new(),

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -396,7 +396,7 @@ pub fn transform(
               let module = module.fold_with(
                 // Replace __dirname and __filename with placeholders in Node env
                 &mut Optional::new(
-                  NodeReplacer {
+                  as_folder(NodeReplacer {
                     source_map: source_map.clone(),
                     items: &mut global_deps,
                     global_mark,
@@ -404,7 +404,7 @@ pub fn transform(
                     filename: Path::new(&config.filename),
                     unresolved_mark,
                     has_node_replacements: &mut result.has_node_replacements,
-                  },
+                  }),
                   config.node_replacer,
                 ),
               );

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -225,7 +225,7 @@ pub struct SourceLocation {
 }
 
 impl SourceLocation {
-  pub fn from(source_map: &swc_core::common::SourceMap, span: swc_core::common::Span) -> Self {
+  pub fn from(source_map: &SourceMap, span: Span) -> Self {
     if span.lo.is_dummy() || span.hi.is_dummy() {
       return SourceLocation {
         start_line: 1,


### PR DESCRIPTION
Refactors `node_replacer.rs` to migrate to `VisitMut`. Adds exhaustive tests for its usage, which were passing for `Fold` implementation and replaces it at its usage sites.