### PR TITLE
Modernize React error overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - run: yarn test:unit
       - name: Upload @parcel/rust artifacts on Linux with Node v20
         if: ${{ runner.os == 'Linux' && matrix.node == 20 }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Rust Linux Binaries
           path: |
@@ -158,7 +158,7 @@ jobs:
       - run: yarn build-native-wasm
       - run: yarn workspace @parcel/repl build
       # - name: Upload REPL
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: REPL
       #     path: 'packages/dev/repl/dist'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         if: ${{ runner.os == 'macOS' && inputs.profile == 'canary' }}
         run: dsymutil packages/*/*/*.node
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.profile == 'canary' }}
         with:
           name: debug-symbols-${{ matrix.name }}
@@ -75,7 +75,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: strip -x packages/*/*/*.node # Must use -x on macOS. This produces larger results on linux.
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.name }}
           path: packages/*/*/*.node
@@ -109,7 +109,7 @@ jobs:
           find packages -name "*.node" -type f -exec objcopy --strip-debug --strip-unneeded {} \;
           find packages -name "*.node" -type f -exec objcopy --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.profile == 'canary' }}
         with:
           name: debug-symbols-linux-gnu-x64
@@ -117,7 +117,7 @@ jobs:
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: strip packages/*/*/*.node
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-linux-gnu-x64
           path: packages/*/*/*.node
@@ -171,7 +171,7 @@ jobs:
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --strip-debug --strip-unneeded {} \;
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.profile == 'canary' }}
         with:
           name: debug-symbols-${{ matrix.target }}
@@ -179,7 +179,7 @@ jobs:
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.target }}
           path: packages/*/*/*.node
@@ -238,7 +238,7 @@ jobs:
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --strip-debug --strip-unneeded {} \;
           find packages -name "*.node" -type f -exec ${{ matrix.objcopy }} --add-gnu-debuglink={}.debug {} \;
       - name: Upload debug symbols
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.profile == 'canary' }}
         with:
           name: debug-symbols-linux-musl-${{ matrix.arch }}
@@ -246,7 +246,7 @@ jobs:
       - name: Strip debug symbols # https://github.com/rust-lang/rust/issues/46034
         run: ${{ matrix.strip }} packages/*/*/*.node
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-linux-musl-${{ matrix.arch }}
           path: packages/*/*/*.node
@@ -272,7 +272,7 @@ jobs:
       - name: Build native packages
         run: yarn build-native-${{ inputs.profile }}
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Move bindings
@@ -285,7 +285,7 @@ jobs:
           find artifacts -name "*.node" -path "**/DWARF/**" -exec cp {} debug-symbols/ \;
           ls -l debug-symbols
       - name: Upload combined debug symbols artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.profile == 'canary' }}
         with:
           name: debug-symbols

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -48,7 +48,7 @@ jobs:
       - run: yarn build-native-wasm
       - run: yarn workspace @parcel/repl build
       # - name: Upload REPL
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: REPL
       #     path: 'packages/dev/repl/dist'

--- a/packages/core/codeframe/src/codeframe.js
+++ b/packages/core/codeframe/src/codeframe.js
@@ -129,11 +129,17 @@ export default function codeFrame(
 
   // Split input into lines and highlight syntax
   let lines = code.split(NEWLINE);
-  let syntaxHighlightedLines = (
-    opts.syntaxHighlighting ? highlightSyntax(code, opts.language) : code
-  )
-    .replace(TAB_REPLACE_REGEX, TAB_REPLACEMENT)
-    .split(NEWLINE);
+  let highlighted = highlightSyntax(
+    lines
+      .slice(startLine, endLineIndex + 1)
+      .join('\n')
+      .replace(TAB_REPLACE_REGEX, TAB_REPLACEMENT),
+    opts.language,
+  ).split(NEWLINE);
+  let syntaxHighlightedLines = lines
+    .slice(0, startLine)
+    .concat(highlighted)
+    .concat(lines.slice(endLineIndex + 2));
 
   // Loop over all lines and create codeframe
   let resultLines = [];

--- a/packages/core/codeframe/src/codeframe.js
+++ b/packages/core/codeframe/src/codeframe.js
@@ -129,16 +129,18 @@ export default function codeFrame(
 
   // Split input into lines and highlight syntax
   let lines = code.split(NEWLINE);
-  let highlighted = highlightSyntax(
-    lines
-      .slice(startLine, endLineIndex + 1)
-      .join('\n')
-      .replace(TAB_REPLACE_REGEX, TAB_REPLACEMENT),
-    opts.language,
-  ).split(NEWLINE);
+  let visibleLines = lines
+    .slice(startLine, endLineIndex + 1)
+    .map(l => l.replace(TAB_REPLACE_REGEX, TAB_REPLACEMENT));
+  if (opts.syntaxHighlighting) {
+    visibleLines = highlightSyntax(
+      visibleLines.join('\n'),
+      opts.language,
+    ).split(NEWLINE);
+  }
   let syntaxHighlightedLines = lines
     .slice(0, startLine)
-    .concat(highlighted)
+    .concat(visibleLines)
     .concat(lines.slice(endLineIndex + 2));
 
   // Loop over all lines and create codeframe

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -448,7 +448,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'const local',
-      generatedStr: 'let i',
+      generatedStr: 'let r',
       sourcePath: 'index.js',
     });
 
@@ -457,7 +457,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'local.a',
-      generatedStr: 'i.a',
+      generatedStr: 'r.a',
       sourcePath: 'index.js',
     });
 

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -681,7 +681,7 @@ function prepareBrowserContext(
   const fakeDocument = {
     head,
     createElement(tag) {
-      return {tag};
+      return {tag, setAttribute() {}, style: {}};
     },
 
     getElementsByTagName() {

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -205,7 +205,8 @@ export class DevPackager {
 
     if (load) {
       usedHelpers |= 1 | 2;
-      prefix = prefix.replace('// INSERT_LOAD_HERE', load);
+      // Remove newlines to avoid messing up source maps
+      prefix = prefix.replace('// INSERT_LOAD_HERE', load.replace(/\n/g, ''));
     }
 
     let contents =
@@ -230,7 +231,7 @@ export class DevPackager {
         distDir += '/';
       }
       contents += ', ' + JSON.stringify(distDir);
-    } else if (usedHelpers & 2) {
+    } else if (usedHelpers & (2 | 32)) {
       contents += ', null';
     }
 
@@ -241,6 +242,18 @@ export class DevPackager {
         publicUrl += '/';
       }
       contents += ', ' + JSON.stringify(publicUrl);
+    } else if (usedHelpers & 32) {
+      contents += ', null';
+    }
+
+    if (usedHelpers & 32) {
+      let code = helpers.$parcel$devServer(
+        this.bundle.env,
+        this.bundle,
+        new Set(),
+        this.options,
+      );
+      contents += ', ' + code.slice('var $parcel$devServer = '.length, -2);
     }
 
     contents += ')\n';

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -536,6 +536,9 @@ export class ScopeHoistingPackager {
         this.needsPrelude = true;
         this.usedHelpers.add('$parcel$extendImportMap');
       }
+      if (usedHelpers & 32) {
+        this.usedHelpers.add('$parcel$devServer');
+      }
     }
 
     if (this.bundle.env.isNode() && asset.meta.has_node_replacements) {
@@ -1397,6 +1400,7 @@ ${code}
           this.bundle.env,
           this.bundle,
           this.usedHelpers,
+          this.options,
         );
       }
       res += currentHelper;

--- a/packages/packagers/js/src/dev-prelude.js
+++ b/packages/packagers/js/src/dev-prelude.js
@@ -6,7 +6,15 @@
 // anything defined in a previous bundle is accessed via the
 // orig method which is the require for previous bundles
 
