### PR TITLE
Forward missing env and transformer inputs

### DIFF
--- a/crates/parcel/src/requests/asset_graph_request.rs
+++ b/crates/parcel/src/requests/asset_graph_request.rs
@@ -163,8 +163,7 @@ impl AssetGraphBuilder {
           code: code.clone(),
           pipeline: pipeline.clone(),
           side_effects,
-          // TODO: Dependency.env should be an Arc by default
-          env: Arc::new(dependency.env.clone()),
+          env: dependency.env.clone(),
           query,
         }
       }

--- a/crates/parcel/src/requests/asset_request.rs
+++ b/crates/parcel/src/requests/asset_request.rs
@@ -68,6 +68,7 @@ impl Request for AssetRequest {
     let mut transform_ctx = RunTransformContext::new(
       request_context.file_system().clone(),
       request_context.options.clone(),
+      request_context.project_root.clone(),
     );
 
     let result = run_pipeline(

--- a/crates/parcel/src/requests/target_request.rs
+++ b/crates/parcel/src/requests/target_request.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use package_json::BrowserField;
 use package_json::BrowsersList;
@@ -365,7 +366,7 @@ impl TargetRequest {
           .clone()
           .unwrap_or_else(|| default_dist_dir(&package_json.path)),
         dist_entry: None,
-        env: Environment {
+        env: Arc::new(Environment {
           context,
           engines: package_json
             .contents
@@ -387,7 +388,7 @@ impl TargetRequest {
             .source_maps
             .then(|| TargetSourceMapOptions::default()),
           source_type: SourceType::Module,
-        },
+        }),
         loc: None,
         name: String::from("default"),
         public_url: self.default_target_options.public_url.clone(),
@@ -492,7 +493,7 @@ impl TargetRequest {
         }
       },
       dist_entry,
-      env: Environment {
+      env: Arc::new(Environment {
         context,
         engines: target_descriptor
           .engines
@@ -526,7 +527,7 @@ impl TargetRequest {
           }),
         },
         ..Environment::default()
-      },
+      }),
       loc: None, // TODO
       name: String::from(target_name),
       public_url: target_descriptor
@@ -603,10 +604,10 @@ mod tests {
   fn default_target() -> Target {
     Target {
       dist_dir: PathBuf::from("packages/test/dist"),
-      env: Environment {
+      env: Arc::new(Environment {
         output_format: OutputFormat::Global,
         ..Environment::default()
-      },
+      }),
       name: String::from("default"),
       ..Target::default()
     }
@@ -872,11 +873,11 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir().join("build"),
           dist_entry: Some(PathBuf::from("browser.js")),
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Browser,
             output_format: OutputFormat::CommonJS,
             ..builtin_default_env()
-          },
+          }),
           name: String::from("browser"),
           ..Target::default()
         }]
@@ -895,11 +896,11 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir().join("build"),
           dist_entry: Some(PathBuf::from("main.js")),
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Node,
             output_format: OutputFormat::CommonJS,
             ..builtin_default_env()
-          },
+          }),
           name: String::from("main"),
           ..Target::default()
         }]
@@ -918,11 +919,11 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir(),
           dist_entry: Some(PathBuf::from("module.js")),
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Node,
             output_format: OutputFormat::EsModule,
             ..builtin_default_env()
-          },
+          }),
           name: String::from("module"),
           ..Target::default()
         }]
@@ -941,11 +942,11 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir(),
           dist_entry: Some(PathBuf::from("types.d.ts")),
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Node,
             output_format: OutputFormat::CommonJS,
             ..builtin_default_env()
-          },
+          }),
           name: String::from("types"),
           ..Target::default()
         }]
