### PR TITLE
Fix temp file ENOENT crash (#8615)

### DIFF
--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -102,7 +102,7 @@ export class NodeFS implements FileSystem {
           await fsPromises.unlink(filePath);
         }
         await fsPromises.rename(tmpFilePath, filePath);
-      } catch (e: any) {
+      } catch (e) {
         // For Windows: if rename fails with EPERM, compare hashes
         if (
           process.platform === 'win32' &&

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -86,33 +86,43 @@ export class NodeFS implements FileSystem {
   createWriteStream(filePath: string, options: any): Writable {
     // Make createWriteStream atomic
     let tmpFilePath = getTempFilePath(filePath);
-    let failed = false;
 
     const move = async () => {
-      if (!failed) {
+      const fsPromises = fs.promises;
+      const exists = (p: string) => {
         try {
-          await fs.promises.rename(tmpFilePath, filePath);
+          return fs.existsSync(p);
         } catch (e) {
-          // This is adapted from fs-write-stream-atomic. Apparently
-          // Windows doesn't like renaming when the target already exists.
-          if (
-            process.platform === 'win32' &&
-            e.syscall &&
-            e.syscall === 'rename' &&
-            e.code &&
-            e.code === 'EPERM'
-          ) {
-            let [hashTmp, hashTarget] = await Promise.all([
-              hashFile(this, tmpFilePath),
-              hashFile(this, filePath),
-            ]);
+          return false;
+        }
+      };
+      try {
+        if (!exists(tmpFilePath)) return;
+        if (exists(filePath)) {
+          await fsPromises.unlink(filePath);
+        }
+        await fsPromises.rename(tmpFilePath, filePath);
+      } catch (e: any) {
+        // For Windows: if rename fails with EPERM, compare hashes
+        if (
+          process.platform === 'win32' &&
+          e.syscall &&
+          e.syscall === 'rename' &&
+          e.code &&
+          e.code === 'EPERM'
+        ) {
+          let [hashTmp, hashTarget] = await Promise.all([
+            hashFile(this, tmpFilePath),
+            hashFile(this, filePath),
+          ]);
 
-            await this.unlink(tmpFilePath);
+          await fsPromises.unlink(tmpFilePath);
 
-            if (hashTmp != hashTarget) {
-              throw e;
-            }
+          if (hashTmp != hashTarget) {
+            throw e;
           }
+        } else {
+          throw e;
         }
       }
     };
@@ -137,8 +147,9 @@ export class NodeFS implements FileSystem {
     });
 
     writeStream.once('error', () => {
-      failed = true;
-      fs.unlinkSync(tmpFilePath);
+      if (fs.existsSync(tmpFilePath)) {
+        fs.unlinkSync(tmpFilePath);
+      }
     });
 
     return writeStream;


### PR DESCRIPTION
Fixes #8615

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->

This should fix a crash that seems to happen to many people, including myself - see issue #8615, #8571 etc.

Full disclosure: I haven't had much success building Parcel and running tests and I really just needed this fixed ASAP, so I just tested this by editing the compiled scripts and then applying the fixes back to the original source file. There might be some issues I'm overlooking, so any help with testing and other necessary steps will be much appreciated. I haven't really seen a good fix anywhere in this repository (that doesn't cause any other issues down the road).

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

For me, the original bug happens on Windows using Parcel 2.15.0, while using the Pug preprocessor. All that's needed to crash Parcel is to run a dev script, make a small change to index.pug, save and hot-reload, make another small change, save again and after the 3rd or 4th save, it crashes pretty reliably, throwing the ENOENT error many have described in the mentioned issue. After applying my fix, it does not happen anymore and everything works well.

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