-(function (modules, entry, mainEntry, parcelRequireName, distDir, publicUrl) {
+(function (
+  modules,
+  entry,
+  mainEntry,
+  parcelRequireName,
+  distDir,
+  publicUrl,
+  devServer
+) {
   /* eslint-disable no-undef */
   var globalObject =
     typeof globalThis !== 'undefined'
@@ -104,6 +112,7 @@
   newRequire.parent = previousRequire;
   newRequire.distDir = distDir;
   newRequire.publicUrl = publicUrl;
+  newRequire.devServer = devServer;
   newRequire.i = importMap;
   newRequire.register = function (id, exports) {
     modules[id] = [

--- a/packages/packagers/js/src/helpers.js
+++ b/packages/packagers/js/src/helpers.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import type {Environment, NamedBundle} from '@parcel/types';
+import type {Environment, NamedBundle, PluginOptions} from '@parcel/types';
 import {relativePath} from '@parcel/utils';
 import path from 'path';
 
@@ -180,6 +180,24 @@ const $parcel$publicUrl = (env: Environment, bundle: NamedBundle): string => {
   return `var $parcel$publicUrl = ${JSON.stringify(publicUrl)};\n`;
 };
 
+const $parcel$devServer = (
+  env: Environment,
+  bundle: NamedBundle,
+  _usedHelpers: Set<string>,
+  options: PluginOptions,
+): string => {
+  if (options.hmrOptions) {
+    let {host = 'localhost', port} = options.hmrOptions;
+    let https = options.serveOptions ? options.serveOptions.https : false;
+    port = port ?? (options.serveOptions ? options.serveOptions.port : null);
+    if (port != null) {
+      let url = (https ? 'https://' : 'http://') + host + ':' + port;
+      return `var $parcel$devServer = ${JSON.stringify(url)};\n`;
+    }
+  }
+  return `var $parcel$devServer = null;\n`;
+};
+
 const $parcel$extendImportMap = (env: Environment): string => {
   let defineImportMap = env.shouldScopeHoist
     ? 'parcelRequire.i ??= {}'
@@ -287,6 +305,7 @@ export const helpers = {
   $parcel$defineInteropFlag,
   $parcel$distDir,
   $parcel$publicUrl,
+  $parcel$devServer,
   $parcel$extendImportMap,
   $parcel$import,
   $parcel$resolve,

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -23,7 +23,9 @@
   "targets": {
     "main": {
       "includeNodeModules": {
+        "@parcel/codeframe": false,
         "@parcel/plugin": false,
+        "@parcel/source-map": false,
         "@parcel/utils": false
       }
     }

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -31,14 +31,14 @@
     }
   },
   "dependencies": {
+    "@parcel/codeframe": "2.13.3",
     "@parcel/plugin": "2.13.3",
+    "@parcel/source-map": "^2.1.1",
     "@parcel/utils": "2.13.3"
   },
   "devDependencies": {
     "@parcel/babel-preset": "2.13.3",
-    "@parcel/codeframe": "2.13.3",
     "@parcel/diagnostic": "2.13.3",
-    "@parcel/source-map": "^2.1.1",
     "@parcel/types": "2.13.3",
     "connect": "^3.7.0",
     "ejs": "^3.1.6",

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -34,7 +34,9 @@
   },
   "devDependencies": {
     "@parcel/babel-preset": "2.13.3",
+    "@parcel/codeframe": "2.13.3",
     "@parcel/diagnostic": "2.13.3",
+    "@parcel/source-map": "^2.1.1",
     "@parcel/types": "2.13.3",
     "connect": "^3.7.0",
     "ejs": "^3.1.6",

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -1,11 +1,10 @@
 // @flow
 import type {
   Asset,
-  BundleGraph,
   Dependency,
-  NamedBundle,
-  PackagedBundle,
   PluginOptions,
+  BuildSuccessEvent,
+  BundledProgressEvent,
 } from '@parcel/types';
 import type {Diagnostic} from '@parcel/diagnostic';
 import type {AnsiDiagnosticResult} from '@parcel/utils';
@@ -19,15 +18,21 @@ import {setHeaders, SOURCES_ENDPOINT} from './Server';
 
 import nullthrows from 'nullthrows';
 import url from 'url';
+import path from 'path';
 import mime from 'mime-types';
 import WebSocket from 'ws';
 import invariant from 'assert';
+import {Readable} from 'stream';
 import {
   ansiHtml,
   createHTTPServer,
   prettyDiagnostic,
   PromiseQueue,
+  isDirectoryInside,
 } from '@parcel/utils';
+import SourceMap from '@parcel/source-map';
+import formatCodeFrame from '@parcel/codeframe';
+import launchEditor from 'launch-editor';
 
 export type HMRAsset = {|
   id: string,
@@ -57,18 +62,42 @@ export type HMRMessage =
 
 const FS_CONCURRENCY = 64;
 const HMR_ENDPOINT = '/__parcel_hmr';
+const CODEFRAME_ENDPOINT = '/__parcel_code_frame';
+const SOURCEMAP_ENDPOINT = '/__parcel_source_map';
+const EDITOR_ENDPOINT = '/__parcel_launch_editor';
 const BROADCAST_MAX_ASSETS = 10000;
 
 export default class HMRServer {
   wss: WebSocket.Server;
   unresolvedError: HMRMessage | null = null;
   options: HMRServerOptions;
-  bundleGraph: BundleGraph<PackagedBundle> | BundleGraph<NamedBundle> | null =
-    null;
+  event: BundledProgressEvent | BuildSuccessEvent | null = null;
   stopServer: ?() => Promise<void>;
+  pending: boolean = true;
+  pendingRequests: Array<[Request, Response]> = [];
 
   constructor(options: HMRServerOptions) {
     this.options = options;
+  }
+
+  buildStart() {
+    this.pending = true;
+  }
+
+  buildSuccess(event: BuildSuccessEvent) {
+    this.pending = false;
+    this.event = event;
+
+    if (this.pendingRequests.length > 0) {
+      let pendingRequests = this.pendingRequests;
+      this.pendingRequests = [];
+      for (let [req, res] of pendingRequests) {
+        if (!this.handle(req, res)) {
+          res.statusCode = 404;
+          res.end();
+        }
+      }
+    }
   }
 
   async start() {
@@ -81,6 +110,11 @@ export default class HMRServer {
         cacheDir: this.options.cacheDir,
         listener: (req, res) => {
           setHeaders(res);
+          if (req.method === 'OPTIONS') {
+            res.statusCode = 200;
+            res.end();
+            return;
+          }
           if (!this.handle(req, res)) {
             res.statusCode = 404;
             res.end();
@@ -106,15 +140,60 @@ export default class HMRServer {
   }
 
   handle(req: Request, res: Response): boolean {
-    let {pathname} = url.parse(req.originalUrl || req.url);
+    let {pathname, query} = url.parse(req.originalUrl || req.url);
     if (pathname != null && pathname.startsWith(HMR_ENDPOINT)) {
       let id = pathname.slice(HMR_ENDPOINT.length + 1);
-      let bundleGraph = nullthrows(this.bundleGraph);
+      let bundleGraph = nullthrows(this.event).bundleGraph;
       let asset = bundleGraph.getAssetById(id);
       this.getHotAssetContents(asset).then(output => {
         res.setHeader('Content-Type', mime.contentType(asset.type));
         res.end(output);
       });
+      return true;
+    } else if (
+      pathname?.startsWith(CODEFRAME_ENDPOINT) &&
+      req.method === 'POST'
+    ) {
+      if (this.pending) {
+        this.pendingRequests.push([req, res]);
+      } else {
+        this.serveCodeFrame(req, res);
+      }
+      return true;
+    } else if (pathname?.startsWith(SOURCEMAP_ENDPOINT)) {
+      if (this.pending) {
+        this.pendingRequests.push([req, res]);
+      } else {
+        let qs = new URLSearchParams(query || '');
+        let filename = qs.get('filename');
+        if (!filename) {
+          return false;
+        }
+        this.getSourceMapContents(filename).then(
+          map => {
+            res.setHeader('Content-Type', 'application/json');
+            res.end(map);
+          },
+          () => {
+            res.statusCode = 500;
+            res.end();
+          },
+        );
+      }
+      return true;
+    } else if (pathname?.startsWith(EDITOR_ENDPOINT) && query) {
+      let qs = new URLSearchParams(query);
+      let file = qs.get('file');
+      if (file) {
+        // File location might start with /__parcel_source_root if it came from a source map.
+        if (file.startsWith(SOURCES_ENDPOINT)) {
+          file = file.slice(SOURCES_ENDPOINT.length + 1);
+        } else if (!path.isAbsolute(file)) {
+          file = path.join(this.options.projectRoot, file);
+        }
+        launchEditor(file);
+      }
+      res.end();
       return true;
     }
     return false;
@@ -160,13 +239,11 @@ export default class HMRServer {
     this.broadcast(this.unresolvedError);
   }
 
-  async getUpdate(event: {
-    +bundleGraph: BundleGraph<PackagedBundle> | BundleGraph<NamedBundle>,
-    +changedAssets: Map<string, Asset>,
-    ...
-  }): Promise<?HMRMessage> {
+  async getUpdate(
+    event: BundledProgressEvent | BuildSuccessEvent,
+  ): Promise<?HMRMessage> {
     this.unresolvedError = null;
-    this.bundleGraph = event.bundleGraph;
+    this.event = event;
 
     let changedAssets = new Set(event.changedAssets.values());
     if (changedAssets.size === 0) return Promise.resolve(null);
@@ -240,7 +317,7 @@ export default class HMRServer {
 
   async getHotAssetContents(asset: Asset): Promise<string> {
     let output = await asset.getCode();
-    let bundleGraph = nullthrows(this.bundleGraph);
+    let bundleGraph = nullthrows(this.event).bundleGraph;
     if (asset.type === 'js') {
       let publicId = bundleGraph.getAssetPublicId(asset);
       output = `parcelHotUpdate['${publicId}'] = function (require, module, exports) {${output}}`;
@@ -265,7 +342,7 @@ export default class HMRServer {
     return output;
   }
 
-  getSourceURL(asset: Asset): string {
+  getSourceURLEndpoint(): string {
     let origin = '';
     if (
       !this.options.devServer ||
@@ -276,7 +353,11 @@ export default class HMRServer {
         this.options.port
       }`;
     }
-    return origin + HMR_ENDPOINT + '/' + asset.id;
+    return origin + HMR_ENDPOINT + '/';
+  }
+
+  getSourceURL(asset: Asset): string {
+    return this.getSourceURLEndpoint() + asset.id;
   }
 
   handleSocketError(err: ServerError) {
@@ -298,6 +379,247 @@ export default class HMRServer {
       ws.send(json);
     }
   }
+
+  async serveCodeFrame(req: Request, res: Response) {
+    let distDir = this.options.distDir;
+    if (!distDir) {
+      res.statusCode = 500;
+      res.end();
+      return;
+    }
+
+    // $FlowFixMe
+    let webRequest = new Request('http://localhost' + req.url, {
+      method: 'POST',
+      headers: req.headers,
+      // $FlowFixMe
+      body: Readable.toWeb(req),
+      duplex: 'half',
+    });
+
+    let json = await webRequest.json();
+
+    let sourceMaps = new Map();
+    for (let frame of json.frames) {
+      try {
+        if (frame.fileName) {
+          let map;
+          let location = this.findSourceMap(frame.fileName);
+          if (location.type === 'bundle') {
+            // Read the corresponding source map for the bundle.
+            if (!sourceMaps.has(location)) {
+              let contents = await this.options.outputFS.readFile(
+                location.filePath + '.map',
+                'utf8',
+              );
+              let sm = new SourceMap(this.options.projectRoot);
+              sm.addVLQMap(JSON.parse(contents));
+              sourceMaps.set(location, sm);
+            }
+            map = sourceMaps.get(location);
+
+            let contents = await this.options.outputFS.readFile(
+              location.filePath,
+              'utf8',
+            );
+            frame.compiledLines = getCodeFrame(
+              frame.lineNumber,
+              frame.columnNumber,
+              contents,
+              json.contextLines,
+              path.extname(location.filePath).slice(1),
+            );
+            frame.fileName = path.relative(
+              this.options.projectRoot,
+              location.filePath,
+            );
+          } else if (location.type === 'asset') {
+            // Get source map from the asset.
+            let contents = await location.asset.getCode();
+            frame.compiledLines = getCodeFrame(
+              frame.lineNumber,
+              frame.columnNumber,
+              contents,
+              json.contextLines,
+              location.asset.type,
+            );
+            frame.fileName = path.relative(
+              this.options.projectRoot,
+              location.asset.filePath,
+            );
+            map = await location.asset.getMap();
+            if (!map) {
+              throw new Error('Asset does not have a source map');
+            }
+          }
+
+          if (map && frame.lineNumber != null) {
+            // Find the original location in the source map.
+            let mapping = map.findClosestMapping(
+              frame.lineNumber,
+              frame.columnNumber,
+            );
+            if (mapping) {
+              let source = mapping.source
+                ? map.getSourceContent(mapping.source) || ''
+                : '';
+              if (mapping.original && mapping.source) {
+                frame.sourceFileName = mapping.source;
+                frame.sourceLineNumber = mapping.original.line;
+                frame.sourceColumnNumber = mapping.original.column;
+                frame.sourceLines = getCodeFrame(
+                  mapping.original.line,
+                  mapping.original.column + 1,
+                  source,
+                  json.contextLines,
+                  path.extname(mapping.source).slice(1),
+                );
+              }
+            }
+          } else if (location.type === 'source') {
+            // This is already a source location. Generate a code frame.
+            frame.sourceFileName = location.filePath;
+            frame.sourceLineNumber = frame.lineNumber;
+            frame.sourceColumnNumber = frame.columnNumber;
+            let contents = await this.options.outputFS.readFile(
+              location.filePath,
+              'utf8',
+            );
+            frame.sourceLines = getCodeFrame(
+              frame.lineNumber,
+              frame.columnNumber,
+              contents,
+              json.contextLines,
+              path.extname(location.filePath).slice(1),
+            );
+            frame.fileName = path.relative(
+              this.options.projectRoot,
+              location.filePath,
+            );
+          }
+        }
+      } catch (err) {
+        continue;
+      }
+    }
+
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(json.frames));
+  }
+
+  async getSourceMapContents(filePath: string): Promise<string> {
+    let location = await this.findSourceMap(filePath);
+    if (location.type === 'bundle') {
+      return this.options.outputFS.readFile(location.filePath + '.map', 'utf8');
+    }
+
+    let map;
+    if (location.type === 'source') {
+      // Return an empty source map
+      map = new SourceMap(this.options.projectRoot);
+      let contents = await this.options.inputFS.readFile(
+        location.filePath,
+        'utf8',
+      );
+      map.addEmptyMap(location.filePath, contents);
+    } else {
+      map = await location.asset.getMap();
+      if (!map) {
+        throw new Error('Asset does not have a source map');
+      }
+    }
+
+    let sourcemapStringified = await map.stringify({
+      format: 'string',
+      sourceRoot: SOURCES_ENDPOINT + '/',
+      // $FlowFixMe
+      fs: this.options.inputFS,
+    });
+    invariant(typeof sourcemapStringified === 'string');
+    return sourcemapStringified;
+  }
+
+  findSourceMap(
+    filePath: string,
+  ):
+    | {|type: 'bundle', filePath: string|}
+    | {|type: 'asset', asset: Asset|}
+    | {|type: 'source', filePath: string|} {
+    let distDir = this.options.distDir;
+    if (!distDir) {
+      throw new Error('Must have a distDir');
+    }
+
+    let event = this.event;
+    invariant(event?.type === 'buildSuccess');
+
+    // React generates URLs like rsc://React/Server/file:///foo/bar
+    if (filePath.startsWith('rsc://')) {
+      let url = new URL(filePath);
+      let index = url.pathname.indexOf('/', 1);
+      if (index >= 0) {
+        filePath = url.pathname.slice(index + 1);
+      } else {
+        throw new Error('Unexpected RSC URL');
+      }
+    }
+
+    // Remove public url prefix first, in case it has a protocol/origin.
+    let publicUrl = this.options.publicUrl;
+    if (publicUrl.endsWith('/')) {
+      publicUrl = publicUrl.slice(0, -1);
+    }
+
+    if (publicUrl.length > 0 && filePath.startsWith(publicUrl + '/')) {
+      filePath = filePath.slice(publicUrl.length + 1);
+    }
+
+    // Get path from URL.
+    if (filePath.startsWith('file://')) {
+      let fileURL = new URL(filePath);
+      filePath = fileURL.pathname;
+    } else {
+      if (/^https?:\/\//.test(filePath)) {
+        let fileURL = new URL(filePath);
+        filePath = fileURL.pathname.slice(1);
+      }
+
+      // If public url is just a subpath, strip it.
+      if (publicUrl.length > 0 && filePath.startsWith(publicUrl)) {
+        filePath = filePath.slice(publicUrl.length);
+      }
+    }
+
+    // If url starts with /__parcel_hmr, get source map by asset id.
+    let hmrEndpoint = this.getSourceURLEndpoint();
+    if (filePath.startsWith(hmrEndpoint)) {
+      let id = filePath.slice(hmrEndpoint.length);
+      return {
+        type: 'asset',
+        asset: event.bundleGraph.getAssetById(id),
+      };
+    }
+
+    if (filePath.startsWith('/')) {
+      filePath = path.normalize(filePath);
+    } else {
+      filePath = path.join(distDir, filePath);
+    }
+
+    // If the file is inside the distDir, it's a bundle path.
+    if (isDirectoryInside(filePath, distDir)) {
+      return {type: 'bundle', filePath: filePath};
+    }
+
+    // Otherwise, assume this refers to a source file.
+    // This can happen if the server uses --enable-source-maps,
+    // in which case Node will have already mapped the location.
+    if (isDirectoryInside(filePath, this.options.projectRoot)) {
+      return {type: 'source', filePath};
+    }
+
+    throw new Error('Source map not found');
+  }
 }
 
 function getSpecifier(dep: Dependency): string {
@@ -306,4 +628,37 @@ function getSpecifier(dep: Dependency): string {
   }
 
   return dep.specifier;
+}
+
+function getCodeFrame(
+  line: number,
+  column: number,
+  source: string,
+  contextLines: number,
+  language: string,
+): string {
+  return formatCodeFrame(
+    source,
+    [
+      {
+        start: {
+          line,
+          column,
+        },
+        end: {
+          line,
+          column,
+        },
+      },
+    ],
+    {
+      useColor: true,
+      syntaxHighlighting: true,
+      padding: {
+        before: contextLines,
+        after: contextLines,
+      },
+      language,
+    },
+  );
 }

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -59,6 +59,8 @@ export default (new Reporter({
               inputFS: options.inputFS,
               outputFS: options.outputFS,
               projectRoot: options.projectRoot,
+              distDir: serveOptions.distDir,
+              publicUrl: serveOptions.publicUrl ?? '/',
             };
             hmrServer = new HMRServer(hmrServerOptions);
             hmrServers.set(serveOptions.port, hmrServer);
@@ -78,6 +80,8 @@ export default (new Reporter({
             inputFS: options.inputFS,
             outputFS: options.outputFS,
             projectRoot: options.projectRoot,
+            distDir: serveOptions ? serveOptions.distDir : null,
+            publicUrl: serveOptions ? serveOptions.publicUrl ?? '/' : '/',
           };
           hmrServer = new HMRServer(hmrServerOptions);
           hmrServers.set(port, hmrServer);
@@ -103,9 +107,8 @@ export default (new Reporter({
         }
         break;
       case 'buildStart':
-        if (server) {
-          server.buildStart();
-        }
+        server?.buildStart();
+        hmrServer?.buildStart();
         nodeRunner?.buildStart();
         break;
       case 'buildProgress':
@@ -154,6 +157,7 @@ export default (new Reporter({
           nodeRunners.set(options.instanceId, nodeRunner);
         }
         nodeRunner?.buildSuccess(event.bundleGraph);
+        hmrServer?.buildSuccess(event);
         break;
       }
       case 'buildFailure':

--- a/packages/reporters/dev-server/src/types.js.flow
+++ b/packages/reporters/dev-server/src/types.js.flow
@@ -54,4 +54,6 @@ export type HMRServerOptions = {|
   inputFS: FileSystem,
   outputFS: FileSystem,
   projectRoot: FilePath,
+  distDir: ?FilePath,
+  publicUrl: string,
 |};

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -105,19 +105,19 @@ if (!WebSocket && typeof module.bundle.root === 'function') {
   }
 }
 
+var hostname = getHostname();
+var port = getPort();
+var protocol =
+  HMR_SECURE ||
+  (typeof location !== 'undefined' &&
+    location.protocol === 'https:' &&
+    !['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname))
+    ? 'wss'
+    : 'ws';
+
 // eslint-disable-next-line no-redeclare
 var parent = module.bundle.parent;
 if (!parent || !parent.isParcelRequire) {
-  var hostname = getHostname();
-  var port = getPort();
-  var protocol =
-    HMR_SECURE ||
-    (typeof location !== 'undefined' &&
-      location.protocol === 'https:' &&
-      !['localhost', '127.0.0.1', '0.0.0.0'].includes(hostname))
-      ? 'wss'
-      : 'ws';
-
   // Web extension context
   var extCtx =
     typeof browser === 'undefined'
@@ -309,7 +309,9 @@ function createErrorOverlay(diagnostics) {
     let stack = diagnostic.frames.length
       ? diagnostic.frames.reduce((p, frame) => {
           return `${p}
-<a href="/__parcel_launch_editor?file=${encodeURIComponent(
+<a href="${
+            protocol === 'wss' ? 'https' : 'http'
+          }://${hostname}:${port}/__parcel_launch_editor?file=${encodeURIComponent(
             frame.location,
           )}" style="text-decoration: underline; color: #888" onclick="fetch(this.href); return false">${
             frame.location

--- a/packages/transformers/babel/src/BabelTransformer.js
+++ b/packages/transformers/babel/src/BabelTransformer.js
@@ -75,6 +75,7 @@ export default (new Transformer({
       sourceFileName,
       sourceMaps: !!asset.env.sourceMap,
       comments: true,
+      importAttributesKeyword: 'with',
     });
 
     let map = new SourceMap(options.projectRoot);

--- a/packages/transformers/babel/src/flow.js
+++ b/packages/transformers/babel/src/flow.js
@@ -19,17 +19,25 @@ export default async function getFlowOptions(
   }
 
   // Only add flow plugin if `flow-bin` is listed as a dependency in the root package.json
-  let conf = await config.getConfigFrom<PackageJSON>(
-    options.projectRoot + '/index',
-    ['package.json'],
-  );
-  let pkg = conf?.contents;
+  // @parcel/error-overlay package in integration tests is an exception
   if (
-    !pkg ||
-    (!(pkg.dependencies && pkg.dependencies['flow-bin']) &&
-      !(pkg.devDependencies && pkg.devDependencies['flow-bin']))
+    !(
+      process.env.PARCEL_BUILD_ENV === 'test' &&
+      config.searchPath.includes('error-overlay')
+    )
   ) {
-    return null;
+    let conf = await config.getConfigFrom<PackageJSON>(
+      options.projectRoot + '/index',
+      ['package.json'],
+    );
+    let pkg = conf?.contents;
+    if (
+      !pkg ||
+      (!(pkg.dependencies && pkg.dependencies['flow-bin']) &&
+        !(pkg.devDependencies && pkg.devDependencies['flow-bin']))
+    ) {
+      return null;
+    }
   }
 
   const babelCore: BabelCore = await options.packageManager.require(

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -113,6 +113,8 @@ bitflags! {
     const RESOLVE = 1 << 3;
     /// `parcelRequire.extendImportMap`
     const EXTEND_IMPORT_MAP = 1 << 4;
+    /// `import.meta.devServer` – URL of Parcel HMR server
+    const DEV_SERVER = 1 << 5;
   }
 }
 
@@ -1526,6 +1528,21 @@ impl<'a> DependencyCollector<'a> {
                   Default::default(),
                   span,
                   module.bundle.publicUrl
+                )))
+              }
+            }
+            "devServer" => {
+              self.helpers |= Helpers::DEV_SERVER;
+              if self.config.scope_hoist {
+                Some(Expr::Ident(Ident::new_no_ctxt(
+                  "$parcel$devServer".into(),
+                  span,
+                )))
+              } else {
+                Some(Expr::Member(member_expr!(
+                  Default::default(),
+                  span,
+                  module.bundle.devServer
                 )))
               }
             }

--- a/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
+++ b/packages/transformers/react-refresh-wrap/src/ReactRefreshWrapTransformer.js
@@ -56,7 +56,7 @@ ${code}
 
     asset.setCode(code);
     if (map) {
-      map.offsetLines(1, 6);
+      map.offsetLines(1, 7);
       asset.setMap(map);
     }
 

--- a/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
+++ b/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
@@ -43,7 +43,7 @@ module.exports.init = function () {
     };
 
     if (typeof window !== 'undefined') {
-      let ErrorOverlay = require('react-error-overlay');
+      let ErrorOverlay = require('@parcel/error-overlay');
       ErrorOverlay.setEditorHandler(function editorHandler(errorLocation) {
         let file = `${errorLocation.fileName}:${
           errorLocation.lineNumber || 1

--- a/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
+++ b/packages/transformers/react-refresh-wrap/src/helpers/helpers.js
@@ -48,7 +48,10 @@ module.exports.init = function () {
         let file = `${errorLocation.fileName}:${
           errorLocation.lineNumber || 1
         }:${errorLocation.colNumber || 1}`;
-        fetch(`/__parcel_launch_editor?file=${encodeURIComponent(file)}`);
+        fetch(
+          import.meta.devServer +
+            `/__parcel_launch_editor?file=${encodeURIComponent(file)}`,
+        );
       });
 
       ErrorOverlay.startReportingRuntimeErrors({

--- a/packages/utils/create-parcel/templates/react-server/package.json
+++ b/packages/utils/create-parcel/templates/react-server/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@parcel/rsc": "canary",
     "express": "^4.21.2",
-    "react": "canary",
-    "react-dom": "canary"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@types/express": "^4",

--- a/packages/utils/create-parcel/templates/react-server/src/server.tsx
+++ b/packages/utils/create-parcel/templates/react-server/src/server.tsx
@@ -14,7 +14,7 @@ app.get('/', async (req, res) => {
 
 app.post('/', async (req, res) => {
   let id = req.get('rsc-action-id');
-  let result = await callAction(req, id);
+  let {result} = await callAction(req, id);
   let root: any = <Page />;
   if (id) {
     root = {result, root};

--- a/packages/utils/create-parcel/templates/react-static/package.json
+++ b/packages/utils/create-parcel/templates/react-static/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@parcel/rsc": "canary",
-    "react": "canary",
-    "react-dom": "canary"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@parcel/config-react-static": "canary",

--- a/packages/utils/error-overlay/package.json
+++ b/packages/utils/error-overlay/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@parcel/transformer-react-refresh-wrap",
+  "name": "@parcel/error-overlay",
   "version": "2.13.3",
   "license": "MIT",
   "publishConfig": {
@@ -13,16 +13,14 @@
     "type": "git",
     "url": "https://github.com/parcel-bundler/parcel.git"
   },
-  "main": "lib/ReactRefreshWrapTransformer.js",
-  "source": "src/ReactRefreshWrapTransformer.js",
+  "main": "lib/index.js",
+  "source": "src/index.js",
   "engines": {
-    "node": ">= 16.0.0",
-    "parcel": "^2.13.3"
+    "node": ">= 16.0.0"
   },
   "dependencies": {
-    "@parcel/error-overlay": "2.13.3",
-    "@parcel/plugin": "2.13.3",
-    "@parcel/utils": "2.13.3",
-    "react-refresh": ">=0.9 <=0.16"
+    "ansi-html-community": "0.0.8",
+    "react": "^19",
+    "react-dom": "^19"
   }
 }

--- a/packages/utils/error-overlay/src/components/CloseButton.js
+++ b/packages/utils/error-overlay/src/components/CloseButton.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import {theme} from '../styles';
+
+const closeButtonStyle = {
+  color: theme.closeColor,
+  lineHeight: '1rem',
+  fontSize: '1.5rem',
+  padding: '1rem',
+  cursor: 'pointer',
+  position: 'absolute',
+  right: 0,
+  top: 0,
+};
+
+type CloseButtonPropsType = {|
+  close: () => void,
+|};
+
+function CloseButton({close}: CloseButtonPropsType): React$Element<any> {
+  return (
+    <span
+      title="Click or press Escape to dismiss."
+      onClick={close}
+      style={closeButtonStyle}
+    >
+      ×
+    </span>
+  );
+}
+
+export default CloseButton;

--- a/packages/utils/error-overlay/src/components/CodeBlock.js
+++ b/packages/utils/error-overlay/src/components/CodeBlock.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import {theme} from '../styles';
+
+const _preStyle = {
+  position: 'relative',
+  display: 'block',
+  padding: '0.5em',
+  marginTop: '0.5em',
+  marginBottom: '0.5em',
+  overflowX: 'auto',
+  whiteSpace: 'pre-wrap',
+  borderRadius: '0.25rem',
+};
+
+const codeStyle = {
+  fontFamily: 'Consolas, Menlo, monospace',
+};
+
+type CodeBlockPropsType = {|
+  main: boolean,
+  codeHTML: string,
+|};
+
+function CodeBlock({main, codeHTML}: CodeBlockPropsType): React$Element<'pre'> {
+  const primaryPreStyle = {
+    ..._preStyle,
+    backgroundColor: theme.primaryPreBackground,
+    color: theme.primaryPreColor,
+  };
+  const secondaryPreStyle = {
+    ..._preStyle,
+    backgroundColor: theme.secondaryPreBackground,
+    color: theme.secondaryPreColor,
+  };
+  const preStyle = main ? primaryPreStyle : secondaryPreStyle;
+  const codeBlock = {__html: codeHTML};
+
+  return (
+    <pre style={preStyle}>
+      <code style={codeStyle} dangerouslySetInnerHTML={codeBlock} />
+    </pre>
+  );
+}
+
+export default CodeBlock;

--- a/packages/utils/error-overlay/src/components/Collapsible.js
+++ b/packages/utils/error-overlay/src/components/Collapsible.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React, {useState} from 'react';
+import {theme} from '../styles';
+
+import type {Element as ReactElement} from 'react';
+
+const _collapsibleStyle = {
+  cursor: 'pointer',
+  border: 'none',
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  fontFamily: 'Consolas, Menlo, monospace',
+  fontSize: '1em',
+  padding: '0px',
+  lineHeight: '1.5',
+};
+
+const collapsibleCollapsedStyle = {
+  ..._collapsibleStyle,
+  color: theme.color,
+  background: theme.background,
+  marginBottom: '1.5em',
+};
+
+const collapsibleExpandedStyle = {
+  ..._collapsibleStyle,
+  color: theme.color,
+  background: theme.background,
+  marginBottom: '0.6em',
+};
+
+type CollapsiblePropsType = {|
+  children: ReactElement<any>[],
+|};
+
+function Collapsible(props: CollapsiblePropsType): React$Element<'details'> {
+  const [collapsed, setCollapsed] = useState(true);
+
+  const toggleCollapsed = () => {
+    setCollapsed(!collapsed);
+  };
+
+  const count = props.children.length;
+  return (
+    <details open={!collapsed} onToggle={toggleCollapsed}>
+      <summary
+        style={collapsed ? collapsibleCollapsedStyle : collapsibleExpandedStyle}
+      >
+        {(collapsed ? '▶' : '▼') +
+          ` ${count} stack frames were ` +
+          (collapsed ? 'collapsed.' : 'expanded.')}
+      </summary>
+      <div>
+        {props.children}
+        <button onClick={toggleCollapsed} style={collapsibleExpandedStyle}>
+          {`▲ ${count} stack frames were expanded.`}
+        </button>
+      </div>
+    </details>
+  );
+}
+
+export default Collapsible;

--- a/packages/utils/error-overlay/src/components/ErrorOverlay.js
+++ b/packages/utils/error-overlay/src/components/ErrorOverlay.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-env browser */
+/* @flow */
+import React, {useEffect} from 'react';
+import {theme} from '../styles';
+
+import type {Node as ReactNode} from 'react';
+
+const overlayStyle = {
+  position: 'relative',
+  display: 'inline-flex',
+  flexDirection: 'column',
+  height: '100%',
+  width: '1024px',
+  maxWidth: '100%',
+  overflowX: 'hidden',
+  overflowY: 'auto',
+  padding: '0.5rem',
+  boxSizing: 'border-box',
+  textAlign: 'left',
+  fontFamily: 'Consolas, Menlo, monospace',
+  fontSize: '11px',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  lineHeight: 1.5,
+  color: theme.color,
+};
+
+type ErrorOverlayPropsType = {|
+  children: ReactNode,
+  shortcutHandler?: (eventKey: string) => void,
+|};
+
+function ErrorOverlay(props: ErrorOverlayPropsType): React$Element<'div'> {
+  const {shortcutHandler} = props;
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (shortcutHandler) {
+        shortcutHandler(e.key);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [shortcutHandler]);
+
+  return <div style={overlayStyle}>{props.children}</div>;
+}
+
+export default ErrorOverlay;

--- a/packages/utils/error-overlay/src/components/Footer.js
+++ b/packages/utils/error-overlay/src/components/Footer.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import {theme} from '../styles';
+
+const footerStyle = {
+  fontFamily: 'sans-serif',
+  color: theme.footer,
+  marginTop: '0.5rem',
+  flex: '0 0 auto',
+};
+
+type FooterPropsType = {|
+  line1: string,
+  line2?: string,
+|};
+
+function Footer(props: FooterPropsType): React$Element<'div'> {
+  return (
+    <div style={footerStyle}>
+      {props.line1}
+      <br />
+      {props.line2}
+    </div>
+  );
+}
+
+export default Footer;

--- a/packages/utils/error-overlay/src/components/Header.js
+++ b/packages/utils/error-overlay/src/components/Header.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import {theme} from '../styles';
+
+const headerStyle = {
+  fontSize: '2em',
+  fontFamily: 'sans-serif',
+  color: theme.headerColor,
+  whiteSpace: 'pre-wrap',
+  // Top bottom margin spaces header
+  // Right margin revents overlap with close button
+  margin: '0 2rem 0.75rem 0',
+  flex: '0 0 auto',
+};
+
+type HeaderPropType = {|
+  headerText: string,
+|};
+
+function Header(props: HeaderPropType): React$Element<'div'> {
+  return <div style={headerStyle}>{props.headerText}</div>;
+}
+
+export default Header;

--- a/packages/utils/error-overlay/src/components/HydrationDiff.js
+++ b/packages/utils/error-overlay/src/components/HydrationDiff.js
@@ -1,0 +1,42 @@
+/** @flow */
+import React from 'react';
+import {theme} from '../styles';
+
+const diffStyle = {
+  backgroundColor: theme.primaryPreBackground,
+  color: theme.primaryPreColor,
+  padding: '0.5em',
+  overflowX: 'auto',
+  whiteSpace: 'pre-wrap',
+  borderRadius: '0.25rem',
+};
+
+export default function HydrationDiff({
+  diff,
+}: {|
+  diff: string,
+|}): React$Element<'pre'> {
+  let lines = diff
+    .split('\n')
+    .flatMap((line, i) => [formatLine(line, i), '\n'])
+    .slice(0, -1);
+  return <pre style={diffStyle}>{lines}</pre>;
+}
+
+function formatLine(line: string, index: number) {
+  if (line.startsWith('+')) {
+    return (
+      <span key={index} style={{color: theme.diffAdded, fontWeight: 'bold'}}>
+        {line}
+      </span>
+    );
+  } else if (line.startsWith('-') || line.startsWith('>')) {
+    return (
+      <span key={index} style={{color: theme.diffRemoved, fontWeight: 'bold'}}>
+        {line}
+      </span>
+    );
+  } else {
+    return line;
+  }
+}

--- a/packages/utils/error-overlay/src/components/NavigationBar.js
+++ b/packages/utils/error-overlay/src/components/NavigationBar.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import {theme} from '../styles';
+
+const navigationBarStyle = {
+  marginBottom: '0.5rem',
+};
+
+const buttonContainerStyle = {
+  marginRight: '1em',
+};
+
+const _navButtonStyle = {
+  border: 'none',
+  borderRadius: '4px',
+  padding: '3px 6px',
+  cursor: 'pointer',
+};
+
+const leftButtonStyle = {
+  ..._navButtonStyle,
+  backgroundColor: theme.navBackground,
+  color: theme.navArrow,
+  borderTopRightRadius: '0px',
+  borderBottomRightRadius: '0px',
+  marginRight: '1px',
+};
+
+const rightButtonStyle = {
+  ..._navButtonStyle,
+  backgroundColor: theme.navBackground,
+  color: theme.navArrow,
+  borderTopLeftRadius: '0px',
+  borderBottomLeftRadius: '0px',
+};
+
+type Callback = () => void;
+
+type NavigationBarPropsType = {|
+  currentError: number,
+  totalErrors: number,
+  previous: Callback,
+  next: Callback,
+|};
+
+function NavigationBar(props: NavigationBarPropsType): React$Element<'div'> {
+  const {currentError, totalErrors, previous, next} = props;
+  return (
+    <div style={navigationBarStyle}>
+      <span style={buttonContainerStyle}>
+        <button onClick={previous} style={leftButtonStyle}>
+          ←
+        </button>
+        <button onClick={next} style={rightButtonStyle}>
+          →
+        </button>
+      </span>
+      {`${currentError} of ${totalErrors} errors on the page`}
+    </div>
+  );
+}
+
+export default NavigationBar;

--- a/packages/utils/error-overlay/src/containers/RuntimeError.js
+++ b/packages/utils/error-overlay/src/containers/RuntimeError.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import Header from '../components/Header';
+import StackTrace from './StackTrace';
+
+import type {StackFrame} from '../utils/stack-frame';
+import type {ErrorLocation} from '..';
+import HydrationDiff from '../components/HydrationDiff';
+
+const wrapperStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+export type ErrorRecord = {|
+  error: Error,
+  unhandledRejection: boolean,
+  contextSize: number,
+  stackFrames: StackFrame[],
+|};
+
+type Props = {|
+  errorRecord: ErrorRecord,
+  editorHandler?: ?(errorLoc: ErrorLocation) => void,
+|};
+
+function RuntimeError({
+  errorRecord,
+  editorHandler,
+}: Props): React$Element<'div'> {
+  const {error, unhandledRejection, contextSize, stackFrames} = errorRecord;
+  const errorName = unhandledRejection
+    ? 'Unhandled Rejection (' + error.name + ')'
+    : error.name;
+
+  // Make header prettier
+  const message = error.message;
+  let headerText =
+    message.match(/^\w*:/) || !errorName ? message : errorName + ': ' + message;
+
+  headerText = headerText
+    // TODO: maybe remove this prefix from fbjs?
+    // It's just scaring people
+    .replace(/^Invariant Violation:\s*/, '')
+    // This is not helpful either:
+    .replace(/^Warning:\s*/, '')
+    // Break the actionable part to the next line.
+    // AFAIK React 16+ should already do this.
+    .replace(' Check the render method', '\n\nCheck the render method')
+    .replace(' Check your code at', '\n\nCheck your code at');
+
+  let link, diff;
+  if (headerText.includes('https://react.dev/link/hydration-mismatch')) {
+    [headerText, diff] = headerText.split(
+      'https://react.dev/link/hydration-mismatch',
+    );
+    link = 'https://react.dev/link/hydration-mismatch';
+  } else if (headerText.includes('This will cause a hydration error.')) {
+    [headerText, diff] = headerText.split('This will cause a hydration error.');
+    headerText += 'This will cause a hydration error.';
+  }
+
+  let lines = headerText.split('\n');
+
+  return (
+    <div style={wrapperStyle}>
+      <Header headerText={lines[0]} />
+      <pre>{lines.slice(1).join('\n').trim()}</pre>
+      {link && (
+        <div>
+          <a href={link} target="_blank" rel="noreferrer">
+            {link}
+          </a>
+        </div>
+      )}
+      {diff && <HydrationDiff diff={diff.trim()} />}
+      <StackTrace
+        stackFrames={stackFrames}
+        errorName={errorName}
+        contextSize={contextSize}
+        editorHandler={editorHandler}
+      />
+    </div>
+  );
+}
+
+export default RuntimeError;

--- a/packages/utils/error-overlay/src/containers/RuntimeErrorContainer.js
+++ b/packages/utils/error-overlay/src/containers/RuntimeErrorContainer.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import ErrorOverlay from '../components/ErrorOverlay';
+import CloseButton from '../components/CloseButton';
+import NavigationBar from '../components/NavigationBar';
+import RuntimeError from './RuntimeError';
+import Footer from '../components/Footer';
+
+import type {ErrorRecord} from './RuntimeError';
+import type {ErrorLocation} from '..';
+import {useState} from 'react';
+
+type Props = {|
+  errorRecords: ErrorRecord[],
+  close: () => void,
+  editorHandler?: ?(errorLoc: ErrorLocation) => void,
+|};
+
+function RuntimeErrorContainer(
+  props: Props,
+): React$Element<typeof ErrorOverlay> {
+  const {errorRecords, close} = props;
+  const totalErrors = errorRecords.length;
+  let [currentIndex, setCurrentIndex] = useState(0);
+
+  let previous = () => {
+    setCurrentIndex(currentIndex > 0 ? currentIndex - 1 : totalErrors - 1);
+  };
+
+  let next = () => {
+    setCurrentIndex(currentIndex < totalErrors - 1 ? currentIndex + 1 : 0);
+  };
+
+  let shortcutHandler = (key: string) => {
+    if (key === 'Escape') {
+      props.close();
+    } else if (key === 'ArrowLeft') {
+      previous();
+    } else if (key === 'ArrowRight') {
+      next();
+    }
+  };
+
+  return (
+    <ErrorOverlay shortcutHandler={shortcutHandler}>
+      <CloseButton close={close} />
+      {totalErrors > 1 && (
+        <NavigationBar
+          currentError={currentIndex + 1}
+          totalErrors={totalErrors}
+          previous={previous}
+          next={next}
+        />
+      )}
+      <RuntimeError
+        errorRecord={errorRecords[currentIndex]}
+        editorHandler={props.editorHandler}
+      />
+      <Footer
+        line1="This screen is visible only in development. It will not appear if the app crashes in production."
+        line2="Open your browser’s developer console to further inspect this error.  Click the 'X' or hit ESC to dismiss this message."
+      />
+    </ErrorOverlay>
+  );
+}
+
+export default RuntimeErrorContainer;

--- a/packages/utils/error-overlay/src/containers/StackFrame.js
+++ b/packages/utils/error-overlay/src/containers/StackFrame.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React, {useState} from 'react';
+import {theme} from '../styles';
+import CodeBlock from '../components/CodeBlock';
+import {getPrettyURL} from '../utils/getPrettyURL';
+
+import type {StackFrame as StackFrameType} from '../utils/stack-frame';
+import type {ErrorLocation} from '..';
+import generateAnsiHTML from '../utils/generateAnsiHTML';
+
+const linkStyle = {
+  fontSize: '0.9em',
+  marginBottom: '0.9em',
+};
+
+const anchorStyle = {
+  textDecoration: 'none',
+  color: theme.anchorColor,
+  cursor: 'pointer',
+};
+
+const codeAnchorStyle = {
+  cursor: 'pointer',
+};
+
+const toggleStyle = {
+  color: theme.toggleColor,
+  cursor: 'pointer',
+  border: 'none',
+  display: 'block',
+  width: '100%',
+  textAlign: 'left',
+  background: theme.toggleBackground,
+  fontFamily: 'Consolas, Menlo, monospace',
+  fontSize: '1em',
+  padding: '0px',
+  lineHeight: '1.5',
+};
+
+type StackFramePropsType = {|
+  frame: StackFrameType,
+  contextSize: number,
+  critical: boolean,
+  showCode: boolean,
+  editorHandler?: ?(errorLoc: ErrorLocation) => void,
+|};
+
+function StackFrame(props: StackFramePropsType): React$Element<'div'> {
+  const {frame, critical, showCode} = props;
+  const {
+    fileName,
+    lineNumber,
+    columnNumber,
+    _scriptCode: scriptLines,
+    _originalFileName: sourceFileName,
+    _originalLineNumber: sourceLineNumber,
+    _originalColumnNumber: sourceColumnNumber,
+    _originalScriptCode: sourceLines,
+  } = frame;
+  const functionName = frame.getFunctionName();
+
+  const [compiled, setCompiled] = useState(!sourceLines);
+
+  const toggleCompiled = () => {
+    setCompiled(!compiled);
+  };
+
+  const getErrorLocation = (): ErrorLocation | null => {
+    const {_originalFileName: fileName, _originalLineNumber: lineNumber} =
+      props.frame;
+    // Unknown file
+    if (!fileName) {
+      return null;
+    }
+    // e.g. "/path-to-my-app/webpack/bootstrap eaddeb46b67d75e4dfc1"
+    const isInternalWebpackBootstrapCode = fileName.trim().indexOf(' ') !== -1;
+    if (isInternalWebpackBootstrapCode) {
+      return null;
+    }
+    // Code is in a real file
+    return {fileName, lineNumber: lineNumber || 1};
+  };
+
+  const editorHandler = () => {
+    const errorLoc = getErrorLocation();
+    if (!errorLoc) {
+      return;
+    }
+    props.editorHandler?.(errorLoc);
+  };
+
+  const onKeyDown = (e: SyntheticKeyboardEvent<any>) => {
+    if (e.key === 'Enter') {
+      editorHandler();
+    }
+  };
+
+  const url = getPrettyURL(
+    sourceFileName,
+    sourceLineNumber,
+    sourceColumnNumber,
+    fileName,
+    lineNumber,
+    columnNumber,
+    compiled,
+  );
+
+  let codeBlockProps = null;
+  if (showCode) {
+    if (
+      compiled &&
+      scriptLines &&
+      scriptLines.length !== 0 &&
+      lineNumber != null
+    ) {
+      codeBlockProps = {
+        codeHTML: generateAnsiHTML(scriptLines),
+        main: critical,
+      };
+    } else if (
+      !compiled &&
+      sourceLines &&
+      sourceLines.length !== 0 &&
+      sourceLineNumber != null
+    ) {
+      codeBlockProps = {
+        codeHTML: generateAnsiHTML(sourceLines),
+        main: critical,
+      };
+    }
+  }
+
+  const canOpenInEditor =
+    getErrorLocation() !== null && props.editorHandler !== null;
+  return (
+    <div>
+      <div>{functionName}</div>
+      <div style={linkStyle}>
+        <span
+          role="link"
+          style={canOpenInEditor ? anchorStyle : null}
+          onClick={canOpenInEditor ? editorHandler : null}
+          onKeyDown={canOpenInEditor ? onKeyDown : null}
+          tabIndex={canOpenInEditor ? '0' : null}
+        >
+          {url}
+        </span>
+      </div>
+      {codeBlockProps && (
+        <div style={{marginBottom: '1.5em'}}>
+          <span
+            onClick={canOpenInEditor ? editorHandler : null}
+            style={canOpenInEditor ? codeAnchorStyle : null}
+          >
+            <CodeBlock {...codeBlockProps} />
+          </span>
+          {scriptLines && sourceLines && (
+            <button style={toggleStyle} onClick={toggleCompiled}>
+              {'View ' + (compiled ? 'source' : 'compiled')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default StackFrame;

--- a/packages/utils/error-overlay/src/containers/StackTrace.js
+++ b/packages/utils/error-overlay/src/containers/StackTrace.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import React from 'react';
+import StackFrame from './StackFrame';
+import Collapsible from '../components/Collapsible';
+import {isInternalFile} from '../utils/isInternalFile';
+import {isBultinErrorName} from '../utils/isBultinErrorName';
+
+import type {StackFrame as StackFrameType} from '../utils/stack-frame';
+import type {ErrorLocation} from '..';
+
+const traceStyle = {
+  fontSize: '1em',
+  flex: '0 1 auto',
+  minHeight: '0px',
+  overflow: 'auto',
+};
+
+type Props = {|
+  stackFrames: StackFrameType[],
+  errorName: string,
+  contextSize: number,
+  editorHandler?: ?(errorLoc: ErrorLocation) => void,
+|};
+
+function StackTrace(props: Props): React$Element<'div'> {
+  const {stackFrames, errorName, contextSize, editorHandler} = props;
+  const renderedFrames = [];
+  let hasReachedAppCode = false,
+    currentBundle = [],
+    bundleCount = 0;
+
+  stackFrames.forEach((frame, index) => {
+    const {fileName, _originalFileName: sourceFileName} = frame;
+    const isInternalUrl = isInternalFile(sourceFileName, fileName);
+    const isThrownIntentionally = !isBultinErrorName(errorName);
+    const shouldCollapse =
+      isInternalUrl && (isThrownIntentionally || hasReachedAppCode);
+
+    if (!isInternalUrl) {
+      hasReachedAppCode = true;
+    }
+
+    const frameEle = (
+      <StackFrame
+        key={'frame-' + index}
+        frame={frame}
+        contextSize={contextSize}
+        critical={index === 0}
+        showCode={!shouldCollapse}
+        editorHandler={editorHandler}
+      />
+    );
+    const lastElement = index === stackFrames.length - 1;
+
+    if (shouldCollapse) {
+      currentBundle.push(frameEle);
+    }
+
+    if (!shouldCollapse || lastElement) {
+      if (currentBundle.length === 1) {
+        renderedFrames.push(currentBundle[0]);
+      } else if (currentBundle.length > 1) {
+        bundleCount++;
+        renderedFrames.push(
+          <Collapsible key={'bundle-' + bundleCount}>
+            {currentBundle}
+          </Collapsible>,
+        );
+      }
+      currentBundle = [];
+    }
+
+    if (!shouldCollapse) {
+      renderedFrames.push(frameEle);
+    }
+  });
+
+  return <div style={traceStyle}>{renderedFrames}</div>;
+}
+
+export default StackTrace;

--- a/packages/utils/error-overlay/src/effects/stackTraceLimit.js
+++ b/packages/utils/error-overlay/src/effects/stackTraceLimit.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+let stackTraceRegistered: boolean = false;
+// Default: https://docs.microsoft.com/en-us/scripting/javascript/reference/stacktracelimit-property-error-javascript
+let restoreStackTraceValue: number = 10;
+
+const MAX_STACK_LENGTH: number = 50;
+
+function registerStackTraceLimit(limit: number = MAX_STACK_LENGTH) {
+  if (stackTraceRegistered) {
+    return;
+  }
+  try {
+    restoreStackTraceValue = Error.stackTraceLimit;
+    Error.stackTraceLimit = limit;
+    stackTraceRegistered = true;
+  } catch (e) {
+    // Not all browsers support this so we don't care if it errors
+  }
+}
+
+function unregisterStackTraceLimit() {
+  if (!stackTraceRegistered) {
+    return;
+  }
+  try {
+    Error.stackTraceLimit = restoreStackTraceValue;
+    stackTraceRegistered = false;
+  } catch (e) {
+    // Not all browsers support this so we don't care if it errors
+  }
+}
+
+export {
+  registerStackTraceLimit as register,
+  unregisterStackTraceLimit as unregister,
+};

--- a/packages/utils/error-overlay/src/effects/unhandledError.js
+++ b/packages/utils/error-overlay/src/effects/unhandledError.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+let boundErrorHandler = null;
+
+type ErrorCallback = (error: Error) => void;
+
+function errorHandler(callback: ErrorCallback, e: Event): void {
+  // $FlowFixMe
+  if (!e.error) {
+    return;
+  }
+  // $FlowFixMe
+  const {error} = e;
+  if (error instanceof Error) {
+    callback(error);
+  } else {
+    // A non-error was thrown, we don't have a trace. :(
+    // Look in your browser's devtools for more information
+    callback(new Error(error));
+  }
+}
+
+function registerUnhandledError(target: EventTarget, callback: ErrorCallback) {
+  if (boundErrorHandler !== null) {
+    return;
+  }
+  boundErrorHandler = errorHandler.bind(undefined, callback);
+  target.addEventListener('error', boundErrorHandler);
+}
+
+function unregisterUnhandledError(target: EventTarget) {
+  if (boundErrorHandler === null) {
+    return;
+  }
+  target.removeEventListener('error', boundErrorHandler);
+  boundErrorHandler = null;
+}
+
+export {
+  registerUnhandledError as register,
+  unregisterUnhandledError as unregister,
+};

--- a/packages/utils/error-overlay/src/effects/unhandledRejection.js
+++ b/packages/utils/error-overlay/src/effects/unhandledRejection.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+let boundRejectionHandler = null;
+
+type ErrorCallback = (error: Error) => void;
+
+function rejectionHandler(
+  callback: ErrorCallback,
+  e: PromiseRejectionEvent,
+): void {
+  if (e == null || e.reason == null) {
+    return callback(new Error('Unknown'));
+  }
+  let {reason} = e;
+  if (reason instanceof Error) {
+    return callback(reason);
+  }
+  // A non-error was rejected, we don't have a trace :(
+  // Look in your browser's devtools for more information
+  return callback(new Error(reason));
+}
+
+function registerUnhandledRejection(
+  target: EventTarget,
+  callback: ErrorCallback,
+) {
+  if (boundRejectionHandler !== null) {
+    return;
+  }
+  boundRejectionHandler = rejectionHandler.bind(undefined, callback);
+  // $FlowFixMe
+  target.addEventListener('unhandledrejection', boundRejectionHandler);
+}
+
+function unregisterUnhandledRejection(target: EventTarget) {
+  if (boundRejectionHandler === null) {
+    return;
+  }
+  // $FlowFixMe
+  target.removeEventListener('unhandledrejection', boundRejectionHandler);
+  boundRejectionHandler = null;
+}
+
+export {
+  registerUnhandledRejection as register,
+  unregisterUnhandledRejection as unregister,
+};

--- a/packages/utils/error-overlay/src/index.js
+++ b/packages/utils/error-overlay/src/index.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-env browser */
+/* eslint-disable react/react-in-jsx-scope, no-console */
+/* @flow */
+import type {ErrorRecord} from './listenToRuntimeErrors';
+import {listenToRuntimeErrors, crashWithFrames} from './listenToRuntimeErrors';
+import {createRoot} from 'react-dom/client';
+import RuntimeErrorContainer from './containers/RuntimeErrorContainer';
+import {overlayStyle} from './styles';
+
+type RuntimeReportingOptions = {|
+  onError: () => void,
+  filename?: string,
+|};
+
+export type ErrorLocation = {|
+  fileName: string,
+  lineNumber: number,
+  colNumber?: number,
+|};
+
+type EditorHandler = (errorLoc: ErrorLocation) => void;
+
+let iframe: null | HTMLIFrameElement = null;
+
+let editorHandler: null | EditorHandler = null;
+let currentRuntimeErrorRecords: Array<ErrorRecord> = [];
+let stopListeningToRuntimeErrors: null | (() => void) = null;
+
+export function setEditorHandler(handler: EditorHandler | null) {
+  editorHandler = handler;
+  if (iframe) {
+    update();
+  }
+}
+
+export function reportRuntimeError(
+  error: Error,
+  options: RuntimeReportingOptions,
+) {
+  crashWithFrames(handleRuntimeError(options))(error, false);
+}
+
+export function startReportingRuntimeErrors(options: RuntimeReportingOptions) {
+  if (stopListeningToRuntimeErrors !== null) {
+    throw new Error('Already listening');
+  }
+  stopListeningToRuntimeErrors = listenToRuntimeErrors(
+    handleRuntimeError(options),
+  );
+}
+
+const handleRuntimeError =
+  (options: RuntimeReportingOptions) => (errorRecord: ErrorRecord) => {
+    try {
+      if (typeof options.onError === 'function') {
+        options.onError.call(null);
+      }
+    } finally {
+      if (
+        currentRuntimeErrorRecords.some(
+          ({error}) => error === errorRecord.error,
+        )
+      ) {
+        // Deduplicate identical errors.
+        // This fixes https://github.com/facebook/create-react-app/issues/3011.
+        // eslint-disable-next-line no-unsafe-finally
+        return;
+      }
+      currentRuntimeErrorRecords = currentRuntimeErrorRecords.concat([
+        errorRecord,
+      ]);
+      update();
+    }
+  };
+
+export function dismissRuntimeErrors() {
+  currentRuntimeErrorRecords = [];
+  update();
+}
+
+export function stopReportingRuntimeErrors() {
+  if (stopListeningToRuntimeErrors === null) {
+    throw new Error('Not currently listening');
+  }
+  try {
+    stopListeningToRuntimeErrors();
+  } finally {
+    stopListeningToRuntimeErrors = null;
+  }
+}
+
+let rootNode;
+let root;
+
+function update() {
+  if (!root) {
+    rootNode = document.createElement('parcel-error-overlay');
+    let shadow = rootNode.attachShadow({mode: 'open'});
+    if (rootNode) {
+      document.body?.appendChild(rootNode);
+      root = createRoot(shadow);
+    }
+  }
+
+  if (currentRuntimeErrorRecords.length > 0 && root) {
+    root.render(
+      <dialog
+        ref={d => (d: any)?.showModal()}
+        style={overlayStyle}
+        onClose={dismissRuntimeErrors}
+      >
+        <ErrorOverlay />
+      </dialog>,
+    );
+  } else {
+    root?.unmount();
+    rootNode?.remove();
+    root = null;
+    rootNode = null;
+  }
+}
+
+function ErrorOverlay() {
+  if (currentRuntimeErrorRecords.length > 0) {
+    return (
+      <RuntimeErrorContainer
+        errorRecords={currentRuntimeErrorRecords}
+        close={dismissRuntimeErrors}
+        editorHandler={editorHandler}
+      />
+    );
+  }
+  return null;
+}
+
+if (process.env.NODE_ENV === 'production') {
+  console.warn(
+    'react-error-overlay is not meant for use in production. You should ' +
+      'ensure it is not included in your build to reduce bundle size.',
+  );
+}

--- a/packages/utils/error-overlay/src/listenToRuntimeErrors.js
+++ b/packages/utils/error-overlay/src/listenToRuntimeErrors.js
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-env browser */
+/** @flow */
+import {
+  register as registerError,
+  unregister as unregisterError,
+} from './effects/unhandledError';
+import {
+  register as registerPromise,
+  unregister as unregisterPromise,
+} from './effects/unhandledRejection';
+import {
+  register as registerStackTraceLimit,
+  unregister as unregisterStackTraceLimit,
+} from './effects/stackTraceLimit';
+import getStackFrames from './utils/getStackFrames';
+import type {StackFrame} from './utils/stack-frame';
+import React from 'react';
+
+const CONTEXT_SIZE: number = 3;
+
+export type ErrorRecord = {|
+  error: Error,
+  unhandledRejection: boolean,
+  contextSize: number,
+  stackFrames: StackFrame[],
+|};
+
+export function crashWithFrames(
+  crash: ErrorRecord => void,
+): (Error, boolean) => void {
+  return (error: Error, unhandledRejection = false) => {
+    getStackFrames(error, CONTEXT_SIZE)
+      .then(stackFrames => {
+        if (stackFrames == null) {
+          return;
+        }
+        crash({
+          error,
+          unhandledRejection,
+          contextSize: CONTEXT_SIZE,
+          stackFrames,
+        });
+      })
+      .catch(e => {
+        // eslint-disable-next-line no-console
+        console.log('Could not get the stack frames of error:', e);
+      });
+  };
+}
+
+function patchConsole(method: string, onError: (err: Error) => void) {
+  /* eslint-disable no-console */
+  let original = console[method];
+  console[method] = (...args) => {
+    let error = null;
+    if (typeof args[0] === 'string') {
+      let format = args[0].match(/%[oOdisfc]/g);
+      if (format) {
+        let errorIndex = format.findIndex(
+          match => match === '%o' || match === '%O',
+        );
+        if (errorIndex < 0) {
+          errorIndex = format.findIndex(match => match === '%s');
+        }
+        if (errorIndex >= 0) {
+          error = args[errorIndex + 1];
+        } else {
+          error = args[1];
+        }
+
+        if (!(error instanceof Error)) {
+          let index = 1;
+          let message = args[0].replace(/%[oOdisfc]/g, match => {
+            switch (match) {
+              case '%s':
+                return String(args[index++]);
+              case '%f':
+                return parseFloat(args[index++]);
+              case '%d':
+              case '%i':
+                return parseInt(args[index++], 10);
+              case '%o':
+              case '%O':
+                if (args[index] instanceof Error) {
+                  return String(args[index++]);
+                } else {
+                  return JSON.stringify(args[index++]);
+                }
+              case '%c':
+                index++;
+                return '';
+            }
+          });
+
+          error = new Error(message);
+        }
+      } else {
+        error = new Error(args[0]);
+      }
+    } else {
+      error = args.find(arg => arg instanceof Error);
+    }
+
+    if (error && !error.message.includes('[parcel]')) {
+      // Attempt to append the React component stack
+      // $FlowFixMe
+      if (typeof React.captureOwnerStack === 'function') {
+        // $FlowFixMe
+        let stack = React.captureOwnerStack();
+        error.stack += stack;
+      } else {
+        const ReactSharedInternals =
+          // $FlowFixMe
+          React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE ||
+          // $FlowFixMe
+          React.__SERVER_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;
+
+        if (typeof ReactSharedInternals?.getCurrentStack === 'function') {
+          // $FlowFixMe
+          let stack = ReactSharedInternals.getCurrentStack();
+          error.stack += stack;
+        }
+      }
+
+      onError(error);
+    }
+
+    original.apply(console, args);
+  };
+  /* eslint-enable no-console */
+}
+
+export function listenToRuntimeErrors(crash: ErrorRecord => void): () => void {
+  const crashWithFramesRunTime = crashWithFrames(crash);
+
+  registerError(window, error => crashWithFramesRunTime(error, false));
+  registerPromise(window, error => crashWithFramesRunTime(error, true));
+  registerStackTraceLimit();
+  patchConsole('error', error => crashWithFramesRunTime(error, false));
+
+  return function stopListening() {
+    unregisterStackTraceLimit();
+    unregisterPromise(window);
+    unregisterError(window);
+  };
+}

--- a/packages/utils/error-overlay/src/styles.js
+++ b/packages/utils/error-overlay/src/styles.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+export type Theme = {|
+  // Colors for components styles
+  background: string, // Page background
+  color: string, // Base text
+  headerColor: string, // Header text
+  primaryPreBackground: string, // <pre/> Error background
+  primaryPreColor: string, // <pre/> Error text
+  secondaryPreBackground: string, // <pre/> Warning background
+  secondaryPreColor: string, // <pre/> Warning text
+  footer: string, // Footer text
+  anchorColor: string, // Link color
+  toggleBackground: string, // Toggle stack background
+  toggleColor: string, // Toggle stack text
+  closeColor: string, // Close button color
+  navBackground: string, // Navigation arrow background
+  navArrow: string, // Navigation arrow color
+  diffRemoved: string,
+  diffAdded: string,
+  // ANSI colors
+  // base00: string; // Default Background
+  base01: string, // Lighter Background (Used for status bars)
+  // base02: string, // Selection Background
+  base03: string, // Comments, Invisibles, Line Highlighting
+  // base04: string, // Dark Foreground (Used for status bars)
+  base05: string, // Default Foreground, Caret, Delimiters, Operators
+  // base06: string, // Light Foreground (Not often used)
+  // base07: string, // Light Background (Not often used)
+  base08: string, // Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted
+  // base09: string, // Integers, Boolean, Constants, XML Attributes, Markup Link Url
+  // base0A: string, // Classes, Markup Bold, Search Text Background
+  base0B: string, // Strings, Inherited Class, Markup Code, Diff Inserted
+  base0C: string, // Support, Regular Expressions, Escape Characters, Markup Quotes
+  // base0D: string, // Functions, Methods, Attribute IDs, Headings
+  base0E: string, // Keywords, Storage, Selector, Markup Italic, Diff Changed
+  // base0F: string, // Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?>
+|};
+const lightTheme: Theme = {
+  // Colors for components styles
+  background: 'white',
+  color: 'black',
+  headerColor: '#ce1126',
+  primaryPreBackground: 'rgba(206, 17, 38, 0.05)',
+  primaryPreColor: 'inherit',
+  secondaryPreBackground: 'rgba(251, 245, 180, 0.3)',
+  secondaryPreColor: 'inherit',
+  footer: '#878e91',
+  anchorColor: '#878e91',
+  toggleBackground: 'transparent',
+  toggleColor: '#878e91',
+  closeColor: '#293238',
+  navBackground: 'rgba(206, 17, 38, 0.05)',
+  navArrow: '#ce1126',
+  diffAdded: 'green',
+  diffRemoved: '#ce1126',
+  // Light color scheme inspired by https://chriskempson.github.io/base16/css/base16-github.css
+  // base00: '#ffffff',
+  base01: '#f5f5f5',
+  // base02: '#c8c8fa',
+  base03: '#6e6e6e',
+  // base04: '#e8e8e8',
+  base05: '#333333',
+  // base06: '#ffffff',
+  // base07: '#ffffff',
+  base08: '#881280',
+  // base09: '#0086b3',
+  // base0A: '#795da3',
+  base0B: '#1155cc',
+  base0C: '#994500',
+  // base0D: '#795da3',
+  base0E: '#c80000',
+  // base0F: '#333333',
+};
+
+const darkTheme: Theme = {
+  // Colors for components styles
+  background: '#353535',
+  color: 'white',
+  headerColor: '#e83b46',
+  primaryPreBackground: 'rgba(206, 17, 38, 0.1)',
+  primaryPreColor: '#fccfcf',
+  secondaryPreBackground: 'rgba(251, 245, 180, 0.1)',
+  secondaryPreColor: '#fbf5b4',
+  footer: '#878e91',
+  anchorColor: '#878e91',
+  toggleBackground: 'transparent',
+  toggleColor: '#878e91',
+  closeColor: '#ffffff',
+  navBackground: 'rgba(206, 17, 38, 0.2)',
+  navArrow: '#ce1126',
+  diffAdded: '#85e285',
+  diffRemoved: '#ff5459',
+  // Dark color scheme inspired by https://github.com/atom/base16-tomorrow-dark-theme/blob/master/styles/colors.less
+  // base00: '#1d1f21',
+  base01: '#282a2e',
+  // base02: '#373b41',
+  base03: '#969896',
+  // base04: '#b4b7b4',
+  base05: '#c5c8c6',
+  // base06: '#e0e0e0',
+  // base07: '#ffffff',
+  base08: '#cc6666',
+  // base09: '#de935f',
+  // base0A: '#f0c674',
+  base0B: '#b5bd68',
+  base0C: '#8abeb7',
+  // base0D: '#81a2be',
+  base0E: '#b294bb',
+  // base0F: '#a3685a',
+};
+
+export const theme: Theme = (Object.fromEntries(
+  Object.keys(lightTheme).map(key => [
+    key,
+    `light-dark(${lightTheme[key]}, ${darkTheme[key]})`,
+  ]),
+): any);
+
+const overlayStyle = {
+  width: '100vw',
+  height: '100vh',
+  maxWidth: 'none',
+  maxHeight: 'none',
+  border: 0,
+  margin: 0,
+  padding: 0,
+  boxSizing: 'border-box',
+  textAlign: 'center',
+  backgroundColor: theme.background,
+  outline: 'none',
+  colorScheme: 'light dark',
+};
+
+export {overlayStyle, lightTheme, darkTheme};

--- a/packages/utils/error-overlay/src/utils/generateAnsiHTML.js
+++ b/packages/utils/error-overlay/src/utils/generateAnsiHTML.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+
+import {theme} from '../styles';
+import ansiHTML from 'ansi-html-community';
+
+// Map ANSI colors from what babel-code-frame uses to base16-github
+// See: https://github.com/babel/babel/blob/e86f62b304d280d0bab52c38d61842b853848ba6/packages/babel-code-frame/src/index.js#L9-L22
+const colors = {
+  reset: [theme.base05, 'transparent'],
+  black: theme.base05,
+  red: theme.base08 /* marker, bg-invalid */,
+  green: theme.base0B /* string */,
+  yellow: theme.base08 /* capitalized, jsx_tag, punctuator */,
+  blue: theme.base0C,
+  magenta: theme.base0C /* regex */,
+  cyan: theme.base0E /* keyword */,
+  gray: theme.base03 /* comment, gutter */,
+  lightgrey: theme.base01,
+  darkgrey: theme.base03,
+};
+
+// $FlowFixMe
+ansiHTML.setColors(colors);
+// $FlowFixMe
+for (let tag in ansiHTML.tags.open) {
+  // $FlowFixMe
+  ansiHTML.tags.open[tag] = ansiHTML.tags.open[tag].replace(
+    /#light-dark/g,
+    'light-dark',
+  );
+}
+
+function generateAnsiHTML(txt: string): string {
+  return ansiHTML(
+    txt.replace(/[&<>"']/g, c => {
+      switch (c) {
+        case '&':
+          return '&amp';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt';
+        case '"':
+          return '&quot;';
+        case "'":
+          return '&#39;';
+        default:
+          return c;
+      }
+    }),
+  );
+}
+
+export default generateAnsiHTML;

--- a/packages/utils/error-overlay/src/utils/getPrettyURL.js
+++ b/packages/utils/error-overlay/src/utils/getPrettyURL.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+function getPrettyURL(
+  sourceFileName: ?string,
+  sourceLineNumber: ?number,
+  sourceColumnNumber: ?number,
+  fileName: ?string,
+  lineNumber: ?number,
+  columnNumber: ?number,
+  compiled: boolean,
+): string {
+  let prettyURL;
+  if (!compiled && sourceFileName && typeof sourceLineNumber === 'number') {
+    // Remove everything up to the first /src/ or /node_modules/
+    const trimMatch = /^[/|\\].*?[/|\\]((src|node_modules)[/|\\].*)/.exec(
+      sourceFileName,
+    );
+    if (trimMatch && trimMatch[1]) {
+      prettyURL = trimMatch[1];
+    } else {
+      prettyURL = sourceFileName;
+    }
+    prettyURL += ':' + sourceLineNumber;
+    // Note: we intentionally skip 0's because they're produced by cheap webpack maps
+    if (sourceColumnNumber) {
+      prettyURL += ':' + sourceColumnNumber;
+    }
+  } else if (fileName && typeof lineNumber === 'number') {
+    prettyURL = fileName + ':' + lineNumber;
+    // Note: we intentionally skip 0's because they're produced by cheap webpack maps
+    if (columnNumber) {
+      prettyURL += ':' + columnNumber;
+    }
+  } else {
+    prettyURL = 'unknown';
+  }
+  return prettyURL.replace('webpack://', '.');
+}
+
+export {getPrettyURL};
+export default getPrettyURL;

--- a/packages/utils/error-overlay/src/utils/getStackFrames.js
+++ b/packages/utils/error-overlay/src/utils/getStackFrames.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import {StackFrame} from './stack-frame';
+import {parse} from './parser';
+
+/**
+ * Enhances a set of <code>StackFrame</code>s with their original positions and code (when available).
+ * @param {StackFrame[]} frames A set of <code>StackFrame</code>s which contain (generated) code positions.
+ * @param {number} [contextLines=3] The number of lines to provide before and after the line specified in the <code>StackFrame</code>.
+ */
+async function getStackFrames(
+  error: Error,
+  contextLines: number = 3,
+): Promise<StackFrame[] | null> {
+  const frames = parse(error);
+  // $FlowFixMe
+  let res = await fetch(import.meta.devServer + '/__parcel_code_frame', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      contextLines,
+      frames: frames.map(f => ({
+        fileName: f.fileName,
+        lineNumber: f.lineNumber,
+        columnNumber: f.columnNumber,
+      })),
+    }),
+  });
+
+  let json = await res.json();
+  return json.map(
+    (f, i) =>
+      new StackFrame(
+        frames[i].functionName,
+        f.fileName,
+        f.lineNumber,
+        f.columnNumber,
+        f.compiledLines,
+        frames[i].functionName,
+        f.sourceFileName,
+        f.sourceLineNumber,
+        f.sourceColumnNumber,
+        f.sourceLines,
+      ),
+  );
+}
+
+export default getStackFrames;
+export {getStackFrames};

--- a/packages/utils/error-overlay/src/utils/isBultinErrorName.js
+++ b/packages/utils/error-overlay/src/utils/isBultinErrorName.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+function isBultinErrorName(errorName: ?string): boolean {
+  switch (errorName) {
+    case 'EvalError':
+    case 'InternalError':
+    case 'RangeError':
+    case 'ReferenceError':
+    case 'SyntaxError':
+    case 'TypeError':
+    case 'URIError':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export {isBultinErrorName};
+export default isBultinErrorName;

--- a/packages/utils/error-overlay/src/utils/isInternalFile.js
+++ b/packages/utils/error-overlay/src/utils/isInternalFile.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+function isInternalFile(sourceFileName: ?string, fileName: ?string): boolean {
+  return (
+    sourceFileName == null ||
+    sourceFileName === '' ||
+    sourceFileName.indexOf('~/') !== -1 ||
+    sourceFileName.indexOf('node_modules/') !== -1 ||
+    sourceFileName.indexOf('error-overlay') !== -1 ||
+    sourceFileName.trim().indexOf(' ') !== -1 ||
+    fileName == null ||
+    fileName === ''
+  );
+}
+
+export {isInternalFile};

--- a/packages/utils/error-overlay/src/utils/parser.js
+++ b/packages/utils/error-overlay/src/utils/parser.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+import StackFrame from './stack-frame';
+
+const regexExtractLocation = /\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/;
+
+function extractLocation(token: string): [string, number, number] {
+  return (
+    // $FlowFixMe
+    regexExtractLocation
+      .exec(token)
+      // $FlowFixMe
+      .slice(1)
+      .map(v => {
+        const p = Number(v);
+        if (!isNaN(p)) {
+          return p;
+        }
+        return v;
+      })
+  );
+}
+
+const regexValidFrame_Chrome = /^\s*(at|in)\s.+(:\d+)/;
+const regexValidFrame_FireFox =
+  /(^|@)\S+:\d+|.+line\s+\d+\s+>\s+(eval|Function).+/;
+
+function parseStack(stack: string[]): StackFrame[] {
+  let frames = stack
+    .filter(
+      e => regexValidFrame_Chrome.test(e) || regexValidFrame_FireFox.test(e),
+    )
+    .map(e => {
+      if (regexValidFrame_FireFox.test(e)) {
+        // Strip eval, we don't care about it
+        let isEval = false;
+        if (/ > (eval|Function)/.test(e)) {
+          e = e.replace(
+            / line (\d+)(?: > eval line \d+)* > (eval|Function):\d+:\d+/g,
+            ':$1',
+          );
+          isEval = true;
+        }
+        const data = e.split(/[@]/g);
+        const last = data.pop();
+        return new StackFrame(
+          data.join('@') || (isEval ? 'eval' : null),
+          ...extractLocation(last),
+        );
+      } else {
+        // Strip eval, we don't care about it
+        if (e.indexOf('(eval ') !== -1) {
+          e = e.replace(/(\(eval at [^()]*)|(\),.*$)/g, '');
+        }
+        if (e.indexOf('(at ') !== -1) {
+          e = e.replace(/\(at /, '(');
+        }
+        const data = e.trim().split(/\s+/g).slice(1);
+        const last = data.pop();
+        return new StackFrame(data.join(' ') || null, ...extractLocation(last));
+      }
+    });
+
+  let index = frames.findIndex(frame =>
+    frame.getFunctionName().includes('react-stack-bottom-frame'),
+  );
+  if (index >= 0) {
+    frames = frames.slice(0, index);
+  }
+
+  return frames;
+}
+
+/**
+ * Turns an <code>Error</code>, or similar object, into a set of <code>StackFrame</code>s.
+ * @alias parse
+ */
+function parseError(error: Error | string | string[]): StackFrame[] {
+  if (error == null) {
+    throw new Error('You cannot pass a null object.');
+  }
+  if (typeof error === 'string') {
+    return parseStack(error.split('\n'));
+  }
+  if (Array.isArray(error)) {
+    return parseStack(error);
+  }
+  if (typeof error.stack === 'string') {
+    return parseStack(error.stack.split('\n'));
+  }
+  throw new Error('The error you provided does not contain a stack trace.');
+}
+
+export {parseError as parse};
+export default parseError;

--- a/packages/utils/error-overlay/src/utils/stack-frame.js
+++ b/packages/utils/error-overlay/src/utils/stack-frame.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* @flow */
+
+/**
+ * A representation of a stack frame.
+ */
+class StackFrame {
+  functionName: string | null;
+  fileName: string | null;
+  lineNumber: number | null;
+  columnNumber: number | null;
+
+  _originalFunctionName: string | null;
+  _originalFileName: string | null;
+  _originalLineNumber: number | null;
+  _originalColumnNumber: number | null;
+
+  _scriptCode: string | null;
+  _originalScriptCode: string | null;
+
+  constructor(
+    functionName: string | null = null,
+    fileName: string | null = null,
+    lineNumber: number | null = null,
+    columnNumber: number | null = null,
+    scriptCode: string | null = null,
+    sourceFunctionName: string | null = null,
+    sourceFileName: string | null = null,
+    sourceLineNumber: number | null = null,
+    sourceColumnNumber: number | null = null,
+    sourceScriptCode: string | null = null,
+  ) {
+    if (functionName && functionName.indexOf('Object.') === 0) {
+      functionName = functionName.slice('Object.'.length);
+    }
+    if (
+      // Chrome has a bug with inferring function.name:
+      // https://github.com/facebook/create-react-app/issues/2097
+      // Let's ignore a meaningless name we get for top-level modules.
+      functionName === 'friendlySyntaxErrorLabel' ||
+      functionName === 'exports.__esModule' ||
+      functionName === '<anonymous>' ||
+      !functionName
+    ) {
+      functionName = null;
+    }
+    this.functionName = functionName;
+
+    this.fileName = fileName;
+    this.lineNumber = lineNumber;
+    this.columnNumber = columnNumber;
+
+    this._originalFunctionName = sourceFunctionName;
+    this._originalFileName = sourceFileName;
+    this._originalLineNumber = sourceLineNumber;
+    this._originalColumnNumber = sourceColumnNumber;
+
+    this._scriptCode = scriptCode;
+    this._originalScriptCode = sourceScriptCode;
+  }
+
+  /**
+   * Returns the name of this function.
+   */
+  getFunctionName(): string {
+    return this.functionName || '(anonymous function)';
+  }
+
+  /**
+   * Returns the source of the frame.
+   * This contains the file name, line number, and column number when available.
+   */
+  getSource(): string {
+    let str = '';
+    if (this.fileName != null) {
+      str += this.fileName + ':';
+    }
+    if (this.lineNumber != null) {
+      str += this.lineNumber + ':';
+    }
+    if (this.columnNumber != null) {
+      str += this.columnNumber + ':';
+    }
+    return str.slice(0, -1);
+  }
+
+  /**
+   * Returns a pretty version of this stack frame.
+   */
+  toString(): string {
+    const functionName = this.getFunctionName();
+    const source = this.getSource();
+    return `${functionName}${source ? ` (${source})` : ``}`;
+  }
+}
+
+export {StackFrame};
+export default StackFrame;

--- a/packages/utils/rsc/src/node.tsx
+++ b/packages/utils/rsc/src/node.tsx
@@ -1,32 +1,55 @@
 /* @jsxRuntime automatic */
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { ReadableStream as NodeReadableStream } from 'stream/web';
+import type { ReactNode } from 'react';
 
 import {Readable} from 'stream';
 import {renderToReadableStream, createTemporaryReferenceSet} from 'react-server-dom-parcel/server.edge';
-import {RSCToHTMLOptions, RSCOptions, renderRSCToHTML as renderRSCToHTMLBase, callAction as callActionBase} from './server';
+import {RSCToHTMLOptions, RSCOptions, renderHTML as renderHTMLBase, callAction as callActionBase, renderDevError} from './server';
 
 export function renderRSC(root: any, options?: RSCOptions): Readable {
   return Readable.fromWeb(renderToReadableStream(root, options) as NodeReadableStream);
 }
 
 export async function renderHTML(root: any, options?: RSCToHTMLOptions): Promise<Readable> {
-  let htmlStream = await renderRSCToHTMLBase(root, options);
+  let htmlStream = await renderHTMLBase(root, options);
   return Readable.fromWeb(htmlStream as NodeReadableStream);
 }
 
-const temporaryReferencesSymbol = Symbol.for('temporaryReferences')
+const temporaryReferencesSymbol = Symbol.for('temporaryReferences');
 
-export async function renderRequest(request: IncomingMessage, response: ServerResponse, root: any, options?: RSCToHTMLOptions): Promise<void> {
+export interface RenderRequestOptions extends RSCToHTMLOptions {
+  renderError?: (err: Error) => ReactNode
+}
+
+export async function renderRequest(request: IncomingMessage, response: ServerResponse, root: any, options?: RenderRequestOptions): Promise<void> {
   options = {
     ...options,
     temporaryReferences: options?.temporaryReferences ?? (request as any)[temporaryReferencesSymbol]
   };
   
   if (request.headers.accept?.includes('text/html')) {
-    let html = await renderHTML(root, options);
-    response.setHeader('Content-Type', 'text/html');
-    html.pipe(response);
+    try {
+      let html = await renderHTML(root, options);
+      response.setHeader('Content-Type', 'text/html');
+      html.pipe(response);
+    } catch (err) {
+      response.statusCode = 500;
+      let error = err instanceof Error ? err : new Error(String(err));
+      let renderedError;
+      try {
+        renderedError = options?.renderError 
+          ? await renderHTMLBase(options.renderError(error), options)
+          : await renderDevError(error, options);
+      } catch {
+        renderedError = '<h1>Something went wrong!</h1>';
+      }
+      if (typeof renderedError === 'string') {
+        response.end(renderedError);
+      } else {
+        Readable.fromWeb(renderedError as NodeReadableStream).pipe(response);
+      }
+    }
   } else {
     response.setHeader('Content-Type', 'text/x-component');
     renderRSC(root, options).pipe(response);

--- a/packages/utils/rsc/src/server.tsx
+++ b/packages/utils/rsc/src/server.tsx
@@ -36,7 +36,7 @@ export interface RSCToHTMLOptions {
   onError?: (error: unknown, errorInfo?: ErrorInfo) => string | void;
 }
 
-export async function renderRSCToHTML(root: any, options?: RSCToHTMLOptions): Promise<ReadableStream> {
+export async function renderHTML(root: any, options?: RSCToHTMLOptions): Promise<ReadableStream> {
   let rscStream = renderToReadableStream(root, options);
 
   // Use client react to render the RSC payload to HTML.
@@ -50,14 +50,15 @@ export async function renderRSCToHTML(root: any, options?: RSCToHTMLOptions): Pr
 
   let htmlStream = await renderHTMLToReadableStream(<Content />, {
     ...options,
-    bootstrapScriptContent: (options?.component as any)?.bootstrapScript
+    bootstrapScriptContent: (options?.component as any)?.bootstrapScript,
   });
 
   return htmlStream.pipeThrough(injectRSCPayload(s2));
 }
 
 export interface RenderRequestOptions extends RSCToHTMLOptions {
-  headers?: HeadersInit
+  headers?: HeadersInit,
+  renderError?: (err: Error) => ReactNode
 }
 
 const temporaryReferencesSymbol = Symbol.for('temporaryReferences')
@@ -69,13 +70,32 @@ export async function renderRequest(request: Request, root: any, options?: Rende
   };
 
   if (request.headers.get('Accept')?.includes('text/html')) {
-    let html = await renderRSCToHTML(root, options);
-    return new Response(html, {
-      headers: {
-        ...options?.headers,
-        'Content-Type': 'text/html'
+    try {
+      let html = await renderHTML(root, options);
+      return new Response(html, {
+        headers: {
+          ...options?.headers,
+          'Content-Type': 'text/html'
+        }
+      });
+    } catch (err) {
+      let error = err instanceof Error ? err : new Error(String(err));
+      let res;
+      try {
+        res = options?.renderError 
+          ? await renderHTML(options.renderError(error), options)
+          : await renderDevError(error, options);
+      } catch {
+        res = '<h1>Something went wrong!</h1>';
       }
-    });
+      return new Response(res, {
+        status: 500,
+        headers: {
+          ...options?.headers,
+          'Content-Type': 'text/html'
+        }
+      });
+    }
   } else {
     let rscStream = renderToReadableStream(root, options);
     return new Response(rscStream, {
@@ -114,5 +134,39 @@ export async function callAction(request: Request, id: string | null | undefined
     // Don't catch error here: this should be handled by the caller (e.g. render an error page).
     let result = await action();
     return {result};
+  }
+}
+
+export async function renderDevError(error: Error, options: RSCToHTMLOptions): Promise<ReadableStream | string> {
+  if (process.env.NODE_ENV !== 'production') {
+    let content = (
+      <html>
+        <meta charSet="utf-8" />
+        <title>Error</title>
+        <body>
+          <noscript>
+            <h1>Error: {error.message}</h1>
+            <pre>{error.stack}</pre>
+          </noscript>
+        </body>
+      </html>
+    );
+
+    // Load bootstrap script containing error overlay, and re-throw server error on the client.
+    let bootstrapScript = (options?.component as any)?.bootstrapScript;
+    bootstrapScript += '.then(() => {';
+    bootstrapScript += `let err = new Error(${JSON.stringify(error.message)});`;
+    bootstrapScript += `err.stack = ${JSON.stringify(error.stack)};`;
+    bootstrapScript += 'throw err;';
+    bootstrapScript += '})';
+
+    return await renderHTML(content, {
+      ...options,
+      component: {
+        bootstrapScript
+      } as any
+    });
+  } else {
+    return '<h1>Something went wrong!</h1>';
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11966,11 +11966,6 @@ react-dom@^19:
   dependencies:
     scheduler "^0.25.0"
 
-react-error-overlay@6.0.9:
-  version "6.0.9"
-  resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
-  integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
-
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
This forks the `react-error-overlay` project originally created for Create React App and modernizes it. Also implements a dev server endpoint to get sourcemaps by bundle or asset URL, needed for RSC debugging. With this, it's possible to display source mapped errors from the server in the browser.

<img width="1354" alt="image" src="https://github.com/user-attachments/assets/da7d274f-2b25-492a-8d50-fccd40b5de99" />

## Changes to react-error-overlay

* Updated to React 19
* Rendered in a shadow DOM dialog element rather than an iframe
* Source map parsing moved out of the client into a dev server API. The stack gets sent to the server, the server uses the native source map library to find the original locations and generate code frames, which are then sent back to the browser and displayed. This should improve performance.
* Handled react console errors and added component stacks, and improved rendering for hydration errors.