### PR TITLE
allow running the react-refresh transformer in custom NODE_ENVs

### DIFF
--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -6,12 +6,13 @@ import {Transformer} from '@parcel/plugin';
 function shouldExclude(asset, options) {
   return (
     !asset.isSource ||
+    !asset.type === 'css' ||
     !options.hmrOptions ||
     !asset.env.isBrowser() ||
     asset.env.isLibrary ||
     asset.env.isWorker() ||
     asset.env.isWorklet() ||
-    options.mode !== 'development' ||
+    options.mode === 'production' ||
     !asset
       .getDependencies()
       .find(


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Instead of running the transformer only when `NODE_ENV=development`, we now only run it as long as the environment is **not** production.

It also explicitly exclude CSS files, since they might have a React dependency but they're not script files. If there's a better way to do this, please let me know!

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

Running `NODE_ENV=stg-east parcel --https --port 8080 --host databases.localhost` will create a bundle that, at runtime, will throw the following error:

```
Uncaught TypeError: $RefreshSig$ is not a function
```

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