@@ -988,44 +989,44 @@ mod tests {
           Target {
             dist_dir: package_dir.join("build"),
             dist_entry: Some(PathBuf::from("browser.js")),
-            env: Environment {
+            env: Arc::new(Environment {
               context: EnvironmentContext::Browser,
               output_format: OutputFormat::CommonJS,
               ..env()
-            },
+            }),
             name: String::from("browser"),
             ..Target::default()
           },
           Target {
             dist_dir: package_dir.join("build"),
             dist_entry: Some(PathBuf::from("main.js")),
-            env: Environment {
+            env: Arc::new(Environment {
               context: EnvironmentContext::Node,
               output_format: OutputFormat::CommonJS,
               ..env()
-            },
+            }),
             name: String::from("main"),
             ..Target::default()
           },
           Target {
             dist_dir: package_dir.clone(),
             dist_entry: Some(PathBuf::from("module.js")),
-            env: Environment {
+            env: Arc::new(Environment {
               context: EnvironmentContext::Node,
               output_format: OutputFormat::EsModule,
               ..env()
-            },
+            }),
             name: String::from("module"),
             ..Target::default()
           },
           Target {
             dist_dir: package_dir,
             dist_entry: Some(PathBuf::from("types.d.ts")),
-            env: Environment {
+            env: Arc::new(Environment {
               context: EnvironmentContext::Node,
               output_format: OutputFormat::CommonJS,
               ..env()
-            },
+            }),
             name: String::from("types"),
             ..Target::default()
           },
@@ -1045,14 +1046,14 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir().join("dist").join("custom"),
           dist_entry: None,
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Browser,
             is_library: false,
             output_format: OutputFormat::Global,
             should_optimize: false,
             should_scope_hoist: false,
             ..Environment::default()
-          },
+          }),
           name: String::from("custom"),
           ..Target::default()
         }]
@@ -1084,13 +1085,13 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir().join("dist"),
           dist_entry: Some(PathBuf::from("custom.js")),
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Node,
             include_node_modules: IncludeNodeModules::Bool(true),
             is_library: false,
             output_format: OutputFormat::CommonJS,
             ..Environment::default()
-          },
+          }),
           name: String::from("custom"),
           ..Target::default()
         }]
