### PR TITLE
feat: support options_page key in web extension manifests

### DIFF
--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -25,6 +25,7 @@ const DEP_LOCS = [
   ['background', 'scripts'],
   ['chrome_url_overrides'],
   ['devtools_page'],
+  ['options_page'],
   ['options_ui', 'page'],
   ['sandbox', 'pages'],
   ['side_panel', 'default_path'],

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -286,7 +286,7 @@ const commonProps = {
   }: SchemaEntity),
   optional_host_permissions: arrStr,
   optional_permissions: arrStr,
-  // options_page is deprecated
+  options_page: string,
   options_ui: {
     type: 'object',
     properties: {


### PR DESCRIPTION
The \`options_page\` manifest key (deprecated in favor of \`options_ui\` but still widely used) wasn't recognized by Parcel's webextension transformer. Added it to the schema validation and the dependency collector so it gets bundled as an isolated HTML entry, same as \`options_ui.page\` already does.

Two-line change — one in the schema, one in the dep locations array.

Fixes #10076