### PR TITLE
feat(reporter-cli): improve terminal error diagnostics readability

### DIFF
--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -141,7 +141,7 @@ export function errorToDiagnostic(
   if (typeof error === 'string') {
     return [
       {
-        origin: defaultValues?.origin ?? 'Error',
+        origin: defaultValues?.origin,
         message: escapeMarkdown(error),
       },
     ];
@@ -183,7 +183,7 @@ export function errorToDiagnostic(
 
   return [
     {
-      origin: defaultValues?.origin ?? 'Error',
+      origin: defaultValues?.origin,
       message: escapeMarkdown(error.message),
       name: error.name,
       stack:

--- a/packages/core/utils/src/prettyDiagnostic.js
+++ b/packages/core/utils/src/prettyDiagnostic.js
@@ -64,7 +64,9 @@ export default async function prettyDiagnostic(
 
   let result = {
     message:
-      md(`**${origin ?? 'unknown'}**: `) +
+    (origin != null && origin !== 'unknown' && origin !== ''
+      ? md(`**${origin}**: `)
+      : '') +
       (skipFormatting ? message : md(message)),
     stack: '',
     codeframe: '',

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -156,6 +156,19 @@ export async function _report(
 
       persistSpinner('buildProgress', 'error', chalk.red.bold('Build failed.'));
 
+      if (event.diagnostics.length > 1){
+         writeOut('');
+         writeOut(
+          chalk.red.bold(`Found ${event.diagnostics.length} errors:`),
+         );
+      }
+      writeOut('');
+      writeOut(
+        chalk.gray(
+          `Environment: Node ${process.version}, ${process.platform} ${process.arch}`,
+        ),
+      )
+
       await writeDiagnostic(options, event.diagnostics, 'red', true);
       break;
     case 'cache':
@@ -226,6 +239,21 @@ async function writeDiagnostic(
       await prettyDiagnostic(diagnostic, options, columns - indent);
     // $FlowFixMe[incompatible-use]
     message = chalk[color](message);
+
+    if (stack) {
+      stack = stack
+        .split('\n')
+        .filter(frame =>{
+          if (!frame.trimStart().startsWith('at ')) return true;
+          return (
+            !frame.includes('/packages/core/') &&
+            !frame.includes('/packages/reporters/') &&
+            !frame.includes('node_modules/@parcel/')
+          );
+        })
+        .join('\n');
+    }
+
 
     if (spaceAfter) {
       writeOut('');


### PR DESCRIPTION
## Summary

This PR improves the terminal error diagnostics output to make build failures more readable and actionable.

- Omit meaningless "unknown" origin prefix in error messages
- Show error count summary for multi-diagnostic build failures
- Filter internal Parcel frames from stack traces
- Display runtime environment (Node/OS/arch) on build failure
- Remove hardcoded 'Error' fallback origin in errorToDiagnostic

## Motivation

When a build fails, the current error output has several readability issues:

1. **Noisy origin prefix** — errors without a meaningful plugin origin display `**unknown**:` which adds no value
2. **Internal stack noise** — Parcel's own frames (`/packages/core/`, `node_modules/@parcel/`) clutter the stack trace, burying user-relevant code
3. **No context** — users filing bug reports have no easy way to see their Node/OS version from the error output
4. **No error overview** — when multiple diagnostics are emitted, there's no summary line showing how many errors occurred

## Changes

| File | Change |
|------|--------|
| `packages/core/utils/src/prettyDiagnostic.js` | Skip origin prefix when it is `null`, `"unknown"`, or empty |
| `packages/reporters/cli/src/CLIReporter.js` | Add environment info line, error count header, and filter internal stack frames |
| `packages/core/diagnostic/src/diagnostic.js` | Remove `?? 'Error'` fallback in `errorToDiagnostic` so origin stays `undefined` |

## Before / After

**Before:**
🚨 Build failed.

🚨 **unknown**: Cannot resolve module 'foo'

src/index.js:1:1

> *"1 | import 'foo'"*;

at Resolver.resolve (/packages/core/core/src/Resolver.js:142:11)

at async Asset.resolve (/packages/core/core/src/Asset.js:89:5)

at async UserCode.transform (src/index.js:1:1)

**After** 

🚨 Build failed.

Environment: Node v20.11.0, linux x64

🚨 Cannot resolve module 'foo'

src/index.js:1:1 

> *"1 | import 'foo';"*

at async UserCode.transform (src/index.js:1:1)

## 🧪 Test instructions

1. Create a project with a broken import (e.g. `import 'nonexistent-module'`)
2. Run `parcel build index.html`
3. Verify:
   - No `**unknown**:` prefix appears before the error message
   - `Environment: Node vX.X.X, platform arch` line is shown
   - Stack trace does not contain `/packages/core/` or `node_modules/@parcel/` frames
   - When multiple errors occur, a `Found N errors:` summary line appears
4. Run `yarn test` — existing diagnostic/codeframe tests should still pass

