### PR TITLE
Code split re-exports when using non-scope hoisting packager

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -199,7 +199,6 @@ export default class BundleGraph {
       if (
         node.type === 'dependency' &&
         node.value.symbols != null &&
-        node.value.env.shouldScopeHoist &&
         // Disable in dev mode because this feature is at odds with safeToIncrementallyBundle
         isProduction
       ) {
@@ -290,7 +289,7 @@ export default class BundleGraph {
               for (let [as, from] of target) {
                 let existing = nodeValueSymbols.get(as);
                 if (existing) {
-                  symbols.set(from, existing);
+                  symbols.set(from, {...existing, meta: {rewritten: as}});
                 } else {
                   invariant(isReexportAll);
                   if (as === from) {

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -4867,11 +4867,11 @@ describe('javascript', function () {
       },
       mode: 'production',
     };
-    let usesSymbolPropagation = shouldScopeHoist;
+    let usesSymbolPropagation = true;
     describe(`sideEffects: false with${
       shouldScopeHoist ? '' : 'out'
     } scope-hoisting`, function () {
-      if (usesSymbolPropagation) {
+      if (shouldScopeHoist) {
         it('supports excluding unused CSS imports', async function () {
           let b = await bundle(
             path.join(
@@ -4965,9 +4965,9 @@ describe('javascript', function () {
         assertBundles(b, [
           {
             type: 'js',
-            assets: usesSymbolPropagation
+            assets: shouldScopeHoist
               ? ['a.js', 'message1.js']
-              : ['a.js', 'esmodule-helpers.js', 'index.js', 'message1.js'],
+              : ['a.js', 'esmodule-helpers.js', 'message1.js'],
           },
         ]);
 
@@ -4987,10 +4987,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['message1'] : ['message1', 'index'],
-        );
+        assert.deepEqual(calls, ['message1']);
         assert.deepEqual(res.output, 'Message 1');
       });
 
@@ -5035,10 +5032,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['message2'] : ['message2', 'index'],
-        );
+        assert.deepEqual(calls, ['message2']);
         assert.deepEqual(res.output, 'Message 2');
       });
 
@@ -5054,9 +5048,9 @@ describe('javascript', function () {
         assertBundles(b, [
           {
             type: 'js',
-            assets: usesSymbolPropagation
+            assets: shouldScopeHoist
               ? ['c.js', 'message3.js']
-              : ['c.js', 'esmodule-helpers.js', 'index.js', 'message3.js'],
+              : ['c.js', 'esmodule-helpers.js', 'message3.js'],
           },
         ]);
 
@@ -5075,10 +5069,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['message3'] : ['message3', 'index'],
-        );
+        assert.deepEqual(calls, ['message3']);
         assert.deepEqual(res.output, {default: 'Message 3'});
       });
 
@@ -5136,15 +5127,11 @@ describe('javascript', function () {
           {require: false},
         );
 
-        if (shouldScopeHoist) {
-          try {
-            assert.deepEqual(calls, ['key', 'foo', 'index']);
-          } catch (e) {
-            // A different dependency order, but this is deemed acceptable as it's sideeffect free
-            assert.deepEqual(calls, ['foo', 'key', 'index']);
-          }
-        } else {
-          assert.deepEqual(calls, ['key', 'foo', 'types', 'index']);
+        try {
+          assert.deepEqual(calls, ['key', 'foo', 'index']);
+        } catch (e) {
+          // A different dependency order, but this is deemed acceptable as it's sideeffect free
+          assert.deepEqual(calls, ['foo', 'key', 'index']);
         }
 
         assert.deepEqual(res.output, ['key', 'foo']);
@@ -5569,10 +5556,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['message1'] : ['message1', 'message'],
-        );
+        assert.deepEqual(calls, ['message1']);
         assert.deepEqual(res.output, 'Message 1');
       });
 
@@ -5626,12 +5610,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist
-            ? ['message1']
-            : ['message1', 'message', 'index2', 'index'],
-        );
+        assert.deepEqual(calls, ['message1']);
         assert.deepEqual(res.output, 'Message 1');
       });
 
@@ -5662,10 +5641,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['other'] : ['other', 'index'],
-        );
+        assert.deepEqual(calls, ['other']);
         assert.deepEqual(res.output, 'bar');
       });
 
@@ -5696,10 +5672,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['other'] : ['other', 'index'],
-        );
+        assert.deepEqual(calls, ['other']);
         assert.deepEqual(res.output, 'bar');
       });
 
