### PR TITLE
feat(webextension): add support for `options_page` manifest key

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -25,6 +25,7 @@ const DEP_LOCS = [
   ['background', 'scripts'],
   ['chrome_url_overrides'],
   ['devtools_page'],
+  ['options_page'],
   ['options_ui', 'page'],
   ['sandbox', 'pages'],
   ['side_panel', 'default_path'],

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -286,7 +286,7 @@ const commonProps = {
   }: SchemaEntity),
   optional_host_permissions: arrStr,
   optional_permissions: arrStr,
-  // options_page is deprecated
+  options_page: string,
   options_ui: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

This PR adds support for the `options_page` manifest key in web extensions.

## Changes

- Add `options_page` to the schema as a string field in `schema.js`
- Add dependency resolution for `options_page` in `WebExtensionTransformer.js`

## Background

Although MDN marks `options_page` as deprecated, it is still widely supported:
- Chrome actively supports it (not marked deprecated in [Chrome docs](https://developer.chrome.com/docs/extensions/develop/ui/options-page))
- Firefox added support in Firefox 113 ([bugzilla.mozilla.org/1816960](https://bugzilla.mozilla.org/show_bug.cgi?id=1816960))

The `options_page` key is equivalent to `options_ui.page` and provides a simpler way to specify an options page without additional configuration like `open_in_tab`.

## Testing

Tested with a minimal manifest:
```json
{
  "name": "Test Extension",
  "version": "1.0.0",
  "manifest_version": 3,
  "options_page": "options.html"
}
```

Closes #10076