### PR TITLE
Add create_directory to file system api

### DIFF
--- a/crates/node-bindings/src/file_system/file_system_napi.rs
+++ b/crates/node-bindings/src/file_system/file_system_napi.rs
@@ -12,6 +12,7 @@ use parcel_napi_helpers::js_callable::JsCallable;
 
 pub struct FileSystemNapi {
   canonicalize_fn: JsCallable,
+  create_directory_fn: JsCallable,
   cwd_fn: JsCallable,
   read_file_fn: JsCallable,
   is_file_fn: JsCallable,
@@ -22,6 +23,7 @@ impl FileSystemNapi {
   pub fn new(js_file_system: &JsObject) -> napi::Result<Self> {
     Ok(Self {
       canonicalize_fn: JsCallable::new_from_object_prop("canonicalize", &js_file_system)?,
+      create_directory_fn: JsCallable::new_from_object_prop("createDirectory", &js_file_system)?,
       cwd_fn: JsCallable::new_from_object_prop("cwd", &js_file_system)?,
       read_file_fn: JsCallable::new_from_object_prop("readFile", &js_file_system)?,
       is_file_fn: JsCallable::new_from_object_prop("isFile", &js_file_system)?,
@@ -34,6 +36,13 @@ impl FileSystem for FileSystemNapi {
   fn canonicalize_base(&self, path: &Path) -> io::Result<PathBuf> {
     self
       .canonicalize_fn
+      .call_with_return_serde(path.to_path_buf())
+      .map_err(|e| io::Error::other(e))
+  }
+
+  fn create_directory(&self, path: &Path) -> std::io::Result<()> {
+    self
+      .create_directory_fn
       .call_with_return_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e))
   }

--- a/crates/node-bindings/src/parcel/parcel/tracing_setup.rs
+++ b/crates/node-bindings/src/parcel/parcel/tracing_setup.rs
@@ -15,7 +15,7 @@ pub struct ParcelTracingOptions {
 impl Default for ParcelTracingOptions {
   fn default() -> Self {
     Self {
-      enabled: true,
+      enabled: false,
       output_file_options: Some(ParcelTracingOutputFileOptions {
         directory: std::env::temp_dir().to_string_lossy().to_string(),
         prefix: "parcel-tracing".to_string(),

--- a/crates/parcel/src/project_root.rs
+++ b/crates/parcel/src/project_root.rs
@@ -312,9 +312,11 @@ mod tests {
       let entries = Some(Entry::Single(String::from("src/a.js")));
       let fs = Arc::new(InMemoryFileSystem::default());
       let root = root();
+      let vcs = root.join(vcs);
 
       fs.set_current_working_directory(cwd());
-      fs.create_directory(&root.join(vcs));
+      fs.create_directory(&vcs)
+        .expect(format!("Expected {} directory to be created", vcs.display()).as_str());
 
       assert_eq!(
         infer_project_root(fs, entries).map_err(|e| e.to_string()),

--- a/crates/parcel_filesystem/src/in_memory_file_system.rs
+++ b/crates/parcel_filesystem/src/in_memory_file_system.rs
@@ -27,12 +27,6 @@ impl InMemoryFileSystem {
     *state = cwd;
   }
 
-  /// Create a directory at path.
-  pub fn create_directory(&self, path: &Path) {
-    let mut files = self.files.write().unwrap();
-    files.insert(path.into(), InMemoryFileSystemEntry::Directory);
-  }
-
   /// Write a file at path.
   pub fn write_file(&self, path: &Path, contents: String) {
     let mut files = self.files.write().unwrap();
@@ -88,6 +82,12 @@ impl FileSystem for InMemoryFileSystem {
     }
 
     Ok(PathBuf::from_iter(result))
+  }
+
+  fn create_directory(&self, path: &Path) -> std::io::Result<()> {
+    let mut files = self.files.write().unwrap();
+    files.insert(path.into(), InMemoryFileSystemEntry::Directory);
+    Ok(())
   }
 
   fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
@@ -196,7 +196,10 @@ mod test {
   #[test]
   fn test_is_dir() {
     let fs = InMemoryFileSystem::default();
-    fs.create_directory(&PathBuf::from("/foo"));
+
+    fs.create_directory(&PathBuf::from("/foo"))
+      .expect("Expected /foo directory to be created");
+
     assert!(fs.is_dir(Path::new("/foo")));
     assert!(!fs.is_dir(Path::new("/foo/bar")));
   }

--- a/crates/parcel_filesystem/src/lib.rs
+++ b/crates/parcel_filesystem/src/lib.rs
@@ -36,12 +36,14 @@ pub trait FileSystem {
       "Not implemented",
     ))
   }
+
   fn canonicalize_base(&self, _path: &Path) -> Result<PathBuf> {
     Err(std::io::Error::new(
       std::io::ErrorKind::Other,
       "Not implemented",
     ))
   }
+
   fn canonicalize(
     &self,
     path: &Path,
@@ -49,6 +51,15 @@ pub trait FileSystem {
   ) -> Result<PathBuf> {
     self.canonicalize_base(path)
   }
+
+  /// Create a directory at the specified path
+  fn create_directory(&self, _path: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+      std::io::ErrorKind::Other,
+      "Not implemented",
+    ))
+  }
+
   fn read_to_string(&self, path: &Path) -> Result<String>;
   fn is_file(&self, path: &Path) -> bool;
   fn is_dir(&self, path: &Path) -> bool;

--- a/crates/parcel_filesystem/src/os_file_system.rs
+++ b/crates/parcel_filesystem/src/os_file_system.rs
@@ -24,6 +24,10 @@ impl FileSystem for OsFileSystem {
     canonicalize(path, cache)
   }
 
+  fn create_directory(&self, path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)
+  }
+
   fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     std::fs::read_to_string(path)
   }

--- a/crates/parcel_filesystem/src/search.rs
+++ b/crates/parcel_filesystem/src/search.rs
@@ -105,9 +105,13 @@ mod tests {
   fn returns_none_when_there_are_no_matching_ancestor_directories() {
     let fs = InMemoryFileSystem::default();
 
-    fs.create_directory(Path::new("srcs"));
-    fs.create_directory(Path::new("packages/parcel/srcs"));
-    fs.create_directory(Path::new("packages/parcel/descendent/src"));
+    fs.create_directory(Path::new("srcs")).unwrap();
+
+    fs.create_directory(Path::new("packages/parcel/srcs"))
+      .unwrap();
+
+    fs.create_directory(Path::new("packages/parcel/descendent/src"))
+      .unwrap();
 
     assert_eq!(
       find_ancestor_directory(
@@ -168,7 +172,8 @@ mod tests {
   fn returns_none_when_ancestor_file_is_a_directory() {
     let fs = InMemoryFileSystem::default();
 
-    fs.create_directory(Path::new("packages/parcel/package.json"));
+    fs.create_directory(Path::new("packages/parcel/package.json"))
+      .unwrap();
 
     assert_eq!(
       find_ancestor_file(
@@ -185,7 +190,7 @@ mod tests {
   fn returns_none_when_ancestor_directory_is_outside_root() {
     let fs = InMemoryFileSystem::default();
 
-    fs.create_directory(Path::new("src"));
+    fs.create_directory(Path::new("src")).unwrap();
 
     assert_eq!(
       find_ancestor_directory(
@@ -219,13 +224,15 @@ mod tests {
   fn returns_first_closest_ancestor_directory_path() {
     let fs = InMemoryFileSystem::default();
 
-    fs.create_directory(Path::new("dist"));
-    fs.create_directory(Path::new("packages/dist"));
-    fs.create_directory(Path::new("packages/parcel/dist"));
+    fs.create_directory(Path::new("dist")).unwrap();
+    fs.create_directory(Path::new("packages/dist")).unwrap();
+    fs.create_directory(Path::new("packages/parcel/dist"))
+      .unwrap();
 
-    fs.create_directory(Path::new("src"));
-    fs.create_directory(Path::new("packages/src"));
-    fs.create_directory(Path::new("packages/parcel/src"));
+    fs.create_directory(Path::new("src")).unwrap();
+    fs.create_directory(Path::new("packages/src")).unwrap();
+    fs.create_directory(Path::new("packages/parcel/src"))
+      .unwrap();
 
     assert_eq!(
       find_ancestor_directory(
@@ -272,9 +279,10 @@ mod tests {
   fn returns_first_closest_ancestor_entry_path() {
     let fs = InMemoryFileSystem::default();
 
-    fs.create_directory(Path::new("src"));
-    fs.create_directory(Path::new("packages/src"));
-    fs.create_directory(Path::new("packages/parcel/src"));
+    fs.create_directory(Path::new("src")).unwrap();
+    fs.create_directory(Path::new("packages/src")).unwrap();
+    fs.create_directory(Path::new("packages/parcel/src"))
+      .unwrap();
 
     fs.write_file(Path::new("package.json"), String::from("{}"));
     fs.write_file(Path::new("packages/package.json"), String::from("{}"));

--- a/packages/core/core/src/parcel-v3/fs.js
+++ b/packages/core/core/src/parcel-v3/fs.js
@@ -1,0 +1,33 @@
+// @flow strict-local
+
+import type {FileSystem} from '@parcel/rust';
+import type {
+  Encoding,
+  FilePath,
+  FileSystem as ClassicFileSystem,
+} from '@parcel/types-internal';
+
+// Move to @parcel/utils or a dedicated v3 / migration package later
+export function toFileSystemV3(fs: ClassicFileSystem): FileSystem {
+  return {
+    canonicalize: (path: FilePath) => fs.realpathSync(path),
+    createDirectory: (path: FilePath) => fs.mkdirp(path),
+    cwd: () => fs.cwd(),
+    readFile: (path: string, encoding?: Encoding) =>
+      fs.readFileSync(path, encoding ?? 'utf8'),
+    isFile: (path: string) => {
+      try {
+        return fs.statSync(path).isFile();
+      } catch {
+        return false;
+      }
+    },
+    isDir: (path: string) => {
+      try {
+        return fs.statSync(path).isDirectory();
+      } catch {
+        return false;
+      }
+    },
+  };
+}

--- a/packages/core/core/src/parcel-v3/index.js
+++ b/packages/core/core/src/parcel-v3/index.js
@@ -1,4 +1,5 @@
 // @flow
 
+export {toFileSystemV3} from './fs';
 export {ParcelV3} from './ParcelV3';
 export type * from './ParcelV3';

--- a/packages/core/integration-tests/test/parcel-v3.js
+++ b/packages/core/integration-tests/test/parcel-v3.js
@@ -3,49 +3,16 @@
 import assert from 'assert';
 import {join} from 'path';
 
-import {ParcelV3} from '@parcel/core';
+import {ParcelV3, toFileSystemV3} from '@parcel/core';
 import {NodePackageManager} from '@parcel/package-manager';
-import type {FileSystem} from '@parcel/rust';
 import {bundle, fsFixture, inputFS, overlayFS, run} from '@parcel/test-utils';
-import type {
-  Encoding,
-  FilePath,
-  FileSystem as ClassicFileSystem,
-} from '@parcel/types-internal';
 
 describe('parcel-v3', function () {
-  // Add to @parcel/utils later
-  function toFileSystemV3(fs: ClassicFileSystem): FileSystem {
-    return {
-      canonicalize: (path: FilePath) => fs.realpathSync(path),
-      cwd: () => fs.cwd(),
-      readFile: (path: string, encoding?: Encoding) =>
-        fs.readFileSync(path, encoding ?? 'utf8'),
-      isFile: (path: string) => {
-        try {
-          return fs.statSync(path).isFile();
-        } catch {
-          return false;
-        }
-      },
-      isDir: (path: string) => {
-        try {
-          return fs.statSync(path).isDirectory();
-        } catch {
-          return false;
-        }
-      },
-    };
-  }
-
   // Duplicated temporarily for convenience, will remove once the Rust stuff works
   it.skip('should produce a basic JS bundle with CommonJS requires', async function () {
     let b = await bundle(join(__dirname, '/integration/commonjs/index.js'), {
       featureFlags: {parcelV3: true},
     });
-
-    // assert.equal(b.assets.size, 8);
-    // assert.equal(b.childBundles.size, 1);
 
     let output = await run(b);
     assert.equal(typeof output, 'function');


### PR DESCRIPTION
# ↪️ Pull Request

Adds a missing `create_directory` fn to the `FileSystem` trait so that any `FileSystemRef` can call into that API when needed, not just the memory file system.

## 🚨 Test instructions

`cargo test`