### PR TITLE
fix(core): improve error message when mixing nightly and stable packages

### DIFF
--- a/packages/core/core/src/loadParcelPlugin.js
+++ b/packages/core/core/src/loadParcelPlugin.js
@@ -202,10 +202,23 @@ export default async function loadPlugin<T>(
           ),
         );
         let pkgContents = await options.inputFS.readFile(pkgFile, 'utf8');
+
+        let hints = [];
+        let isPluginNightly = parcelVersionRange.includes('nightly');
+        let isParcelNightly = PARCEL_VERSION.includes('nightly');
+        if (isPluginNightly !== isParcelNightly) {
+          hints.push(
+            isParcelNightly
+              ? 'You are using a nightly version of Parcel. Install nightly versions of all Parcel plugins, or switch to stable releases for everything.'
+              : 'The plugin requires a nightly version of Parcel. Install stable versions of all Parcel packages, or switch to nightly releases for everything.',
+          );
+        }
+
         throw new ThrowableDiagnostic({
           diagnostic: {
             message: md`The plugin "${pluginName}" is not compatible with the current version of Parcel. Requires "${parcelVersionRange}" but the current version is "${PARCEL_VERSION}".`,
             origin: '@parcel/core',
+            hints,
             codeFrames: [
               {
                 filePath: pkgFile,


### PR DESCRIPTION
When a plugin version mismatch occurs due to mixing nightly and stable Parcel packages, the error now includes a hint explaining the issue and suggesting to use either all nightly or all stable versions.

The issue happened when users installed a nightly plugin with stable Parcel (or vice versa). The error just said versions didn't match, without explaining why. Now when the mismatch is specifically between nightly and stable, it shows a helpful hint like:

- 'You are using a nightly version of Parcel. Install nightly versions of all Parcel plugins, or switch to stable releases for everything.'
- 'The plugin requires a nightly version of Parcel. Install stable versions of all Parcel packages, or switch to nightly releases for everything.'

Fixes #7946