@@ -5757,10 +5730,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['other'] : ['other', 'index'],
-        );
+        assert.deepEqual(calls, ['other']);
         assert.deepEqual(res.output, ['foo']);
       });
 
@@ -5792,10 +5762,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['other'] : ['other', 'index'],
-        );
+        assert.deepEqual(calls, ['other']);
         assert.deepEqual(res.output, ['bar']);
       });
 
@@ -5827,10 +5794,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['other'] : ['other', 'index'],
-        );
+        assert.deepEqual(calls, ['other']);
         assert.deepEqual(res.output, ['foo', 'bar']);
       });
 
@@ -5858,16 +5822,11 @@ describe('javascript', function () {
 
         let [v, async] = res;
 
-        assert.deepEqual(calls, shouldScopeHoist ? ['b'] : ['b', 'index']);
+        assert.deepEqual(calls, ['b']);
         assert.deepEqual(v, 2);
 
         v = await async();
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist
-            ? ['b', 'a', 'index', 'dynamic']
-            : ['b', 'index', 'a', 'dynamic'],
-        );
+        assert.deepEqual(calls, ['b', 'a', 'index', 'dynamic']);
         assert.deepEqual(v.default, [1, 3]);
       });
 
@@ -5893,10 +5852,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['esm1'] : ['esm1', 'index'],
-        );
+        assert.deepEqual(calls, ['esm1']);
         assert.deepEqual(res.output, 'Message 1');
       });
 
@@ -5918,7 +5874,7 @@ describe('javascript', function () {
           assert.deepStrictEqual(
             new Set(b.getUsedSymbols(nullthrows(findAsset(b, 'commonjs.js')))),
             // the exports object is used freely
-            new Set(['*', 'message1']),
+            new Set(shouldScopeHoist ? ['*', 'message1'] : ['message1']),
           );
           assert.deepStrictEqual(
             new Set(
@@ -5958,7 +5914,7 @@ describe('javascript', function () {
           assert.deepStrictEqual(
             new Set(b.getUsedSymbols(nullthrows(findAsset(b, 'commonjs.js')))),
             // the exports object is used freely
-            new Set(['*', 'message2']),
+            new Set(shouldScopeHoist ? ['*', 'message2'] : ['message2']),
           );
         }
 
@@ -5972,10 +5928,7 @@ describe('javascript', function () {
           },
           {require: false},
         );
-        assert.deepEqual(
-          calls,
-          shouldScopeHoist ? ['commonjs'] : ['commonjs', 'index'],
-        );
+        assert.deepEqual(calls, ['commonjs']);
         assert.deepEqual(res.output, 'Message 2');
       });
     });

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -453,7 +453,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'const local',
-      generatedStr: 'let r',
+      generatedStr: 'let o',
       sourcePath: 'index.js',
     });
 
@@ -462,7 +462,7 @@ describe('sourcemaps', function () {
       source: inputs[0],
       generated: raw,
       str: 'local.a',
-      generatedStr: 'r.a',
+      generatedStr: 'o.a',
       sourcePath: 'index.js',
     });
 
@@ -471,7 +471,7 @@ describe('sourcemaps', function () {
       source: inputs[1],
       generated: raw,
       str: 'exports.a',
-      generatedStr: 'o.a',
+      generatedStr: 'r.a',
       sourcePath: 'local.js',
     });
 
