### PR TITLE
Load svgo version from project

### DIFF
--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -15,6 +15,7 @@ import {
 } from '@parcel/test-utils';
 import path from 'path';
 import Logger from '@parcel/logger';
+import {md} from '@parcel/diagnostic';
 
 describe('html', function () {
   beforeEach(async () => {
@@ -721,7 +722,7 @@ describe('html', function () {
       // autoinstall is disabled
       assert.equal(
         err.diagnostics[0].message,
-        `Could not resolve module "svgo" from "${path.resolve(
+        md`Could not resolve module "svgo" from "${path.resolve(
           overlayFS.cwd(),
           '/htmlnano-svgo-version/index',
         )}"`,

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -721,7 +721,10 @@ describe('html', function () {
       // autoinstall is disabled
       assert.equal(
         err.diagnostics[0].message,
-        'Could not resolve module "svgo" from "/htmlnano-svgo-version/index"',
+        `Could not resolve module "svgo" from "${path.resolve(
+          overlayFS.cwd(),
+          '/htmlnano-svgo-version/index',
+        )}"`,
       );
     }
 
@@ -1073,7 +1076,7 @@ describe('html', function () {
     let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(
       contents.includes(
-        '<svg><symbol id="all"><rect width="100" height="100"/></symbol></svg><svg><use xlink:href="#all" href="#all"/></svg>',
+        '<svg><symbol id="all"><rect width="100" height="100"/></symbol></svg><svg><use href="#all"/></svg>',
       ),
     );
   });
@@ -3000,7 +3003,11 @@ describe('html', function () {
 
     let output = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
     assert(output.includes('<x-custom stddeviation="0.5"'));
-    assert(output.includes('<svg role="img" viewBox='));
+    assert(
+      output.includes(
+        '<svg preserveAspectRatio="xMinYMin meet" role="img" viewBox=',
+      ),
+    );
     assert(output.includes('<filter'));
     assert(output.includes('<feGaussianBlur in="SourceGraphic" stdDeviation='));
   });

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -737,7 +737,10 @@ describe('html', function () {
     );
     assert.deepEqual(messages[0].diagnostics[0].codeFrames, [
       {
-        filePath: path.normalize('/htmlnano-svgo-version/.htmlnanorc'),
+        filePath: path.resolve(
+          overlayFS.cwd(),
+          '/htmlnano-svgo-version/.htmlnanorc',
+        ),
         codeHighlights: [
           {
             message: undefined,

--- a/packages/core/integration-tests/test/integration/svgo-config/svgo.config.js
+++ b/packages/core/integration-tests/test/integration/svgo-config/svgo.config.js
@@ -1,10 +1,12 @@
-const { extendDefaultPlugins } = require('svgo');
-
 module.exports = {
-  plugins: extendDefaultPlugins([
+  plugins: [
     {
-      name: 'removeComments',
-      active: false
+      name: 'preset-default',
+      params: {
+        overrides: {
+          removeComments: false
+        }
+      }
     }
-  ])
+  ]
 }

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -1,6 +1,14 @@
 import assert from 'assert';
-import {assertBundles, bundle, distDir, outputFS} from '@parcel/test-utils';
+import {
+  assertBundles,
+  bundle,
+  distDir,
+  outputFS,
+  overlayFS,
+  fsFixture,
+} from '@parcel/test-utils';
 import path from 'path';
+import Logger from '@parcel/logger';
 
 describe('svg', function () {
   it('should support bundling SVG', async () => {
@@ -126,6 +134,73 @@ describe('svg', function () {
     assert(file.includes('comment'));
   });
 
+  it('should detect the version of SVGO to use', async function () {
+    // Test is outside parcel so that svgo is not already installed.
+    await fsFixture(overlayFS, '/')`
+      svgo-version
+        icon.svg:
+          <svg></svg>
+
+        index.html:
+          <img src="icon.svg" />
+
+        svgo.config.json:
+          {
+            "full": true
+          }
+
+        yarn.lock:
+    `;
+
+    let messages = [];
+    let loggerDisposable = Logger.onLog(message => {
+      if (message.level !== 'verbose') {
+        messages.push(message);
+      }
+    });
+
+    try {
+      await bundle(path.join('/svgo-version/index.html'), {
+        inputFS: overlayFS,
+        defaultTargetOptions: {
+          shouldOptimize: true,
+        },
+        shouldAutoinstall: false,
+      });
+    } catch (err) {
+      // autoinstall is disabled
+      assert.equal(
+        err.diagnostics[0].message,
+        'Could not resolve module "svgo" from "/svgo-version/index"',
+      );
+    }
+
+    loggerDisposable.dispose();
+    assert(
+      messages[0].diagnostics[0].message.startsWith(
+        'Detected deprecated SVGO v2 options in',
+      ),
+    );
+    assert.deepEqual(messages[0].diagnostics[0].codeFrames, [
+      {
+        filePath: path.normalize('/svgo-version/svgo.config.json'),
+        codeHighlights: [
+          {
+            message: undefined,
+            start: {
+              line: 2,
+              column: 3,
+            },
+            end: {
+              line: 2,
+              column: 14,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
   it('should detect xml-stylesheet processing instructions', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/svg-xml-stylesheet/img.svg'),
@@ -222,7 +297,7 @@ describe('svg', function () {
 
     const svg = await outputFS.readFile(path.join(distDir, 'img.svg'), 'utf8');
 
-    assert(svg.includes('<style>:root{fill:red}</style>'));
+    assert(svg.includes('style="fill:red"'));
   });
 
   it('should be in separate bundles', async function () {

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -171,7 +171,10 @@ describe('svg', function () {
       // autoinstall is disabled
       assert.equal(
         err.diagnostics[0].message,
-        'Could not resolve module "svgo" from "/svgo-version/index"',
+        `Could not resolve module "svgo" from "${path.resolve(
+          overlayFS.cwd(),
+          '/svgo-version/index',
+        )}"`,
       );
     }
 

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -187,7 +187,10 @@ describe('svg', function () {
     );
     assert.deepEqual(messages[0].diagnostics[0].codeFrames, [
       {
-        filePath: path.normalize('/svgo-version/svgo.config.json'),
+        filePath: path.resolve(
+          overlayFS.cwd(),
+          '/svgo-version/svgo.config.json',
+        ),
         codeHighlights: [
           {
             message: undefined,

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -9,6 +9,7 @@ import {
 } from '@parcel/test-utils';
 import path from 'path';
 import Logger from '@parcel/logger';
+import {md} from '@parcel/diagnostic';
 
 describe('svg', function () {
   it('should support bundling SVG', async () => {
@@ -171,7 +172,7 @@ describe('svg', function () {
       // autoinstall is disabled
       assert.equal(
         err.diagnostics[0].message,
-        `Could not resolve module "svgo" from "${path.resolve(
+        md`Could not resolve module "svgo" from "${path.resolve(
           overlayFS.cwd(),
           '/svgo-version/index',
         )}"`,

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -86,3 +86,4 @@ export {
   remapSourceLocation,
 } from './sourcemap';
 export {default as stripAnsi} from 'strip-ansi';
+export {detectSVGOVersion} from './svgo';

--- a/packages/core/utils/src/svgo.js
+++ b/packages/core/utils/src/svgo.js
@@ -1,0 +1,50 @@
+// @flow
+export function detectSVGOVersion(
+  config: any,
+): {|version: 3|} | {|version: 2, path: string|} {
+  if (!config) {
+    return {version: 3};
+  }
+
+  // These options were removed in v2.
+  if (config.full != null || config.svg2js != null) {
+    return {version: 2, path: config.full != null ? '/full' : '/svg2js'};
+  }
+
+  if (Array.isArray(config.plugins)) {
+    // Custom plugins in v2 had additional (required) fields that don't exist anymore.
+    let v2Plugin = config.plugins.findIndex(
+      p => p?.type != null || (p?.fn && p?.params != null),
+    );
+    if (v2Plugin !== -1) {
+      let field = config.plugins[v2Plugin].type != null ? 'type' : 'params';
+      return {version: 2, path: `/plugins/${v2Plugin}/${field}`};
+    }
+
+    // the cleanupIDs plugin lost the prefix option in v3.
+    let cleanupIdsIndex = config.plugins.findIndex(
+      p => p?.name === 'cleanupIDs',
+    );
+    let cleanupIDs =
+      cleanupIdsIndex !== -1 ? config.plugins[cleanupIdsIndex] : null;
+    if (cleanupIDs?.params?.prefix != null) {
+      return {version: 2, path: `/plugins/${cleanupIdsIndex}/params/prefix`};
+    }
+
+    // Automatically migrate some options from SVGO 2 config files.
+    config.plugins = config.plugins.filter(p => p?.active !== false);
+
+    for (let i = 0; i < config.plugins.length; i++) {
+      let p = config.plugins[i];
+      if (p === 'cleanupIDs') {
+        config.plugins[i] = 'cleanupIds';
+      }
+
+      if (p?.name === 'cleanupIDs') {
+        config.plugins[i].name = 'cleanupIds';
+      }
+    }
+  }
+
+  return {version: 3};
+}

--- a/packages/optimizers/htmlnano/package.json
+++ b/packages/optimizers/htmlnano/package.json
@@ -20,10 +20,14 @@
     "parcel": "^2.12.0"
   },
   "dependencies": {
+    "@parcel/diagnostic": "2.12.0",
     "@parcel/plugin": "2.12.0",
+    "@parcel/utils": "2.12.0",
     "htmlnano": "^2.0.0",
     "nullthrows": "^1.1.1",
-    "posthtml": "^0.16.5",
-    "svgo": "^2.4.0"
+    "posthtml": "^0.16.5"
+  },
+  "devDependencies": {
+    "svgo": "^3.3.2"
   }
 }

--- a/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
+++ b/packages/optimizers/htmlnano/src/HTMLNanoOptimizer.js
@@ -257,11 +257,13 @@ async function minifySvg(tree, options, svgoVersion, svgoOptions, logger) {
               // inline SVGs because they could actually be referenced
               // by a separate inline SVG.
               [cleanupIds]: false,
+              removeHiddenElems: false,
             },
           },
         },
         // XML namespaces are not required in HTML.
         'removeXMLNS',
+        'removeXlink',
       ],
     };
   }

--- a/packages/optimizers/svgo/package.json
+++ b/packages/optimizers/svgo/package.json
@@ -22,7 +22,9 @@
   "dependencies": {
     "@parcel/diagnostic": "2.12.0",
     "@parcel/plugin": "2.12.0",
-    "@parcel/utils": "2.12.0",
-    "svgo": "^2.4.0"
+    "@parcel/utils": "2.12.0"
+  },
+  "devDependencies": {
+    "svgo": "^3.3.2"
   }
 }

--- a/packages/optimizers/svgo/src/SVGOOptimizer.js
+++ b/packages/optimizers/svgo/src/SVGOOptimizer.js
@@ -1,13 +1,16 @@
 // @flow
 
 import {Optimizer} from '@parcel/plugin';
-import ThrowableDiagnostic from '@parcel/diagnostic';
-import {blobToString} from '@parcel/utils';
-
-import * as svgo from 'svgo';
+import ThrowableDiagnostic, {
+  errorToDiagnostic,
+  md,
+  generateJSONCodeHighlights,
+} from '@parcel/diagnostic';
+import {blobToString, detectSVGOVersion} from '@parcel/utils';
+import path from 'path';
 
 export default (new Optimizer({
-  async loadConfig({config}) {
+  async loadConfig({config, logger, options}) {
     let configFile = await config.getConfig([
       'svgo.config.js',
       'svgo.config.cjs',
@@ -15,33 +18,101 @@ export default (new Optimizer({
       'svgo.config.json',
     ]);
 
-    return configFile?.contents;
+    // See if svgo is already installed.
+    let resolved;
+    try {
+      resolved = await options.packageManager.resolve(
+        'svgo',
+        path.join(options.projectRoot, 'index'),
+        {shouldAutoInstall: false},
+      );
+    } catch (err) {
+      // ignore.
+    }
+
+    // If so, use the existing installed version.
+    let version = 3;
+    if (resolved) {
+      if (resolved.pkg?.version) {
+        version = parseInt(resolved.pkg.version);
+      }
+    } else {
+      // Otherwise try to detect the version based on the config file.
+      let v = detectSVGOVersion(configFile?.contents);
+      if (configFile != null && v.version === 2) {
+        logger.warn({
+          message: md`Detected deprecated SVGO v2 options in ${path.relative(
+            process.cwd(),
+            configFile.filePath,
+          )}`,
+          codeFrames: [
+            {
+              filePath: configFile.filePath,
+              codeHighlights:
+                path.extname(configFile.filePath) === '.json'
+                  ? generateJSONCodeHighlights(
+                      await options.inputFS.readFile(
+                        configFile.filePath,
+                        'utf8',
+                      ),
+                      [{key: v.path}],
+                    )
+                  : [],
+            },
+          ],
+        });
+      }
+
+      version = v.version;
+    }
+
+    return {
+      contents: configFile?.contents,
+      version,
+    };
   },
 
-  async optimize({bundle, contents, config}) {
+  async optimize({bundle, contents, config, options}) {
     if (!bundle.env.shouldOptimize) {
       return {contents};
     }
 
+    const svgo = await options.packageManager.require(
+      'svgo',
+      path.join(options.projectRoot, 'index'),
+      {
+        range: `^${config.version}`,
+        saveDev: true,
+        shouldAutoInstall: options.shouldAutoInstall,
+      },
+    );
+
     let code = await blobToString(contents);
-    let result = svgo.optimize(code, {
-      plugins: [
-        {
-          name: 'preset-default',
-          params: {
-            overrides: {
-              // Removing ids could break SVG sprites.
-              cleanupIDs: false,
-              // <style> elements and attributes are already minified before they
-              // are re-inserted by the packager.
-              minifyStyles: false,
+    let cleanupIds: string = config.version === 2 ? 'cleanupIDs' : 'cleanupIds';
+    let result;
+    try {
+      result = svgo.optimize(code, {
+        plugins: [
+          {
+            name: 'preset-default',
+            params: {
+              overrides: {
+                // Removing ids could break SVG sprites.
+                [cleanupIds]: false,
+                // <style> elements and attributes are already minified before they
+                // are re-inserted by the packager.
+                minifyStyles: false,
+              },
             },
           },
-        },
-      ],
-      ...config,
-    });
+        ],
+        ...config.contents,
+      });
+    } catch (err) {
+      throw errorToDiagnostic(err);
+    }
 
+    // For svgo v2.
     if (result.error != null) {
       throw new ThrowableDiagnostic({
         diagnostic: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13866,7 +13866,7 @@ svg-parser@^2.0.4:
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
   integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
 
-svgo@^2.4.0, svgo@^2.8.0:
+svgo@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
   integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==


### PR DESCRIPTION
Closes #9045, closes #9935, fixes #8948, fixes #9660

This is another attempt at upgrading SVGO to v3. In order to avoid breaking changes, this moves the dependency from the Parcel plugin to the project. To handle the migration, we attempt to detect the version of SVGO needed by inspecting the config file and determining if any options that were removed in v3 are present. If so, we'll log a warning and install v2. Otherwise we will install v3.

This means that new projects, and existing projects with no config or a config compatible with v3, will be upgraded automatically by installing v3 into their project. Existing projects that are using deprecated options in v2 will install v2 into their project. From then on, Parcel will load svgo relative to the project root (as it probably should have all along).