### PR TITLE
docs: fix various typos in source and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ When developing plugins, you should disable caching with the `--no-cache` CLI or
 
 _Please don't commit these examples._
 
-You can create a temporary example for debugging in the folder `packages/examples`. Start by copying the `simple` example and try to reproduce the bug. It has everything setup for working on local changes and you can run `yarn build` to build the project. If you're re-using another example or creating one from scratch, make sure to use the `--no-cache` flag for `parcel build` to see your local changes reflected.
+You can create a temporary example for debugging in the folder `packages/examples`. Start by copying the `simple` example and try to reproduce the bug. It has everything setup for working on local changes and you can run `yarn build` to build the project. If you're reusing another example or creating one from scratch, make sure to use the `--no-cache` flag for `parcel build` to see your local changes reflected.
 
 ### Testing outside of the monorepo
 

--- a/crates/html/src/oxvg.rs
+++ b/crates/html/src/oxvg.rs
@@ -1005,7 +1005,7 @@ impl PartialEq for Element<'_> {
   }
 }
 
-/// A whitespace seperated set of tokens of a class attribute's value.
+/// A whitespace separated set of tokens of a class attribute's value.
 pub struct ClassList<'arena> {
   attrs: Attributes<'arena>,
   tokens: Vec<StrTendril>,

--- a/crates/parcel-resolver/src/error.rs
+++ b/crates/parcel-resolver/src/error.rs
@@ -3,7 +3,7 @@ use crate::specifier::SpecifierError;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// An error that occcured during resolution.
+/// An error that occurred during resolution.
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
 #[serde(tag = "type")]
 pub enum ResolverError {

--- a/docs/Symbol Propagation.md
+++ b/docs/Symbol Propagation.md
@@ -181,7 +181,7 @@ For better codesplitting and to hide the fact that symbol propagation runs on th
 To compute this information of where a symbol resolves to, the up traversal doesn't work with sets of symbols anymore but with a [map that lists the symbols together with the asset that symbol resolves to](https://github.com/parcel-bundler/parcel/blob/f65889ebd768e9b2e146537b47d4d5d82ff177b8/packages/core/core/src/types.js#L324-L333). The rules are:
 
 - if a symbol is exported directly (not reexported), then this is stored as the map entry value.
-- if a symbol is reexported and the reexporting asset is side-effect free and the symbol unambigously resolves to a single reexport, then the map entry value is just copied over from the outgoing dependency (and still points to the original asset).
+- if a symbol is reexported and the reexporting asset is side-effect free and the symbol unambiguously resolves to a single reexport, then the map entry value is just copied over from the outgoing dependency (and still points to the original asset).
 - otherwise if a symbol is reexported, then the map entry value is instead the reexporting asset (which will lead to a correct lookup at runtime, as described [above](#two-passes)).
 
 The rewriting of dependencies then happens in [`BundleGraph.fromAssetGraph`.](https://github.com/parcel-bundler/parcel/blob/6211c79f30e8fe2a1e079339277f11dba4acab2c/packages/core/core/src/BundleGraph.js#L210-L226)

--- a/flow-libs/commander.js.flow
+++ b/flow-libs/commander.js.flow
@@ -93,7 +93,7 @@ declare module 'commander' {
      * Validation of option argument failed.
      * Intended for use from custom argument processing functions.
      */
-    argumentRejected(messsage: string): empty;
+    argumentRejected(message: string): empty;
 
     /**
      * Only allow option value to be one of choices.

--- a/flow-libs/node-ipc.js.flow
+++ b/flow-libs/node-ipc.js.flow
@@ -46,7 +46,7 @@ declare module 'node-ipc' {
      * https://www.npmjs.com/package/node-ipc#connecttonet
      * Used to connect as a client to a TCP or TLS socket via the network card.
      * This can be local or remote, if local, it is recommended that you use the Unix
-     * and Windows Socket Implementaion of connectTo instead as it is much faster since it avoids the network card altogether.
+     * and Windows Socket Implementation of connectTo instead as it is much faster since it avoids the network card altogether.
      * For TLS and SSL Sockets see the node-ipc TLS and SSL docs.
      * They have a few additional requirements, and things to know about and so have their own doc.
      * @param id is the string id of the socket being connected to. For TCP & TLS sockets,
@@ -66,7 +66,7 @@ declare module 'node-ipc' {
      * https://www.npmjs.com/package/node-ipc#connecttonet
      * Used to connect as a client to a TCP or TLS socket via the network card.
      * This can be local or remote, if local, it is recommended that you use the Unix
-     * and Windows Socket Implementaion of connectTo instead as it is much faster since it avoids the network card altogether.
+     * and Windows Socket Implementation of connectTo instead as it is much faster since it avoids the network card altogether.
      * For TLS and SSL Sockets see the node-ipc TLS and SSL docs.
      * They have a few additional requirements, and things to know about and so have their own doc.
      * @param id is the string id of the socket being connected to. For TCP & TLS sockets,
@@ -78,7 +78,7 @@ declare module 'node-ipc' {
      * https://www.npmjs.com/package/node-ipc#connecttonet
      * Used to connect as a client to a TCP or TLS socket via the network card.
      * This can be local or remote, if local, it is recommended that you use the Unix
-     * and Windows Socket Implementaion of connectTo instead as it is much faster since it avoids the network card altogether.
+     * and Windows Socket Implementation of connectTo instead as it is much faster since it avoids the network card altogether.
      * For TLS and SSL Sockets see the node-ipc TLS and SSL docs.
      * They have a few additional requirements, and things to know about and so have their own doc.
      * @param id is the string id of the socket being connected to.


### PR DESCRIPTION
Fix minor typos in source comments and documentation:\n- 'occcured' -> 'occurred' in crates/parcel-resolver/src/error.rs\n- 'seperated' -> 'separated' in crates/html/src/oxvg.rs\n- 'unambigously' -> 'unambiguously' in docs/Symbol Propagation.md\n- 're-using' -> 'reusing' in CONTRIBUTING.md\n- 'messsage' -> 'message' in flow-libs/commander.js.flow\n- 'Implementaion' -> 'Implementation' in flow-libs/node-ipc.js.flow