@@ -480,7 +480,7 @@ describe('sourcemaps', function () {
       source: inputs[2],
       generated: raw,
       str: 'exports.count = function(a, b) {',
-      generatedStr: 'o.count=function(e,n){',
+      generatedStr: 'r.count=function(e,n){',
       sourcePath: 'utils/util.js',
     });
   });

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -118,7 +118,31 @@ export class DevPackager {
           if (this.bundleGraph.isDependencySkipped(dep)) {
             deps[specifier] = false;
           } else if (resolved) {
-            deps[specifier] = this.bundleGraph.getAssetPublicId(resolved);
+            let assetId = this.bundleGraph.getAssetPublicId(resolved);
+            let resolution = assetId;
+
+            // Dependencies may be re-targeted to follow re-exports.
+            // Pass these re-writes into the prelude.
+            for (let [name, sym] of dep.symbols) {
+              let rewritten = sym.meta?.rewritten;
+              if (typeof rewritten === 'string') {
+                let r =
+                  rewritten === name
+                    ? [rewritten, assetId]
+                    : [rewritten, assetId, name];
+                if (typeof resolution === 'string') {
+                  resolution = [r];
+                } else {
+                  resolution.push(r);
+                }
+              }
+            }
+
+            if (Array.isArray(deps[specifier]) && Array.isArray(resolution)) {
+              deps[specifier].push(...resolution);
+            } else {
+              deps[specifier] = resolution;
+            }
           } else {
             // An external module - map placeholder to original specifier.
             deps[specifier] = dep.specifier;
@@ -128,6 +152,18 @@ export class DevPackager {
             ) {
               externals.add(dep.specifier);
             }
+          }
+        }
+
+        // Simplify dependency resolutions when all symbols point to a single asset.
+        for (let specifier in deps) {
+          let resolution = deps[specifier];
+          if (
+            Array.isArray(resolution) &&
+            resolution.length > 0 &&
+            resolution.every(r => r.length === 2 && r[1] === resolution[0][1])
+          ) {
+            deps[specifier] = resolution[0][1];
           }
         }
 

