### PR TITLE
Fix svgo option HTMLNanoOptimizer.js

### DIFF
--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -73,7 +73,7 @@ export default (new Optimizer({
                 // Do not minify ids or remove unreferenced elements in
                 // inline SVGs because they could actually be referenced
                 // by a separate inline SVG.
-                cleanupIDs: false,
+                cleanupIds: false,
               },
             },
           },


### PR DESCRIPTION
Fix ``cleanupIDs`` to ``cleanupIds`` according to https://github.com/svg/svgo/releases/tag/v3.0.0

Without this fix parcel build throws a warning:

```
You are trying to configure cleanupIDs which is not part of preset-default.
Try to put it before or after, for example

plugins: [
  {
    name: 'preset-default',
  },
  'cleanupIDs'
]
```
And ``"cleanupIDs": false`` is ignored resulting in clearing IDs from SVG tags.

The bug was also mentioned in this issue: https://github.com/parcel-bundler/parcel/issues/9171 