### PR TITLE
Support default_state key in chrome.action

### DIFF
--- a/packages/core/integration-tests/test/integration/webextension-mv3/manifest.json
+++ b/packages/core/integration-tests/test/integration/webextension-mv3/manifest.json
@@ -18,7 +18,8 @@
     "world": "ISOLATED"
   }],
   "action": {
-    "default_popup": "popup.html"
+    "default_popup": "popup.html",
+    "default_state": "disabled"
   },
   "side_panel": {
     "default_path": "side-panel.html"

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -32,6 +32,10 @@ const actionProps = {
   },
   default_popup: string,
   default_title: string,
+  default_state: {
+    type: 'string',
+    enum: ['disabled', 'enabled'],
+  },
 };
 
 const arrStr = {


### PR DESCRIPTION
https://developer.chrome.com/docs/extensions/reference/api/action#enabled_state

# ↪️ Pull Request

Allow enabled_state in manifest.json action, fixes #10061

## 💻 Examples

See #10061

## 🚨 Test instructions

Unit test provided.

## ✔️ PR Todo

- [X] Added/updated unit tests for this change
- [X] Filled out test instructions (In case there aren't any unit tests)
- [X] Included links to related issues/PRs
