### PR TITLE
Enable minification during JS tree-shaking and add `not_contains` test assertion

### DIFF
--- a/crates/parcel/tests/fixtures/module-interop/esm-tree-shake-unused/test.json
+++ b/crates/parcel/tests/fixtures/module-interop/esm-tree-shake-unused/test.json
@@ -8,6 +8,13 @@
     "description": "ESM: tree-shake - only foo is imported; bar/baz should not appear in production bundle",
     "input": "index.js",
     "options": {"mode": "production"},
-    "output": 2
+    "bundles": [
+      {
+        "type": "js",
+        "assets": ["dep.js", "esmodule-helpers.js", "index.js"],
+        "contains": ["foo"],
+        "notContains": ["bar", "baz"]
+      }
+    ]
   }
 ]

--- a/crates/parcel/tests/test.rs
+++ b/crates/parcel/tests/test.rs
@@ -205,6 +205,18 @@ fn run_test_with_options(fixture_dir: &Path, entries: Vec<String>, test: TestJso
           );
         }
       }
+      if !found.not_contains.is_empty() {
+        let contents = output_fs.read_to_string(bundle.dist_path()).unwrap();
+        for substring in &found.not_contains {
+          assert!(
+            !contents.contains(substring),
+            "Bundle {:?} contained unexpected substring {:?}\n\nBundle contents: {}",
+            bundle.name.as_ref().unwrap(),
+            substring,
+            contents
+          );
+        }
+      }
     }
   }
 
@@ -506,6 +518,8 @@ struct TestBundle {
   ty: Option<AssetType>,
   #[serde(default)]
   contains: Vec<String>,
+  #[serde(default)]
+  not_contains: Vec<String>,
 }
 
 #[derive(serde::Deserialize, Default)]

