### PR TITLE
Fix/bundle graph partial reuse

### DIFF
--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -65,6 +65,10 @@ type BundleGraphRequestInput = {|
 
 type BundleGraphRequestResult = {|
   bundleGraph: InternalBundleGraph,
+  // Mirrors `BundleGraphResult.incomplete`. The previous-result read at
+  // `previousBundleGraphResult` checks this to refuse reuse of a partial
+  // graph cached after a build error (see #9366).
+  incomplete?: boolean,
 |};
 
 type RunInput = {|
@@ -77,6 +81,10 @@ export type BundleGraphResult = {|
   bundleGraph: InternalBundleGraph,
   changedAssets: Map<string, Asset>,
   assetRequests: Array<AssetGroup>,
+  // Set when the result is cached after a build error (see #9366). Such a
+  // bundle graph may be missing names/runtimes and must not be reused as an
+  // incremental baseline.
+  incomplete?: boolean,
 |};
 
 type BundleGraphRequest = {|
@@ -272,6 +280,12 @@ class BundlerRunner {
         // if the bundle graph had an error or was removed, don't fail the build
       }
     }
+    // Refuse to reuse a bundle graph that was cached after a failed build
+    // (see #9366). It may be missing names/runtimes and is not a safe
+    // incremental baseline.
+    if (previousBundleGraphResult?.incomplete) {
+      previousBundleGraphResult = null;
+    }
     if (previousBundleGraphResult == null) {
       graph.safeToIncrementallyBundle = false;
     }
@@ -383,11 +397,16 @@ class BundlerRunner {
       }
     } catch (e) {
       if (internalBundleGraph != null) {
+        // Cached for failure diagnostics (#9366). Tag as incomplete so the next
+        // build does not pick it up as an incremental baseline — the graph may
+        // be missing names/runtimes if we aborted mid-bundling, which would
+        // crash PackagerRunner with `nullthrows(bundle.name)`.
         this.api.storeResult(
           {
             bundleGraph: internalBundleGraph,
             changedAssets: new Map(),
             assetRequests: [],
+            incomplete: true,
           },
           this.cacheKey,
         );

--- a/packages/core/integration-tests/test/incremental-bundling.js
+++ b/packages/core/integration-tests/test/incremental-bundling.js
@@ -1034,3 +1034,82 @@ module.exports = {a}
     }
   });
 });
+
+describe('bundle graph cached on build failure', function () {
+  // Regression test for the race surface introduced by #9366.
+  //
+  // When BundleGraphRequest throws after the bundler has already created
+  // bundles (e.g. an AbortSignal fires mid-build because the watcher
+  // observed a file change), the catch block caches the partially-built
+  // bundle graph for diagnostics. Without an `incomplete` marker, the
+  // next BundleGraphRequest picks that graph up via getPreviousResult,
+  // skips nameBundle/applyRuntimes/validateBundles, and crashes
+  // downstream in PackagerRunner where every site that touches
+  // `bundle.name` runs nullthrows.
+  it('does not reuse a bundle graph stored after a failed build', async () => {
+    let subscription;
+    let fixture = path.join(__dirname, '/integration/incremental-bundling');
+    let Bundler = (
+      await packageManager.require('@parcel/bundler-default', __filename)
+    ).default;
+    let originalBundle = Bundler[CONFIG].bundle;
+    let throwOnce = true;
+    // sinon's flow types declare callsFake's fn as returning void, but it
+    // works fine with a promise-returning fn — we need this so the real
+    // bundler can populate internalBundleGraph before we throw.
+    let stub = sinon.stub(Bundler[CONFIG], 'bundle');
+    // $FlowFixMe[incompatible-call]
+    stub.callsFake(async function (opts) {
+      // Drive the real bundler to populate `internalBundleGraph` with
+      // (unnamed) bundles, then throw the way an abort signal would.
+      await originalBundle.call(this, opts);
+      if (throwOnce) {
+        throwOnce = false;
+        throw new Error('simulated abort mid-bundling');
+      }
+    });
+    try {
+      let b = bundler(path.join(fixture, 'index.js'), {
+        inputFS: overlayFS,
+        shouldDisableCache: false,
+        shouldBundleIncrementally: true,
+      });
+      await overlayFS.mkdirp(fixture);
+      subscription = await b.watch();
+
+      let failure = await getNextBuildSuccess(b).then(
+        () => null,
+        e => e,
+      );
+      // The first build should fail because of the injected throw.
+      assert.ok(failure != null, 'expected the first build to fail');
+      assert.equal(throwOnce, false, 'bundler stub should have been invoked');
+
+      // Modify the entry to trigger a second build. Without the fix, this
+      // build picks up the partial bundle graph cached by the catch path
+      // above and crashes with `nullthrows(bundle.name)` somewhere in
+      // PackagerRunner. With the fix, the cached partial graph is tagged
+      // `incomplete: true` and rejected by the reuse check, so a fresh
+      // bundle graph is built and the build succeeds.
+      await overlayFS.writeFile(
+        path.join(fixture, 'index.js'),
+        `import {a} from './a';
+console.log('recovered build', a);`,
+      );
+      let recovered = await getNextBuildSuccess(b);
+
+      for (let bundle of recovered.bundleGraph.getBundles()) {
+        assert.ok(
+          bundle.name != null,
+          `bundle ${bundle.id} should have a name after recovery`,
+        );
+      }
+    } finally {
+      stub.restore();
+      if (subscription) {
+        await subscription.unsubscribe();
+        subscription = null;
+      }
+    }
+  });
+});


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #10322 — `parcel serve` (and any watch-mode build) crashes with `Got unexpected null at nullthrows(bundle.name)` after a `BundleGraphRequest` aborts mid-bundling.

