### PR TITLE
Use request context in path request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,6 +1719,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dyn-hash",
+ "mockall",
  "num_cpus",
  "parcel-resolver",
  "parcel_config",

--- a/crates/parcel/Cargo.toml
+++ b/crates/parcel/Cargo.toml
@@ -30,3 +30,6 @@ serde_json = "1.0.116"
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
+
+[dev-dependencies]
+mockall = "0.12.1"

--- a/crates/parcel/src/parcel.rs
+++ b/crates/parcel/src/parcel.rs
@@ -5,12 +5,9 @@ use parcel_config::parcel_rc_config_loader::LoadConfigOptions;
 use parcel_config::parcel_rc_config_loader::ParcelRcConfigLoader;
 use parcel_core::cache::MockCache;
 use parcel_core::config_loader::ConfigLoader;
-use parcel_core::plugin::composite_reporter_plugin::CompositeReporterPlugin;
 use parcel_core::plugin::PluginContext;
 use parcel_core::plugin::PluginLogger;
 use parcel_core::plugin::PluginOptions;
-use parcel_core::plugin::ReporterEvent;
-use parcel_core::plugin::ReporterPlugin;
 use parcel_core::types::ParcelOptions;
 use parcel_filesystem::os_file_system::OsFileSystem;
 use parcel_filesystem::FileSystemRef;
@@ -19,7 +16,7 @@ use parcel_package_manager::PackageManagerRef;
 use parcel_plugin_rpc::RpcHostRef;
 use parcel_plugin_rpc::RpcWorkerRef;
 
-use crate::plugins::Plugins;
+use crate::plugins::config_plugins::ConfigPlugins;
 use crate::project_root::infer_project_root;
 use crate::request_tracker::RequestTracker;
 
@@ -80,7 +77,7 @@ impl Parcel {
       search_path: self.project_root.join("index"),
     });
 
