### PR TITLE
Disable jemalloc on canary macOS builds

### DIFF
--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -59,6 +59,8 @@ getrandom = { version = "0.2", features = ["custom"], default-features = false }
 napi = { version = "2.16.4", features = ["serde-json"] }
 
 [target.'cfg(all(target_os = "macos", not(feature = "canary")))'.dependencies]
+# jemallocator is disabled on canary builds to experiment with its performance
+# and reliability
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -58,7 +58,7 @@ rayon = "1.7.0"
 getrandom = { version = "0.2", features = ["custom"], default-features = false }
 napi = { version = "2.16.4", features = ["serde-json"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(all(target_os = "macos", not(feature = "canary")))'.dependencies]
 jemallocator = { version = "0.3.2", features = ["disable_initial_exec_tls"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -5,7 +5,7 @@ use std::alloc::alloc;
 #[cfg(target_arch = "wasm32")]
 use std::alloc::Layout;
 
-#[cfg(all(target_os = "macos", not(miri)))]
+#[cfg(all(target_os = "macos", not(miri), not(feature = "canary")))]
 #[global_allocator]
 static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
Replaces #9907 

We get a few memory errors around jemalloc code.

This points to:

* Memory corruption caused by some other faulty code, which I believe could be lmdb-js
* Allocator has problems

I want to remove it on canary builds to see if it addresses our problems. This will also provide an understanding of what impact it has on performance if any.