@@ -1119,7 +1120,7 @@ mod tests {
         targets: vec![Target {
           dist_dir: package_dir().join("dist"),
           dist_entry: Some(PathBuf::from("custom.js")),
-          env: Environment {
+          env: Arc::new(Environment {
             context: EnvironmentContext::Browser,
             engines: Engines {
               browsers: Browsers {
@@ -1132,7 +1133,7 @@ mod tests {
             include_node_modules: IncludeNodeModules::Bool(true),
             output_format: OutputFormat::Global,
             ..Environment::default()
-          },
+          }),
           name: String::from("custom"),
           ..Target::default()
         }]
@@ -1150,13 +1151,13 @@ mod tests {
           targets: vec![Target {
             dist_dir: package_dir().join("dist"),
             dist_entry: Some(PathBuf::from("custom.js")),
-            env: Environment {
+            env: Arc::new(Environment {
               context: EnvironmentContext::Node,
               engines,
               include_node_modules: IncludeNodeModules::Bool(false),
               output_format: OutputFormat::CommonJS,
               ..Environment::default()
-            },
+            }),
             name: String::from("custom"),
             ..Target::default()
           }]
@@ -1230,10 +1231,10 @@ mod tests {
           targets: vec![Target {
             dist_dir: package_dir().join("dist"),
             dist_entry: Some(PathBuf::from(format!("custom.{ext}"))),
-            env: Environment {
+            env: Arc::new(Environment {
               output_format,
               ..Environment::default()
-            },
+            }),
             name: String::from("custom"),
             ..Target::default()
           }],

--- a/crates/parcel_core/src/plugin/transformer_plugin.rs
+++ b/crates/parcel_core/src/plugin/transformer_plugin.rs
@@ -71,12 +71,20 @@ impl TransformationInput {
       TransformationInput::Asset(asset) => Ok(asset.code.clone()),
     }
   }
+
+  pub fn side_effects(&self) -> bool {
+    match self {
+      TransformationInput::InitialAsset(raw_asset) => raw_asset.side_effects,
+      TransformationInput::Asset(asset) => asset.side_effects,
+    }
+  }
 }
 
 /// Context parameters for the transformer, other than the input.
 pub struct RunTransformContext {
   file_system: FileSystemRef,
   options: Arc<ParcelOptions>,
+  project_root: PathBuf,
 }
 
 impl Default for RunTransformContext {
@@ -84,15 +92,21 @@ impl Default for RunTransformContext {
     Self {
       file_system: Arc::new(OsFileSystem::default()),
       options: Arc::new(ParcelOptions::default()),
+      project_root: PathBuf::default(),
     }
   }
 }
 
 impl RunTransformContext {
-  pub fn new(file_system: FileSystemRef, options: Arc<ParcelOptions>) -> Self {
+  pub fn new(
+    file_system: FileSystemRef,
+    options: Arc<ParcelOptions>,
+    project_root: PathBuf,
+  ) -> Self {
     Self {
       file_system,
       options,
+      project_root,
     }
   }
 
@@ -102,6 +116,10 @@ impl RunTransformContext {
 
   pub fn options(&self) -> &Arc<ParcelOptions> {
     &self.options
+  }
+
+  pub fn project_root(&self) -> &Path {
+    &self.project_root
   }
 }
 

--- a/crates/parcel_core/src/types/asset.rs
+++ b/crates/parcel_core/src/types/asset.rs
@@ -7,8 +7,6 @@ use std::sync::Arc;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::types::EnvironmentContext;
-
 use super::bundle::BundleBehavior;
 use super::environment::Environment;
 use super::file_type::FileType;
@@ -156,24 +154,6 @@ impl Asset {
     self.unique_key.hash(&mut hasher);
 
     hasher.finish()
-  }
-
-  /// Build a new empty asset
-  pub fn new_empty(file_path: PathBuf, source_code: Arc<Code>) -> Self {
-    let asset_type =
-      FileType::from_extension(file_path.extension().and_then(|s| s.to_str()).unwrap_or(""));
-
-    // TODO: rest of this
-    Self {
-      file_path,
-      asset_type,
-      env: Arc::new(Environment {
-        context: EnvironmentContext::Browser,
-        ..Default::default()
-      }),
-      code: source_code,
-      ..Default::default()
-    }
   }
 
   pub fn set_interpreter(&mut self, shebang: impl Into<serde_json::Value>) {

--- a/crates/parcel_core/src/types/dependency.rs
+++ b/crates/parcel_core/src/types/dependency.rs
@@ -1,6 +1,7 @@
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -27,7 +28,7 @@ pub struct Dependency {
   pub bundle_behavior: BundleBehavior,
 
   /// The environment of the dependency
-  pub env: Environment,
+  pub env: Arc<Environment>,
 
   /// The location within the source file where the dependency was found
   #[serde(default)]
@@ -142,7 +143,7 @@ impl Dependency {
     }
   }
 
-  pub fn new(specifier: String, env: Environment) -> Dependency {
+  pub fn new(specifier: String, env: Arc<Environment>) -> Dependency {
     Dependency {
       env,
       meta: JSONObject::new(),

--- a/crates/parcel_core/src/types/target.rs
+++ b/crates/parcel_core/src/types/target.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,7 +25,7 @@ pub struct Target {
   ///
   /// This influences how Parcel compiles your code, including what syntax to transpile.
   ///
-  pub env: Environment,
+  pub env: Arc<Environment>,
 
   /// The location that created the target
   ///
@@ -44,7 +45,7 @@ impl Default for Target {
     Self {
       dist_dir: PathBuf::default(),
       dist_entry: None,
-      env: Environment::default(),
+      env: Arc::new(Environment::default()),
       loc: None,
       name: String::from("default"),
       public_url: String::from("/"),


### PR DESCRIPTION
# ↪️ Pull Request

These changes primarily forward through missing inputs from the transformer plugin to the transformer, as well as the asset environment. In doing so, the target and dependency env have been updated to an arc which is consistent with other definitions.

**Future improvements:**
* Actually share the dependency env instead of creating new instances, or intern it
* Pass through remaining inputs to the transformer based on config or otherwise

## 🚨 Test instructions

`cargo test`