### PR TITLE
Ensure feature flags don't get included in fs build

### DIFF
--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -25,6 +25,7 @@
     "main": {
       "includeNodeModules": {
         "@parcel/core": false,
+        "@parcel/feature-flags": false,
         "@parcel/rust": false,
         "@parcel/types-internal": false,
         "@parcel/utils": false,
@@ -36,6 +37,7 @@
     "browser": {
       "includeNodeModules": {
         "@parcel/core": false,
+        "@parcel/feature-flags": false,
         "@parcel/rust": false,
         "@parcel/types-internal": false,
         "@parcel/utils": false,


### PR DESCRIPTION
Without this, the `@parcel/feature-flags` package gets inlined into `@parcel/fs` which means the features don't sync up.