### PR TITLE
Sanitize target name before resolving

### DIFF
--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -12,6 +12,7 @@ import {
   findAlternativeFiles,
 } from '@parcel/utils';
 import ThrowableDiagnostic, {
+  encodeJSONKeyComponent,
   md,
   generateJSONCodeHighlights,
   getJSONSourceLocation,
@@ -220,9 +221,9 @@ export class EntryResolver {
                 } else {
                   sources = [source];
                 }
-                let keyPath = `/targets/${targetName}/source${
-                  Array.isArray(target.source) ? `/${i}` : ''
-                }`;
+                let keyPath = `/targets/${encodeJSONKeyComponent(
+                  targetName,
+                )}/source${Array.isArray(target.source) ? `/${i}` : ''}`;
                 for (let relativeSource of sources) {
                   let source = path.join(entry, relativeSource);
                   await assertFile(

--- a/packages/core/core/src/requests/TargetRequest.js
+++ b/packages/core/core/src/requests/TargetRequest.js
@@ -942,7 +942,7 @@ export class TargetResolver {
         loc = {
           filePath: pkgFilePath,
           ...getJSONSourceLocation(
-            pkgMap.pointers[`/targets/${targetName}`],
+            pkgMap.pointers[`/targets/${encodeJSONKeyComponent(targetName)}`],
             'key',
           ),
         };

--- a/packages/core/core/test/TargetRequest.test.js
+++ b/packages/core/core/test/TargetRequest.test.js
@@ -561,7 +561,7 @@ describe('TargetResolver', () => {
       await targetResolver.resolve(CUSTOM_TARGETS_DISTDIR_FIXTURE_PATH),
       [
         {
-          name: 'app',
+          name: '/dist/app',
           distDir: 'fixtures/custom-targets-distdir/www',
           distEntry: undefined,
           publicUrl: 'www',
@@ -590,7 +590,7 @@ describe('TargetResolver', () => {
             },
             end: {
               line: 3,
-              column: 10,
+              column: 16,
             },
           },
         },

--- a/packages/core/core/test/fixtures/custom-targets-distdir/package.json
+++ b/packages/core/core/test/fixtures/custom-targets-distdir/package.json
@@ -1,6 +1,6 @@
 {
   "targets": {
-    "app": {
+    "/dist/app": {
       "engines": {
         "browsers": "> 0.25%"
       },


### PR DESCRIPTION
# ↪️ Pull Request
Closes #9001 

Before this PR, parcel will throw an error when target name contains slash. To fix this, we wrap `targetName` with `encodeJSONKeyComponent` so that the slash gets encoded properly. 

## 💻 Examples
```
    "/dist/server_commonjs": {
      "isLibrary": true,
      "source": "src/index.ts",
      "optimize": false,
      "context": "node",
      "outputFormat": "commonjs",
      "distDir": "dist/server/commonjs"
    }
```
Previously, this error would pop up: 
`Error: Cannot use 'in' operator to search for 'key' in undefined`

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
