### PR TITLE
Fix compilation and use function instead of macro

### DIFF
--- a/crates/parcel/src/parcel.rs
+++ b/crates/parcel/src/parcel.rs
@@ -96,6 +96,7 @@ impl Parcel {
       Arc::clone(&config_loader),
       Arc::clone(&self.fs),
       Arc::new(plugins),
+      Arc::new(ParcelOptions::default()),
       self.project_root.clone(),
     );
 

--- a/crates/parcel/src/plugins.rs
+++ b/crates/parcel/src/plugins.rs
@@ -22,24 +22,31 @@ pub mod config_plugins;
 
 #[cfg_attr(test, automock)]
 pub trait Plugins {
+  #[allow(unused)]
   fn bundler(&self) -> Result<Box<dyn BundlerPlugin>, anyhow::Error>;
+  #[allow(unused)]
   fn compressors(&self, path: &Path) -> Result<Vec<Box<dyn CompressorPlugin>>, anyhow::Error>;
   fn named_pipelines(&self) -> Vec<String>;
+  #[allow(unused)]
   fn namers(&self) -> Result<Vec<Box<dyn NamerPlugin>>, anyhow::Error>;
+  #[allow(unused)]
   fn optimizers(
     &self,
     path: &Path,
     pipeline: Option<String>,
   ) -> Result<Vec<Box<dyn OptimizerPlugin>>, anyhow::Error>;
+  #[allow(unused)]
   fn packager(&self, path: &Path) -> Result<Box<dyn PackagerPlugin>, anyhow::Error>;
   fn reporter(&self) -> Arc<dyn ReporterPlugin>;
   fn resolvers(&self) -> Result<Vec<Box<dyn ResolverPlugin>>, anyhow::Error>;
+  #[allow(unused)]
   fn runtimes(&self) -> Result<Vec<Box<dyn RuntimePlugin>>, anyhow::Error>;
   fn transformers(
     &self,
     path: &Path,
     pipeline: Option<String>,
   ) -> Result<TransformerPipeline, anyhow::Error>;
+  #[allow(unused)]
   fn validators(&self, _path: &Path) -> Result<Vec<Box<dyn ValidatorPlugin>>, anyhow::Error>;
 }
 

--- a/crates/parcel/src/request_tracker/request.rs
+++ b/crates/parcel/src/request_tracker/request.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 
 use dyn_hash::DynHash;
 use parcel_core::config_loader::ConfigLoaderRef;

--- a/crates/parcel/src/request_tracker/request_tracker.rs
+++ b/crates/parcel/src/request_tracker/request_tracker.rs
@@ -1,10 +1,12 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use parcel_core::config_loader::ConfigLoaderRef;
 use parcel_core::diagnostic_error;
+use parcel_core::types::ParcelOptions;
 use parcel_filesystem::FileSystemRef;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableDiGraph;
