### PR TITLE
feat(webextension): add support for options_page manifest key

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -25,6 +25,7 @@ const DEP_LOCS = [
   ['background', 'scripts'],
   ['chrome_url_overrides'],
   ['devtools_page'],
+  ['options_page'],
   ['options_ui', 'page'],
   ['sandbox', 'pages'],
   ['side_panel', 'default_path'],

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -286,7 +286,8 @@ const commonProps = {
   }: SchemaEntity),
   optional_host_permissions: arrStr,
   optional_permissions: arrStr,
-  // options_page is deprecated
+  // options_page is a legacy key but still supported by Chrome and Firefox
+  options_page: string,
   options_ui: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

Add support for the `options_page` manifest key in web extensions, which was previously being ignored.

Closes #10076

## Changes

### schema.js
- Added `options_page` as a valid string property in `commonProps`
- Updated comment to reflect that `options_page` is a legacy key but still supported by browsers

### WebExtensionTransformer.js
- Added `['options_page']` to `DEP_LOCS` array so the file is processed as a dependency

## Background

While `options_ui` is the modern way to specify an options page, `options_page` is still fully supported by both:
- [Chrome](https://developer.chrome.com/docs/extensions/develop/ui/options-page)
- [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1816960) (added support in 2023)

The two keys are functionally equivalent - `options_page` just specifies a path directly while `options_ui.page` is nested in an object with additional options.

## Testing

The change follows the same pattern as existing `options_ui.page` handling. When a manifest contains:

```json
{
  "options_page": "options.html"
}
```

The `options.html` file will now be correctly bundled and processed.