### PR TITLE
Improve performance of RSC builds

### DIFF
--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -67,6 +67,11 @@ export default async function applyRuntimes<TResult: RequestResult>({
   let connections: Array<RuntimeConnection> = [];
 
   let bundles = bundleGraph.getBundles({includeInline: true});
+  let publicBundleGraph = new BundleGraph<INamedBundle>(
+    bundleGraph,
+    NamedBundle.get.bind(NamedBundle),
+    options,
+  );
   for (let bundle of bundles) {
     for (let runtime of runtimes) {
       let measurement;
@@ -79,11 +84,7 @@ export default async function applyRuntimes<TResult: RequestResult>({
         );
         let applied = await runtime.plugin.apply({
           bundle: namedBundle,
-          bundleGraph: new BundleGraph<INamedBundle>(
-            bundleGraph,
-            NamedBundle.get.bind(NamedBundle),
-            options,
-          ),
+          bundleGraph: publicBundleGraph,
           config: configs.get(runtime.name)?.result,
           options: pluginOptions,
           logger: new PluginLogger({origin: runtime.name}),

--- a/packages/core/utils/src/import-map.js
+++ b/packages/core/utils/src/import-map.js
@@ -2,10 +2,23 @@
 import type {BundleGraph, NamedBundle} from '@parcel/types';
 import {normalizeSeparators} from './path';
 
+let importMapCache = new WeakMap();
+
 export function getImportMap(
   bundleGraph: BundleGraph<NamedBundle>,
   entryBundle: NamedBundle,
 ): {[string]: string} {
+  let cache = importMapCache.get(bundleGraph);
+  if (!cache) {
+    cache = new WeakMap();
+    importMapCache.set(bundleGraph, cache);
+  }
+
+  let cached = cache.get(entryBundle);
+  if (cached) {
+    return cached;
+  }
+
   let mappings = {};
   for (let childBundle of bundleGraph.getChildBundles(entryBundle)) {
     bundleGraph.traverseBundles((bundle, _, actions) => {
@@ -25,6 +38,7 @@ export function getImportMap(
     }, childBundle);
   }
 
+  cache.set(entryBundle, mappings);
   return mappings;
 }
 

--- a/packages/core/utils/src/import-map.js
+++ b/packages/core/utils/src/import-map.js
@@ -47,11 +47,7 @@ function isNewContext(
   bundleGraph: BundleGraph<NamedBundle>,
 ): boolean {
   let parents = bundleGraph.getParentBundles(bundle);
-  let isInEntryBundleGroup = bundleGraph
-    .getBundleGroupsContainingBundle(bundle)
-    .some(g => bundleGraph.isEntryBundleGroup(g));
   return (
-    isInEntryBundleGroup ||
     parents.length === 0 ||
     parents.some(
       parent =>

--- a/packages/packagers/react-static/src/ReactStaticPackager.js
+++ b/packages/packagers/react-static/src/ReactStaticPackager.js
@@ -45,6 +45,7 @@ let packagingBundles = new Map<NamedBundle, Async<{|contents: Blob|}>>();
 let moduleCache = new Map<string, ParcelModule>();
 let loadedBundles = new Map<NamedBundle, any>();
 let context: any = vm.createContext();
+let bundleLookupCache = new WeakMap();
 
 export default (new Packager({
   async loadConfig({options, config}) {
@@ -491,10 +492,18 @@ async function loadBundleUncached(
     publicUrl,
   };
 
+  let bundleLookup = bundleLookupCache.get(bundleGraph);
+  if (!bundleLookup) {
+    bundleLookup = new Map();
+    for (let bundle of bundleGraph.getBundles()) {
+      bundleLookup.set(bundle.publicId, bundle);
+      bundleLookup.set(bundle.name, bundle);
+    }
+    bundleLookupCache.set(bundleGraph, bundleLookup);
+  }
+
   parcelRequire.load = async (filePath: string) => {
-    let bundle = bundleGraph
-      .getBundles()
-      .find(b => b.publicId === filePath || b.name === filePath);
+    let bundle = bundleLookup?.get(filePath);
     if (bundle) {
       let {assets: subAssets} = await loadBundle(
         bundle,
@@ -514,9 +523,7 @@ async function loadBundleUncached(
   };
 
   parcelRequire.resolve = (url: string) => {
-    let bundle = bundleGraph
-      .getBundles()
-      .find(b => b.publicId === url || b.name === url);
+    let bundle = bundleLookup?.get(url);
     if (bundle) {
       return urlJoin(bundle.target.publicUrl, bundle.name);
     } else {

--- a/packages/packagers/react-static/src/ReactStaticPackager.js
+++ b/packages/packagers/react-static/src/ReactStaticPackager.js
@@ -331,15 +331,15 @@ async function loadBundleUncached(
 
   for (let b of bundleGraph.getReferencedBundles(bundle)) {
     if (b.type === 'js') {
-    queue.add(async () => {
-      let {assets: subAssets} = await loadBundle(
-        b,
-        bundleGraph,
-        getInlineBundleContents,
-      );
-      return Array.from(subAssets);
-    });
-  }
+      queue.add(async () => {
+        let {assets: subAssets} = await loadBundle(
+          b,
+          bundleGraph,
+          getInlineBundleContents,
+        );
+        return Array.from(subAssets);
+      });
+    }
   }
 
   let assets = new Map<string, [NamedBundle, Asset, string]>(

--- a/packages/packagers/react-static/src/ReactStaticPackager.js
+++ b/packages/packagers/react-static/src/ReactStaticPackager.js
@@ -311,7 +311,7 @@ async function loadBundleUncached(
             ],
           ];
         });
-      } else if (entryBundle) {
+      } else if (entryBundle?.type === 'js') {
         queue.add(async () => {
           let {assets: subAssets} = await loadBundle(
             entryBundle,
@@ -330,6 +330,7 @@ async function loadBundleUncached(
   });
 
   for (let b of bundleGraph.getReferencedBundles(bundle)) {
+    if (b.type === 'js') {
     queue.add(async () => {
       let {assets: subAssets} = await loadBundle(
         b,
@@ -338,6 +339,7 @@ async function loadBundleUncached(
       );
       return Array.from(subAssets);
     });
+  }
   }
 
   let assets = new Map<string, [NamedBundle, Asset, string]>(

--- a/packages/packagers/react-static/src/ReactStaticPackager.js
+++ b/packages/packagers/react-static/src/ReactStaticPackager.js
@@ -98,7 +98,9 @@ export default (new Packager({
       includeInline: false,
       includeIsolated: false,
     })) {
-      referencedBundles.push(b.getContentHash());
+      if (b.type === 'js') {
+        referencedBundles.push(b.getContentHash());
+      }
     }
 
     return {pages, referencedBundles};

--- a/packages/runtimes/rsc/src/RSCRuntime.js
+++ b/packages/runtimes/rsc/src/RSCRuntime.js
@@ -385,30 +385,7 @@ export default (new Runtime({
       bundle.env.isServer() &&
       bundleGraph.getParentBundles(bundle).length === 0
     ) {
-      let serverActions = '';
-      bundleGraph.traverse(node => {
-        if (
-          node.type === 'asset' &&
-          Array.isArray(node.value.meta?.directives) &&
-          node.value.meta.directives.includes('use server')
-        ) {
-          let bundlesWithAsset = bundleGraph.getBundlesWithAsset(node.value);
-          let bundles = new Set();
-          let referenced = bundleGraph.getReferencedBundles(
-            bundlesWithAsset[0],
-          );
-          bundles.add(normalizeSeparators(bundlesWithAsset[0].name));
-          for (let r of referenced) {
-            if (r.type === 'js' && r.env.context === bundle.env.context) {
-              bundles.add(normalizeSeparators(r.name));
-            }
-          }
-          serverActions += `  ${JSON.stringify(
-            bundleGraph.getAssetPublicId(node.value),
-          )}: ${JSON.stringify([...bundles])},\n`;
-        }
-      });
-
+      let serverActions = getServerActions(bundleGraph);
       let code = '';
       if (serverActions.length > 0) {
         code +=
@@ -460,4 +437,35 @@ function resolveURL(from, to) {
   }
 
   return `{parcelRequire.resolve(${JSON.stringify(to.publicId)})}`;
+}
+
+let serverActionsCache = new WeakMap();
+function getServerActions(bundleGraph) {
+  let cached = serverActionsCache.get(bundleGraph);
+  if (cached != null) {
+    return cached;
+  }
+  let serverActions = '';
+  bundleGraph.traverse(node => {
+    if (
+      node.type === 'asset' &&
+      Array.isArray(node.value.meta?.directives) &&
+      node.value.meta.directives.includes('use server')
+    ) {
+      let bundlesWithAsset = bundleGraph.getBundlesWithAsset(node.value);
+      let bundles = new Set();
+      let referenced = bundleGraph.getReferencedBundles(bundlesWithAsset[0]);
+      bundles.add(normalizeSeparators(bundlesWithAsset[0].name));
+      for (let r of referenced) {
+        if (r.type === 'js' && r.env.context === 'react-server') {
+          bundles.add(normalizeSeparators(r.name));
+        }
+      }
+      serverActions += `  ${JSON.stringify(
+        bundleGraph.getAssetPublicId(node.value),
+      )}: ${JSON.stringify([...bundles])},\n`;
+    }
+  });
+  serverActionsCache.set(bundleGraph, serverActions);
+  return serverActions;
 }


### PR DESCRIPTION
Caches import map and server actions, which are commonly accessed. Also only loads JS bundles in static packager.