### PR TITLE
fix: duplicated words in parcel docs and resolveOptions comment

### DIFF
--- a/docs/AdjacencyList.md
+++ b/docs/AdjacencyList.md
@@ -305,7 +305,7 @@ The `EdgeTypeMap` extends `SharedTypeMap` with API for:
 Edges are identified by a hash of their `to`, `from`, and `type` values.
 
 For any given set of these values, the hash function deterministically produces
-a number that that fits within the **current capacity** of the `EdgeTypeMap`.
+a number that fits within the **current capacity** of the `EdgeTypeMap`.
 
 That hash number is then the index in the hash table where the _head_
 of the linked list of edges with this hash is stored.

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -75,7 +75,7 @@ export default async function resolveOptions(
   }
 
   // getRootDir treats the input as files, so getRootDir(["/home/user/myproject"]) returns "/home/user".
-  // Instead we need to make the the entry refer to some file inside the specified folders if entries refers to the directory.
+  // Instead we need to make the entry refer to some file inside the specified folders if entries refers to the directory.
   let entryRoot = getRootDir(
     shouldMakeEntryReferFolder ? [path.join(entries[0], 'index')] : entries,
   );

--- a/packages/transformers/js/hoist.md
+++ b/packages/transformers/js/hoist.md
@@ -19,7 +19,7 @@ The new scope hoisting implementation operates in just two phases.
 
 ## Transforming
 
-The hoist phase should do as much work as possible as it operates on ASTs and and in parallel on individual files. It's also implemented in Rust using SWC for performance.
+The hoist phase should do as much work as possible as it operates on ASTs and in parallel on individual files. It's also implemented in Rust using SWC for performance.
 
 This is implemented in two passes. The first pass analyzes and collects data about the module, which is used in the second pass, which actually transforms the module.
 


### PR DESCRIPTION
Three one-line typo fixes for duplicated words:
- `packages/transformers/js/hoist.md` — "ASTs and and in parallel" → "ASTs and in parallel"
- `packages/core/core/src/resolveOptions.js` — "make the the entry refer to" → "make the entry refer to"
- `docs/AdjacencyList.md` — "a number that that fits within" → "a number that fits within"

No code/behavior change.