### PR TITLE
Add a default txt file transformer

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -43,6 +43,7 @@
       "@parcel/transformer-image"
     ],
     "*.svg": ["@parcel/transformer-svg"],
+    "*.txt": ["@parcel/transformer-raw"],
     "*.{xml,rss,atom}": ["@parcel/transformer-xml"],
     "url:*": ["...", "@parcel/transformer-raw"]
   },


### PR DESCRIPTION
# ↪️ Pull Request

Resolves #9893 by adding a transformer for txt files in the default config to mimic Parcel 1.

## 💻 Examples

Being able to include txt files such as `robots.txt` as entrypoints without having to configure Parcel.

## 🚨 Test instructions

Build a project that includes a txt file as an entrypoint, it should be copied to the output folder without changes.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
