### PR TITLE
Support bundling node native modules

### DIFF
--- a/packages/configs/default/index.json
+++ b/packages/configs/default/index.json
@@ -44,6 +44,7 @@
     ],
     "*.svg": ["@parcel/transformer-svg"],
     "*.{xml,rss,atom}": ["@parcel/transformer-xml"],
+    "*.node": ["@parcel/transformer-node"],
     "url:*": ["...", "@parcel/transformer-raw"]
   },
   "namers": ["@parcel/namer-default"],

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -44,6 +44,7 @@
     "@parcel/transformer-image": "2.13.3",
     "@parcel/transformer-js": "2.13.3",
     "@parcel/transformer-json": "2.13.3",
+    "@parcel/transformer-node": "2.13.3",
     "@parcel/transformer-postcss": "2.13.3",
     "@parcel/transformer-posthtml": "2.13.3",
     "@parcel/transformer-raw": "2.13.3",

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -314,7 +314,7 @@ describe('svg', function () {
 
     assertBundles(b, [
       {
-        assets: ['index.js', 'bundle-url.js'],
+        assets: ['index.js'],
       },
       {
         assets: ['circle.svg'],

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -365,6 +365,9 @@ export async function runBundles(
       overlayFS,
       externalModules,
       true,
+      target === 'node' ||
+        target === 'electron-main' ||
+        target === 'react-server',
     );
 
     esmOutput = bundles.length === 1 ? res[0] : res;
@@ -927,6 +930,9 @@ function prepareNodeContext(
           readFileSync: (file, encoding) => {
             return overlayFS.readFileSync(file, encoding);
           },
+          existsSync: file => {
+            return overlayFS.existsSync(file);
+          },
         };
       }
 
@@ -937,6 +943,10 @@ function prepareNodeContext(
 
       if (path.extname(res) === '.css') {
         return {};
+      }
+
+      if (path.extname(res) === '.node') {
+        return require(res);
       }
 
       let cached = nodeCache.get(res);
@@ -1002,6 +1012,7 @@ export async function runESM(
   fs: FileSystem,
   externalModules: ExternalModules = {},
   requireExtensions: boolean = false,
+  isNode: boolean = false,
 ): Promise<Array<{|[string]: mixed|}>> {
   let id = instanceId++;
   let cache = new Map();
@@ -1048,7 +1059,11 @@ export async function runESM(
           entry(specifier, referrer),
         context,
         initializeImportMeta(meta) {
-          meta.url = `http://localhost/${path.basename(filename)}`;
+          if (isNode) {
+            meta.url = url.pathToFileURL(filename).toString();
+          } else {
+            meta.url = `http://localhost/${path.basename(filename)}`;
+          }
         },
       });
       cache.set(filename, m);

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -946,6 +946,7 @@ function prepareNodeContext(
       }
 
       if (path.extname(res) === '.node') {
+        // $FlowFixMe[unsupported-syntax]
         return require(res);
       }
 

--- a/packages/runtimes/js/src/helpers/node/node-loader.js
+++ b/packages/runtimes/js/src/helpers/node/node-loader.js
@@ -1,0 +1,8 @@
+const url = require('url');
+const {createRequire} = require('module');
+
+module.exports = function loadNodeModule(bundle) {
+  let path = url.fileURLToPath(bundle);
+  let require = createRequire(path);
+  return require(path);
+};

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -489,6 +489,7 @@ pub fn transform(
                     filename: Path::new(&config.filename),
                     unresolved_mark,
                     has_node_replacements: &mut result.has_node_replacements,
+                    is_esm: config.is_esm_output,
                   },
                   config.node_replacer(),
                 ),

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -485,7 +485,7 @@ pub fn transform(
                     source_map: source_map.clone(),
                     items: &mut global_deps,
                     global_mark,
-                    globals: HashMap::new(),
+                    globals: IndexMap::new(),
                     filename: Path::new(&config.filename),
                     unresolved_mark,
                     has_node_replacements: &mut result.has_node_replacements,

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -3,9 +3,9 @@ use std::{collections::HashMap, ffi::OsStr, path::Path};
 use swc_core::{
   common::{sync::Lrc, Mark, SourceMap, SyntaxContext, DUMMY_SP},
   ecma::{
-    ast,
-    ast::MemberProp,
+    ast::{self, MemberProp},
     atoms::JsWord,
+    utils::member_expr,
     visit::{VisitMut, VisitMutWith},
   },
 };
@@ -26,6 +26,7 @@ pub struct NodeReplacer<'a> {
   pub global_mark: Mark,
   pub globals: HashMap<JsWord, (SyntaxContext, ast::Stmt)>,
   pub filename: &'a Path,
+  pub is_esm: bool,
   pub unresolved_mark: Mark,
   /// This will be set to true if the file has either __dirname or __filename replacements inserted
   pub has_node_replacements: &'a mut bool,
@@ -50,6 +51,7 @@ impl<'a> VisitMut for NodeReplacer<'a> {
             let replace_me_value = swc_core::ecma::atoms::JsWord::from("$parcel$filenameReplace");
 
             let unresolved_mark = self.unresolved_mark;
+            let is_esm = self.is_esm;
             let expr = |this: &NodeReplacer| {
               let filename = if let Some(name) = this.filename.file_name() {
                 name
@@ -63,14 +65,9 @@ impl<'a> VisitMut for NodeReplacer<'a> {
                 args: vec![
                   ast::ExprOrSpread {
                     spread: None,
-                    expr: Box::new(ast::Expr::Ident(ast::Ident {
-                      optional: false,
-                      span: DUMMY_SP,
-                      ctxt: SyntaxContext::empty(),
-                      // This also uses __dirname as later in the path.join call the hierarchy is then correct
-                      // Otherwise path.join(__filename, '..') would be one level to shallow (due to the /filename.js at the end)
-                      sym: swc_core::ecma::atoms::JsWord::from("__dirname"),
-                    })),
+                    // This also uses __dirname as later in the path.join call the hierarchy is then correct
+                    // Otherwise path.join(__filename, '..') would be one level to shallow (due to the /filename.js at the end)
+                    expr: Box::new(dirname(is_esm, unresolved_mark)),
                   },
                   ast::ExprOrSpread {
                     spread: None,
@@ -119,6 +116,7 @@ impl<'a> VisitMut for NodeReplacer<'a> {
             let replace_me_value = swc_core::ecma::atoms::JsWord::from("$parcel$dirnameReplace");
 
             let unresolved_mark = self.unresolved_mark;
+            let is_esm = self.is_esm;
             if self.update_binding(id, "$parcel$__dirname".into(), |_| {
               Call(ast::CallExpr {
                 span: DUMMY_SP,
@@ -127,12 +125,7 @@ impl<'a> VisitMut for NodeReplacer<'a> {
                 args: vec![
                   ast::ExprOrSpread {
                     spread: None,
-                    expr: Box::new(ast::Expr::Ident(ast::Ident {
-                      optional: false,
-                      span: DUMMY_SP,
-                      ctxt: SyntaxContext::empty(),
-                      sym: swc_core::ecma::atoms::JsWord::from("__dirname"),
-                    })),
+                    expr: Box::new(dirname(is_esm, unresolved_mark)),
                   },
                   ast::ExprOrSpread {
                     spread: None,
@@ -220,6 +213,43 @@ impl NodeReplacer<'_> {
   }
 }
 
+fn dirname(is_esm: bool, unresolved_mark: Mark) -> ast::Expr {
+  if is_esm {
+    use ast::*;
+    // require('path').dirname(require('url').fileURLToPath(import.meta.url))
+    // TODO: use import.meta.dirname if available?
+    Expr::Call(CallExpr {
+      callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+        obj: Box::new(Expr::Call(create_require("path".into(), unresolved_mark))),
+        prop: MemberProp::Ident(IdentName::new("dirname".into(), DUMMY_SP)),
+        span: DUMMY_SP,
+      }))),
+      args: vec![ExprOrSpread {
+        expr: Box::new(Expr::Call(CallExpr {
+          callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+            obj: Box::new(Expr::Call(create_require("url".into(), unresolved_mark))),
+            prop: MemberProp::Ident(IdentName::new("fileURLToPath".into(), DUMMY_SP)),
+            span: DUMMY_SP,
+          }))),
+          args: vec![ExprOrSpread {
+            expr: Box::new(Expr::Member(member_expr!(
+              Default::default(),
+              DUMMY_SP,
+              import.meta.url
+            ))),
+            spread: None,
+          }],
+          ..Default::default()
+        })),
+        spread: None,
+      }],
+      ..Default::default()
+    })
+  } else {
+    ast::Expr::Ident(ast::Ident::new_no_ctxt("__dirname".into(), DUMMY_SP))
+  }
+}
+
 #[cfg(test)]
 mod test {
   use crate::test_utils::run_visit;
@@ -243,6 +273,7 @@ console.log(__filename);
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
+      is_esm: false,
     })
     .output_code;
 
@@ -277,6 +308,7 @@ console.log(__dirname);
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
+      is_esm: false,
     })
     .output_code;
 
@@ -314,6 +346,7 @@ function something(__filename, __dirname) {
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
+      is_esm: false,
     })
     .output_code;
 
@@ -346,6 +379,7 @@ const filename = obj.__filename;
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
+      is_esm: false,
     })
     .output_code;
 
@@ -374,6 +408,7 @@ const filename = obj[__filename];
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
+      is_esm: false,
     })
     .output_code;
 
@@ -385,5 +420,38 @@ const filename = obj[$parcel$__filename];
     assert_eq!(output_code, expected_code);
     assert_eq!(has_node_replacements, true);
     assert_eq!(items.len(), 1);
+  }
+
+  #[test]
+  fn test_esm() {
+    let mut has_node_replacements = false;
+    let mut items = vec![];
+
+    let code = r#"
+console.log(__filename);
+console.log(__dirname);
+    "#;
+    let output_code = run_visit(code, |context| NodeReplacer {
+      source_map: context.source_map.clone(),
+      global_mark: context.global_mark,
+      globals: HashMap::new(),
+      filename: Path::new("/path/random.js"),
+      has_node_replacements: &mut has_node_replacements,
+      items: &mut items,
+      unresolved_mark: context.unresolved_mark,
+      is_esm: true,
+    })
+    .output_code;
+
+    let expected_code = r#"
+var $parcel$__filename = require("path").resolve(require("path").dirname(require("url").fileURLToPath(import.meta.url)), "$parcel$filenameReplace", "random.js");
+var $parcel$__dirname = require("path").resolve(require("path").dirname(require("url").fileURLToPath(import.meta.url)), "$parcel$dirnameReplace");
+console.log($parcel$__filename);
+console.log($parcel$__dirname);
+"#
+    .trim_start();
+    assert_eq!(output_code, expected_code);
+    assert_eq!(has_node_replacements, true);
+    assert_eq!(items.len(), 2);
   }
 }

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, ffi::OsStr, path::Path};
+use std::{ffi::OsStr, path::Path};
 
