### PR TITLE
Add --no-cors option

### DIFF
--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -636,4 +636,57 @@ describe('server', function () {
 
     assert(data.includes(path.basename(localCSS.filePath)));
   });
+
+  it('should support cors by default', async function () {
+    let port = await getPort();
+    let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
+      defaultTargetOptions: {
+        distDir,
+      },
+      config,
+      serveOptions: {
+        https: false,
+        port: port,
+        host: 'localhost',
+      },
+    });
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let res = await fetch(`http://localhost:${port}/index.js`);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Methods'),
+      'GET, HEAD, PUT, PATCH, POST, DELETE',
+    );
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Headers'),
+      'Origin, X-Requested-With, Content-Type, Accept, Content-Type',
+    );
+  });
+
+  it('should support --no-cors', async function () {
+    let port = await getPort();
+    let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
+      defaultTargetOptions: {
+        distDir,
+      },
+      config,
+      serveOptions: {
+        https: false,
+        port: port,
+        host: 'localhost',
+        cors: false,
+      },
+    });
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let res = await fetch(`http://localhost:${port}/index.js`);
+    assert.equal(res.headers.has('Access-Control-Allow-Origin'), false);
+    assert.equal(res.headers.has('Access-Control-Allow-Methods'), false);
+    assert.equal(res.headers.has('Access-Control-Allow-Headers'), false);
+  });
 });

--- a/packages/core/parcel/src/cli.js
+++ b/packages/core/parcel/src/cli.js
@@ -173,6 +173,7 @@ var hmrOptions = {
   '--key <path>': 'path to private key to use with HTTPS',
   '--hmr-port <port>': ['hot module replacement port', process.env.HMR_PORT],
   '--hmr-host <host>': ['hot module replacement host', process.env.HMR_HOST],
+  '--no-cors': 'disable cors',
 };
 
 function applyOptions(cmd, options) {
@@ -484,13 +485,14 @@ async function normalizeOptions(
   }
 
   if (command.name() === 'serve') {
-    let {publicUrl} = command;
+    let {publicUrl, cors} = command;
 
     serveOptions = {
       https,
       port,
       host,
       publicUrl,
+      cors,
     };
   }
 
@@ -502,6 +504,7 @@ async function normalizeOptions(
     hmrOptions = {
       port: hmrport,
       host: hmrhost,
+      cors: command.cors,
     };
   }
 

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -103,6 +103,7 @@ export type RawParcelConfigPipeline = Array<PackageName>;
 export type HMROptions = {
   port?: number,
   host?: string,
+  cors?: boolean,
   ...
 };
 
@@ -405,6 +406,7 @@ export type InitialServerOptions = {|
   +host?: string,
   +port: number,
   +https?: HTTPSOptions | boolean,
+  +cors?: boolean,
 |};
 
 export interface PluginOptions {
@@ -432,6 +434,7 @@ export type ServerOptions = {|
   +port: number,
   +https?: HTTPSOptions | boolean,
   +publicUrl?: string,
+  +cors?: boolean,
 |};
 
 export type HTTPSOptions = {|

--- a/packages/reporters/dev-server/src/HMRServer.js
+++ b/packages/reporters/dev-server/src/HMRServer.js
@@ -110,7 +110,7 @@ export default class HMRServer {
         outputFS: this.options.outputFS,
         cacheDir: this.options.cacheDir,
         listener: (req, res) => {
-          setHeaders(res);
+          setHeaders(res, this.options.cors ?? true);
           if (req.method === 'OPTIONS') {
             res.statusCode = 200;
             res.end();

--- a/packages/reporters/dev-server/src/Server.js
+++ b/packages/reporters/dev-server/src/Server.js
@@ -32,16 +32,18 @@ import {createProxyMiddleware} from 'http-proxy-middleware';
 import {URL} from 'url';
 import fresh from 'fresh';
 
-export function setHeaders(res: Response) {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    'GET, HEAD, PUT, PATCH, POST, DELETE',
-  );
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'Origin, X-Requested-With, Content-Type, Accept, Content-Type',
-  );
+export function setHeaders(res: Response, cors: boolean) {
+  if (cors) {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader(
+      'Access-Control-Allow-Methods',
+      'GET, HEAD, PUT, PATCH, POST, DELETE',
+    );
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept, Content-Type',
+    );
+  }
   res.setHeader('Cache-Control', 'max-age=0, must-revalidate');
 }
 
@@ -479,7 +481,7 @@ export default class Server {
 
     const app = connect();
     app.use((req, res, next) => {
-      setHeaders(res);
+      setHeaders(res, this.options.cors ?? true);
       if (req.method === 'OPTIONS') {
         res.statusCode = 200;
         res.end();

--- a/packages/reporters/dev-server/src/ServerReporter.js
+++ b/packages/reporters/dev-server/src/ServerReporter.js
@@ -150,6 +150,7 @@ async function startDevServer(options, logger, isBrowser) {
         projectRoot: options.projectRoot,
         distDir: serveOptions.distDir,
         publicUrl: serveOptions.publicUrl ?? '/',
+        cors: serveOptions.cors,
       };
       hmrServer = new HMRServer(hmrServerOptions);
       hmrServers.set(serveOptions.port, hmrServer);
@@ -171,6 +172,8 @@ async function startDevServer(options, logger, isBrowser) {
       projectRoot: options.projectRoot,
       distDir: serveOptions ? serveOptions.distDir : null,
       publicUrl: serveOptions ? serveOptions.publicUrl ?? '/' : '/',
+      cors:
+        hmrOptions?.cors ?? (serveOptions ? serveOptions.cors : true) ?? true,
     };
     hmrServer = new HMRServer(hmrServerOptions);
     hmrServers.set(port, hmrServer);

--- a/packages/reporters/dev-server/src/types.js.flow
+++ b/packages/reporters/dev-server/src/types.js.flow
@@ -56,4 +56,5 @@ export type HMRServerOptions = {|
   projectRoot: FilePath,
   distDir: ?FilePath,
   publicUrl: string,
+  cors: ?boolean
 |};


### PR DESCRIPTION
Fixes #10216, closes #10138

Adds a `--no-cors` option to disable CORS headers in the dev server and hmr server.