### PR TITLE
Fix perf regression in incremental builds

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -112,7 +112,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
   hash: ?string;
   envCache: Map<string, Environment>;
   safeToIncrementallyBundle: boolean = true;
-  usedDependencies: Set<Dependency>;
+  undeferredDependencies: Set<Dependency>;
 
   constructor(opts: ?AssetGraphOpts) {
     if (opts) {
@@ -130,7 +130,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
       );
     }
 
-    this.usedDependencies = new Set();
+    this.undeferredDependencies = new Set();
     this.envCache = new Map();
   }
 
@@ -420,7 +420,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     for (const d of deps) {
       // If this dependency has already been through this process, and we
       // know it's not deferrable, then there's no need to re-check
-      if (this.usedDependencies.has(d)) {
+      if (this.undeferredDependencies.has(d)) {
         return false;
       }
 
@@ -435,7 +435,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
 
       if (!depIsDeferrable) {
         // Mark this dep as not deferrable so it doesn't have to be re-checked
-        this.usedDependencies.add(d);
+        this.undeferredDependencies.add(d);
         return false;
       }
     }

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -376,41 +376,60 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     sideEffects: ?boolean,
     canDefer: boolean,
   ): boolean {
-    let defer = false;
     let dependencySymbols = dependency.symbols;
-    if (
-      dependencySymbols &&
+
+    // Doing this separately keeps Flow happy further down
+    if (!dependencySymbols) {
+      return false;
+    }
+
+    let isDeferrable =
       [...dependencySymbols].every(([, {isWeak}]) => isWeak) &&
       sideEffects === false &&
       canDefer &&
-      !dependencySymbols.has('*')
-    ) {
-      let depNodeId = this.getNodeIdByContentKey(dependency.id);
-      let depNode = this.getNode(depNodeId);
-      invariant(depNode);
+      !dependencySymbols.has('*');
 
-      let assets = this.getNodeIdsConnectedTo(depNodeId);
-      let symbols = new Map(
-        [...dependencySymbols].map(([key, val]) => [val.local, key]),
-      );
-      invariant(assets.length === 1);
-      let firstAsset = nullthrows(this.getNode(assets[0]));
-      invariant(firstAsset.type === 'asset');
-      let resolvedAsset = firstAsset.value;
-      let deps = this.getIncomingDependencies(resolvedAsset);
-      defer = deps.every(
-        d =>
-          d.symbols &&
-          !(d.env.isLibrary && d.isEntry) &&
-          !d.symbols.has('*') &&
-          ![...d.symbols.keys()].some(symbol => {
-            if (!resolvedAsset.symbols) return true;
-            let assetSymbol = resolvedAsset.symbols?.get(symbol)?.local;
-            return assetSymbol != null && symbols.has(assetSymbol);
-          }),
-      );
+    if (!isDeferrable) {
+      return false;
     }
-    return defer;
+
+    let depNodeId = this.getNodeIdByContentKey(dependency.id);
+    let depNode = this.getNode(depNodeId);
+    invariant(depNode);
+
+    let assets = this.getNodeIdsConnectedTo(depNodeId);
+    let symbols = new Map(
+      [...dependencySymbols].map(([key, val]) => [val.local, key]),
+    );
+    invariant(assets.length === 1);
+    let firstAsset = nullthrows(this.getNode(assets[0]));
+    invariant(firstAsset.type === 'asset');
+    let resolvedAsset = firstAsset.value;
+
+    // This doesn't change from here, so checking it now saves
+    // us some calls to `getIncomingDependency`
+    if (!resolvedAsset.symbols) {
+      return true;
+    }
+
+    let deps = this.getIncomingDependencies(resolvedAsset);
+
+    for (const d of deps) {
+      let depIsDeferrable =
+        d.symbols &&
+        !(d.env.isLibrary && d.isEntry) &&
+        !d.symbols.has('*') &&
+        ![...d.symbols.keys()].some(symbol => {
+          let assetSymbol = resolvedAsset.symbols?.get(symbol)?.local;
+          return assetSymbol != null && symbols.has(assetSymbol);
+        });
+
+      if (!depIsDeferrable) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   resolveAssetGroup(

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -417,7 +417,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
 
     let deps = this.getIncomingDependencies(resolvedAsset);
 
-    for (const d of deps) {
+    return deps.every(d => {
       // If this dependency has already been through this process, and we
       // know it's not deferrable, then there's no need to re-check
       if (this.undeferredDependencies.has(d)) {
@@ -438,9 +438,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
         this.undeferredDependencies.add(d);
         return false;
       }
-    }
-
-    return true;
+    });
   }
 
   resolveAssetGroup(

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -70,11 +70,11 @@ type AssetGraphRequest = {|
 |};
 
 export default function createAssetGraphRequest(
-  input: AssetGraphRequestInput,
+  requestInput: AssetGraphRequestInput,
 ): AssetGraphRequest {
   return {
     type: requestTypes.asset_graph_request,
-    id: input.name,
+    id: requestInput.name,
     run: async input => {
       let prevResult =
         await input.api.getPreviousResult<AssetGraphRequestResult>();
@@ -92,7 +92,7 @@ export default function createAssetGraphRequest(
 
       return assetGraphRequest;
     },
-    input,
+    input: requestInput,
   };
 }
 

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -143,7 +143,7 @@ export class AssetGraphBuilder {
       entries,
       assetGroups,
     });
-    assetGraph.usedDependencies.clear();
+    assetGraph.undeferredDependencies.clear();
     this.assetGroupsWithRemovedParents =
       prevResult?.assetGroupsWithRemovedParents ?? new Set();
     this.previousSymbolPropagationErrors =

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -143,6 +143,7 @@ export class AssetGraphBuilder {
       entries,
       assetGroups,
     });
+    assetGraph.usedDependencies.clear();
     this.assetGroupsWithRemovedParents =
       prevResult?.assetGroupsWithRemovedParents ?? new Set();
     this.previousSymbolPropagationErrors =


### PR DESCRIPTION
This PR fixes a decrease in performance that could occur in large apps where `shouldDeferDependency` is called many times on Assets that have many incoming dependencies. In some cases, this can bottleneck the main thread causing incremental builds/lazy mode builds to take much longer. 

The workaround is to add a cache thats fresh for each `AssetGraphRequest` that tracks which  dependencies are already known to be not deferable. 