### PR TITLE
fix: handle UTF-8 BOM in JSON parsing

### DIFF
--- a/packages/core/package-manager/src/JSONParseStream.js
+++ b/packages/core/package-manager/src/JSONParseStream.js
@@ -4,6 +4,7 @@ import type {JSONObject} from '@parcel/types';
 
 import logger from '@parcel/logger';
 import {Transform} from 'stream';
+import {stripBOM} from '@parcel/utils';
 
 // Transforms chunks of json strings to parsed objects.
 // Pair with split2 to parse stream of newline-delimited text.
@@ -21,7 +22,7 @@ export default class JSONParseStream extends Transform {
     try {
       let parsed;
       try {
-        parsed = JSON.parse(chunk.toString());
+        parsed = JSON.parse(stripBOM(chunk.toString()));
       } catch (e) {
         // Be permissive and ignoreJSON parse errors in case there was
         // a non-JSON line in the package manager's stdout.

--- a/packages/core/utils/src/config.js
+++ b/packages/core/utils/src/config.js
@@ -8,6 +8,7 @@ import clone from 'clone';
 import json5 from 'json5';
 import {parse as toml} from '@iarna/toml';
 import {LRUCache} from 'lru-cache';
+import stripBOM from './stripBOM';
 
 export type ConfigOutput = {|
   config: ConfigResult,
@@ -112,7 +113,7 @@ export async function readConfig(
   }
 
   try {
-    let configContent = await fs.readFile(configFile, 'utf8');
+    let configContent = stripBOM(await fs.readFile(configFile, 'utf8'));
     let config;
     if (parse === false) {
       config = configContent;

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -24,6 +24,7 @@ export {default as TapStream} from './TapStream';
 export {default as urlJoin} from './urlJoin';
 export {default as relativeUrl} from './relativeUrl';
 export {default as createDependencyLocation} from './dependency-location';
+export {default as stripBOM} from './stripBOM';
 export {default as debounce} from './debounce';
 export {default as throttle} from './throttle';
 export {default as openInBrowser} from './openInBrowser';

--- a/packages/core/utils/src/stripBOM.js
+++ b/packages/core/utils/src/stripBOM.js
@@ -1,0 +1,13 @@
+// @flow strict-local
+
+// UTF-8 BOM (Byte Order Mark) is the character \uFEFF at the start of a file.
+// Some editors on Windows (like Visual Studio) add this to UTF-8 files.
+// This function strips it if present to prevent JSON parse errors.
+const BOM = '\uFEFF';
+
+export default function stripBOM(content: string): string {
+  if (content.charCodeAt(0) === 0xfeff) {
+    return content.slice(1);
+  }
+  return content;
+}

--- a/packages/core/utils/src/stripBOM.js
+++ b/packages/core/utils/src/stripBOM.js
@@ -3,9 +3,9 @@
 // UTF-8 BOM (Byte Order Mark) is the character \uFEFF at the start of a file.
 // Some editors on Windows (like Visual Studio) add this to UTF-8 files.
 // This function strips it if present to prevent JSON parse errors.
-const BOM = '\uFEFF';
 
 export default function stripBOM(content: string): string {
+  // 0xFEFF is the UTF-8 BOM character code
   if (content.charCodeAt(0) === 0xfeff) {
     return content.slice(1);
   }

--- a/packages/core/utils/test/stripBOM.test.js
+++ b/packages/core/utils/test/stripBOM.test.js
@@ -1,0 +1,36 @@
+// @flow strict-local
+
+import assert from 'assert';
+import stripBOM from '../src/stripBOM';
+
+describe('stripBOM', () => {
+  it('should strip UTF-8 BOM from the start of a string', () => {
+    const withBOM = '\uFEFF{"name": "test"}';
+    const result = stripBOM(withBOM);
+    assert.strictEqual(result, '{"name": "test"}');
+  });
+
+  it('should not modify strings without BOM', () => {
+    const withoutBOM = '{"name": "test"}';
+    const result = stripBOM(withoutBOM);
+    assert.strictEqual(result, '{"name": "test"}');
+  });
+
+  it('should handle empty strings', () => {
+    const empty = '';
+    const result = stripBOM(empty);
+    assert.strictEqual(result, '');
+  });
+
+  it('should only strip BOM at the beginning', () => {
+    const bomInMiddle = '{"name": "\uFEFFtest"}';
+    const result = stripBOM(bomInMiddle);
+    assert.strictEqual(result, '{"name": "\uFEFFtest"}');
+  });
+
+  it('should allow JSON.parse to work after stripping BOM', () => {
+    const withBOM = '\uFEFF{"name": "test", "version": "1.0.0"}';
+    const result = JSON.parse(stripBOM(withBOM));
+    assert.deepStrictEqual(result, {name: 'test', version: '1.0.0'});
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #8378

Some editors on Windows (like Visual Studio) add a UTF-8 BOM (Byte Order Mark) character (`\uFEFF`) at the beginning of files. This caused JSON parse errors like:

```
Error parsing package.json: Unexpected token ﻿ in JSON at position 0
```

## Changes

- Add `stripBOM` utility function to `@parcel/utils`
- Apply BOM stripping in config file loading (`readConfig`)
- Apply BOM stripping in `JSONParseStream` for package manager output
- Add unit tests for `stripBOM` function

## Approach

This approach is similar to how npm and Yarn handle BOM characters:
- [Yarn's implementation](https://github.com/yarnpkg/berry/blob/863a2c486e6959dc465c37972d5fa735b64ae6bd/packages/yarnpkg-core/sources/Manifest.ts#L137)
- [npm's json-parse-even-better-errors](https://github.com/npm/json-parse-even-better-errors/blob/74c9a7e27cf4884568c8e956f37f5911f1cbec8f/index.js#L112)

## Test plan

- [x] Added unit tests for `stripBOM` function
- [ ] Manual testing with a BOM-prefixed package.json file


Made with [Cursor](https://cursor.com)