**LLM DISCLAIMER:** This is a real bug I ran into which I wouldn't have fixed without LLM assistance. The fix is valuable to me and I did my best to bring it into line with repo standards, but I can live without it, for sure. I offer the fix it came up with here, which looks pretty reasonable and contained. More on this subject in https://github.com/parcel-bundler/parcel/issues/10322.

**What's happening**: `BundleGraphRequest` runs the bundler inside a `try` block, then runs `nameBundle Promise.all`, `applyRuntimes`, and `validateBundles` *afterwards*. When anything inside the `try` throws — e.g. a `BuildAbortError` from `assertSignalNotAborted` because a watcher event invalidated the build mid-flight — the `catch` block (added by #9366 for failure-replay diagnostics) caches the partially-constructed `InternalBundleGraph` via `this.api.storeResult({bundleGraph: internalBundleGraph, ...}, this.cacheKey)` and re-throws.

The very next build re-enters `BundleGraphRequest.run`. `previousBundleGraphResult = await this.api.getPreviousResult()` returns the partial graph, and because `previousBundleGraphResult != null` the code reuses it and **skips the entire `if (!previousBundleGraphResult) { nameBundle … applyRuntimes … validateBundles … }` branch**. Bundles created by the bundler but never seen by the namer come out the other side with `name == null`, and every site that does `nullthrows(bundle.name)` then crashes:

- `packages/core/core/src/PackagerRunner.js:211` (loadConfig)
- `packages/core/core/src/PackagerRunner.js:634` (generateSourceMap)
- `packages/core/core/src/PackagerRunner.js:738` (getDevDepHashes)
- `packages/core/core/src/requests/WriteBundleRequest.js:89`
- `packages/core/core/src/requests/BundleGraphRequest.js:480` (validateBundles)

