### PR TITLE
Use max level compression for brotli compressor

### DIFF
--- a/packages/compressors/brotli/src/BrotliCompressor.js
+++ b/packages/compressors/brotli/src/BrotliCompressor.js
@@ -9,7 +9,12 @@ export default (new Compressor({
     }
 
     return {
-      stream: stream.pipe(zlib.createBrotliCompress()),
+      stream: stream.pipe(
+        zlib.createBrotliCompress({
+          [zlib.constants.BROTLI_PARAM_QUALITY]:
+            zlib.constants.BROTLI_MAX_QUALITY,
+        }),
+      ),
       type: 'br',
     };
   },


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

Forces the brotli compressor to use the maximum level compression setting rather than the default setting. Very simple change.

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

N/A

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

Test the brotli compressor with & without this change, and compare the size of them.

I've chosen not to add tests, as there are no compression level tests for any of the other compressors.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [ ] Included links to related issues/PRs