--- a/packages/transformers/js/core/src/tree_shake.rs
+++ b/packages/transformers/js/core/src/tree_shake.rs
@@ -2,9 +2,11 @@ use std::{borrow::Cow, collections::HashSet};
 
 use indexmap::IndexMap;
 use swc_core::{
-  common::{DUMMY_SP, Mark},
+  common::{util::take::Take, DUMMY_SP, Mark},
   ecma::{
     ast::*,
+    minifier::option::{CompressOptions, MangleOptions, TopLevelOptions},
+    transforms::base::fixer::fixer,
     atoms::Atom as JsWord,
     visit::{VisitMut, VisitMutWith},
   },
@@ -71,10 +73,10 @@ pub fn tree_shake<'a>(
   used_symbols: HashSet<JsWord>,
   resolutions: IndexMap<String, Resolution<'a>>,
   dirname: JsWord,
-  _minify: bool,
+  minify: bool,
 ) {
   swc_core::common::GLOBALS.set(&*ast.globals, || {
-    // let global_mark = Mark::fresh(Mark::root());
+    let global_mark = Mark::fresh(Mark::root());
     let unresolved_mark = Mark::fresh(Mark::root());
     let mut shake = TreeShake {
       used_symbols,
@@ -86,35 +88,35 @@ pub fn tree_shake<'a>(
 
     ast.program.visit_mut_with(&mut shake);
 
-    // if minify {
-    //   let module = std::mem::take(&mut ast.program);
-    //   let mut program = swc_core::ecma::minifier::optimize(
-    //     Program::Module(module),
-    //     ast.source_map.clone(),
-    //     Some(&ast.comments),
-    //     None,
-    //     &swc_core::ecma::minifier::option::MinifyOptions {
-    //       rename: true,
-    //       compress: Some(CompressOptions {
-    //         top_level: Some(TopLevelOptions { functions: true }),
-    //         ..Default::default()
-    //       }),
-    //       mangle: Some(MangleOptions {
-    //         top_level: Some(true),
-    //         ..Default::default()
-    //       }),
-    //       ..Default::default()
-    //     },
-    //     &swc_core::ecma::minifier::option::ExtraOptions {
-    //       mangle_name_cache: None,
-    //       top_level_mark: global_mark,
-    //       unresolved_mark,
-    //     },
-    //   );
+    if minify {
+      let module = std::mem::take(&mut ast.program);
+      let mut program = swc_core::ecma::minifier::optimize(
+        Program::Module(module),
+        ast.source_map.clone(),
+        Some(&ast.comments),
+        None,
+        &swc_core::ecma::minifier::option::MinifyOptions {
+          rename: true,
+          compress: Some(CompressOptions {
+            top_level: Some(TopLevelOptions { functions: true }),
+            ..Default::default()
+          }),
+          mangle: Some(MangleOptions {
+            top_level: Some(true),
+            ..Default::default()
+          }),
+          ..Default::default()
+        },
+        &swc_core::ecma::minifier::option::ExtraOptions {
+          mangle_name_cache: None,
+          top_level_mark: global_mark,
+          unresolved_mark,
+        },
+      );
 
-    //   program.mutate(&mut fixer(Some(&ast.comments)));
-    //   ast.program = program.expect_module();
-    // }
+      program.mutate(&mut fixer(Some(&ast.comments)));
+      ast.program = program.expect_module();
+    }
   })
 }
 
@@ -160,12 +162,11 @@ impl<'a> VisitMut for TreeShake<'a> {
             _ => return,
           };
 
-          // if !self.used_symbols.contains(&name) {
-          //   println!("TREE SHAKE {}", name);
-          //   stmt.expr = assign.right.take();
-          //   self.mutated = true;
-          //   return;
-          // }
+          if !self.used_symbols.contains(&name) {
+            stmt.expr = assign.right.take();
+            self.mutated = true;
+            return;
+          }
         }
       }
       Expr::Call(call) => {
@@ -176,8 +177,7 @@ impl<'a> VisitMut for TreeShake<'a> {
           return;
         };
 
-        if !(matches!(&*member.obj, Expr::Ident(id) if id.sym == "parcelHelpers")
-          && matches!(match_property_name(&member), Some((name, _)) if name == "export"))
+        if !matches!(match_property_name(&member), Some((name, _)) if name == "export")
         {
           return;
         }
@@ -190,11 +190,10 @@ impl<'a> VisitMut for TreeShake<'a> {
           return;
         };
 
-        // if !self.used_symbols.contains(&name.value) {
-        //   println!("TREE SHAKE {}", name.value);
-        //   *node = Stmt::Empty(EmptyStmt { span: DUMMY_SP });
-        //   self.mutated = true;
-        // }
+        if !self.used_symbols.contains(&name.value) {
+          *node = Stmt::Empty(EmptyStmt { span: DUMMY_SP });
+          self.mutated = true;
+        }
       }
       _ => {}
     }


### PR DESCRIPTION
### Motivation
- Ensure unused exports are actually removed during tree-shaking in production/minified builds.
- Make tests able to assert that specific substrings are absent from generated bundles in production scenarios.

### Description
- Enable SWC minifier invocation in `tree_shake` when `minify` is true and apply `fixer` after optimization by wiring up `MinifyOptions`, `CompressOptions`, `MangleOptions`, and `ExtraOptions` and restoring the optimized module to `ast.program`.
- Implement removal of unused export assignments by replacing the assignment expression with its right-hand side and removing unused helper `export` calls by replacing the statement with an empty statement when the symbol is not in `used_symbols`.
- Relax the match for export calls to rely on `match_property_name` for `.export` rather than requiring a specific helper identifier.
- Add a `not_contains` field to `TestBundle` (with `serde` default) and assert that listed substrings are not present in bundle contents during `run_test_with_options`.
- Update the `esm-tree-shake-unused` test fixture to use the new `bundles` expectation with `contains` and `notContains` checks.

### Testing
- Ran the Rust test suite for the parcel crate tests that exercise fixture assertions via `cargo test` and the modified `run_test_with_options` logic; assertions for `contains` and `not_contains` executed and passed.
- Exercised JS tree-shaking behavior by running the `esm-tree-shake-unused` fixture, which verified `foo` is present and `bar`/`baz` are not present in the production bundle.
- Run of transformations including the minifier path was invoked as part of the tree-shake tests and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42ef64afe88329895998e207ad8a81)