### PR TITLE
Support running node bundles in dev server

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -2107,4 +2107,33 @@ export default class BundleGraph {
     this._targetEntryRoots.set(target.distDir, root);
     return root;
   }
+
+  getEntryBundles(): Array<Bundle> {
+    let entryBundleGroupIds = this._graph.getNodeIdsConnectedFrom(
+      nullthrows(this._graph.rootNodeId),
+      bundleGraphEdgeTypes.bundle,
+    );
+
+    let entries = [];
+    for (let bundleGroupId of entryBundleGroupIds) {
+      let bundleGroupNode = this._graph.getNode(bundleGroupId);
+      invariant(bundleGroupNode?.type === 'bundle_group');
+
+      let entryBundle = this.getBundlesInBundleGroup(
+        bundleGroupNode.value,
+      ).find(b => {
+        let mainEntryId = b.entryAssetIds[b.entryAssetIds.length - 1];
+        return (
+          mainEntryId != null &&
+          bundleGroupNode.value.entryAssetId === mainEntryId
+        );
+      });
+
+      if (entryBundle) {
+        entries.push(entryBundle);
+      }
+    }
+
+    return entries;
+  }
 }

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -332,4 +332,10 @@ export default class BundleGraph<TBundle: IBundle>
       targetToInternalTarget(target),
     );
   }
+
+  getEntryBundles(): Array<TBundle> {
+    return this.#graph
+      .getEntryBundles()
+      .map(b => this.#createBundle(b, this.#graph, this.#options));
+  }
 }

