### PR TITLE
Make package.json optional in target request

### DIFF
--- a/crates/parcel/src/requests/target_request/package_json.rs
+++ b/crates/parcel/src/requests/target_request/package_json.rs
@@ -66,7 +66,7 @@ impl Display for ModuleFormat {
   }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct PackageJson {
   pub name: Option<String>,
 

--- a/crates/parcel_core/src/types/diagnostic.rs
+++ b/crates/parcel_core/src/types/diagnostic.rs
@@ -11,6 +11,14 @@ use std::{
 
 use super::File;
 
+/// Represents the kind of diagnostic
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub enum ErrorKind {
+  NotFound,
+  #[default]
+  Unknown,
+}
+
 /// This is a user facing error for Parcel.
 ///
 /// Usually but not always this is linked to a source-code location.
@@ -18,6 +26,9 @@ use super::File;
 #[builder(derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
+  #[builder(default)]
+  pub kind: ErrorKind,
+
   /// A list of files with source-code highlights
   #[builder(default)]
   pub code_frames: Vec<CodeFrame>,


### PR DESCRIPTION
# ↪️ Pull Request

Currently a `package.json` file is expected to be located in the `TargetRequest` which does not match the current v2 behaviour. These changes update the target request so that it defaults the target when the file is not found.

* Add `kind` to `Diagnostic` type to differentiate specific errors, as there's no other way to do so, and apply `NotFound` to relevant errors throughout the codebase
* Return a default `PackageJson` instance, and thus default targets, when `package.json` is not found in target request

## 🚨 Test instructions

`cargo test`