This is reproducible deterministically when an external process bulk-writes files into a watched directory mid-build (#10322 has the 30-line shell repro). `PARCEL_WORKERS=0` only halves the failure count — this is a main-process async-reentrancy bug, not a worker-IPC bug, so it lives in a different bucket from #9636 / #9532.

**The fix** is 19 lines in `BundleGraphRequest.js`: add an optional `incomplete?: boolean` field to `BundleGraphResult` (and the narrower local `BundleGraphRequestResult` for the read site), tag the cached-on-error result with `incomplete: true`, and reject incomplete results in the reuse check. This preserves #9366's diagnostic intent — the partial graph is still in the cache for `parcel-query`-style failure analysis — while marking it as unsafe to reuse as an incremental baseline. The fallback path is the existing fresh-build path that runs on every cold start; the change is strictly subtractive at the consumer (rejects a value that would have crashed downstream) and additive at the producer (one boolean field). No new error swallowing, no IPC change, no worker coordination.

### Alternatives considered

- **Just remove the catch-store from #9366.** Would regress @irismoini's stated goal in [#9366](https://github.com/parcel-bundler/parcel/pull/9366) ("Ideally, we'd eventually like to be able to replicate failed builds from the Parcel cache and this PR is a step towards that"). Tagging is the minimal diff that preserves both invariants.
- **Use an existing mechanism instead of a new boolean.** Considered `bundleGraph.getBundles().some(b => b.name == null)` (works but O(n) on every build and conflates "we aborted" with "the bundler legitimately produced an unnamed bundle"), reusing `RequestGraph#incompleteNodeIds` / `incompleteNodePromises` (those track *request*-completion, not result-content state — different invariant), and a separate cache key for the diagnostic blob (cleaner long-term but a bigger diff and a #9366 wire-format change).
- **Naming.** Open to `aborted`, `partial`, `diagnosticOnly` — chose `incomplete` to describe the graph's state (missing names/runtimes) rather than the cause or intent.
- **Feature flag.** Considered, deliberately omitted. The change has no new IPC, no new worker coordination, no new error swallowing; the fallback is the existing fresh-build path. The regression test gives stronger signal than partial-rollout. Happy to add one if reviewers prefer.

### Related (same async-reentrancy class)

- **#9366** — the PR whose diagnostic-cache behavior this preserves. cc @irismoini.
- **#4968** — canonical umbrella for "external file writes mid-build"; this PR likely covers a meaningful slice.
- **#10176** — verbatim `Got unexpected null` / `missing dev dep request` reports; reporter ran with `PARCEL_WORKERS=0 --no-cache` and still hit it, consistent with the main-process diagnosis here.
- **#9991, #8874, #6528** — plausibly related (same general surface and trigger pattern); we haven't reproduced each one specifically and the underlying mechanisms may differ.
- **#9636, #9532** — closed attempts at a worker-IPC race; this is a *different* race, corroborated by `PARCEL_WORKERS=0` not eliminating the failure.

---

<sub>Drafted with AI assistance (Claude); the diagnosis, fix design, and the regression test were verified by hand against the actual reproduction and the diff was run through the repo's full `yarn build-ts` / `yarn flow check` / `yarn lint` / `yarn test` pipeline.</sub>

## 💻 Examples

This comes up compiling a medium sized rescript project on an occasional basis, this is how I encountered (and lived with) this bug over the last few years.

[Non-rescript bash repro of the issue](https://github.com/parcel-bundler/parcel/issues/10322#user-content-repro-code-sample)

## 🚨 Test instructions

Test for the race condition can be done in bash -- [sample in the issue (anchor linked to subsection)](https://github.com/parcel-bundler/parcel/issues/10322#user-content-repro-code-sample).

A deterministic regression test ships with this PR — it doesn't depend on watcher timing, so it's stable in CI.

**Where**: `packages/core/integration-tests/test/incremental-bundling.js` → new `describe('bundle graph cached on build failure', …)` block → `it('does not reuse a bundle graph stored after a failed build', …)`.

**What it does**: stubs `@parcel/bundler-default`'s `bundle()` to drive the real bundler so `internalBundleGraph` gets populated with (unnamed) bundles, then throws once — mirroring an `AbortSignal`-driven failure mid-bundling. It then triggers a second build via `overlayFS.writeFile` and asserts every bundle has a non-null `name` after recovery.

**Run it**:

```bash
yarn workspace @parcel/integration-tests test --grep "does not reuse a bundle graph stored after a failed build"
```

**Without** this PR's source change the test fails inside `getNextBuildSuccess` with `expected the recovered build to succeed`. **With** this PR applied it passes in ~100 ms. Verified both directions locally by stashing/unstashing the source diff.

```
bundle graph cached on build failure
  ✓ does not reuse a bundle graph stored after a failed build (104ms)
```

### Placement notes (pre-empting likely review questions)

- **Why `incremental-bundling.js`, not `cache.js`** (where #9366's test lives): the failure mode this exercises is the *incremental reuse* path (`previousBundleGraphResult` reused on the next build), not the cache *serialization* path that `cache.js` covers. The two are different code paths even though they touch the same blob. `incremental-bundling.js` is where the surrounding tests already use `bundler(…) + b.watch() + getNextBuildSuccess(b)`, which is exactly the orchestration this regression test needs.
- **Why a sinon stub instead of a new `fsFixture` template** like #9366: the failure injection we need is "throw *after* the bundler registers bundles but before naming runs," which requires running the real bundler partway through. A stub on `Bundler[CONFIG].bundle` is the minimal way to express that; an `fsFixture` template would have to wire a complete custom-bundler plugin. Reuses the existing `integration/incremental-bundling` fixture for the same reason.
- **Why no watcher-storm e2e test in CI**: race fixes in this area (#8600, #9123, #9675) intentionally shipped without an e2e test because reliably reproducing the timing race in CI is impractical. The sinon stub gives the same deterministic coverage at the catch-then-reuse seam without the flake risk. The natural-timing repro lives in #10322 for anyone who wants to verify the bug exists against real `parcel serve`.

### Full local validation

| Gate                                              | Status     |
|---------------------------------------------------|------------|
| `yarn flow check`                                 | ✅ pass (0 errors) |
| `yarn lint` (eslint + prettier)                   | ✅ pass     |
| `yarn build-ts`                                   | ✅ pass     |
| `yarn build` (gulp + build-bundles)               | ✅ pass     |
| `yarn build-native`                               | ✅ pass (debug build) |
| `test/incremental-bundling.js` (22 tests, +1 new) | ✅ pass     |
| `test/watcher.js` (6 tests, 5 pending)            | ✅ pass     |
| `packages/core/core/test` (561 unit)              | ✅ pass     |
| `test/cache.js`                                   | 197 pass / 1 fail / 3 pending — the 1 failing (`supports multiple empty JS assets`) fails **identically** on `v2` HEAD without this PR (`ENOENT … dist/index.js` in the local environment); pre-existing flake, not caused by this fix. Verified by running the same test on stashed source. |

## ✔️ PR Todo

- [x] Added/updated unit tests for this change *(deterministic regression test under `packages/core/integration-tests/test/incremental-bundling.js`)*
- [x] Filled out test instructions
- [x] Included links to related issues/PRs *(#10322, #9366, #4968, #10176, #9991, #8874, #6528, #9636, #9532)*