--- a/packages/core/logger/src/Logger.js
+++ b/packages/core/logger/src/Logger.js
@@ -102,9 +102,9 @@ export class PluginLogger implements IPluginLogger {
   ): Diagnostic | Array<Diagnostic> {
     return Array.isArray(diagnostic)
       ? diagnostic.map(d => {
-          return {...d, origin: this.origin};
+          return {...d, origin: d.origin ?? this.origin};
         })
-      : {...diagnostic, origin: this.origin};
+      : {...diagnostic, origin: diagnostic.origin ?? this.origin};
   }
 
   verbose(

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1622,6 +1622,8 @@ export interface BundleGraph<TBundle: Bundle> {
   getUsedSymbols(Asset | Dependency): ?$ReadOnlySet<Symbol>;
   /** Returns the common root directory for the entry assets of a target. */
   getEntryRoot(target: Target): FilePath;
+  /** Returns a list of entry bundles. */
+  getEntryBundles(): Array<TBundle>;
 }
 
 /**

--- a/packages/examples/react-server-components/package.json
+++ b/packages/examples/react-server-components/package.json
@@ -12,6 +12,11 @@
       }
     }
   },
+  "scripts": {
+    "dev": "parcel",
+    "build": "parcel build",
+    "start": "node dist/server.js"
+  },
   "dependencies": {
     "express": "^4.18.2",
     "react": "^19",

--- a/packages/examples/react-server-components/package.json
+++ b/packages/examples/react-server-components/package.json
@@ -23,8 +23,5 @@
     "react-dom": "^19",
     "react-server-dom-parcel": "^0.0.1",
     "rsc-html-stream": "^0.0.4"
-  },
-  "@parcel/resolver-default": {
-    "packageExports": true
   }
 }

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -57,18 +57,6 @@ export async function _report(
       // Clear any previous output
       resetWindow();
 
-      if (options.serveOptions) {
-        persistMessage(
-          chalk.blue.bold(
-            `Server running at ${
-              options.serveOptions.https ? 'https' : 'http'
-            }://${options.serveOptions.host ?? 'localhost'}:${
-              options.serveOptions.port
-            }`,
-          ),
-        );
-      }
-
       break;
     }
     case 'buildProgress': {
@@ -120,6 +108,21 @@ export async function _report(
       }
 
       phaseStartTimes['buildSuccess'] = Date.now();
+
+      if (
+        options.serveOptions &&
+        event.bundleGraph.getEntryBundles().some(b => b.env.isBrowser())
+      ) {
+        persistMessage(
+          chalk.blue.bold(
+            `Server running at ${
+              options.serveOptions.https ? 'https' : 'http'
+            }://${options.serveOptions.host ?? 'localhost'}:${
+              options.serveOptions.port
+            }`,
+          ),
+        );
+      }
 
       persistSpinner(
         'buildProgress',

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -268,9 +268,9 @@ export default class HMRServer {
 
   getSourceURL(asset: Asset): string {
     let origin = '';
-    // $FlowFixMe
     if (
       !this.options.devServer ||
+      // $FlowFixMe
       this.bundleGraph?.getEntryBundles().some(b => b.env.isServer())
     ) {
       origin = `http://${this.options.host || 'localhost'}:${

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -251,7 +251,9 @@ export default class HMRServer {
     if (sourcemap) {
       let sourcemapStringified = await sourcemap.stringify({
         format: 'inline',
-        sourceRoot: SOURCES_ENDPOINT + '/',
+        sourceRoot:
+          (asset.env.isNode() ? this.options.projectRoot : SOURCES_ENDPOINT) +
+          '/',
         // $FlowFixMe
         fs: asset.fs,
       });
@@ -266,7 +268,11 @@ export default class HMRServer {
 
   getSourceURL(asset: Asset): string {
     let origin = '';
-    if (!this.options.devServer) {
+    // $FlowFixMe
+    if (
+      !this.options.devServer ||
+      this.bundleGraph?.getEntryBundles().some(b => b.env.isServer())
+    ) {
       origin = `http://${this.options.host || 'localhost'}:${
         this.options.port
       }`;

--- a/packages/reporters/dev-server/src/NodeRunner.js
+++ b/packages/reporters/dev-server/src/NodeRunner.js
@@ -1,0 +1,111 @@
+// @flow
+import type {PluginLogger, BundleGraph, PackagedBundle} from '@parcel/types';
+
+import {md, errorToDiagnostic} from '@parcel/diagnostic';
+import nullthrows from 'nullthrows';
+import {Worker} from 'worker_threads';
+import path from 'path';
+
+export type NodeRunnerOptions = {|
+  hmr: boolean,
+  logger: PluginLogger,
+|};
+
+export class NodeRunner {
+  worker: Worker | null = null;
+  bundleGraph: BundleGraph<PackagedBundle> | null = null;
+  pending: boolean = true;
+  logger: PluginLogger;
+  hmr: boolean;
+
+  constructor(options: NodeRunnerOptions) {
+    this.logger = options.logger;
+    this.hmr = options.hmr;
+  }
+
+  buildStart() {
+    this.pending = true;
+  }
+
+  buildSuccess(bundleGraph: BundleGraph<PackagedBundle>) {
+    this.bundleGraph = bundleGraph;
+    this.pending = false;
+    if (this.worker == null) {
+      this.startWorker();
+    } else if (!this.hmr) {
+      this.restartWorker();
+    }
+  }
+
+  startWorker() {
+    let entry = nullthrows(this.bundleGraph)
+      .getEntryBundles()
+      .find(b => b.env.isNode() && b.type === 'js');
+    if (entry) {
+      let relativePath = path.relative(process.cwd(), entry.filePath);
+      this.logger.log({message: md`Starting __${relativePath}__...`});
+      let worker = new Worker(entry.filePath, {
+        execArgv: ['--enable-source-maps'],
+        workerData: {
+          // Used by the hmr-runtime to detect when to send restart messages.
+          __parcel: true,
+        },
+        stdout: true,
+        stderr: true,
+      });
+
+      worker.on('message', msg => {
+        if (msg === 'restart') {
+          this.restartWorker();
+        }
+      });
+
+      worker.on('error', (err: Error) => {
+        this.logger.error(errorToDiagnostic(err));
+      });
+
+      worker.stderr.setEncoding('utf8');
+      worker.stderr.on('data', data => {
+        for (let line of data.split('\n')) {
+          this.logger.error({
+            origin: relativePath,
+            message: line,
+            skipFormatting: true,
+          });
+        }
+      });
+
+      worker.stdout.setEncoding('utf8');
+      worker.stdout.on('data', data => {
+        for (let line of data.split('\n')) {
+          this.logger.log({
+            origin: relativePath,
+            message: line,
+            skipFormatting: true,
+          });
+        }
+      });
+
+      worker.on('exit', () => {
+        this.worker = null;
+      });
+
+      this.worker = worker;
+    }
+  }
+
+  async stop(): Promise<void> {
+    await this.worker?.terminate();
+    this.worker = null;
+  }
+
+  async restartWorker(): Promise<void> {
+    await this.stop();
+
+    // HMR updates are sent before packaging is complete.
+    // If the build is still pending, wait until it completes to restart.
+    if (!this.pending) {
+      this.startWorker();
+    }
+  }
+}

--- a/packages/reporters/dev-server/src/types.js.flow
+++ b/packages/reporters/dev-server/src/types.js.flow
@@ -53,4 +53,5 @@ export type HMRServerOptions = {|
   cacheDir: FilePath,
   inputFS: FileSystem,
   outputFS: FileSystem,
+  projectRoot: FilePath,
 |};

--- a/packages/runtimes/hmr/src/HMRRuntime.js
+++ b/packages/runtimes/hmr/src/HMRRuntime.js
@@ -19,7 +19,7 @@ const HMR_RUNTIME = fs.readFileSync(
 );
 
 export default (new Runtime({
-  apply({bundle, options}) {
+  apply({bundle, bundleGraph, options}) {
     if (
       bundle.type !== 'js' ||
       !options.hmrOptions ||
@@ -31,6 +31,10 @@ export default (new Runtime({
     }
 
     const {host, port} = options.hmrOptions;
+    let hasServerBundles = bundleGraph
+      .getEntryBundles()
+      .some(b => b.env.isServer());
+
     return {
       filePath: FILENAME,
       code:
@@ -41,7 +45,9 @@ export default (new Runtime({
           port != null &&
             // Default to the HTTP port in the browser, only override
             // in watch mode or if hmr port != serve port
-            (!options.serveOptions || options.serveOptions.port !== port)
+            (!options.serveOptions ||
+              options.serveOptions.port !== port ||
+              hasServerBundles)
             ? port
             : null,
         )};` +

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -329,9 +329,18 @@ function fullReload() {
   ) {
     extCtx.runtime.reload();
   } else {
-    console.error(
-      '[parcel] ⚠️ An HMR update was not accepted. Please restart the process.',
-    );
+    try {
+      let {workerData, parentPort} = (module.bundle.root(
+        'node:worker_threads',
+      ) /*: any*/);
+      if (workerData?.__parcel) {
+        parentPort.postMessage('restart');
+      }
+    } catch (err) {
+      console.error(
+        '[parcel] ⚠️ An HMR update was not accepted. Please restart the process.',
+      );
+    }
   }
 }
 

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -125,7 +125,10 @@ export default class NodeResolver {
           options.env,
           this.options.mode,
         ),
-        packageExports: this.options.packageExports ?? false,
+        packageExports:
+          this.options.packageExports ||
+          options.env.context === 'react-server' ||
+          options.env.context === 'react-client',
         moduleDirResolver:
           process.versions.pnp != null
             ? (module, from) => {


### PR DESCRIPTION
This enables using `parcel serve` (or just `parcel`) when the entry point of your app is a Node server, e.g. when using React Server Components. In this case, `@parcel/reporter-dev-server` will run your server entry point in a `Worker` for you, and forward its stdio to the Parcel logger. In addition, it will automatically restart your node program when it changes, and it integrates with HMR as well to only restart when needed.

I think this finally closes #355 and closes #737!