### PR TITLE
Fix crash in EntryRequest with multiple globs in the source field

### DIFF
--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -249,8 +249,8 @@ export class EntryResolver {
                       ),
                     },
                   });
-                  i++;
                 }
+                i++;
               }
             }
           }
@@ -300,8 +300,8 @@ export class EntryResolver {
                   ...getJSONSourceLocation(pkg.map.pointers[keyPath], 'value'),
                 },
               });
-              i++;
             }
+            i++;
           }
         }
 


### PR DESCRIPTION
Fixes a bug introduced in #9590. The EntryRequest would crash if the package.json "source" field contained multiple globs that matched multiple files. This is because the index used to get the source location of the entry in the package.json was counting all of the matched files rather than the correct index in the array of sources. This resulted in passing `undefined` to `getJSONSourceLocation` which then crashed.

Added a test for this case and fixed it.

Fixes https://github.com/parcel-bundler/parcel/issues/9713