### PR TITLE
Support Ranges & Integer Validation In Config Schemas

### DIFF
--- a/packages/bundlers/default/src/DefaultBundler.js
+++ b/packages/bundlers/default/src/DefaultBundler.js
@@ -1658,6 +1658,7 @@ const CONFIG_SCHEMA: SchemaEntity = {
           },
           split: {
             type: 'number',
+            min: 1,
           },
         },
         required: ['name', 'assets'],
@@ -1666,12 +1667,15 @@ const CONFIG_SCHEMA: SchemaEntity = {
     },
     minBundles: {
       type: 'number',
+      min: 1,
     },
     minBundleSize: {
       type: 'number',
+      min: 1,
     },
     maxParallelRequests: {
       type: 'number',
+      min: 1,
     },
     disableSharedBundles: {
       type: 'boolean',

--- a/packages/core/utils/src/schema.js
+++ b/packages/core/utils/src/schema.js
@@ -47,6 +47,9 @@ export type SchemaString = {|
 export type SchemaNumber = {|
   type: 'number',
   enum?: Array<number>,
+  min?: number,
+  max?: number,
+  integer?: boolean,
   __type?: string,
 |};
 export type SchemaEnum = {|
@@ -76,6 +79,26 @@ export type SchemaError =
       expectedValues: Array<mixed>,
       dataType: 'key' | 'value',
       actualValue: mixed,
+
+      dataPath: string,
+      ancestors: Array<SchemaEntity>,
+      prettyType?: string,
+    |}
+  | {|
+      type: 'range',
+      min?: number,
+      max?: number,
+      dataType: 'key',
+      actualValue: number,
+
+      dataPath: string,
+      ancestors: Array<SchemaEntity>,
+      prettyType?: string,
+    |}
+  | {|
+      type: 'integer',
+      dataType: 'key',
+      actualValue: number,
 
       dataPath: string,
       ancestors: Array<SchemaEntity>,
@@ -193,6 +216,38 @@ function validateSchema(schema: SchemaEntity, data: mixed): Array<SchemaError> {
                   actualValue: value,
                   ancestors: schemaAncestors,
                 };
+              }
+            } else if (schemaNode.min) {
+              if (value < schemaNode.min) {
+                return {
+                  type: 'range',
+                  dataType: 'value',
+                  dataPath,
+                  min: schemaNode.min,
+                  actualValue: value,
+                  ancestors: schemaAncestors,
+                };
+              }
+            } else if (schemaNode.max) {
+              if (value > schemaNode.max) {
+                return {
+                  type: 'range',
+                  dataType: 'value',
+                  dataPath,
+                  max: schemaNode.max,
+                  actualValue: value,
+                  ancestors: schemaAncestors,
+                };
+              } else if (schemaNode.integer) {
+                if (!Number.isInteger(value)) {
+                  return {
+                    type: 'integer',
+                    dataType: 'value',
+                    dataPath,
+                    actualValue: value,
+                    ancestors: schemaAncestors,
+                  };
+                }
               }
             }
             break;
@@ -435,6 +490,16 @@ validateSchema.diagnostic = function (
         } else {
           message = 'Unexpected value';
         }
+      } else if (e.type === 'range') {
+        if (e.min && e.max) {
+          message = `Expected to be in range [${e.min}, ${e.max}]`;
+        } else if (e.min) {
+          message = `Expected to be at least ${e.min}`;
+        } else if (e.max) {
+          message = `Expected to be at most ${e.max}`;
+        }
+      } else if (e.type === 'integer') {
+        message = `Expected to be an integer`;
       } else if (e.type === 'forbidden-prop') {
         let {prop, expectedProps, actualProps} = e;
         let likely = fuzzySearch(expectedProps, prop).filter(

--- a/packages/transformers/image/src/validateConfig.js
+++ b/packages/transformers/image/src/validateConfig.js
@@ -2,18 +2,24 @@
 import type {SchemaEntity} from '@parcel/utils';
 import {validateSchema} from '@parcel/utils';
 
+const QUALITY_PROPERTY = {
+  type: 'number',
+  min: 1,
+  max: 100,
+  integer: true,
+};
+
 // https://sharp.pixelplumbing.com/api-output#jpeg
 const JPEG_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    quality: {
-      type: 'number',
-    },
+    quality: QUALITY_PROPERTY,
     progressive: {
       type: 'boolean',
     },
     chromaSubsampling: {
       type: 'string',
+      enum: ['4:2:0', '4:4:4'],
     },
     optimiseCoding: {
       type: 'boolean',
@@ -38,9 +44,15 @@ const JPEG_OUTPUT_SCHEMA: SchemaEntity = {
     },
     quantisationTable: {
       type: 'number',
+      min: 0,
+      max: 8,
+      integer: true,
     },
     quantizationTable: {
       type: 'number',
+      min: 0,
+      max: 8,
+      integer: true,
     },
     force: {
       type: 'boolean',
@@ -53,14 +65,19 @@ const JPEG_OUTPUT_SCHEMA: SchemaEntity = {
 const PNG_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
+    // yes, for png in specific quality is 0-100. everything else is 1-100
     quality: {
-      type: 'number',
+      ...QUALITY_PROPERTY,
+      min: 0,
     },
     progressive: {
       type: 'boolean',
     },
     compressionLevel: {
       type: 'number',
+      min: 0,
+      max: 9,
+      integer: true,
     },
     adaptiveFiltering: {
       type: 'boolean',
@@ -68,14 +85,28 @@ const PNG_OUTPUT_SCHEMA: SchemaEntity = {
     palette: {
       type: 'boolean',
     },
+    effort: {
+      type: 'number',
+      min: 1,
+      max: 10,
+      integer: true,
+    },
     colours: {
       type: 'number',
+      min: 2,
+      max: 256,
+      integer: true,
     },
     colors: {
       type: 'number',
+      min: 0,
+      max: 256,
+      integer: true,
     },
     dither: {
       type: 'number',
+      min: 0.0,
+      max: 1.0,
     },
     force: {
       type: 'boolean',
@@ -84,15 +115,43 @@ const PNG_OUTPUT_SCHEMA: SchemaEntity = {
   additionalProperties: true,
 };
 
+const ANIMATED_OPTIONS_SCHEMA = {
+  loop: {
+    type: 'number',
+    min: 0,
+    max: 65536,
+  },
+  // max & integer requirement are undocumented, but sharp will throw an error
+  delay: {
+    oneOf: [
+      {
+        type: 'array',
+        items: {
+          type: 'number',
+          min: 0,
+          max: 65535,
+          integer: true,
+        },
+      },
+      {
+        type: 'number',
+        min: 0,
+        max: 65535,
+        integer: true,
+      },
+    ],
+  },
+};
+
 // https://sharp.pixelplumbing.com/api-output#webp
 const WEBP_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    quality: {
-      type: 'number',
-    },
+    quality: QUALITY_PROPERTY,
     alphaQuality: {
       type: 'number',
+      min: 0,
+      max: 100,
     },
     lossless: {
       type: 'boolean',
@@ -103,24 +162,26 @@ const WEBP_OUTPUT_SCHEMA: SchemaEntity = {
     smartSubsample: {
       type: 'boolean',
     },
-    reductionEffort: {
-      type: 'number',
+    preset: {
+      type: 'string',
+      enum: ['default', 'photo', 'picture', 'drawing', 'icon', 'text'],
     },
-    pageHeight: {
+    effort: {
       type: 'number',
+      min: 0,
+      max: 6,
+      integer: true,
     },
-    loop: {
-      type: 'number',
+    minSize: {
+      type: 'boolean',
     },
-    delay: {
-      type: 'array',
-      items: {
-        type: 'number',
-      },
+    mixed: {
+      type: 'boolean',
     },
     force: {
       type: 'boolean',
     },
+    ...ANIMATED_OPTIONS_SCHEMA,
   },
   additionalProperties: true,
 };
@@ -129,21 +190,48 @@ const WEBP_OUTPUT_SCHEMA: SchemaEntity = {
 const GIF_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    pageHeight: {
+    reuse: {
+      type: 'boolean',
+    },
+    progressive: {
+      type: 'boolean',
+    },
+    colours: {
       type: 'number',
+      min: 2,
+      max: 256,
+      integer: true,
+    },
+    effort: {
+      type: 'number',
+      min: 1,
+      max: 10,
+      integer: true,
+    },
+    dither: {
+      type: 'number',
+      min: 0.0,
+      max: 1.0,
+    },
+    interFrameMaxError: {
+      type: 'number',
+      min: 0,
+      max: 32,
+    },
+    interPaletteMaxError: {
+      type: 'number',
+      min: 0,
+      max: 256,
     },
     loop: {
       type: 'number',
-    },
-    delay: {
-      type: 'array',
-      items: {
-        type: 'number',
-      },
+      min: 0,
+      max: 65536,
     },
     force: {
       type: 'boolean',
     },
+    ...ANIMATED_OPTIONS_SCHEMA,
   },
   additionalProperties: true,
 };
@@ -152,17 +240,27 @@ const GIF_OUTPUT_SCHEMA: SchemaEntity = {
 const TIFF_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    quality: {
-      type: 'number',
-    },
+    quality: QUALITY_PROPERTY,
     force: {
       type: 'boolean',
     },
     compression: {
       type: 'string',
+      enum: [
+        'none',
+        'jpeg',
+        'deflate',
+        'packbits',
+        'c,cittfax4',
+        'lzw',
+        'webp',
+        'zstd',
+        'jp2k',
+      ],
     },
     predictor: {
       type: 'string',
+      enum: ['none', 'horizontal', 'float'],
     },
     pyramid: {
       type: 'boolean',
@@ -172,39 +270,62 @@ const TIFF_OUTPUT_SCHEMA: SchemaEntity = {
     },
     tileWidth: {
       type: 'number',
+      min: 0,
+      integer: true,
     },
     tileHeight: {
       type: 'number',
+      min: 0,
+      integer: true,
     },
     xres: {
       type: 'number',
+      min: 0,
     },
     yres: {
       type: 'number',
+      min: 0,
+    },
+    resolutionUnit: {
+      type: 'string',
+      enum: ['inch', 'cm'],
     },
     bitdepth: {
       type: 'number',
     },
+    miniswhite: {
+      type: 'boolean',
+    },
   },
   additionalProperties: true,
+};
+
+const AVIF_HEIF_SHARED_PROPERTIES = {
+  quality: QUALITY_PROPERTY,
+  lossless: {
+    type: 'boolean',
+  },
+  effort: {
+    type: 'number',
+    min: 0,
+    max: 100,
+    integer: true,
+  },
+  chromaSubsampling: {
+    type: 'string',
+    enum: ['4:2:0', '4:4:4'],
+  },
+  bitdepth: {
+    type: 'number',
+    enum: [8, 10, 12],
+  },
 };
 
 // https://sharp.pixelplumbing.com/api-output#avif
 const AVIF_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    quality: {
-      type: 'number',
-    },
-    lossless: {
-      type: 'boolean',
-    },
-    speed: {
-      type: 'number',
-    },
-    chromaSubsampling: {
-      type: 'string',
-    },
+    ...AVIF_HEIF_SHARED_PROPERTIES,
   },
   additionalProperties: true,
 };
@@ -213,21 +334,11 @@ const AVIF_OUTPUT_SCHEMA: SchemaEntity = {
 const HEIF_OUTPUT_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
-    quality: {
-      type: 'number',
-    },
     compression: {
       type: 'string',
+      enum: ['av1', 'hevc'],
     },
-    lossless: {
-      type: 'boolean',
-    },
-    speed: {
-      type: 'number',
-    },
-    chromaSubsampling: {
-      type: 'string',
-    },
+    ...AVIF_HEIF_SHARED_PROPERTIES,
   },
   additionalProperties: true,
 };
@@ -236,9 +347,7 @@ const CONFIG_SCHEMA: SchemaEntity = {
   type: 'object',
   properties: {
     // Fallback quality
-    quality: {
-      type: 'number',
-    },
+    quality: QUALITY_PROPERTY,
     jpeg: JPEG_OUTPUT_SCHEMA,
     png: PNG_OUTPUT_SCHEMA,
     webp: WEBP_OUTPUT_SCHEMA,

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -55,7 +55,11 @@ const browserAction = {
         properties: {
           light: string,
           dark: string,
-          size: {type: 'number'},
+          size: {
+            type: 'number',
+            min: 0,
+            integer: true,
+          },
         },
         additionalProperties: false,
         required: ['light', 'dark', 'size'],


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Adds support for config schemas with ranges & integer restrictions.

Closes #10117

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

## 💻 Examples

<!-- Examples help us understand the requested feature better -->
Example usage:
```javascript
const JPEG_OUTPUT_SCHEMA: SchemaEntity = {
  type: 'object',
  properties: {
    quality: {
      type: 'number',
      min: 1,
      max: 100,
      integer: true,
    }
  }
}
```
this restricts the `quality` parameter to be an integer in the range of 1-100, and it will fail with an error if it is not.

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

I did not add any tests for it because there wasn't really any existing tests for the config schema stuff.
Testing it manually should be quite easy, just make a config schema with a restriction on the range or a restriction to only integers, and then make a config which violates that restriction.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
