### PR TITLE
ci: pin DeMoorJasper/stale to a full commit SHA

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,7 +16,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: DeMoorJasper/stale@master
+      - uses: DeMoorJasper/stale@d4a18e296fceab5e544df362752ed2c91154cbab # frozen fork of actions/stale (2020-01-17)
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-label: Stale


### PR DESCRIPTION
## What
Pin `DeMoorJasper/stale` in `.github/workflows/stale.yml` from the mutable `@master` branch to the commit it currently resolves to.

## Why
The `stale` job grants `issues: write` + `pull-requests: write` and passes `repo-token: ${{ secrets.GITHUB_TOKEN }}` to this action. It's referenced by `@master` on an **unmaintained personal fork of `actions/stale`** (last updated 2020), so whoever can push to that fork can change the code that runs with the token — the third-party-action supply-chain risk. Pinning to a full SHA makes it immutable; behaviour is unchanged.

You may also want to migrate to the maintained `actions/stale` in a follow-up, but I kept this to the minimal hardening.

I used AI assistance to help identify this and draft the change; I verified every line against the live workflow myself and take responsibility for it.