### PR TITLE
Move all dependencies for v3 rust prototype behind a feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,6 +1811,7 @@ dependencies = [
  "parcel-macros",
  "parcel-resolver",
  "parcel_core",
+ "parcel_filesystem",
  "parcel_napi_helpers",
  "parcel_package_manager",
  "parcel_plugin_transformer_js",

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -8,38 +8,55 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-canary = ["sentry", "whoami", "rustls"]
-
+canary = ["sentry", "whoami", "rustls", "v3-prototype"]
+v3-prototype = [
+  "parcel",
+  "parcel_core",
+  "parcel_package_manager",
+  "parcel_plugin_transformer_js",
+  "parcel_napi_helpers",
+  "anyhow",
+  "glob",
+  "log",
+  "mockall",
+  "num_cpus",
+  "parking_lot",
+  "toml",
+  "tracing",
+  "tracing-appender",
+  "tracing-subscriber",
+]
 rustls = ["sentry/rustls"]
 openssl = ["sentry/native-tls"]
 
 [dependencies]
-parcel = { path = "../parcel" }
-parcel_core = { path = "../parcel_core" }
+parcel = { path = "../parcel", optional = true }
+parcel_core = { path = "../parcel_core", optional = true }
 parcel-js-swc-core = { path = "../../packages/transformers/js/core" }
 parcel-resolver = { path = "../../packages/utils/node-resolver-rs" }
-parcel_package_manager = { path = "../parcel_package_manager" }
-parcel_plugin_transformer_js = { path = "../parcel_plugin_transformer_js" }
-parcel_napi_helpers = { path = "../parcel_napi_helpers" }
+parcel_package_manager = { path = "../parcel_package_manager", optional = true }
+parcel_plugin_transformer_js = { path = "../parcel_plugin_transformer_js", optional = true }
+parcel_napi_helpers = { path = "../parcel_napi_helpers", optional = true }
+parcel_filesystem = { path = "../parcel_filesystem" }
 
-anyhow = "1.0.82"
+anyhow = { version = "1.0.82", optional = true }
 dashmap = "5.4.0"
-glob = "0.3.1"
-log = "0.4.21"
-mockall = "0.12.1"
+glob = { version = "0.3.1", optional = true }
+log = { version = "0.4.21", optional = true }
+mockall = { version = "0.12.1", optional = true }
 napi-derive = "2.16.3"
-num_cpus = "1.16.0"
-parking_lot = "0.12"
+num_cpus = { version = "1.16.0", optional = true }
+parking_lot = { version = "0.12", optional = true }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
-toml = "0.8.12"
-tracing = "0.1.40"
-tracing-appender = "0.2.3"
-tracing-subscriber = "0.3.18"
+toml = { version = "0.8.12", optional = true }
+tracing = { version = "0.1.40", optional = true }
+tracing-appender = { version = "0.2.3", optional = true }
+tracing-subscriber = { version = "0.3.18", optional = true }
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-parcel = { path = "../parcel", features = ["nodejs"] }
+parcel = { path = "../parcel", features = ["nodejs"], optional = true }
 parcel-dev-dep-resolver = { path = "../../packages/utils/dev-dep-resolver" }
 parcel-macros = { path = "../macros", features = ["napi"] }
 
@@ -47,11 +64,23 @@ crossbeam-channel = "0.5.6"
 indexmap = "1.9.2"
 libc = "0.2"
 mozjpeg-sys = "1.0.0"
-napi = { version = "2.16.4", features = ["async", "napi4", "napi5", "serde-json"] }
+napi = { version = "2.16.4", features = [
+  "async",
+  "napi4",
+  "napi5",
+  "serde-json",
+] }
 once_cell = { version = "1.19.0" }
 oxipng = "8.0.0"
 rayon = "1.7.0"
-sentry = { version = "0.32.2", optional = true, default-features = false, features = ["anyhow", "backtrace", "contexts", "debug-images", "panic", "reqwest"] }
+sentry = { version = "0.32.2", optional = true, default-features = false, features = [
+  "anyhow",
+  "backtrace",
+  "contexts",
+  "debug-images",
+  "panic",
+  "reqwest",
+] }
 whoami = { version = "1.5.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -5,6 +5,7 @@ use std::alloc::alloc;
 #[cfg(target_arch = "wasm32")]
 use std::alloc::Layout;
 
+#[cfg(feature = "sentry")]
 mod init_sentry;
 
 #[cfg(all(target_os = "macos", not(miri)))]
@@ -15,7 +16,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "v3-prototype", not(target_arch = "wasm32")))]
 mod file_system;
 
 /// napi versions of `crate::core::requests`
