### PR TITLE
Fix #9769: 该 Issue 指出 JS Transformer 在处理较新的 core-js 特性（如 3.24 版本引入的 s...

### DIFF
--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -104,6 +104,7 @@ pub struct Config {
   pub is_swc_helpers: bool,
   pub standalone: bool,
   pub inline_constants: bool,
+  pub core_js_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -463,6 +464,9 @@ pub fn transform(
               preset_env_config.shipped_proposals = true;
               preset_env_config.mode = Some(Entry);
               preset_env_config.bugfixes = true;
+              if let Some(core_js_version) = &config.core_js_version {
+                preset_env_config.core_js = Some(core_js_version.clone().into());
+              }
             }
           }
 

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -319,6 +319,20 @@ export default (new Transformer({
         conf.contents?.unstable_inlineConstants ?? inlineConstants;
     }
 
+    // Detect core-js version for polyfills
+    let coreJsVersion = null;
+    let coreJsRange =
+      pkg?.dependencies?.['core-js'] ||
+      pkg?.devDependencies?.['core-js'] ||
+      pkg?.peerDependencies?.['core-js'];
+    if (coreJsRange) {
+      let minVersion = semver.minVersion(coreJsRange);
+      if (minVersion) {
+        // SWC expects the version in "major.minor" format (e.g., "3.37")
+        coreJsVersion = `${minVersion.major}.${minVersion.minor}`;
+      }
+    }
+
     return {
       isJSX,
       automaticJSXRuntime,
@@ -331,6 +345,7 @@ export default (new Transformer({
       reactRefresh,
       decorators,
       useDefineForClassFields,
+      coreJsVersion,
     };
   },
   async transform({asset, config, options, logger}) {
@@ -473,6 +488,7 @@ export default (new Transformer({
       is_swc_helpers: /@swc[/\\]helpers/.test(asset.filePath),
       standalone: asset.query.has('standalone'),
       inline_constants: config.inlineConstants,
+      core_js_version: config?.coreJsVersion,
       callMacro: asset.isSource
         ? async (err, src, exportName, args, loc) => {
             let mod;


### PR DESCRIPTION
Fixes #9769

Fix for #9769: 该 Issue 指出 JS Transformer 在处理较新的 core-js 特性（如 3.24 版本引入的 structuredClone）时，未能正确注入所需的 Polyfill，导致旧版浏览器报错。问题根源在于 SWC 默认将 core-js 版本视为 3.0，导致其忽略 3.0 之后添加的特性支持。