### PR TITLE
Only error if versions don't match when versions are set by react-refresh

### DIFF
--- a/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
+++ b/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
@@ -41,9 +41,12 @@ module.exports.prelude = function (module) {
   window.__REACT_REFRESH_VERSION_TRANSFORMER = version;
   window.$RefreshReg$ = function (type, id) {
     if (
+      window.__REACT_REFRESH_VERSION_TRANSFORMER &&
+      window.__REACT_REFRESH_VERSION_RUNTIME &&
       window.__REACT_REFRESH_VERSION_TRANSFORMER !==
-      window.__REACT_REFRESH_VERSION_RUNTIME
+        window.__REACT_REFRESH_VERSION_RUNTIME
     ) {
+      // Both versions were set and they did not match
       throw new Error(
         `react-refresh versions did not match between transformer and runtime. Please check your dependencies. Transformer: ${window.__REACT_REFRESH_VERSION_TRANSFORMER}, Runtime: ${window.__REACT_REFRESH_VERSION_RUNTIME}`,
       );


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Quick bugfix for an issue that can occur in some cases, where the transformer has run but the runtime has not. We can handle this pretty trivially by making sure both versions are set before erroring.