@@ -25,7 +26,7 @@ mod hash;
 #[cfg(not(target_arch = "wasm32"))]
 mod image;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(feature = "v3-prototype", not(target_arch = "wasm32")))]
 mod parcel;
 mod resolver;
 mod transformer;

--- a/crates/node-bindings/src/resolver.rs
+++ b/crates/node-bindings/src/resolver.rs
@@ -18,7 +18,7 @@ use napi::JsUnknown;
 use napi::Ref;
 use napi::Result;
 use napi_derive::napi;
-use parcel::file_system::FileSystemRef;
+use parcel_filesystem::FileSystemRef;
 use parcel_resolver::ExportsCondition;
 use parcel_resolver::Extensions;
 use parcel_resolver::Fields;

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -3,18 +3,18 @@ use napi::JsObject;
 use napi::JsUnknown;
 use napi_derive::napi;
 
-use parcel_core::plugin::{
-  InitialAsset, RunTransformContext, TransformationInput, TransformerPlugin,
-};
-use parcel_plugin_transformer_js::ParcelJsTransformerPlugin;
-
-use parcel_napi_helpers::anyhow_to_napi;
-
+#[cfg(feature = "v3-prototype")]
 #[napi]
 pub fn _testing_run_parcel_js_transformer_plugin(
   target_path: String,
   env: Env,
 ) -> napi::Result<JsUnknown> {
+  use parcel_core::plugin::{
+    InitialAsset, RunTransformContext, TransformationInput, TransformerPlugin,
+  };
+  use parcel_napi_helpers::anyhow_to_napi;
+  use parcel_plugin_transformer_js::ParcelJsTransformerPlugin;
+
   let mut transformer = ParcelJsTransformerPlugin::new();
   let mut context = RunTransformContext::default();
   let input = TransformationInput::InitialAsset(InitialAsset {

--- a/packages/core/core/src/parcel-v3/ParcelV3.js
+++ b/packages/core/core/src/parcel-v3/ParcelV3.js
@@ -15,6 +15,8 @@ export type ParcelV3Options = {|
 export class ParcelV3 {
   _internal: ParcelNapi;
 
+  static available: boolean = !!ParcelNapi;
+
   constructor({
     fs,
     nodeWorkers,

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -14,6 +14,10 @@ import type {
 } from '@parcel/types-internal';
 
 describe('parcel-v3', function () {
+  if (!ParcelV3.available) {
+    return;
+  }
+
   // Add to @parcel/utils later
   function toFileSystemV3(fs: ClassicFileSystem): FileSystem {
     return {

--- a/packages/core/rust/package.json
+++ b/packages/core/rust/package.json
@@ -34,7 +34,7 @@
     "napi-wasm": "^1.0.1"
   },
   "scripts": {
-    "build": "napi build --platform --cargo-cwd ../../../crates/node-bindings",
+    "build": "napi build --platform --features canary --cargo-cwd ../../../crates/node-bindings",
     "build-canary": "napi build --platform --profile canary --features canary --cargo-cwd ../../../crates/node-bindings",
     "build-release": "napi build --platform --release --cargo-cwd ../../../crates/node-bindings",
     "wasm:build": "cargo build -p parcel-node-bindings --target wasm32-unknown-unknown && cp ../../../target/wasm32-unknown-unknown/debug/parcel_node_bindings.wasm .",

--- a/packages/transformers/js/test/JSTransformer.test.js
+++ b/packages/transformers/js/test/JSTransformer.test.js
@@ -2,6 +2,10 @@ import {testingRunParcelJsTransformerPlugin} from '@parcel/rust';
 import assert from 'node:assert';
 
 describe('rust transformer', () => {
+  if (!testingRunParcelJsTransformerPlugin) {
+    return;
+  }
+
   it('runs', async () => {
     const result = await testingRunParcelJsTransformerPlugin(__filename);
     assert(result != null);


### PR DESCRIPTION
This is in preparation for the next v2 release. I noticed that the `@parcel/rust` npm package has grown 25% since v2.12.0 due to the addition of the rust core prototype. This moves all of that work behind a Cargo feature, which is only enabled in canary builds and development builds.