### PR TITLE
fix: add options_page support to webextension transformer

### DIFF
--- a/packages/core/integration-tests/test/integration/webextension-mv3/manifest.json
+++ b/packages/core/integration-tests/test/integration/webextension-mv3/manifest.json
@@ -22,5 +22,6 @@
   },
   "side_panel": {
     "default_path": "side-panel.html"
-  }
+  },
+  "options_page": "options.html"
 }

--- a/packages/core/integration-tests/test/integration/webextension-mv3/options.html
+++ b/packages/core/integration-tests/test/integration/webextension-mv3/options.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Options</title>
+</head>
+<body>
+  <h1>Options</h1>
+</body>
+</html>

--- a/packages/core/integration-tests/test/webextension.js
+++ b/packages/core/integration-tests/test/webextension.js
@@ -115,6 +115,7 @@ describe('webextension', function () {
       {assets: ['popup.css']},
       {assets: ['popup.js', 'esmodule-helpers.js']},
       {assets: ['side-panel.html']},
+      {assets: ['options.html']},
       {assets: ['content-script.js']},
       {assets: ['other-content-script.js']},
       {assets: ['injected.css']},
@@ -128,6 +129,11 @@ describe('webextension', function () {
       (await outputFS.readFile(path.join(distDir, css[0]), 'utf-8')).includes(
         'Comic Sans MS',
       ),
+    );
+    assert(manifest.options_page, 'options_page should be set in manifest');
+    assert(
+      await outputFS.exists(path.join(distDir, manifest.options_page)),
+      'options_page file should exist in output',
     );
   });
   // TODO: Test error-checking

--- a/packages/transformers/webextension/src/WebExtensionTransformer.js
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.js
@@ -25,6 +25,7 @@ const DEP_LOCS = [
   ['background', 'scripts'],
   ['chrome_url_overrides'],
   ['devtools_page'],
+  ['options_page'],
   ['options_ui', 'page'],
   ['sandbox', 'pages'],
   ['side_panel', 'default_path'],

--- a/packages/transformers/webextension/src/schema.js
+++ b/packages/transformers/webextension/src/schema.js
@@ -286,7 +286,7 @@ const commonProps = {
   }: SchemaEntity),
   optional_host_permissions: arrStr,
   optional_permissions: arrStr,
-  // options_page is deprecated
+  options_page: string,
   options_ui: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

Closes #10076

Adds support for the `options_page` manifest key in Parcel's webextension transformer.

### What changed
- allow `options_page` in the webextension schema
- treat `options_page` as a dependency so the referenced HTML is bundled
- extend the MV3 integration fixture/test to assert:\n  - `options_page` is preserved in the output manifest\n  - the referenced `options.html` file exists in dist

### Why
Currently Parcel supports keys like `devtools_page`, `side_panel.default_path`, and `options_ui.page`, but not the legacy/single-page `options_page` key. This causes valid webextension manifests using `options_page` to miss bundling/validation support.

This patch keeps the change minimal and adds regression coverage.