### PR TITLE
[workers] skip more argv for node 24.7.0+

### DIFF
--- a/packages/core/workers/src/Worker.js
+++ b/packages/core/workers/src/Worker.js
@@ -52,7 +52,7 @@ export default class Worker extends EventEmitter {
     if (process.execArgv) {
       filteredArgs = process.execArgv.filter(
         v =>
-          !/^--(debug|inspect|no-opt|max-old-space-size=|max-semi-space-size=|expose-gc)/.test(
+          !/^--(debug|inspect|no-opt|max-old-space-size=|max-semi-space-size=|expose-gc|tls-cipher-list=|v8-pool-size=|trace-event-file-pattern=|secure-heap(-min)?=|node-snapshot|use-largepages=|stack-trace-limit=)/.test(
             v,
           ),
       );

--- a/packages/core/workers/test/Worker.test.js
+++ b/packages/core/workers/test/Worker.test.js
@@ -1,0 +1,161 @@
+import assert from 'assert';
+
+import Worker from '../src/Worker';
+
+const PROCESS_WORKER_PATH = require.resolve('../src/process/ProcessWorker');
+
+// Stub the ProcessWorker backend so we can capture the execArgv that Worker.fork()
+// passes to it, without spawning a real child process. The backend's start() is
+// rejected so fork() bails out fast after the constructor runs.
+function installBackendStub() {
+  let captured = {args: null};
+  let previous = require.cache[PROCESS_WORKER_PATH];
+
+  class FakeBackend {
+    constructor(execArgv) {
+      captured.args = execArgv;
+    }
+    start() {
+      return Promise.reject(new Error('halt — backend stubbed by test'));
+    }
+    stop() {
+      return Promise.resolve();
+    }
+    send() {}
+  }
+
+  require.cache[PROCESS_WORKER_PATH] = {
+    id: PROCESS_WORKER_PATH,
+    filename: PROCESS_WORKER_PATH,
+    loaded: true,
+    children: [],
+    paths: [],
+    exports: {__esModule: true, default: FakeBackend},
+  };
+
+  return {
+    captured,
+    restore() {
+      if (previous) {
+        require.cache[PROCESS_WORKER_PATH] = previous;
+      } else {
+        delete require.cache[PROCESS_WORKER_PATH];
+      }
+    },
+  };
+}
+
+async function getFilteredArgs(execArgv) {
+  let originalExecArgv = process.execArgv;
+  let originalNodeOptions = process.env.NODE_OPTIONS;
+  let stub = installBackendStub();
+  process.execArgv = execArgv;
+  delete process.env.NODE_OPTIONS;
+  try {
+    let worker = new Worker({
+      forcedKillTime: 100,
+      backend: 'process',
+      sharedReferences: new Map(),
+    });
+    await assert.rejects(() => worker.fork(__filename));
+    return stub.captured.args;
+  } finally {
+    process.execArgv = originalExecArgv;
+    if (originalNodeOptions === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = originalNodeOptions;
+    }
+    stub.restore();
+  }
+}
+
+describe('Worker.fork execArgv filtering', () => {
+  it('strips debugger and inspector flags', async () => {
+    assert.deepStrictEqual(
+      await getFilteredArgs([
+        '--inspect',
+        '--inspect-brk',
+        '--inspect=0.0.0.0:9229',
+        '--debug',
+        '--debug-brk',
+      ]),
+      [],
+    );
+  });
+
+  it('strips V8 tuning flags', async () => {
+    assert.deepStrictEqual(
+      await getFilteredArgs([
+        '--no-opt',
+        '--max-old-space-size=4096',
+        '--max-semi-space-size=64',
+        '--expose-gc',
+      ]),
+      [],
+    );
+  });
+
+  it('strips flags that crashed workers on node 24.7.0+', async () => {
+    assert.deepStrictEqual(
+      await getFilteredArgs([
+        '--tls-cipher-list=HIGH',
+        '--v8-pool-size=4',
+        '--trace-event-file-pattern=trace-${pid}.log',
+        '--secure-heap=8192',
+        '--secure-heap-min=4096',
+        '--node-snapshot',
+        '--use-largepages=on',
+        '--stack-trace-limit=20',
+      ]),
+      [],
+    );
+  });
+
+  it('strips -r @parcel/register and --title together with their values', async () => {
+    assert.deepStrictEqual(
+      await getFilteredArgs([
+        '-r',
+        '@parcel/register',
+        '--require',
+        '@parcel/register',
+        '--title',
+        'parcel-worker',
+      ]),
+      [],
+    );
+  });
+
+  it('keeps -r/--require when the value is not @parcel/register', async () => {
+    assert.deepStrictEqual(
+      await getFilteredArgs([
+        '-r',
+        'ts-node/register',
+        '--require',
+        'dotenv/config',
+      ]),
+      ['-r', 'ts-node/register', '--require', 'dotenv/config'],
+    );
+  });
+
+  it('keeps unrelated flags', async () => {
+    let argv = ['--enable-source-maps', '--experimental-vm-modules'];
+    assert.deepStrictEqual(await getFilteredArgs(argv), argv);
+  });
+
+  it('handles a mix of excluded and preserved flags', async () => {
+    assert.deepStrictEqual(
+      await getFilteredArgs([
+        '--enable-source-maps',
+        '--max-old-space-size=4096',
+        '--stack-trace-limit=20',
+        '-r',
+        '@parcel/register',
+        '--experimental-vm-modules',
+        '--title',
+        'parcel-worker',
+      ]),
+      ['--enable-source-maps', '--experimental-vm-modules'],
+    );
+  });
+});


### PR DESCRIPTION
# ↪️ Pull Request

Apply the patch suggested in https://github.com/parcel-bundler/parcel/issues/10238#issuecomment-4470152117 to fix https://github.com/parcel-bundler/parcel/issues/10238

When using node 24.7.0+, Parcel can crash because of new argvs:

```
  Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid execArgv flags: --stack-trace-limit=10, --tls-cipher-list=TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES256-SHA384:ECDHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA256:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA, --use-largepages=off, --secure-heap-min=2, --v8-pool-size=4, --node-snapshot, --trace-event-file-pattern=node_trace.${rotation}.log, --secure-heap=0
```

## 💻 Examples

Check out https://github.com/Ayc0/code-splitting-tests and remove the patch (that applies this PR) to see the crash

## 🚨 Test instructions

New tests were added

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
