### PR TITLE
fix(core): error when entry glob matches no files

### DIFF
--- a/packages/core/core/src/loadParcelPlugin.js
+++ b/packages/core/core/src/loadParcelPlugin.js
@@ -202,10 +202,23 @@ export default async function loadPlugin<T>(
           ),
         );
         let pkgContents = await options.inputFS.readFile(pkgFile, 'utf8');
+
+        let hints = [];
+        let isPluginNightly = parcelVersionRange.includes('nightly');
+        let isParcelNightly = PARCEL_VERSION.includes('nightly');
+        if (isPluginNightly !== isParcelNightly) {
+          hints.push(
+            isParcelNightly
+              ? 'You are using a nightly version of Parcel. Install nightly versions of all Parcel plugins, or switch to stable releases for everything.'
+              : 'The plugin requires a nightly version of Parcel. Install stable versions of all Parcel packages, or switch to nightly releases for everything.',
+          );
+        }
+
         throw new ThrowableDiagnostic({
           diagnostic: {
             message: md`The plugin "${pluginName}" is not compatible with the current version of Parcel. Requires "${parcelVersionRange}" but the current version is "${PARCEL_VERSION}".`,
             origin: '@parcel/core',
+            hints,
             codeFrames: [
               {
                 filePath: pkgFile,

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -173,6 +173,16 @@ export class EntryResolver {
         absolute: true,
         onlyFiles: false,
       });
+      if (files.length === 0) {
+        throw new ThrowableDiagnostic({
+          diagnostic: {
+            message: md`No files found matching entry glob ${entry}`,
+            hints: [
+              'If you are trying to use a literal file path containing special characters like { or }, escape them or use a path without glob characters.',
+            ],
+          },
+        });
+      }
       let results = await Promise.all(
         files.map(f => this.resolveEntry(path.normalize(f))),
       );


### PR DESCRIPTION
Previously, when an entry path was interpreted as a glob (containing characters like { or }) but matched no files, parcel would silently succeed without building anything. This was particularly confusing on Windows where directory names like 'test {dir}' would cause the build to complete with no output.

The fix adds a check after glob matching to throw an error when no files match, with a hint suggesting to escape special characters if they were not intended as glob syntax.

Example:

Before:
\\\
$ parcel build 'foo{bar}'
Built in 209ms
\\\

After:
\\\
$ parcel build 'foo{bar}'
Error: No files found matching entry glob foo{bar}
Hint: If you are trying to use a literal file path containing special characters like { or }, escape them or use a path without glob characters.
\\\

Fixes #7486