### PR TITLE
Ensure glob results are deterministic

### DIFF
--- a/packages/core/utils/src/glob.js
+++ b/packages/core/utils/src/glob.js
@@ -63,7 +63,7 @@ export function globSync(
   };
 
   // $FlowFixMe
-  return fastGlob.sync(normalizeSeparators(p), options);
+  return fastGlob.sync(normalizeSeparators(p), options).sort();
 }
 
 export function glob(
@@ -107,5 +107,7 @@ export function glob(
   };
 
   // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381
-  return fastGlob(normalizeSeparators(p), options);
+  return fastGlob(normalizeSeparators(p), options).then(results =>
+    results.sort(),
+  );
 }

--- a/packages/core/utils/test/glob.test.js
+++ b/packages/core/utils/test/glob.test.js
@@ -1,0 +1,83 @@
+// @flow
+
+import assert from 'assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {NodeFS} from '@parcel/fs';
+
+import {glob, globSync, normalizeSeparators} from '../src';
+
+/**
+ * Create NodeFS that returns files in the reverse order.
+ */
+function createUnsortedFS(): NodeFS {
+  let parcelFS = new NodeFS();
+
+  let originalReaddirSync = parcelFS.readdirSync.bind(parcelFS);
+  let originalReaddir = parcelFS.readdir.bind(parcelFS);
+
+  parcelFS.readdirSync = (dir, opts) => {
+    let entries = originalReaddirSync(dir, opts);
+    return entries.slice().reverse();
+  };
+
+  parcelFS.readdir = async (dir, opts) => {
+    let entries = await originalReaddir(dir, opts);
+    return entries.slice().reverse();
+  };
+
+  return parcelFS;
+}
+
+async function setupFixture<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  let root = fs.mkdtempSync(path.join(os.tmpdir(), 'parcel-glob-test-'));
+
+  try {
+    fs.mkdirSync(path.join(root, 'nested'), {recursive: true});
+    fs.writeFileSync(path.join(root, 'nested', 'd.txt'), 'd');
+    fs.writeFileSync(path.join(root, 'nested', 'c.txt'), 'c');
+    fs.writeFileSync(path.join(root, 'b.txt'), 'b');
+    fs.writeFileSync(path.join(root, 'a.txt'), 'a');
+    return await fn(root);
+  } finally {
+    fs.rmSync(root, {recursive: true, force: true});
+  }
+}
+
+describe('glob', () => {
+  it('globSync() should return results in stable order', async () => {
+    await setupFixture(async root => {
+      let result = globSync(
+        path.join(root, '**/*.txt'),
+        createUnsortedFS(),
+        {},
+      );
+
+      assert.deepEqual(result.map(normalizeSeparators), [
+        normalizeSeparators(path.join(root, 'a.txt')),
+        normalizeSeparators(path.join(root, 'b.txt')),
+        normalizeSeparators(path.join(root, 'nested', 'c.txt')),
+        normalizeSeparators(path.join(root, 'nested', 'd.txt')),
+      ]);
+    });
+  });
+
+  it('glob() should return results in stable order', async () => {
+    await setupFixture(async root => {
+      let result = await glob(
+        path.join(root, '**/*.txt'),
+        createUnsortedFS(),
+        {},
+      );
+
+      assert.deepEqual(result.map(normalizeSeparators), [
+        normalizeSeparators(path.join(root, 'a.txt')),
+        normalizeSeparators(path.join(root, 'b.txt')),
+        normalizeSeparators(path.join(root, 'nested', 'c.txt')),
+        normalizeSeparators(path.join(root, 'nested', 'd.txt')),
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
# ↪️ Pull Request

This PR sorts `glob` and `globSync` results before returning them to make sure builds are always deterministic, as `fast-glob` can return results in arbitrary order. This should fix #9946.

## 💻 Examples

Because `fast-glob` can return results in arbitrary order, this causes `@parcel/resolver-glob` to include imports in arbitrary order, which causes non-deterministic builds.

## 🚨 Test instructions

I have added unit tests.

You can also check my extension which uses glob imports and was previously affected by non-deterministic builds:

[firefoxpwa-extension-test.zip](https://github.com/user-attachments/files/28957034/firefoxpwa-extension-test.zip)

There is a simple script `debug-build.py` which will repeatedly call build until it is different. Without this PR, it should encounter a different build in less than 10 attempts. With the PR, builds remain stable.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
