### PR TITLE
Fix duplicate bundles error message empty bundle list

### DIFF
--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -27,7 +27,6 @@ import MutableBundleGraph from '../public/MutableBundleGraph';
 import {Bundle, NamedBundle} from '../public/Bundle';
 import {report} from '../ReporterRunner';
 import dumpGraphToGraphViz from '../dumpGraphToGraphViz';
-import {unique, setDifference} from '@parcel/utils';
 import {hashString} from '@parcel/rust';
 import PluginOptions from '../public/PluginOptions';
 import applyRuntimes from '../applyRuntimes';
@@ -482,20 +481,16 @@ class BundlerRunner {
     );
 
     let seenNames = new Set<ProjectPath>();
-    let duplicatesNames = new Set<ProjectPath>();
-
-    for (let b of bundleNames) {
-      if (seenNames.has(b)) {
-        duplicatesNames.add(b);
-      } else {
-        seenNames.add(b);
-      }
-    }
+    let duplicateNames = bundleNames.filter(name => {
+      let isDuplicate = seenNames.has(name);
+      seenNames.add(name);
+      return isDuplicate;
+    });
 
     assert(
-      duplicatesNames.size === 0,
-      'Bundles must have unique name. Conflicting names: ' +
-        [...duplicatesNames].join(),
+      duplicateNames.length === 0,
+      'Bundles must have unique names. Conflicting names: ' +
+        duplicateNames.join(', '),
     );
   }
 

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -56,6 +56,7 @@ import {
 import createAssetGraphRequest from './AssetGraphRequest';
 import {tracer, PluginTracer} from '@parcel/profiler';
 import {requestTypes} from '../RequestTracker';
+import type {ProjectPath} from '../projectPath';
 
 type BundleGraphRequestInput = {|
   requestedAssetIds: Set<string>,
@@ -476,17 +477,25 @@ class BundlerRunner {
 
   validateBundles(bundleGraph: InternalBundleGraph): void {
     let bundles = bundleGraph.getBundles();
-
     let bundleNames = bundles.map(b =>
       joinProjectPath(b.target.distDir, nullthrows(b.name)),
     );
-    assert.deepEqual(
-      bundleNames,
-      unique(bundleNames),
+
+    let seenNames = new Set<ProjectPath>();
+    let duplicatesNames = new Set<ProjectPath>();
+
+    for (let b of bundleNames) {
+      if (seenNames.has(b)) {
+        duplicatesNames.add(b);
+      } else {
+        seenNames.add(b);
+      }
+    }
+
+    assert(
+      duplicatesNames.size === 0,
       'Bundles must have unique name. Conflicting names: ' +
-        [
-          ...setDifference(new Set(bundleNames), new Set(unique(bundleNames))),
-        ].join(),
+        [...duplicatesNames].join(),
     );
   }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

Fixes #10125

# ↪️ Pull Request

`setDifference(new Set(bundleNames), new Set(unique(bundleNames)))` always returns an empty Set, resulting in an empty bundle list in the error message.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
