### PR TITLE
Add optional peer dependency in @parcel/rust

### DIFF
--- a/packages/core/rust/package.json
+++ b/packages/core/rust/package.json
@@ -33,6 +33,14 @@
     "@napi-rs/cli": "^2.15.2",
     "napi-wasm": "^1.1.2"
   },
+  "peerDependencies": {
+    "napi-wasm": "^1.1.2"
+  },
+  "peerDependenciesMeta": {
+    "napi-wasm": {
+      "optional": true
+    }
+  },
   "scripts": {
     "build": "napi build --platform --cargo-cwd ../../../crates/node-bindings",
     "build-canary": "napi build --platform --profile canary --cargo-cwd ../../../crates/node-bindings",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Add missing dependencies `napi-wasm` for `@parcel/rust` which is used in `packages/core/rust/browser.js`

https://github.com/parcel-bundler/parcel/blob/6f68c78b1fa2b9653e298fd893e43e875ff6bdb8/packages/core/rust/browser.js#L1

Previously `napi-wasm` was put in `devDependencies`, this PR moves it to `dependencies`

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

The original issue is that when I try to bundle `@parcel/fs` in a browser environment like parcel repl did, it says "Could not resolve napi-wasm" since `napi-wasm` is only declared in `devDependencies`

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