+use indexmap::IndexMap;
 use swc_core::{
   common::{sync::Lrc, Mark, SourceMap, SyntaxContext, DUMMY_SP},
   ecma::{
@@ -24,7 +25,7 @@ use crate::{
 pub struct NodeReplacer<'a> {
   pub source_map: Lrc<SourceMap>,
   pub global_mark: Mark,
-  pub globals: HashMap<JsWord, (SyntaxContext, ast::Stmt)>,
+  pub globals: IndexMap<JsWord, (SyntaxContext, ast::Stmt)>,
   pub filename: &'a Path,
   pub is_esm: bool,
   pub unresolved_mark: Mark,
@@ -186,7 +187,7 @@ impl<'a> VisitMut for NodeReplacer<'a> {
       0..0,
       self
         .globals
-        .drain()
+        .drain(..)
         .map(|(_, (_, stmt))| ast::ModuleItem::Stmt(stmt)),
     );
   }
@@ -268,7 +269,7 @@ console.log(__filename);
     let output_code = run_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
-      globals: HashMap::new(),
+      globals: IndexMap::new(),
       filename: Path::new("/path/random.js"),
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
@@ -303,7 +304,7 @@ console.log(__dirname);
     let output_code = run_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
-      globals: HashMap::new(),
+      globals: IndexMap::new(),
       filename: Path::new("/path/random.js"),
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
@@ -341,7 +342,7 @@ function something(__filename, __dirname) {
     let output_code = run_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
-      globals: HashMap::new(),
+      globals: IndexMap::new(),
       filename: Path::new("/path/random.js"),
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
@@ -374,7 +375,7 @@ const filename = obj.__filename;
     let output_code = run_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
-      globals: HashMap::new(),
+      globals: IndexMap::new(),
       filename: Path::new("/path/random.js"),
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
@@ -403,7 +404,7 @@ const filename = obj[__filename];
     let output_code = run_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
-      globals: HashMap::new(),
+      globals: IndexMap::new(),
       filename: Path::new("/path/random.js"),
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
@@ -434,7 +435,7 @@ console.log(__dirname);
     let output_code = run_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
-      globals: HashMap::new(),
+      globals: IndexMap::new(),
       filename: Path::new("/path/random.js"),
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,

--- a/packages/transformers/node/package.json
+++ b/packages/transformers/node/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@parcel/transformer-node",
+  "version": "2.13.3",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/parcel"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/parcel-bundler/parcel.git"
+  },
+  "main": "lib/NodeTransformer.js",
+  "source": "src/NodeTransformer.js",
+  "engines": {
+    "node": ">= 16.0.0",
+    "parcel": "^2.13.3"
+  },
+  "dependencies": {
+    "@parcel/plugin": "2.13.3"
+  }
+}

--- a/packages/transformers/node/src/NodeTransformer.js
+++ b/packages/transformers/node/src/NodeTransformer.js
@@ -1,0 +1,10 @@
+// @flow strict-local
+
+import {Transformer} from '@parcel/plugin';
+
+export default (new Transformer({
+  transform({asset}) {
+    asset.bundleBehavior = 'isolated';
+    return [asset];
+  },
+}): Transformer);


### PR DESCRIPTION
Closes #8183

Separate transformer from the raw transformer because node shouldn't produce a URL. The runtime injects a loader that works in both CJS and ESM by using `module.createRequire`. Also updated the replacer for `__dirname` to support ESM using `fileURLToPath`.