@@ -48,6 +50,7 @@ impl RequestTracker {
     config_loader: ConfigLoaderRef,
     file_system: FileSystemRef,
     plugins: PluginsRef,
+    parcel_options: Arc<ParcelOptions>,
     project_root: PathBuf,
   ) -> Self {
     let mut graph = StableDiGraph::<RequestNode<RequestResult>, RequestEdgeType>::new();
@@ -57,6 +60,7 @@ impl RequestTracker {
       config_loader,
       file_system,
       graph,
+      options: parcel_options,
       plugins,
       project_root,
       request_index: HashMap::new(),

--- a/crates/parcel/src/requests/asset_graph_request.rs
+++ b/crates/parcel/src/requests/asset_graph_request.rs
@@ -66,7 +66,7 @@ impl Request for AssetGraphRequest {
         };
 
         request_id_to_dep_node_index.insert(request.id(), dependency_node_index);
-        println!(
+        tracing::debug!(
           "queueing a path request from on_undeferred, {}",
           dependency.specifier
         );
@@ -88,7 +88,7 @@ impl Request for AssetGraphRequest {
 
       match result {
         Ok((RequestResult::Entry(EntryRequestOutput { entries }), _request_id)) => {
-          println!("EntryRequestOutput");
+          tracing::debug!("EntryRequestOutput");
           for entry in entries {
             let target_request = TargetRequest {
               default_target_options: request_context.options.default_target_options.clone(),
@@ -102,7 +102,7 @@ impl Request for AssetGraphRequest {
           }
         }
         Ok((RequestResult::Target(TargetRequestOutput { entry, targets }), _request_id)) => {
-          println!("TargetRequestOutput");
+          tracing::debug!("TargetRequestOutput");
           for target in targets {
             let entry =
               diff_paths(&entry, &request_context.project_root).unwrap_or_else(|| entry.clone());
@@ -132,7 +132,7 @@ impl Request for AssetGraphRequest {
           }),
           request_id,
         )) => {
-          println!("AssetRequestOutput: {}", asset.file_path.display());
+          tracing::debug!("AssetRequestOutput: {}", asset.file_path.display());
           let incoming_dep_node_index = *request_id_to_dep_node_index
             .get(&request_id)
             .expect("Missing node index for request id {request_id}");
@@ -177,7 +177,7 @@ impl Request for AssetGraphRequest {
           }
         }
         Ok((RequestResult::Path(result), request_id)) => {
-          println!("PathRequestOutput: {:?}", result);
+          tracing::debug!("PathRequestOutput: {:?}", result);
           let node = *request_id_to_dep_node_index
             .get(&request_id)
             .expect("Missing node index for request id {request_id}");
@@ -225,14 +225,14 @@ impl Request for AssetGraphRequest {
           let id = asset_request.id();
 
           if visited.insert(id) {
-            println!("queueing asset request for {}", dependency.specifier);
+            tracing::debug!("queueing asset request for {}", dependency.specifier);
             request_id_to_dep_node_index.insert(id, node);
             work_count += 1;
             let _ = request_context.queue_request(asset_request, tx.clone());
           } else if let Some(asset_node_index) = asset_request_to_asset.get(&id) {
             // We have already completed this AssetRequest so we can connect the
             // Dependency to the Asset immediately
-            println!("queueing path request for {}", dependency.specifier);
+            tracing::debug!("queueing path request for {}", dependency.specifier);
             graph.add_edge(asset_node_index, &node);
             graph.propagate_requested_symbols(
               *asset_node_index,
@@ -248,7 +248,7 @@ impl Request for AssetGraphRequest {
             // The AssetRequest has already been kicked off but is yet to
             // complete. Register this Dependency to be connected once it
             // completes
-            println!("adding to waiting {}", dependency.specifier);
+            tracing::debug!("adding to waiting {}", dependency.specifier);
             waiting_asset_requests
               .entry(id)
               .and_modify(|nodes| {

--- a/crates/parcel/src/requests/target_request/package_json.rs
+++ b/crates/parcel/src/requests/target_request/package_json.rs
@@ -99,7 +99,9 @@ pub struct PackageJson {
 
 #[derive(Debug, Clone, Deserialize)]
 pub enum SourceField {
+  #[allow(unused)]
   Source(String),
+  #[allow(unused)]
   Sources(Vec<String>),
 }
 

--- a/crates/parcel/src/test_utils.rs
+++ b/crates/parcel/src/test_utils.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use parcel_config::parcel_config_fixtures::default_config;
+use parcel_core::types::ParcelOptions;
 use parcel_core::{
-  cache::MockCache,
   config_loader::ConfigLoader,
   plugin::{PluginContext, PluginLogger, PluginOptions},
 };
@@ -73,10 +73,10 @@ pub(crate) fn request_tracker(options: RequestTrackerTestOptions) -> RequestTrac
   });
 
   RequestTracker::new(
-    Arc::new(MockCache::new()),
     Arc::clone(&config_loader),
     fs,
     plugins,
+    Arc::new(ParcelOptions::default()),
     project_root,
   )
 }


### PR DESCRIPTION
This fixes compilation of the native asset request branch and uses a function instead of a macro for the undeferred lambda.

Macros are a bit harder to use with editor integration / intellisense.
