### PR TITLE
Improve HMR

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -530,6 +530,14 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
           ...depNode.value.meta,
           ...existing.value.resolverMeta,
         };
+        depNode.value.resolverMeta = existing.value.resolverMeta;
+      }
+      if (
+        existing?.type === 'dependency' &&
+        existing.value.resolverPriority != null
+      ) {
+        depNode.value.priority = existing.value.resolverPriority;
+        depNode.value.resolverPriority = existing.value.resolverPriority;
       }
       let dependentAsset = dependentAssets.find(
         a => a.uniqueKey === dep.specifier,

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -315,7 +315,8 @@ export class ResolverRunner {
           }
 
           if (result.priority != null) {
-            dependency.priority = Priority[result.priority];
+            dependency.priority = dependency.resolverPriority =
+              Priority[result.priority];
           }
 
           if (result.invalidateOnEnvChange) {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -142,6 +142,7 @@ export type Dependency = {|
   customPackageConditions?: Array<string>,
   meta: Meta,
   resolverMeta?: ?Meta,
+  resolverPriority?: $Values<typeof Priority>,
   target: ?Target,
   sourceAssetId: ?string,
   sourcePath: ?ProjectPath,

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -527,6 +527,40 @@ module.hot.dispose((data) => {
       assert(!reloaded);
     });
 
+    it('should bubble to parents if child returns additional parents', async function () {
+      let {reloaded, outputs} = await testHMRClient('hmr-parents', outputs => {
+        assert.deepEqual(outputs, ['child 2', 'root']);
+        return {
+          'updated.js': 'exports.a = 3;',
+        };
+      });
+
+      assert.deepEqual(outputs, [
+        'child 2',
+        'root',
+        'child 3',
+        'accept child',
+        'root',
+        'accept root',
+      ]);
+      assert(!reloaded);
+    });
+
+    it('should bubble to parents and reload if they do not accept', async function () {
+      let {reloaded, outputs} = await testHMRClient(
+        'hmr-parents-reload',
+        outputs => {
+          assert.deepEqual(outputs, ['child 2', 'root']);
+          return {
+            'updated.js': 'exports.a = 3;',
+          };
+        },
+      );
+
+      assert.deepEqual(outputs, []);
+      assert(reloaded);
+    });
+
     it('should work with urls', async function () {
       let search;
       let {outputs} = await testHMRClient('hmr-url', outputs => {

--- a/packages/core/integration-tests/test/hmr.js
+++ b/packages/core/integration-tests/test/hmr.js
@@ -516,15 +516,15 @@ module.hot.dispose((data) => {
     });
 
     it('should work across bundles', async function () {
-      let {reloaded} = await testHMRClient('hmr-dynamic', outputs => {
+      let {reloaded, outputs} = await testHMRClient('hmr-dynamic', outputs => {
         assert.deepEqual(outputs, [3]);
         return {
           'local.js': 'exports.a = 5; exports.b = 5;',
         };
       });
 
-      // assert.deepEqual(outputs, [3, 10]);
-      assert(reloaded); // TODO: this should eventually not reload...
+      assert.deepEqual(outputs, [3, 10]);
+      assert(!reloaded);
     });
 
     it('should work with urls', async function () {

--- a/packages/core/integration-tests/test/integration/hmr-parents-reload/child.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents-reload/child.js
@@ -1,0 +1,7 @@
+const updated = require('./updated');
+
+output('child ' + updated.a);
+module.hot.accept(getParents => {
+  output('accept child');
+  return getParents();
+});

--- a/packages/core/integration-tests/test/integration/hmr-parents-reload/index.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents-reload/index.js
@@ -1,0 +1,3 @@
+require('./middle');
+
+output('root');

--- a/packages/core/integration-tests/test/integration/hmr-parents-reload/middle.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents-reload/middle.js
@@ -1,0 +1,1 @@
+require('./child');

--- a/packages/core/integration-tests/test/integration/hmr-parents-reload/updated.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents-reload/updated.js
@@ -1,0 +1,1 @@
+exports.a = 2;

--- a/packages/core/integration-tests/test/integration/hmr-parents/child.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents/child.js
@@ -1,0 +1,7 @@
+const updated = require('./updated');
+
+output('child ' + updated.a);
+module.hot.accept(getParents => {
+  output('accept child');
+  return getParents();
+});

--- a/packages/core/integration-tests/test/integration/hmr-parents/index.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents/index.js
@@ -1,0 +1,6 @@
+require('./middle');
+
+output('root');
+module.hot.accept(() => {
+  output('accept root');
+});

--- a/packages/core/integration-tests/test/integration/hmr-parents/middle.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents/middle.js
@@ -1,0 +1,1 @@
+require('./child');

--- a/packages/core/integration-tests/test/integration/hmr-parents/updated.js
+++ b/packages/core/integration-tests/test/integration/hmr-parents/updated.js
@@ -1,0 +1,1 @@
+exports.a = 2;

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -112,6 +112,16 @@ export class DevPackager {
           }
         }
 
+        // Add dependencies for parcelRequire calls added by runtimes
+        // so that the HMR runtime can correctly traverse parents.
+        let hmrDeps = asset.meta.hmrDeps;
+        if (this.options.hmrOptions && Array.isArray(hmrDeps)) {
+          for (let id of hmrDeps) {
+            invariant(typeof id === 'string');
+            deps[id] = id;
+          }
+        }
+
         let {code, mapBuffer} = results[i];
         let output = code || '';
         wrapped +=

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -549,7 +549,7 @@ function getURLRuntime(
   to: NamedBundle,
   options: PluginOptions,
 ): RuntimeAsset {
-  let relativePathExpr = getRelativePathExpr(from, to, options);
+  let relativePathExpr = getRelativePathExpr(from, to, options, true);
   let code;
 
   if (dependency.meta.webworker === true && !from.env.isLibrary) {
@@ -630,10 +630,11 @@ function getRelativePathExpr(
   from: NamedBundle,
   to: NamedBundle,
   options: PluginOptions,
+  isURL = to.type !== 'js',
 ): string {
   let relativePath = relativeBundlePath(from, to, {leadingDotSlash: false});
   let res = JSON.stringify(relativePath);
-  if (options.hmrOptions) {
+  if (isURL && options.hmrOptions) {
     res += ' + "?" + Date.now()';
   }
 

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -94,7 +94,7 @@ export default (new Runtime({
           // The linker handles this for scope-hoisting.
           assets.push({
             filePath: __filename,
-            code: `module.exports = Promise.resolve(module.bundle.root(${JSON.stringify(
+            code: `module.exports = Promise.resolve(parcelRequire(${JSON.stringify(
               bundleGraph.getAssetPublicId(resolved.value),
             )}))`,
             dependency,
@@ -422,10 +422,7 @@ function getLoaderRuntime({
   }
 
   if (mainBundle.type === 'js') {
-    let parcelRequire = bundle.env.shouldScopeHoist
-      ? 'parcelRequire'
-      : 'module.bundle.root';
-    loaderCode += `.then(() => ${parcelRequire}('${bundleGraph.getAssetPublicId(
+    loaderCode += `.then(() => parcelRequire('${bundleGraph.getAssetPublicId(
       bundleGraph.getAssetById(bundleGroup.entryAssetId),
     )}'))`;
   }


### PR DESCRIPTION
* Supports HMR across dynamic import boundaries by ensuring that updates bubble properly through runtime assets. This did not work previously because the runtime uses `parcelRequire` to load a module by id, so a dependency was never added to the graph. The HMR runtime relies on dependencies being declared so it can traverse parents. In this PR we track the ids that are `parcelRequire`ed and add them in the dev packager so that we can travers from the child through runtimes.
* We added a query parameter to URL dependency runtimes so that updating them forced them to reload. However, we do not want this for dynamic imports or multiple copies of JS bundles will be loaded. We don't need to force JS bundles to reload (in fact we don't want them to) because the HMR runtime replaces them in place.
* If `module.hot.accept` decides that it cannot handle an update for whatever reason, it can call `getParents` and return additional assets to bubble to. However, we previously only bubbled to those direct parents and no further. This PR fixes that so that we continue bubbling, and reload if not accepted.
* Fixed another issue where a resolver could return a `priority` (e.g. the glob resolver), but this was overwritten in core the next time it was resolved instead of merging. Solved similar to how we did for `meta`.