### PR TITLE
Fix collapsing stack frames loop in error-overlay

### DIFF
--- a/packages/utils/error-overlay/src/components/Collapsible.js
+++ b/packages/utils/error-overlay/src/components/Collapsible.js
@@ -6,7 +6,7 @@
  */
 
 /* @flow */
-import {useState} from 'preact/hooks';
+import {useRef} from 'preact/hooks';
 import {theme} from '../styles';
 
 const _collapsibleStyle = {
@@ -40,15 +40,12 @@ type CollapsiblePropsType = {|
 |};
 
 function Collapsible(props: CollapsiblePropsType): React$Element<'details'> {
-  const [collapsed, setCollapsed] = useState(true);
-
-  const toggleCollapsed = () => {
-    setCollapsed(!collapsed);
-  };
+  const ref = useRef(null);
+  const collapsed = ref.current?.open;
 
   const count = props.children.length;
   return (
-    <details open={!collapsed} onToggle={toggleCollapsed}>
+    <details ref={ref}>
       <summary
         style={collapsed ? collapsibleCollapsedStyle : collapsibleExpandedStyle}
       >
@@ -58,7 +55,10 @@ function Collapsible(props: CollapsiblePropsType): React$Element<'details'> {
       </summary>
       <div>
         {props.children}
-        <button onClick={toggleCollapsed} style={collapsibleExpandedStyle}>
+        <button
+          onClick={() => ref.current?.removeAttribute('open')}
+          style={collapsibleExpandedStyle}
+        >
           {`▲ ${count} stack frames were expanded.`}
         </button>
       </div>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes https://github.com/parcel-bundler/parcel/issues/10179

## 💻 Examples

<!-- Examples help us understand the requested feature better -->

## 🚨 Test instructions

<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
