### PR TITLE
Forward tsconfig transformer options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "parcel-js-swc-core",
  "parcel_core",
  "parcel_filesystem",
+ "serde",
  "swc_core",
 ]
 

--- a/crates/node-bindings/src/transformer.rs
+++ b/crates/node-bindings/src/transformer.rs
@@ -3,31 +3,6 @@ use napi::JsObject;
 use napi::JsUnknown;
 use napi_derive::napi;
 
-use parcel_core::plugin::{
-  InitialAsset, RunTransformContext, TransformationInput, TransformerPlugin,
-};
-use parcel_plugin_transformer_js::ParcelJsTransformerPlugin;
-
-use parcel_napi_helpers::anyhow_to_napi;
-
-#[napi]
-pub fn _testing_run_parcel_js_transformer_plugin(
-  target_path: String,
-  env: Env,
-) -> napi::Result<JsUnknown> {
-  let mut transformer = ParcelJsTransformerPlugin::new();
-  let mut context = RunTransformContext::default();
-  let input = TransformationInput::InitialAsset(InitialAsset {
-    file_path: target_path.into(),
-    ..Default::default()
-  });
-  let result = transformer
-    .transform(&mut context, input)
-    .map_err(anyhow_to_napi)?;
-  let result = env.to_js_value(&result)?;
-  Ok(result)
-}
-
 #[napi]
 pub fn transform(opts: JsObject, env: Env) -> napi::Result<JsUnknown> {
   let config: parcel_js_swc_core::Config = env.from_js_value(opts)?;

--- a/crates/parcel/src/parcel.rs
+++ b/crates/parcel/src/parcel.rs
@@ -97,7 +97,11 @@ impl Parcel {
       config,
       PluginContext {
         config: Arc::clone(&config_loader),
+        file_system: self.fs.clone(),
         options: Arc::new(PluginOptions {
+          core_path: self.options.core_path.clone(),
+          env: self.options.env.clone(),
+          log_level: self.options.log_level.clone(),
           mode: self.options.mode.clone(),
           project_root: self.project_root.clone(),
         }),

--- a/crates/parcel/src/plugins/config_plugins.rs
+++ b/crates/parcel/src/plugins/config_plugins.rs
@@ -198,7 +198,7 @@ impl Plugins for ConfigPlugins {
       }
 
       if transformer.package_name == "@parcel/transformer-js" {
-        transformers.push(Box::new(ParcelJsTransformerPlugin::new()));
+        transformers.push(Box::new(ParcelJsTransformerPlugin::new(&self.ctx)?));
         continue;
       }
 
@@ -305,13 +305,21 @@ mod tests {
 
   #[test]
   fn returns_transformers() {
-    let transformers = config_plugins(make_test_plugin_context())
+    let pipeline = config_plugins(make_test_plugin_context())
       .transformers(Path::new("a.ts"), None)
       .expect("Not to panic");
 
     assert_eq!(
-      format!("{:?}", transformers),
-      r"TransformerPipeline { transformers: [ParcelJsTransformerPlugin] }"
-    )
+      format!("{:?}", pipeline),
+      format!(
+        "{:?}",
+        TransformerPipeline {
+          transformers: vec![Box::new(
+            ParcelJsTransformerPlugin::new(&make_test_plugin_context()).unwrap()
+          )],
+          hash: 1
+        }
+      )
+    );
   }
 }

--- a/crates/parcel/src/test_utils.rs
+++ b/crates/parcel/src/test_utils.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use parcel_config::parcel_config_fixtures::default_config;
-use parcel_core::types::BuildMode;
 use parcel_core::{
   config_loader::ConfigLoader,
   plugin::{PluginContext, PluginLogger, PluginOptions},
@@ -16,12 +15,15 @@ use crate::{
 };
 
 pub(crate) fn make_test_plugin_context() -> PluginContext {
+  let fs = Arc::new(InMemoryFileSystem::default());
+
   PluginContext {
     config: Arc::new(ConfigLoader {
-      fs: Arc::new(InMemoryFileSystem::default()),
+      fs: fs.clone(),
       project_root: PathBuf::default(),
       search_path: PathBuf::default(),
     }),
+    file_system: fs.clone(),
     options: Arc::new(PluginOptions::default()),
     logger: PluginLogger::default(),
   }
@@ -71,8 +73,12 @@ pub(crate) fn request_tracker(options: RequestTrackerTestOptions) -> RequestTrac
   let plugins = plugins.unwrap_or_else(|| {
     config_plugins(PluginContext {
       config: Arc::clone(&config_loader),
+      file_system: fs.clone(),
       options: Arc::new(PluginOptions {
-        mode: BuildMode::default(),
+        core_path: parcel_options.core_path.clone(),
+        env: parcel_options.env.clone(),
+        log_level: parcel_options.log_level.clone(),
+        mode: parcel_options.mode.clone(),
         project_root: project_root.clone(),
       }),
       logger: PluginLogger::default(),

--- a/crates/parcel_core/src/plugin.rs
+++ b/crates/parcel_core/src/plugin.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -17,6 +18,7 @@ mod packager_plugin;
 pub use packager_plugin::*;
 
 mod reporter_plugin;
+use parcel_filesystem::FileSystemRef;
 pub use reporter_plugin::*;
 
 mod resolver_plugin;
@@ -31,13 +33,14 @@ pub use transformer_plugin::*;
 mod validator_plugin;
 pub use validator_plugin::*;
 
-use crate::config_loader::ConfigLoader;
-use crate::types::BuildMode;
+use crate::config_loader::{ConfigLoader, ConfigLoaderRef};
+use crate::types::{BuildMode, LogLevel};
 
 pub struct PluginContext {
-  pub config: Arc<ConfigLoader>,
-  pub options: Arc<PluginOptions>,
+  pub config: ConfigLoaderRef,
+  pub file_system: FileSystemRef,
   pub logger: PluginLogger,
+  pub options: Arc<PluginOptions>,
 }
 
 #[derive(Default)]
@@ -45,6 +48,9 @@ pub struct PluginLogger {}
 
 #[derive(Debug, Default)]
 pub struct PluginOptions {
+  pub core_path: PathBuf,
+  pub env: Option<HashMap<String, String>>,
+  pub log_level: LogLevel,
   pub mode: BuildMode,
   pub project_root: PathBuf,
 }

--- a/crates/parcel_core/src/types/asset.rs
+++ b/crates/parcel_core/src/types/asset.rs
@@ -52,10 +52,6 @@ impl From<String> for Code {
 #[derive(Default, PartialEq, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Asset {
-  /// The file type of the asset, which may change during transformation
-  #[serde(rename = "type")]
-  pub asset_type: FileType,
-
   /// Controls which bundle the asset is placed into
   pub bundle_behavior: BundleBehavior,
 
@@ -64,6 +60,10 @@ pub struct Asset {
 
   /// The file path to the asset
   pub file_path: PathBuf,
+
+  /// The file type of the asset, which may change during transformation
+  #[serde(rename = "type")]
+  pub file_type: FileType,
 
   /// The code of this asset, initially read from disk, then becoming the
   /// transformed output
@@ -146,9 +146,9 @@ impl Asset {
   pub fn id(&self) -> u64 {
     let mut hasher = crate::hash::IdentifierHasher::default();
 
-    self.asset_type.hash(&mut hasher);
     self.env.hash(&mut hasher);
     self.file_path.hash(&mut hasher);
+    self.file_type.hash(&mut hasher);
     self.pipeline.hash(&mut hasher);
     self.query.hash(&mut hasher);
     self.unique_key.hash(&mut hasher);

--- a/crates/parcel_core/src/types/environment.rs
+++ b/crates/parcel_core/src/types/environment.rs
@@ -136,6 +136,11 @@ impl EnvironmentContext {
     matches!(self, WebWorker | ServiceWorker)
   }
 
+  pub fn is_worklet(&self) -> bool {
+    use EnvironmentContext::*;
+    matches!(self, Worklet)
+  }
+
   pub fn is_electron(&self) -> bool {
     use EnvironmentContext::*;
     matches!(self, ElectronMain | ElectronRenderer)

--- a/crates/parcel_core/src/types/environment/browsers.rs
+++ b/crates/parcel_core/src/types/environment/browsers.rs
@@ -21,15 +21,44 @@ pub struct Browsers {
 
 impl Browsers {
   pub fn is_empty(&self) -> bool {
-    self.android.is_none()
-      && self.chrome.is_none()
-      && self.edge.is_none()
-      && self.firefox.is_none()
-      && self.ie.is_none()
-      && self.ios_saf.is_none()
-      && self.opera.is_none()
-      && self.safari.is_none()
-      && self.samsung.is_none()
+    self.iter().all(|(_browser, version)| version.is_none())
+  }
+
+  pub fn iter(&self) -> BrowsersIterator {
+    BrowsersIterator {
+      browsers: self,
+      index: 0,
+    }
+  }
+}
+
+pub struct BrowsersIterator<'a> {
+  browsers: &'a Browsers,
+  index: usize,
+}
+
+impl<'a> Iterator for BrowsersIterator<'a> {
+  type Item = (&'a str, Option<Version>);
+
+  fn next(&mut self) -> Option<Self::Item> {
+    let browser = match self.index {
+      0 => Some(("android", self.browsers.android)),
+      1 => Some(("chrome", self.browsers.chrome)),
+      2 => Some(("edge", self.browsers.edge)),
+      3 => Some(("firefox", self.browsers.firefox)),
+      4 => Some(("ie", self.browsers.ie)),
+      5 => Some(("ios_saf", self.browsers.ios_saf)),
+      6 => Some(("opera", self.browsers.opera)),
+      7 => Some(("safari", self.browsers.safari)),
+      8 => Some(("samsung", self.browsers.samsung)),
+      _ => None,
+    };
+
+    if self.index < 9 {
+      self.index += 1;
+    }
+
+    browser
   }
 }
 

--- a/crates/parcel_plugin_resolver/src/parcel_resolver.rs
+++ b/crates/parcel_plugin_resolver/src/parcel_resolver.rs
@@ -418,6 +418,7 @@ mod test {
         project_root: PathBuf::default(),
         search_path: PathBuf::default(),
       }),
+      file_system: Arc::new(InMemoryFileSystem::default()),
       logger: PluginLogger::default(),
       options: Arc::new(PluginOptions::default()),
     }
@@ -505,6 +506,7 @@ mod test {
         project_root: PathBuf::default(),
         search_path: PathBuf::from("/foo"),
       }),
+      file_system: Arc::new(InMemoryFileSystem::default()),
       logger: PluginLogger::default(),
       options: Arc::new(PluginOptions::default()),
     };

--- a/crates/parcel_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/parcel_plugin_rpc/src/plugin/transformer.rs
@@ -6,7 +6,7 @@ use anyhow::Error;
 use parcel_config::PluginNode;
 use parcel_core::plugin::PluginContext;
 use parcel_core::plugin::TransformerPlugin;
-use parcel_core::plugin::{RunTransformContext, TransformResult, TransformationInput};
+use parcel_core::plugin::{TransformResult, TransformationInput};
 
 pub struct RpcTransformerPlugin {
   _name: String,
@@ -27,11 +27,7 @@ impl RpcTransformerPlugin {
 }
 
 impl TransformerPlugin for RpcTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: &mut RunTransformContext,
-    _asset: TransformationInput,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&mut self, _asset: TransformationInput) -> Result<TransformResult, Error> {
     todo!()
   }
 }

--- a/crates/parcel_plugin_transformer_js/Cargo.toml
+++ b/crates/parcel_plugin_transformer_js/Cargo.toml
@@ -6,10 +6,10 @@ description = "JavaScript Transformer Plugin for the Parcel Bundler"
 
 [dependencies]
 parcel_core = { path = "../parcel_core" }
-anyhow = "1"
-parcel-js-swc-core = { path = "../../packages/transformers/js/core" }
-swc_core = { version = "0.96", features = ["ecma_ast"] }
-indexmap = "2.2.6"
-
-[dev-dependencies]
 parcel_filesystem = { path = "../parcel_filesystem" }
+
+anyhow = "1"
+indexmap = "2.2.6"
+parcel-js-swc-core = { path = "../../packages/transformers/js/core" }
+serde = { version = "1.0.200", features = ["derive"] }
+swc_core = { version = "0.96", features = ["ecma_ast"] }

--- a/crates/parcel_plugin_transformer_js/src/lib.rs
+++ b/crates/parcel_plugin_transformer_js/src/lib.rs
@@ -3,3 +3,4 @@
 pub use transformer::ParcelJsTransformerPlugin;
 
 mod transformer;
+mod ts_config;

--- a/crates/parcel_plugin_transformer_js/src/transformer/conversion.rs
+++ b/crates/parcel_plugin_transformer_js/src/transformer/conversion.rs
@@ -5,11 +5,11 @@ use indexmap::IndexMap;
 use parcel_core::diagnostic;
 use swc_core::atoms::Atom;
 
-use parcel_core::plugin::TransformResult;
+use parcel_core::plugin::{PluginOptions, TransformResult};
 use parcel_core::types::engines::EnvironmentFeature;
 use parcel_core::types::{
   Asset, BundleBehavior, Code, CodeFrame, CodeHighlight, Dependency, Diagnostic, DiagnosticBuilder,
-  Environment, EnvironmentContext, File, FileType, IncludeNodeModules, OutputFormat, ParcelOptions,
+  Environment, EnvironmentContext, File, FileType, IncludeNodeModules, OutputFormat,
   SourceLocation, SourceType, SpecifierType, Symbol,
 };
 
@@ -29,7 +29,7 @@ pub(crate) fn convert_result(
   mut asset: Asset,
   transformer_config: &parcel_js_swc_core::Config,
   result: parcel_js_swc_core::TransformResult,
-  options: &ParcelOptions,
+  options: &PluginOptions,
 ) -> Result<TransformResult, Vec<Diagnostic>> {
   let asset_file_path = asset.file_path.to_path_buf();
   let asset_environment = asset.env.clone();
@@ -252,7 +252,7 @@ pub(crate) fn convert_result(
   if asset.unique_key.is_none() {
     asset.unique_key = Some(format!("{:016x}", asset_id));
   }
-  asset.asset_type = FileType::Js;
+  asset.file_type = FileType::Js;
 
   // Overwrite the source-code with SWC output
   let result_source_code_string = String::from_utf8(result.code)
@@ -333,7 +333,7 @@ fn make_export_star_symbol(asset_id: u64) -> Symbol {
 }
 
 fn make_esm_helpers_dependency(
-  options: &ParcelOptions,
+  options: &PluginOptions,
   asset_file_path: &PathBuf,
   asset_environment: Environment,
   has_symbols: bool,

--- a/crates/parcel_plugin_transformer_js/src/ts_config.rs
+++ b/crates/parcel_plugin_transformer_js/src/ts_config.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Deserializer};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Jsx {
+  Preserve,
+  React,
+  ReactJsx,
+  #[serde(rename = "react-jsxdev")]
+  ReactJsxDev,
+  ReactNative,
+}
+
+pub enum Target {
+  ES3,
+  ES5,
+  ES6,
+  ES2015,
+  ES2016,
+  ES2017,
+  ES2018,
+  ES2019,
+  ES2020,
+  ES2021,
+  ES2022,
+  ES2023,
+  ESNext,
+  #[allow(dead_code)]
+  Other(String),
+}
+
+impl<'de> Deserialize<'de> for Target {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let target = String::deserialize(deserializer)?.to_lowercase();
+
+    Ok(match target.as_str() {
+      "es3" => Target::ES3,
+      "es5" => Target::ES5,
+      "es6" => Target::ES6,
+      "es2015" => Target::ES2015,
+      "es2016" => Target::ES2016,
+      "es2017" => Target::ES2017,
+      "es2018" => Target::ES2018,
+      "es2019" => Target::ES2019,
+      "es2020" => Target::ES2020,
+      "es2021" => Target::ES2021,
+      "es2022" => Target::ES2022,
+      "es2023" => Target::ES2023,
+      "esnext" => Target::ESNext,
+      other => Target::Other(other.to_string()),
+    })
+  }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompilerOptions {
+  pub experimental_decorators: Option<bool>,
+  pub jsx: Option<Jsx>,
+  pub jsx_factory: Option<String>,
+  pub jsx_import_source: Option<String>,
+  pub jsx_fragment_factory: Option<String>,
+  pub target: Option<Target>,
+  pub use_define_for_class_fields: Option<bool>,
+}
+
+/// Refer to https://www.typescriptlang.org/tsconfig
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TsConfig {
+  pub compiler_options: Option<CompilerOptions>,
+}

--- a/packages/core/core/src/CommittedAsset.js
+++ b/packages/core/core/src/CommittedAsset.js
@@ -6,7 +6,6 @@ import type {Asset, Dependency, ParcelOptions} from './types';
 import {Readable} from 'stream';
 import SourceMap from '@parcel/source-map';
 import {bufferStream, blobToStream, streamFromPromise} from '@parcel/utils';
-import {getFeatureFlag} from '@parcel/feature-flags';
 import {generateFromAST} from './assetUtils';
 import {deserializeRaw} from './serializer';
 
@@ -23,9 +22,7 @@ export default class CommittedAsset {
 
   constructor(value: Asset, options: ParcelOptions) {
     this.value = value;
-    this.key = getFeatureFlag('parcelV3')
-      ? this.value.id
-      : this.value.contentKey;
+    this.key = this.value.contentKey;
     this.options = options;
   }
 

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -123,6 +123,7 @@ function getAssetGraph(serializedGraph, options) {
         ...asset,
         id,
         committed: true,
+        contentKey: id,
         filePath: toProjectPath(options.projectRoot, asset.filePath),
         symbols: asset.hasSymbols
           ? new Map(
@@ -149,6 +150,7 @@ function getAssetGraph(serializedGraph, options) {
       dependency = {
         ...dependency,
         id,
+        contentKey: id,
         sourcePath: dependency.sourcePath
           ? toProjectPath(options.projectRoot, dependency.sourcePath)
           : null,

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -481,74 +481,65 @@ describe('javascript', function () {
     assert(!mainBundleContent.includes('foo:'));
   });
 
-  it.v2(
-    'should split bundles when a dynamic import is used with a node environment',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/dynamic-node/index.js'),
-      );
+  it('should split bundles when a dynamic import is used with a node environment', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/dynamic-node/index.js'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['index.js'],
-        },
-        {
-          assets: ['local.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js'],
+      },
+      {
+        assets: ['local.js'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.equal(typeof output, 'function');
-      assert.equal(await output(), 3);
-    },
-  );
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(await output(), 3);
+  });
 
-  it.v2(
-    'should split bundles when a dynamic import is used with an electron-main environment',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/dynamic-electron-main/index.js'),
-      );
+  it('should split bundles when a dynamic import is used with an electron-main environment', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/dynamic-electron-main/index.js'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['index.js'],
-        },
-        {
-          assets: ['local.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js'],
+      },
+      {
+        assets: ['local.js'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.equal(typeof output, 'function');
-      assert.equal(await output(), 3);
-    },
-  );
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(await output(), 3);
+  });
 
-  it.v2(
-    'should split bundles when a dynamic import is used with an electron-renderer environment',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/dynamic-electron-renderer/index.js'),
-      );
+  it('should split bundles when a dynamic import is used with an electron-renderer environment', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/dynamic-electron-renderer/index.js'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['index.js'],
-        },
-        {
-          assets: ['local.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js'],
+      },
+      {
+        assets: ['local.js'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.equal(typeof output, 'function');
-      assert.equal(await output(), 3);
-    },
-  );
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(await output(), 3);
+  });
 
   it.skip('should load dynamic bundle when entry is in a subdirectory', async function () {
     let bu = await bundler(
@@ -1183,7 +1174,7 @@ describe('javascript', function () {
     assert(!js.includes('local.a'));
   });
 
-  it.v2('should use terser config', async function () {
+  it('should use terser config', async function () {
     await bundle(path.join(__dirname, '/integration/terser-config/index.js'), {
       defaultTargetOptions: {
         shouldOptimize: true,
@@ -1389,35 +1380,29 @@ describe('javascript', function () {
     },
   );
 
-  it.v2(
-    'should not insert global variables in dead branches',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/globals-unused/a.js'),
-      );
+  it('should not insert global variables in dead branches', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/globals-unused/a.js'),
+    );
 
-      assertBundles(b, [
-        {
-          assets: ['a.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        assets: ['a.js'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.deepEqual(output, 'foo');
-    },
-  );
+    let output = await run(b);
+    assert.deepEqual(output, 'foo');
+  });
 
-  it.v2(
-    'should handle re-declaration of the global constant',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/global-redeclare/index.js'),
-      );
+  it('should handle re-declaration of the global constant', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/global-redeclare/index.js'),
+    );
 
-      let output = await run(b);
-      assert.deepEqual(output(), false);
-    },
-  );
+    let output = await run(b);
+    assert.deepEqual(output(), false);
+  });
 
   it.v2(
     'should insert environment variables inserted by a prior transform',
@@ -1434,18 +1419,15 @@ describe('javascript', function () {
     },
   );
 
-  it.v2(
-    'should not insert environment variables in node environment',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/env-node/index.js'),
-      );
+  it('should not insert environment variables in node environment', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/env-node/index.js'),
+    );
 
-      let output = await run(b);
-      assert.ok(output.toString().includes('process.env'));
-      assert.equal(output(), 'test:test');
-    },
-  );
+    let output = await run(b);
+    assert.ok(output.toString().includes('process.env'));
+    assert.equal(output(), 'test:test');
+  });
 
   it.v2(
     'should not replace process.env.hasOwnProperty with undefined',

--- a/packages/transformers/js/test/JSTransformer.test.js
+++ b/packages/transformers/js/test/JSTransformer.test.js
@@ -1,9 +1,0 @@
-import {testingRunParcelJsTransformerPlugin} from '@parcel/rust';
-import assert from 'node:assert';
-
-describe('rust transformer', () => {
-  it('runs', async () => {
-    const result = await testingRunParcelJsTransformerPlugin(__filename);
-    assert(result != null);
-  });
-});


### PR DESCRIPTION
# ↪️ Pull Request

Passes in the relevant tsconfig options from the transformer plugin into the transformer crate. Refactors some of the signatures to distinguish once off operations / setup as well to be consistent with other plugins.

## 🚨 Test instructions

`yarn build-native && cargo test && yarn test:integration`