--- a/packages/packagers/js/src/dev-prelude.js
+++ b/packages/packagers/js/src/dev-prelude.js
@@ -94,7 +94,54 @@
 
     function localRequire(x) {
       var res = localRequire.resolve(x);
-      return res === false ? {} : newRequire(res);
+      if (res === false) {
+        return {};
+      }
+      // Synthesize a module to follow re-exports.
+      if (Array.isArray(res)) {
+        var m = {__esModule: true};
+        res.forEach(function (v) {
+          var key = v[0];
+          var id = v[1];
+          var exp = v[2] || v[0];
+          var x = newRequire(id);
+          if (key === '*') {
+            Object.keys(x).forEach(function (key) {
+              if (
+                key === 'default' ||
+                key === '__esModule' ||
+                Object.prototype.hasOwnProperty.call(m, key)
+              ) {
+                return;
+              }
+
+              Object.defineProperty(m, key, {
+                enumerable: true,
+                get: function () {
+                  return x[key];
+                },
+              });
+            });
+          } else if (exp === '*') {
+            Object.defineProperty(m, key, {
+              enumerable: true,
+              value: x,
+            });
+          } else {
+            Object.defineProperty(m, key, {
+              enumerable: true,
+              get: function () {
+                if (exp === 'default') {
+                  return x.__esModule ? x.default : x;
+                }
+                return x[exp];
+              },
+            });
+          }
+        });
+        return m;
+      }
+      return newRequire(res);
     }
 
     function resolve(x) {

--- a/packages/packagers/react-static/src/ReactStaticPackager.js
+++ b/packages/packagers/react-static/src/ReactStaticPackager.js
@@ -375,7 +375,27 @@ async function loadBundleUncached(
         if (resolved.type !== 'js') {
           deps.set(getSpecifier(dep), {skipped: true});
         } else {
-          deps.set(getSpecifier(dep), {id: resolved.id});
+          let resolution = {id: resolved.id};
+
+          // Dependencies may be re-targeted to follow re-exports.
+          for (let [name, sym] of dep.symbols) {
+            let rewritten = sym.meta?.rewritten;
+            if (typeof rewritten === 'string') {
+              if (Array.isArray(resolution)) {
+                resolution.push([rewritten, resolved.id, name]);
+              } else {
+                resolution = [[rewritten, resolved.id, name]];
+              }
+            }
+          }
+
+          let specifier = getSpecifier(dep);
+          let cur = deps.get(specifier);
+          if (Array.isArray(cur) && Array.isArray(resolution)) {
+            cur.push(...resolution);
+          } else {
+            deps.set(specifier, resolution);
+          }
         }
       } else {
         deps.set(getSpecifier(dep), {specifier: dep.specifier});
@@ -387,6 +407,52 @@ async function loadBundleUncached(
       let resolution = deps.get(id);
       if (resolution?.skipped) {
         return {};
+      }
+
+      // Synthesize a module to follow re-exports.
+      if (Array.isArray(resolution)) {
+        var m = {__esModule: true};
+        resolution.forEach(function (v) {
+          var key = v[0];
+          var id = v[1];
+          var exp = v[2];
+          var x = loadAsset(id);
+          if (key === '*') {
+            Object.keys(x).forEach(function (key) {
+              if (
+                key === 'default' ||
+                key === '__esModule' ||
+                // $FlowFixMe
+                Object.prototype.hasOwnProperty.call(m, key)
+              ) {
+                return;
+              }
+
+              Object.defineProperty(m, key, {
+                enumerable: true,
+                get: function () {
+                  return x[key];
+                },
+              });
+            });
+          } else if (exp === '*') {
+            Object.defineProperty(m, key, {
+              enumerable: true,
+              value: x,
+            });
+          } else {
+            Object.defineProperty(m, key, {
+              enumerable: true,
+              get: function () {
+                if (exp === 'default') {
+                  return x.__esModule ? x.default : x;
+                }
+                return x[exp];
+              },
+            });
+          }
+        });
+        return m;
       }
 
       if (resolution?.id) {

--- a/packages/runtimes/rsc/src/RSCRuntime.js
+++ b/packages/runtimes/rsc/src/RSCRuntime.js
@@ -42,12 +42,25 @@ export default (new Runtime({
         let resolvedAsset = bundleGraph.getResolvedAsset(node.value, bundle);
         let directives = resolvedAsset?.meta?.directives;
 
-        // Server dependency on a client component.
         if (
           node.value.env.isServer() &&
           resolvedAsset &&
           Array.isArray(directives) &&
-          directives.includes('use client')
+          directives.includes('use client-entry')
+        ) {
+          // Resolve to an empty module so the client entry does not run on the server.
+          runtimes.push({
+            filePath: replaceExtension(resolvedAsset.filePath),
+            code: '',
+            dependency: node.value,
+            env: {sourceType: 'module'},
+          });
+
+          // Server dependency on a client component.
+        } else if (
+          node.value.env.isServer() &&
+          resolvedAsset &&
+          resolvedAsset.env.context === 'react-client'
         ) {
           let bundles;
           let async = bundleGraph.resolveAsyncDependency(node.value, bundle);
@@ -188,21 +201,6 @@ export default (new Runtime({
             dependency: node.value,
             env: {sourceType: 'module'},
             shouldReplaceResolution: true,
-          });
-
-          // Server dependency on a client entry.
-        } else if (
-          node.value.env.isServer() &&
-          resolvedAsset &&
-          Array.isArray(directives) &&
-          directives.includes('use client-entry')
-        ) {
-          // Resolve to an empty module so the client entry does not run on the server.
-          runtimes.push({
-            filePath: replaceExtension(resolvedAsset.filePath),
-            code: '',
-            dependency: node.value,
-            env: {sourceType: 'module'},
           });
         } else {
           // Handle bundle group boundaries to automatically inject resources like CSS.

--- a/packages/transformers/js/core/src/collect.rs
+++ b/packages/transformers/js/core/src/collect.rs
@@ -411,9 +411,9 @@ impl Visit for Collect {
         }
         ExportSpecifier::Default(default) => {
           self.exports.insert(
-            "default".into(),
+            default.exported.sym.clone(),
             Export {
-              specifier: default.exported.sym.clone(),
+              specifier: "default".into(),
               loc: SourceLocation::from(&self.source_map, default.exported.span),
               source,
               is_esm: true,


### PR DESCRIPTION
This enables code splitting across re-exports when using the non-scope hoisting packager. This significantly reduces bundle sizes when using libraries with barrel files, and not using scope hoisting (e.g. RSC static packager).

The packager injects resolutions for each symbol, and the prelude synthesizes a module that follows re-exports at runtime.