### PR TITLE
Verify Host and Origin headers in dev server

### DIFF
--- a/flow-libs/ws.js.flow
+++ b/flow-libs/ws.js.flow
@@ -14,6 +14,10 @@ declare type ws$PerMessageDeflateOptions = {|
   maxPayload?: number,
 |};
 
+declare type ws$ClientInfo = {|
+  origin: string
+|};
+
 // $FlowFixMe[incompatible-extend]
 declare class ws$WebSocketServer extends events$EventEmitter {
   /**
@@ -31,7 +35,7 @@ declare class ws$WebSocketServer extends events$EventEmitter {
       perMessageDeflate?: boolean | ws$PerMessageDeflateOptions,
       port: number,
       server?: http$Server | https$Server,
-      verifyClient?: () => mixed,
+      verifyClient?: (info: ws$ClientInfo) => mixed,
     |},
     callback?: () => mixed
   ): this;
@@ -47,7 +51,7 @@ declare class ws$WebSocketServer extends events$EventEmitter {
       perMessageDeflate?: boolean | ws$PerMessageDeflateOptions,
       port?: number,
       server: http$Server | https$Server,
-      verifyClient?: () => mixed,
+      verifyClient?: (info: ws$ClientInfo) => mixed,
     |},
     callback?: () => mixed
   ): this;
@@ -63,7 +67,7 @@ declare class ws$WebSocketServer extends events$EventEmitter {
       perMessageDeflate?: boolean | ws$PerMessageDeflateOptions,
       port?: number,
       server?: http$Server | https$Server,
-      verifyClient?: () => mixed,
+      verifyClient?: (info: ws$ClientInfo) => mixed,
     |},
     callback?: () => mixed
   ): this;

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -14,7 +14,7 @@ import type {
   Request,
   Response,
 } from './types.js.flow';
-import {setHeaders, SOURCES_ENDPOINT} from './Server';
+import {setHeaders, verifyOrigin, SOURCES_ENDPOINT} from './Server';
 
 import nullthrows from 'nullthrows';
 import url, {fileURLToPath} from 'url';
@@ -110,7 +110,7 @@ export default class HMRServer {
         outputFS: this.options.outputFS,
         cacheDir: this.options.cacheDir,
         listener: (req, res) => {
-          setHeaders(res);
+          setHeaders(req.headers.origin, this.options.host, res);
           if (req.method === 'OPTIONS') {
             res.statusCode = 200;
             res.end();
@@ -128,7 +128,17 @@ export default class HMRServer {
     } else {
       this.options.addMiddleware?.((req, res) => this.handle(req, res));
     }
-    this.wss = new WebSocket.Server({server});
+    this.wss = new WebSocket.Server({
+      server,
+      verifyClient: info => {
+        // Validate Origin header to prevent Cross-Site WebSocket Hijacking.
+        // If there is no Origin header, assume this request is from Node.js or another non-browser client.
+        if (!info.origin) {
+          return true;
+        }
+        return verifyOrigin(info.origin, this.options.host);
+      },
+    });
 
     this.wss.on('connection', ws => {
       if (this.unresolvedError) {

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -31,9 +31,39 @@ import serveHandler from 'serve-handler';
 import {createProxyMiddleware} from 'http-proxy-middleware';
 import {URL} from 'url';
 import fresh from 'fresh';
+import os from 'os';
 
-export function setHeaders(res: Response) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
+// Default allowed hosts include `localhost` and all local ip addresses.
+let defaultAllowedHostsCache = null;
+export function getDefaultAllowedHosts(): string[] {
+  if (!defaultAllowedHostsCache) {
+    defaultAllowedHostsCache = ['localhost'];
+    let interfaces = os.networkInterfaces();
+    for (let name in interfaces) {
+      for (let addr of interfaces[name]) {
+        defaultAllowedHostsCache.push(
+          addr.family === 'IPv6' ? `[${addr.address}]` : addr.address,
+        );
+      }
+    }
+  }
+
+  return defaultAllowedHostsCache;
+}
+
+export function setHeaders(
+  origin: ?string,
+  allowedHostname: ?string,
+  res: Response,
+) {
+  res.setHeader('Cache-Control', 'max-age=0, must-revalidate');
+
+  // Add CORS headers if the Origin header is valid.
+  if (!origin || !verifyOrigin(origin, allowedHostname)) {
+    return;
+  }
+
+  res.setHeader('Access-Control-Allow-Origin', origin);
   res.setHeader(
     'Access-Control-Allow-Methods',
     'GET, HEAD, PUT, PATCH, POST, DELETE',
@@ -42,7 +72,53 @@ export function setHeaders(res: Response) {
     'Access-Control-Allow-Headers',
     'Origin, X-Requested-With, Content-Type, Accept, Content-Type',
   );
-  res.setHeader('Cache-Control', 'max-age=0, must-revalidate');
+}
+
+export function verifyOrigin(
+  origin: string,
+  allowedHostname: ?string,
+): boolean {
+  try {
+    let url = new URL(origin);
+    if (
+      url.protocol === 'file:' ||
+      url.protocol === 'chrome-extension:' ||
+      url.protocol === 'moz-extension:'
+    ) {
+      return true;
+    }
+
+    return verifyHost(url.hostname, allowedHostname);
+  } catch {
+    return false;
+  }
+}
+
+export function verifyHost(
+  requestHost: string,
+  allowedHostname: ?string,
+): boolean {
+  // IPv6 address
+  if (requestHost[0] === '[') {
+    let index = requestHost.indexOf(']');
+    if (index < 0) {
+      return false;
+    }
+
+    requestHost = requestHost.slice(0, index + 1);
+  } else {
+    // Remove port
+    let index = requestHost.indexOf(':');
+    if (index >= 0) {
+      requestHost = requestHost.slice(0, index);
+    }
+  }
+
+  if (allowedHostname) {
+    return requestHost === allowedHostname;
+  }
+
+  return getDefaultAllowedHosts().includes(requestHost);
 }
 
 const SLASH_REGEX = /\//g;
@@ -479,7 +555,14 @@ export default class Server {
 
     const app = connect();
     app.use((req, res, next) => {
-      setHeaders(res);
+      // Validate the Host header to prevent DNS rebinding attacks.
+      if (!verifyHost(req.headers.host, this.options.host)) {
+        res.statusCode = 403;
+        res.end('Host not allowed.');
+        return;
+      }
+
+      setHeaders(req.headers.origin, this.options.host, res);
       if (req.method === 'OPTIONS') {
         res.statusCode = 200;
         res.end();


### PR DESCRIPTION
Previously we allowed all requests in the dev server, but this could potentially allow another website to access local source code.

This implements 3 mitigations:

1. Validate the `Origin` header matches an allowed host. By default `localhost` and local IP addresses are allowed. The existing `--host` option can be specified to use a different host. Set `Access-Control-Allow-Origin` to only that origin instead of `*`.
2. Validate the `Origin` header when a WebSocket connects. This allows localhost by default, or the `--hmr-host`/`--host` option.
3. Validate the `Host` header to prevent DNS rebinding attacks.

One problem is that reverse proxy services such as [Cloudflare Tunnels](https://developers.cloudflare.com/pages/how-to/preview-with-cloudflare-tunnel/) no longer work due to Host validation. Setting the `--host` option does not work because that also sets the network interface, and the cloudflare host is not valid in that situation. We would need to add an additional option to either disable host validation or provide additional allowed hosts. Unfortunately we don't have a great place to put this. Environment variable? New CLI option? Seems important to solve this one.

Another downside is if you use custom hostnames (e.g. configured via `/etc/hosts`), these are not allowed by default. You'd need to manually set the `--host` option now, and only one at a time can be used. Would be nice if these could automatically be added to the allowed hosts (e.g. could do a reverse DNS lookup for `127.0.0.1`), but would this then be susceptible to DNS rebinding?

Unless we can solve the above items this is also technically a breaking change...