### PR TITLE
Scope macro asset unique keys to the parent asset

### DIFF
--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -500,7 +500,9 @@ export default (new Transformer({
                 let ctx: MacroContext = {
                   // Allows macros to emit additional assets to add as dependencies (e.g. css).
                   addAsset(a: MacroAsset) {
-                    let k = String(macroAssets.length);
+                    let k =
+                      (asset.uniqueKey ? asset.uniqueKey + ':' : '') +
+                      String(macroAssets.length);
                     let map;
                     if (asset.env.sourceMap) {
                       // Generate a source map that maps each line of the asset to the original macro call.


### PR DESCRIPTION
We return a flattened list of assets from transformation, so if a transformer returns multiple assets (e.g. MDX) which each have sub-assets (e.g. macros), their unique keys can conflict. This adds the parent asset's unique key as a prefix of the child asset unique keys to avoid this.