-    let plugins = Plugins::new(
+    let plugins = ConfigPlugins::new(
       config,
       PluginContext {
         config: Arc::clone(&config_loader),
@@ -93,16 +90,14 @@ impl Parcel {
       },
     );
 
-    // TODO: Revisit plugins, so that the request tracker only has access to the composite plugin
-    let reporter = CompositeReporterPlugin::new(plugins.reporters());
-
-    reporter.report(&ReporterEvent::BuildStart)?;
+    // TODO Reinstate this when we are in a full build
+    // plugins.reporter().report(&ReporterEvent::BuildStart)?;
 
     let _request_tracker = RequestTracker::new(
       Arc::new(MockCache::new()),
       Arc::clone(&config_loader),
       Arc::clone(&self.fs),
-      plugins,
+      Arc::new(plugins),
       self.project_root.clone(),
     );
 

--- a/crates/parcel/src/plugins.rs
+++ b/crates/parcel/src/plugins.rs
@@ -1,214 +1,46 @@
 use std::fmt::Debug;
-use std::hash::Hash;
-use std::hash::Hasher;
 use std::path::Path;
 use std::sync::Arc;
 use std::u64;
 
-use parcel_config::map::NamedPattern;
-use parcel_config::ParcelConfig;
-use parcel_core::diagnostic_error;
+#[cfg(test)]
+use mockall::automock;
 use parcel_core::plugin::BundlerPlugin;
 use parcel_core::plugin::CompressorPlugin;
 use parcel_core::plugin::NamerPlugin;
 use parcel_core::plugin::OptimizerPlugin;
 use parcel_core::plugin::PackagerPlugin;
-use parcel_core::plugin::PluginContext;
 use parcel_core::plugin::ReporterPlugin;
 use parcel_core::plugin::ResolverPlugin;
 use parcel_core::plugin::RuntimePlugin;
 use parcel_core::plugin::TransformerPlugin;
 use parcel_core::plugin::ValidatorPlugin;
-use parcel_plugin_resolver::ParcelResolver;
-use parcel_plugin_rpc::plugin::RpcBundlerPlugin;
-use parcel_plugin_rpc::plugin::RpcCompressorPlugin;
-use parcel_plugin_rpc::plugin::RpcNamerPlugin;
-use parcel_plugin_rpc::plugin::RpcOptimizerPlugin;
-use parcel_plugin_rpc::plugin::RpcPackagerPlugin;
-use parcel_plugin_rpc::plugin::RpcReporterPlugin;
-use parcel_plugin_rpc::plugin::RpcResolverPlugin;
-use parcel_plugin_rpc::plugin::RpcRuntimePlugin;
-use parcel_plugin_rpc::plugin::RpcTransformerPlugin;
-use parcel_plugin_transformer_js::ParcelJsTransformerPlugin;
 
-// TODO Implement specifics of injecting env for napi plugins
+pub type PluginsRef = Arc<dyn Plugins + Send + Sync>;
 
-pub type PluginsRef = Arc<Plugins>;
+pub mod config_plugins;
 
-/// Loads plugins based on the Parcel config
-pub struct Plugins {
-  /// The Parcel config that determines what plugins will be loaded
-  config: ParcelConfig,
-
-  /// Dependencies available to all plugin types
-  ctx: PluginContext,
-}
-
-impl Plugins {
-  #[allow(unused)]
-  pub fn new(config: ParcelConfig, ctx: PluginContext) -> Self {
-    Plugins { config, ctx }
-  }
-
-  fn missing_plugin(&self, path: &Path, phase: &str) -> anyhow::Error {
-    diagnostic_error!("No {phase} found for path {}", path.display())
-  }
-
-  fn missing_pipeline_plugin(&self, path: &Path, phase: &str, pipeline: &str) -> anyhow::Error {
-    diagnostic_error!(
-      "No {phase} found for path {} with pipeline {pipeline}",
-      path.display(),
-    )
-  }
-
-  #[allow(unused)]
-  pub fn bundler(&self) -> Result<Box<dyn BundlerPlugin>, anyhow::Error> {
-    Ok(Box::new(RpcBundlerPlugin::new(
-      &self.ctx,
-      &self.config.bundler,
-    )?))
-  }
-
-  #[allow(unused)]
-  pub fn compressors(&self, path: &Path) -> Result<Vec<Box<dyn CompressorPlugin>>, anyhow::Error> {
-    let mut compressors: Vec<Box<dyn CompressorPlugin>> = Vec::new();
-
-    for compressor in self.config.compressors.get(path).iter() {
-      compressors.push(Box::new(RpcCompressorPlugin::new(&self.ctx, compressor)));
-    }
-
-    if compressors.is_empty() {
-      return Err(self.missing_plugin(path, "compressors"));
-    }
-
-    Ok(compressors)
-  }
-
-  #[allow(unused)]
-  pub fn named_pipelines(&self) -> Vec<String> {
-    self.config.transformers.named_pipelines()
-  }
-
-  #[allow(unused)]
-  pub fn namers(&self) -> Result<Vec<Box<dyn NamerPlugin>>, anyhow::Error> {
-    let mut namers: Vec<Box<dyn NamerPlugin>> = Vec::new();
-
-    for namer in self.config.namers.iter() {
-      namers.push(Box::new(RpcNamerPlugin::new(&self.ctx, namer)?));
-    }
-
-    Ok(namers)
-  }
-
-  #[allow(unused)]
-  pub fn optimizers(
+#[cfg_attr(test, automock)]
+pub trait Plugins {
+  fn bundler(&self) -> Result<Box<dyn BundlerPlugin>, anyhow::Error>;
+  fn compressors(&self, path: &Path) -> Result<Vec<Box<dyn CompressorPlugin>>, anyhow::Error>;
+  fn named_pipelines(&self) -> Vec<String>;
+  fn namers(&self) -> Result<Vec<Box<dyn NamerPlugin>>, anyhow::Error>;
+  fn optimizers(
     &self,
     path: &Path,
-    pipeline: Option<&str>,
-  ) -> Result<Vec<Box<dyn OptimizerPlugin>>, anyhow::Error> {
-    let mut optimizers: Vec<Box<dyn OptimizerPlugin>> = Vec::new();
-    let named_pattern = pipeline.map(|pipeline| NamedPattern {
-      pipeline: pipeline.as_ref(),
-      use_fallback: true,
-    });
-
-    for optimizer in self.config.optimizers.get(path, named_pattern).iter() {
-      optimizers.push(Box::new(RpcOptimizerPlugin::new(&self.ctx, optimizer)?));
-    }
-
-    Ok(optimizers)
-  }
-
-  #[allow(unused)]
-  pub fn packager(&self, path: &Path) -> Result<Box<dyn PackagerPlugin>, anyhow::Error> {
-    let packager = self.config.packagers.get(path);
-
-    match packager {
-      None => Err(self.missing_plugin(path, "packager")),
-      Some(packager) => Ok(Box::new(RpcPackagerPlugin::new(&self.ctx, packager)?)),
-    }
-  }
-
-  #[allow(unused)]
-  pub fn reporters(&self) -> Vec<Box<dyn ReporterPlugin>> {
-    let mut reporters: Vec<Box<dyn ReporterPlugin>> = Vec::new();
-
-    for reporter in self.config.reporters.iter() {
-      reporters.push(Box::new(RpcReporterPlugin::new(&self.ctx, reporter)));
-    }
-
-    reporters
-  }
-
-  #[allow(unused)]
-  pub fn resolvers(&self) -> Result<Vec<Box<dyn ResolverPlugin>>, anyhow::Error> {
-    let mut resolvers: Vec<Box<dyn ResolverPlugin>> = Vec::new();
-
-    for resolver in self.config.resolvers.iter() {
-      if resolver.package_name == "@parcel/resolver-default" {
-        resolvers.push(Box::new(ParcelResolver::new(&self.ctx)));
-        continue;
-      }
-
-      resolvers.push(Box::new(RpcResolverPlugin::new(&self.ctx, resolver)?));
-    }
-
-    Ok(resolvers)
-  }
-
-  #[allow(unused)]
-  pub fn runtimes(&self) -> Result<Vec<Box<dyn RuntimePlugin>>, anyhow::Error> {
-    let mut runtimes: Vec<Box<dyn RuntimePlugin>> = Vec::new();
-
-    for runtime in self.config.runtimes.iter() {
-      runtimes.push(Box::new(RpcRuntimePlugin::new(&self.ctx, runtime)?));
-    }
-
-    Ok(runtimes)
-  }
-
-  /// Resolve and load transformer plugins for a given path.
-  #[allow(unused)]
-  pub fn transformers(
+    pipeline: Option<String>,
+  ) -> Result<Vec<Box<dyn OptimizerPlugin>>, anyhow::Error>;
+  fn packager(&self, path: &Path) -> Result<Box<dyn PackagerPlugin>, anyhow::Error>;
+  fn reporter(&self) -> Arc<dyn ReporterPlugin>;
+  fn resolvers(&self) -> Result<Vec<Box<dyn ResolverPlugin>>, anyhow::Error>;
+  fn runtimes(&self) -> Result<Vec<Box<dyn RuntimePlugin>>, anyhow::Error>;
+  fn transformers(
     &self,
     path: &Path,
-    pipeline: Option<&str>,
-  ) -> Result<TransformerPipeline, anyhow::Error> {
-    let mut transformers: Vec<Box<dyn TransformerPlugin>> = Vec::new();
-    let named_pattern = pipeline.map(|pipeline| NamedPattern {
-      pipeline,
-      use_fallback: false,
-    });
-
-    let mut hasher = parcel_core::hash::IdentifierHasher::default();
-
-    for transformer in self.config.transformers.get(path, named_pattern).iter() {
-      transformer.hash(&mut hasher);
-      if transformer.package_name == "@parcel/transformer-js" {
-        transformers.push(Box::new(ParcelJsTransformerPlugin::new()));
-        continue;
-      }
-
-      transformers.push(Box::new(RpcTransformerPlugin::new(&self.ctx, transformer)?));
-    }
-
-    if transformers.is_empty() {
-      return match pipeline {
-        None => Err(self.missing_plugin(path, "transformers")),
-        Some(pipeline) => Err(self.missing_pipeline_plugin(path, "transformers", pipeline)),
-      };
-    }
-
-    Ok(TransformerPipeline {
-      transformers,
-      hash: hasher.finish(),
-    })
-  }
-
-  #[allow(unused)]
-  pub fn validators(&self, _path: &Path) -> Result<Vec<Box<dyn ValidatorPlugin>>, anyhow::Error> {
-    todo!()
-  }
+    pipeline: Option<String>,
+  ) -> Result<TransformerPipeline, anyhow::Error>;
+  fn validators(&self, _path: &Path) -> Result<Vec<Box<dyn ValidatorPlugin>>, anyhow::Error>;
 }
 
 pub struct TransformerPipeline {
@@ -227,94 +59,5 @@ impl Debug for TransformerPipeline {
     f.debug_struct("TransformerPipeline")
       .field("transformers", &self.transformers)
       .finish()
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use crate::test_utils::{make_test_plugin_context, plugins};
-
-  use super::*;
-
-  #[test]
-  fn returns_bundler() {
-    let bundler = plugins(make_test_plugin_context())
-      .bundler()
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", bundler), "RpcBundlerPlugin")
-  }
-
-  #[test]
-  fn returns_compressors() {
-    let compressors = plugins(make_test_plugin_context())
-      .compressors(Path::new("a.js"))
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", compressors), "[RpcCompressorPlugin]")
-  }
-
-  #[test]
-  fn returns_namers() {
-    let namers = plugins(make_test_plugin_context())
-      .namers()
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", namers), "[RpcNamerPlugin]")
-  }
-
-  #[test]
-  fn returns_optimizers() {
-    let optimizers = plugins(make_test_plugin_context())
-      .optimizers(Path::new("a.js"), None)
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", optimizers), "[RpcOptimizerPlugin]")
-  }
-
-  #[test]
-  fn returns_packager() {
-    let packager = plugins(make_test_plugin_context())
-      .packager(Path::new("a.js"))
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", packager), "RpcPackagerPlugin")
-  }
-
-  #[test]
-  fn returns_reporters() {
-    let reporters = plugins(make_test_plugin_context()).reporters();
-
-    assert_eq!(format!("{:?}", reporters), "[RpcReporterPlugin]")
-  }
-
-  #[test]
-  fn returns_resolvers() {
-    let resolvers = plugins(make_test_plugin_context())
-      .resolvers()
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", resolvers), "[ParcelResolver]")
-  }
-
-  #[test]
-  fn returns_runtimes() {
-    let runtimes = plugins(make_test_plugin_context())
-      .runtimes()
-      .expect("Not to panic");
-
-    assert_eq!(format!("{:?}", runtimes), "[RpcRuntimePlugin]")
-  }
-
-  #[test]
-  fn returns_transformers() {
-    let transformers = plugins(make_test_plugin_context())
-      .transformers(Path::new("a.ts"), None)
-      .expect("Not to panic");
-
-    assert_eq!(
-      format!("{:?}", transformers),
-      r"TransformerPipeline { transformers: [ParcelJsTransformerPlugin] }"
-    )
   }
 }

--- a/crates/parcel/src/plugins/config_plugins.rs
+++ b/crates/parcel/src/plugins/config_plugins.rs
@@ -1,0 +1,308 @@
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::path::Path;
+use std::sync::Arc;
+
+use parcel_config::map::NamedPattern;
+use parcel_config::ParcelConfig;
+use parcel_core::diagnostic_error;
+use parcel_core::plugin::composite_reporter_plugin::CompositeReporterPlugin;
+use parcel_core::plugin::BundlerPlugin;
+use parcel_core::plugin::CompressorPlugin;
+use parcel_core::plugin::NamerPlugin;
+use parcel_core::plugin::OptimizerPlugin;
+use parcel_core::plugin::PackagerPlugin;
+use parcel_core::plugin::PluginContext;
+use parcel_core::plugin::ReporterPlugin;
+use parcel_core::plugin::ResolverPlugin;
+use parcel_core::plugin::RuntimePlugin;
+use parcel_core::plugin::TransformerPlugin;
+use parcel_core::plugin::ValidatorPlugin;
+use parcel_plugin_resolver::ParcelResolver;
+use parcel_plugin_rpc::plugin::RpcBundlerPlugin;
+use parcel_plugin_rpc::plugin::RpcCompressorPlugin;
+use parcel_plugin_rpc::plugin::RpcNamerPlugin;
+use parcel_plugin_rpc::plugin::RpcOptimizerPlugin;
+use parcel_plugin_rpc::plugin::RpcPackagerPlugin;
+use parcel_plugin_rpc::plugin::RpcReporterPlugin;
+use parcel_plugin_rpc::plugin::RpcResolverPlugin;
+use parcel_plugin_rpc::plugin::RpcRuntimePlugin;
+use parcel_plugin_rpc::plugin::RpcTransformerPlugin;
+use parcel_plugin_transformer_js::ParcelJsTransformerPlugin;
+
+use super::Plugins;
+use super::TransformerPipeline;
+
+/// Loads plugins based on the Parcel config
+pub struct ConfigPlugins {
+  /// The Parcel config that determines what plugins will be loaded
+  config: ParcelConfig,
+
+  /// Dependencies available to all plugin types
+  ctx: PluginContext,
+
+  /// A reporter that runs all reporter plugins
+  reporter: Arc<dyn ReporterPlugin>,
+}
+
+impl ConfigPlugins {
+  pub fn new(config: ParcelConfig, ctx: PluginContext) -> Self {
+    let mut reporters: Vec<Box<dyn ReporterPlugin>> = Vec::new();
+
+    for reporter in config.reporters.iter() {
+      reporters.push(Box::new(RpcReporterPlugin::new(&ctx, reporter)));
+    }
+
+    let reporter = Arc::new(CompositeReporterPlugin::new(reporters));
+
+    ConfigPlugins {
+      config,
+      ctx,
+      reporter,
+    }
+  }
+
+  fn missing_plugin(&self, path: &Path, phase: &str) -> anyhow::Error {
+    diagnostic_error!("No {phase} found for path {}", path.display())
+  }
+
+  fn missing_pipeline_plugin(&self, path: &Path, phase: &str, pipeline: &str) -> anyhow::Error {
+    diagnostic_error!(
+      "No {phase} found for path {} with pipeline {pipeline}",
+      path.display(),
+    )
+  }
+}
+
+impl Plugins for ConfigPlugins {
+  #[allow(unused)]
+  fn bundler(&self) -> Result<Box<dyn BundlerPlugin>, anyhow::Error> {
+    Ok(Box::new(RpcBundlerPlugin::new(
+      &self.ctx,
+      &self.config.bundler,
+    )?))
+  }
+
+  #[allow(unused)]
+  fn compressors(&self, path: &Path) -> Result<Vec<Box<dyn CompressorPlugin>>, anyhow::Error> {
+    let mut compressors: Vec<Box<dyn CompressorPlugin>> = Vec::new();
+
+    for compressor in self.config.compressors.get(path).iter() {
+      compressors.push(Box::new(RpcCompressorPlugin::new(&self.ctx, compressor)));
+    }
+
+    if compressors.is_empty() {
+      return Err(self.missing_plugin(path, "compressors"));
+    }
+
+    Ok(compressors)
+  }
+
+  fn named_pipelines(&self) -> Vec<String> {
+    self.config.transformers.named_pipelines()
+  }
+
+  #[allow(unused)]
+  fn namers(&self) -> Result<Vec<Box<dyn NamerPlugin>>, anyhow::Error> {
+    let mut namers: Vec<Box<dyn NamerPlugin>> = Vec::new();
+
+    for namer in self.config.namers.iter() {
+      namers.push(Box::new(RpcNamerPlugin::new(&self.ctx, namer)?));
+    }
+
+    Ok(namers)
+  }
+
+  #[allow(unused)]
+  fn optimizers(
+    &self,
+    path: &Path,
+    pipeline: Option<String>,
+  ) -> Result<Vec<Box<dyn OptimizerPlugin>>, anyhow::Error> {
+    let mut optimizers: Vec<Box<dyn OptimizerPlugin>> = Vec::new();
+    let named_pattern = pipeline.as_ref().map(|pipeline| NamedPattern {
+      pipeline,
+      use_fallback: true,
+    });
+
+    for optimizer in self.config.optimizers.get(path, named_pattern).iter() {
+      optimizers.push(Box::new(RpcOptimizerPlugin::new(&self.ctx, optimizer)?));
+    }
+
+    Ok(optimizers)
+  }
+
+  #[allow(unused)]
+  fn packager(&self, path: &Path) -> Result<Box<dyn PackagerPlugin>, anyhow::Error> {
+    let packager = self.config.packagers.get(path);
+
+    match packager {
+      None => Err(self.missing_plugin(path, "packager")),
+      Some(packager) => Ok(Box::new(RpcPackagerPlugin::new(&self.ctx, packager)?)),
+    }
+  }
+
+  fn reporter(&self) -> Arc<dyn ReporterPlugin> {
+    self.reporter.clone()
+  }
+
+  fn resolvers(&self) -> Result<Vec<Box<dyn ResolverPlugin>>, anyhow::Error> {
+    let mut resolvers: Vec<Box<dyn ResolverPlugin>> = Vec::new();
+
+    for resolver in self.config.resolvers.iter() {
+      if resolver.package_name == "@parcel/resolver-default" {
+        resolvers.push(Box::new(ParcelResolver::new(&self.ctx)));
+        continue;
+      }
+
+      resolvers.push(Box::new(RpcResolverPlugin::new(&self.ctx, resolver)?));
+    }
+
+    Ok(resolvers)
+  }
+
+  #[allow(unused)]
+  fn runtimes(&self) -> Result<Vec<Box<dyn RuntimePlugin>>, anyhow::Error> {
+    let mut runtimes: Vec<Box<dyn RuntimePlugin>> = Vec::new();
+
+    for runtime in self.config.runtimes.iter() {
+      runtimes.push(Box::new(RpcRuntimePlugin::new(&self.ctx, runtime)?));
+    }
+
+    Ok(runtimes)
+  }
+
+  /// Resolve and load transformer plugins for a given path.
+  fn transformers(
+    &self,
+    path: &Path,
+    pipeline: Option<String>,
+  ) -> Result<TransformerPipeline, anyhow::Error> {
+    let mut transformers: Vec<Box<dyn TransformerPlugin>> = Vec::new();
+    let named_pattern = pipeline.as_ref().map(|pipeline| NamedPattern {
+      pipeline,
+      use_fallback: false,
+    });
+
+    let mut hasher = parcel_core::hash::IdentifierHasher::default();
+
+    for transformer in self.config.transformers.get(path, named_pattern).iter() {
+      transformer.hash(&mut hasher);
+      if transformer.package_name == "@parcel/transformer-js" {
+        transformers.push(Box::new(ParcelJsTransformerPlugin::new()));
+        continue;
+      }
+
+      transformers.push(Box::new(RpcTransformerPlugin::new(&self.ctx, transformer)?));
+    }
+
+    if transformers.is_empty() {
+      return match pipeline {
+        None => Err(self.missing_plugin(path, "transformers")),
+        Some(pipeline) => Err(self.missing_pipeline_plugin(path, "transformers", &pipeline)),
+      };
+    }
+
+    Ok(TransformerPipeline {
+      transformers,
+      hash: hasher.finish(),
+    })
+  }
+
+  #[allow(unused)]
+  fn validators(&self, _path: &Path) -> Result<Vec<Box<dyn ValidatorPlugin>>, anyhow::Error> {
+    todo!()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::test_utils::{config_plugins, make_test_plugin_context};
+
+  use super::*;
+
+  #[test]
+  fn returns_bundler() {
+    let bundler = config_plugins(make_test_plugin_context())
+      .bundler()
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", bundler), "RpcBundlerPlugin")
+  }
+
+  #[test]
+  fn returns_compressors() {
+    let compressors = config_plugins(make_test_plugin_context())
+      .compressors(Path::new("a.js"))
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", compressors), "[RpcCompressorPlugin]")
+  }
+
+  #[test]
+  fn returns_namers() {
+    let namers = config_plugins(make_test_plugin_context())
+      .namers()
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", namers), "[RpcNamerPlugin]")
+  }
+
+  #[test]
+  fn returns_optimizers() {
+    let optimizers = config_plugins(make_test_plugin_context())
+      .optimizers(Path::new("a.js"), None)
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", optimizers), "[RpcOptimizerPlugin]")
+  }
+
+  #[test]
+  fn returns_packager() {
+    let packager = config_plugins(make_test_plugin_context())
+      .packager(Path::new("a.js"))
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", packager), "RpcPackagerPlugin")
+  }
+
+  #[test]
+  fn returns_reporter() {
+    let reporter = config_plugins(make_test_plugin_context()).reporter();
+
+    assert_eq!(
+      format!("{:?}", reporter),
+      "CompositeReporterPlugin { reporters: [RpcReporterPlugin] }"
+    )
+  }
+
+  #[test]
+  fn returns_resolvers() {
+    let resolvers = config_plugins(make_test_plugin_context())
+      .resolvers()
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", resolvers), "[ParcelResolver]")
+  }
+
+  #[test]
+  fn returns_runtimes() {
+    let runtimes = config_plugins(make_test_plugin_context())
+      .runtimes()
+      .expect("Not to panic");
+
+    assert_eq!(format!("{:?}", runtimes), "[RpcRuntimePlugin]")
+  }
+
+  #[test]
+  fn returns_transformers() {
+    let transformers = config_plugins(make_test_plugin_context())
+      .transformers(Path::new("a.ts"), None)
+      .expect("Not to panic");
+
+    assert_eq!(
+      format!("{:?}", transformers),
+      r"TransformerPipeline { transformers: [ParcelJsTransformerPlugin] }"
+    )
+  }
+}

--- a/crates/parcel/src/request_tracker/request.rs
+++ b/crates/parcel/src/request_tracker/request.rs
@@ -3,7 +3,6 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
-use std::sync::Arc;
 
 use dyn_hash::DynHash;
 use parcel_core::config_loader::ConfigLoaderRef;
@@ -12,7 +11,6 @@ use crate::plugins::PluginsRef;
 use crate::requests::RequestResult;
 use parcel_core::cache::CacheRef;
 use parcel_core::plugin::ReporterEvent;
-use parcel_core::plugin::ReporterPlugin;
 use parcel_core::types::Invalidation;
 use parcel_filesystem::FileSystemRef;
 
@@ -36,7 +34,6 @@ pub struct RunRequestContext {
   parent_request_id: Option<u64>,
   plugins: PluginsRef,
   pub project_root: PathBuf,
-  reporter: Arc<dyn ReporterPlugin + Send>,
   run_request_fn: RunRequestFn,
 }
 
@@ -48,7 +45,6 @@ impl RunRequestContext {
     parent_request_id: Option<u64>,
     plugins: PluginsRef,
     project_root: PathBuf,
-    reporter: Arc<dyn ReporterPlugin + Send>,
     run_request_fn: RunRequestFn,
   ) -> Self {
     Self {
@@ -58,7 +54,6 @@ impl RunRequestContext {
       parent_request_id,
       plugins,
       project_root,
-      reporter,
       run_request_fn,
     }
   }
@@ -66,7 +61,8 @@ impl RunRequestContext {
   /// Report an event
   pub fn report(&self, event: ReporterEvent) {
     self
-      .reporter
+      .plugins()
+      .reporter()
       .report(&event)
       .expect("TODO this should be handled?")
   }

--- a/crates/parcel/src/requests/asset_request.rs
+++ b/crates/parcel/src/requests/asset_request.rs
@@ -16,7 +16,7 @@ use parcel_core::types::Dependency;
 use parcel_core::types::Environment;
 use parcel_core::types::FileType;
 
-use crate::plugins::Plugins;
+use crate::plugins::PluginsRef;
 use crate::plugins::TransformerPipeline;
 use crate::request_tracker::{Request, ResultAndInvalidations, RunRequestContext, RunRequestError};
 
@@ -56,7 +56,7 @@ impl Request for AssetRequest {
 
     let pipeline = request_context
       .plugins()
-      .transformers(&self.file_path, self.pipeline.as_deref())?;
+      .transformers(&self.file_path, self.pipeline.clone())?;
     let asset_type = FileType::from_extension(
       self
         .file_path
@@ -76,7 +76,7 @@ impl Request for AssetRequest {
         side_effects: self.side_effects,
       }),
       asset_type,
-      request_context.plugins(),
+      request_context.plugins().clone(),
       &mut transform_ctx,
     )?;
 
@@ -108,7 +108,7 @@ fn run_pipeline(
   mut pipeline: TransformerPipeline,
   input: TransformationInput,
   asset_type: FileType,
-  plugins: &Plugins,
+  plugins: PluginsRef,
   transform_ctx: &mut RunTransformContext,
 ) -> anyhow::Result<TransformResult> {
   let mut dependencies = vec![];

--- a/crates/parcel/src/test_utils.rs
+++ b/crates/parcel/src/test_utils.rs
@@ -9,7 +9,10 @@ use parcel_core::{
 };
 use parcel_filesystem::{in_memory_file_system::InMemoryFileSystem, FileSystemRef};
 
-use crate::{plugins::Plugins, request_tracker::RequestTracker};
+use crate::{
+  plugins::{config_plugins::ConfigPlugins, PluginsRef},
+  request_tracker::RequestTracker,
+};
 
 pub(crate) fn make_test_plugin_context() -> PluginContext {
   PluginContext {
@@ -23,14 +26,15 @@ pub(crate) fn make_test_plugin_context() -> PluginContext {
   }
 }
 
-pub(crate) fn plugins(ctx: PluginContext) -> Plugins {
+pub(crate) fn config_plugins(ctx: PluginContext) -> PluginsRef {
   let fixture = default_config(Arc::new(PathBuf::default()));
 
-  Plugins::new(fixture.parcel_config, ctx)
+  Arc::new(ConfigPlugins::new(fixture.parcel_config, ctx))
 }
 
 pub struct RequestTrackerTestOptions {
   pub fs: FileSystemRef,
+  pub plugins: Option<PluginsRef>,
   pub project_root: PathBuf,
   pub search_path: PathBuf,
 }
@@ -39,8 +43,9 @@ impl Default for RequestTrackerTestOptions {
   fn default() -> Self {
     Self {
       fs: Arc::new(InMemoryFileSystem::default()),
-      search_path: PathBuf::default(),
+      plugins: None,
       project_root: PathBuf::default(),
+      search_path: PathBuf::default(),
     }
   }
 }
@@ -48,8 +53,9 @@ impl Default for RequestTrackerTestOptions {
 pub(crate) fn request_tracker(options: RequestTrackerTestOptions) -> RequestTracker {
   let RequestTrackerTestOptions {
     fs,
-    search_path,
+    plugins,
     project_root,
+    search_path,
   } = options;
 
   let config_loader = Arc::new(ConfigLoader {
@@ -58,15 +64,19 @@ pub(crate) fn request_tracker(options: RequestTrackerTestOptions) -> RequestTrac
     search_path,
   });
 
+  let plugins = plugins.unwrap_or_else(|| {
+    config_plugins(PluginContext {
+      config: Arc::clone(&config_loader),
+      options: Arc::new(PluginOptions::default()),
+      logger: PluginLogger::default(),
+    })
+  });
+
   RequestTracker::new(
     Arc::new(MockCache::new()),
     Arc::clone(&config_loader),
     fs,
-    plugins(PluginContext {
-      config: Arc::clone(&config_loader),
-      options: Arc::new(PluginOptions::default()),
-      logger: PluginLogger::default(),
-    }),
+    plugins,
     project_root,
   )
 }

--- a/crates/parcel_core/src/plugin/reporter_plugin/composite_reporter_plugin.rs
+++ b/crates/parcel_core/src/plugin/reporter_plugin/composite_reporter_plugin.rs
@@ -9,7 +9,7 @@ type Reporter = Box<dyn ReporterPlugin>;
 type Reporter = crate::plugin::MockReporterPlugin;
 
 /// A reporter plugin that delegates to multiple other reporters.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CompositeReporterPlugin {
   reporters: Vec<Reporter>,
 }


### PR DESCRIPTION
# ↪️ Pull Request

Simplifies the path request instantiation by using the dependencies available in the request context, instead of manually injecting named pipelines and resolvers

* Add `mockall` dependency for testing this change
* Create a `Plugins` trait so that a mock instance can be passed into the request tracker, and move the existing implementation to `ConfigPlugins`
* Consolidate `reporters` into a single composite reporter within `ConfigPlugins` to remove odd coupling in request tracker
* Update path request to use request context and remove those dependencies from the input
* Use `PluginsRef` over `&Plugins` in the request tracker, so mock instances can be passed in for tests

## 🚨 Test instructions

`cargo test`