### PR TITLE
Preserve siblings after <svg>

### DIFF
--- a/crates/html/src/optimize.rs
+++ b/crates/html/src/optimize.rs
@@ -389,10 +389,14 @@ pub fn optimize<'arena>(
           remove_whitespace(node, &options);
 
           if should_optimize_svg {
+            // Detach the node to prevent Oxvg from altering following siblings.
+            let parent = node.parent.take();
+            let previous_sibling = node.previous_sibling.take();
+            let next_sibling = node.next_sibling.take();
+
             // Synthesize a fake document node to act as the root of the SVG.
             let document = arena.alloc(Node::new(NodeData::Document, 0));
-            document.first_child.set(Some(node));
-            document.last_child.set(Some(node));
+            document.append(node);
 
             let jobs = options.minify_svg.into_jobs(OxvgKind::Html);
             match jobs.run(
@@ -402,6 +406,11 @@ pub fn optimize<'arena>(
               Err(_err) => {}
               Ok(()) => {}
             }
+
+            // Reattach in original position.
+            node.parent.set(parent);
+            node.previous_sibling.set(previous_sibling);
+            node.next_sibling.set(next_sibling);
           }
         }
         _ => {
@@ -820,6 +829,23 @@ mod tests {
     test(
       "<svg><style>.foo{fill:red}</style><rect width=100 height=100 class=foo /></svg>",
       "<svg><rect width=100 height=100 style=fill:red /></svg>",
+    );
+    test(
+      "<p>a</p><svg></svg><p>b</p><p>c</p>",
+      "<p>a</p><svg></svg><p>b</p><p>c</p>",
+    );
+    test(
+      "<main><svg><style>.foo{fill:red}</style><rect width=100 height=100 class=foo /></svg><span>after</span></main>",
+      "<main><svg><rect width=100 height=100 style=fill:red /></svg><span>after</span></main>",
+    );
+    test(
+      r#"<svg xmlns:editor2="link2" fill="" b="" xmlns:xlink="http://www.w3.org/1999/xlink" class="foo" xmlns:editor1="link1" xmlns="" d="">
+        <rect editor2:b="" editor1:b="" editor2:a="" editor1:a="" />
+      </svg>
+      <div>
+        <svg fill="" id="a"></svg>
+      </div>"#,
+      "<svg class=foo><rect></rect></svg>\n      <div>\n        <svg id=a></svg>\n      </div>",
     );
   }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

<!---
Provide a general summary of the pull request here
Please look for any issues that this PR resolves and tag them in the PR.
-->
This pull-request fixes issue #10172 where an `<svg>` tag makes the next siblings disappear.

## 💻 Examples

Let's say you have the following HTML:

```
<svg><circle/></svg>
<p>aaa</p>
<p>bbb</p>
```

You would expect `parcel build` to keep the `<p>` elements, but it actually removed those elements. What adds to the confusion is that the bug did not happen with `parcel serve` and `parcel build --no-optimize`. So, it will be nice to have this bug fixed.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Included links to related issues/PRs
