### PR TITLE
Add retriable dynamic imports behind a feature flag

### DIFF
--- a/packages/core/core/test/test-utils.js
+++ b/packages/core/core/test/test-utils.js
@@ -56,6 +56,7 @@ export const DEFAULT_OPTIONS: ParcelOptions = {
     exampleFeature: false,
     configKeyInvalidation: false,
     parcelV3: false,
+    importRetry: false,
   },
 };
 

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -9,6 +9,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   exampleFeature: false,
   configKeyInvalidation: false,
   parcelV3: false,
+  importRetry: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -13,4 +13,8 @@ export type FeatureFlags = {|
    * Rust backed requests
    */
   +parcelV3: boolean,
+  /**
+   * Configure runtime to enable retriable dynamic imports
+   */
+  importRetry: boolean,
 |};

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -475,6 +475,24 @@ function getLoaderRuntime({
     loaderCode = `(${loaderCode})`;
   }
 
+  if (needsEsmLoadPrelude && options.featureFlags.importRetry) {
+    const assetId = bundleGraph.getAssetById(bundleGroup.entryAssetId);
+    loaderCode = `
+      Object.defineProperty(module, 'exports', { get: () => {
+        let load = require('./helpers/browser/esm-js-loader-retry');
+        return ${loaderCode}.then(() => parcelRequire("${bundleGraph.getAssetPublicId(
+      assetId,
+    )}"));
+      }})`;
+
+    return {
+      filePath: __filename,
+      code: loaderCode,
+      dependency,
+      env: {sourceType: 'module'},
+    };
+  }
+
   if (mainBundle.type === 'js') {
     let parcelRequire = bundle.env.shouldScopeHoist
       ? 'parcelRequire'

--- a/packages/runtimes/js/src/helpers/browser/esm-js-loader-retry.js
+++ b/packages/runtimes/js/src/helpers/browser/esm-js-loader-retry.js
@@ -1,0 +1,26 @@
+async function load(id) {
+  if (!parcelRequire.retryState) {
+    parcelRequire.retryState = {};
+  }
+
+  if (!globalThis.navigator.onLine) {
+    await new Promise(res =>
+      globalThis.addEventListener('online', res, {once: true}),
+    );
+  }
+
+  let url = require('../bundle-manifest').resolve(id);
+
+  if (parcelRequire.retryState[id] != undefined) {
+    url = `${url}?retry=${parcelRequire.retryState[id]}`;
+  }
+
+  try {
+    // eslint-disable-next-line no-undef
+    return await __parcel__import__(url);
+  } catch (error) {
+    parcelRequire.retryState[id] = Date.now();
+  }
+}
+
+module.exports = load;


### PR DESCRIPTION
This PR adds the ability to retry dynamic imports. This will be re-implemented when we revisit the runtime during the native rewrite.

## 💻 Examples

```typescript
while true {
  try {
    await import('./foo.js').then(console.log)
    break
  } catch (error) {
    await new Promise(res => setTimeout(res, 1000))
  }
}
```

```
npx parcel build --feature-flag importRetry=true
```
