### PR TITLE
core: normalize codeFrame.code on thrown build errors

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -18,7 +18,10 @@ import type {FarmOptions, SharedReference} from '@parcel/workers';
 import type {Diagnostic} from '@parcel/diagnostic';
 
 import invariant from 'assert';
-import ThrowableDiagnostic, {anyToDiagnostic} from '@parcel/diagnostic';
+import ThrowableDiagnostic, {
+  anyToDiagnostic,
+  normalizeCodeFrames,
+} from '@parcel/diagnostic';
 import {assetFromValue} from './public/Asset';
 import {PackagedBundle} from './public/Bundle';
 import BundleGraph from './public/BundleGraph';
@@ -174,7 +177,14 @@ export default class Parcel {
     await this._end();
 
     if (result.type === 'buildFailure') {
-      throw new BuildError(result.diagnostics);
+      let resolvedOptions = nullthrows(this.#resolvedOptions);
+      throw new BuildError(
+        await normalizeCodeFrames(
+          result.diagnostics,
+          filePath => resolvedOptions.inputFS.readFile(filePath, 'utf8'),
+          resolvedOptions.projectRoot,
+        ),
+      );
     }
 
     return result;
@@ -356,7 +366,13 @@ export default class Parcel {
           let results = await this.#watchQueue.run();
           let result = results.filter(Boolean).pop();
           if (result.type === 'buildFailure') {
-            throw new BuildError(result.diagnostics);
+            throw new BuildError(
+              await normalizeCodeFrames(
+                result.diagnostics,
+                filePath => options.inputFS.readFile(filePath, 'utf8'),
+                options.projectRoot,
+              ),
+            );
           }
 
           return result;

--- a/packages/core/diagnostic/src/diagnostic.js
+++ b/packages/core/diagnostic/src/diagnostic.js
@@ -1,6 +1,7 @@
 // @flow strict-local
 
 import invariant from 'assert';
+import path from 'path';
 import nullthrows from 'nullthrows';
 import {parse, type Mapping} from '@mischnic/json-sourcemap';
 
@@ -193,6 +194,50 @@ export function errorToDiagnostic(
       codeFrames,
     },
   ];
+}
+
+/**
+ * Fills in `codeFrame.code` for any code frames that omit it, by reading
+ * the corresponding file from disk. This lets consumers of thrown
+ * diagnostics (e.g. `error.diagnostics[i].codeFrames[j].code`) rely on
+ * `code` being present without duplicating the same file-read fallback
+ * that reporters like `prettyDiagnostic` already perform for display.
+ */
+export async function normalizeCodeFrames(
+  diagnostics: Array<Diagnostic>,
+  readFile: (filePath: string) => Promise<string>,
+  projectRoot?: string,
+): Promise<Array<Diagnostic>> {
+  return Promise.all(
+    diagnostics.map(async diagnostic => {
+      if (diagnostic.codeFrames == null) {
+        return diagnostic;
+      }
+
+      let codeFrames = await Promise.all(
+        diagnostic.codeFrames.map(async codeFrame => {
+          if (codeFrame.code != null || codeFrame.filePath == null) {
+            return codeFrame;
+          }
+
+          let filePath =
+            projectRoot != null && !path.isAbsolute(codeFrame.filePath)
+              ? path.join(projectRoot, codeFrame.filePath)
+              : codeFrame.filePath;
+
+          try {
+            return {...codeFrame, code: await readFile(filePath)};
+          } catch {
+            // The file may no longer exist (e.g. it was deleted after the
+            // diagnostic was created). Leave `code` unset in that case.
+            return codeFrame;
+          }
+        }),
+      );
+
+      return {...diagnostic, codeFrames};
+    }),
+  );
 }
 
 type ThrowableDiagnosticOpts = {

--- a/packages/core/diagnostic/test/normalizeCodeFrames.test.js
+++ b/packages/core/diagnostic/test/normalizeCodeFrames.test.js
@@ -1,0 +1,112 @@
+// @flow
+import assert from 'assert';
+
+import {normalizeCodeFrames} from '../src/diagnostic';
+
+describe('normalizeCodeFrames', () => {
+  it('leaves diagnostics without codeFrames untouched', async () => {
+    let diagnostics = [{message: 'oops'}];
+    let result = await normalizeCodeFrames(diagnostics, async () => {
+      throw new Error('should not be called');
+    });
+    assert.deepStrictEqual(result, diagnostics);
+  });
+
+  it('leaves an existing codeFrame.code untouched', async () => {
+    let diagnostics = [
+      {
+        message: 'oops',
+        codeFrames: [
+          {
+            code: 'const x = 1;',
+            filePath: 'index.js',
+            codeHighlights: [],
+          },
+        ],
+      },
+    ];
+    let result = await normalizeCodeFrames(diagnostics, async () => {
+      throw new Error('should not be called');
+    });
+    assert.strictEqual(result[0].codeFrames?.[0].code, 'const x = 1;');
+  });
+
+  it('fills in codeFrame.code by reading the file when missing', async () => {
+    let diagnostics = [
+      {
+        message: 'oops',
+        codeFrames: [
+          {
+            filePath: 'index.js',
+            codeHighlights: [],
+          },
+        ],
+      },
+    ];
+
+    let readFilePaths = [];
+    let result = await normalizeCodeFrames(diagnostics, async filePath => {
+      readFilePaths.push(filePath);
+      return 'const x = 1;';
+    });
+
+    assert.deepStrictEqual(readFilePaths, ['index.js']);
+    assert.strictEqual(result[0].codeFrames?.[0].code, 'const x = 1;');
+  });
+
+  it('joins a relative filePath with projectRoot before reading', async () => {
+    let diagnostics = [
+      {
+        message: 'oops',
+        codeFrames: [
+          {
+            filePath: 'src/index.js',
+            codeHighlights: [],
+          },
+        ],
+      },
+    ];
+
+    let readFilePaths = [];
+    let result = await normalizeCodeFrames(
+      diagnostics,
+      async filePath => {
+        readFilePaths.push(filePath);
+        return 'const x = 1;';
+      },
+      '/project',
+    );
+
+    assert.strictEqual(readFilePaths[0], '/project/src/index.js');
+    assert.strictEqual(result[0].codeFrames?.[0].code, 'const x = 1;');
+  });
+
+  it('leaves codeFrame.code unset if the file cannot be read', async () => {
+    let diagnostics = [
+      {
+        message: 'oops',
+        codeFrames: [
+          {
+            filePath: 'deleted.js',
+            codeHighlights: [],
+          },
+        ],
+      },
+    ];
+
+    let result = await normalizeCodeFrames(diagnostics, async () => {
+      throw new Error('ENOENT: no such file');
+    });
+
+    assert.strictEqual(result[0].codeFrames?.[0].code, undefined);
+  });
+
+  it('does not mutate the input diagnostics', async () => {
+    let codeFrame = {filePath: 'index.js', codeHighlights: []};
+    let diagnostics = [{message: 'oops', codeFrames: [codeFrame]}];
+
+    await normalizeCodeFrames(diagnostics, async () => 'const x = 1;');
+
+    assert.strictEqual(codeFrame.code, undefined);
+  });
+});


### PR DESCRIPTION
Fixes #5115.

## Problem

When using the Parcel API and a build fails, the thrown `BuildError`'s diagnostics may have code frames where `codeFrame.code` is `undefined` -- it's only guaranteed to be filled in when a reporter (like the CLI) calls `prettyDiagnostic()`, which reads the file from disk as a fallback purely for rendering. A consumer catching the thrown error and inspecting `error.diagnostics[i].codeFrames[j].code` directly has to duplicate that same file-read fallback themselves.

## Fix

Added `normalizeCodeFrames()` to `@parcel/diagnostic` (`packages/core/diagnostic/src/diagnostic.js`). It walks a list of diagnostics and, for any code frame missing `code`, fills it in by reading the file (via an injected `readFile` function, resolving relative paths against an optional `projectRoot` -- mirroring the existing logic in `prettyDiagnostic.js`). It leaves already-populated code untouched, doesn't mutate its input, and swallows read failures (e.g. a deleted file) by leaving `code` unset rather than throwing.

Called it at both `BuildError` throw sites in `packages/core/core/src/Parcel.js` (`run()` and the `requestBundle` callback inside `_build()`), using the resolved options' `inputFS`/`projectRoot` -- the same values `prettyDiagnostic` already receives via `PluginOptions`.

This is a pure JS/Flow change; no native/Rust code is touched.

## Testing

Added `packages/core/diagnostic/test/normalizeCodeFrames.test.js` covering:
- diagnostics without `codeFrames` pass through untouched
- an already-set `codeFrame.code` is left alone (and `readFile` is never called)
- missing `code` is filled in via `readFile`
- a relative `filePath` is joined with `projectRoot` before reading
- a failing `readFile` leaves `code` unset instead of throwing
- the input diagnostics array/objects are not mutated

I wasn't able to run the monorepo's own `yarn test:unit` in this environment (would require a full `yarn install` across the workspace), so I additionally hand-verified the exact control flow in `normalizeCodeFrames` against a plain-Node reproduction of the same logic to confirm all six scenarios behave as asserted in the test file.
