### PR TITLE
Improve package exports disabled diagnostic

### DIFF
--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -507,11 +507,40 @@ export default class NodeResolver {
           relative = './' + relative;
         }
 
+        let hints = potentialFiles.map(r => {
+          return `Did you mean '__${error.module}/${r}__'?`;
+        });
+        let packageExportsEnabled =
+          this.options.packageExports ||
+          options.env.context === 'react-server' ||
+          options.env.context === 'react-client';
+        let packageExportKeys =
+          pkg.exports != null &&
+          typeof pkg.exports === 'object' &&
+          !Array.isArray(pkg.exports)
+            ? Object.keys(pkg.exports)
+            : [];
+        let hasMatchingPackageExport = packageExportKeys.some(key => {
+          if (key === relative) {
+            return true;
+          }
+
+          let wildcardIndex = key.indexOf('*');
+          return (
+            wildcardIndex >= 0 &&
+            relative.startsWith(key.slice(0, wildcardIndex)) &&
+            relative.endsWith(key.slice(wildcardIndex + 1))
+          );
+        });
+        if (!packageExportsEnabled && hasMatchingPackageExport) {
+          hints.push(
+            'Add "@parcel/resolver-default": { "packageExports": true } to your package.json to enable package exports.',
+          );
+        }
+
         return {
           message: md`Cannot load file '${relative}' from module '${error.module}'`,
-          hints: potentialFiles.map(r => {
-            return `Did you mean '__${error.module}/${r}__'?`;
-          }),
+          hints,
         };
       }
       case 'JsonError': {

--- a/packages/utils/node-resolver-core/test/fixture/node_modules/package-exports/package.json
+++ b/packages/utils/node-resolver-core/test/fixture/node_modules/package-exports/package.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./main.mjs",
     "./foo": "./foo.mjs",
+    "./redirect": "./features/test.mjs",
     "./features/*": "./features/*.mjs",
     "./invalid": "../foo/index.js",
     "./space": "./with%20space.mjs",

--- a/packages/utils/node-resolver-core/test/resolver.js
+++ b/packages/utils/node-resolver-core/test/resolver.js
@@ -2493,6 +2493,70 @@ describe('resolver', function () {
       });
     });
 
+    it('should suggest enabling package exports for exported subpaths', async function () {
+      let resolver = new NodeResolver({
+        fs: overlayFS,
+        projectRoot: rootDir,
+        mode: 'development',
+        packageExports: false,
+      });
+      let result = await resolver.resolve({
+        env: BROWSER_ENV,
+        filename: 'package-exports/redirect',
+        specifierType: 'esm',
+        parent: path.join(rootDir, 'foo.js'),
+      });
+
+      assert.deepEqual(nullthrows(nullthrows(result).diagnostics)[0], {
+        message: `Cannot load file './redirect' from module 'package-exports'`,
+        hints: [
+          'Add "@parcel/resolver-default": { "packageExports": true } to your package.json to enable package exports.',
+        ],
+      });
+    });
+
+    it('should suggest enabling package exports for wildcard subpaths', async function () {
+      let resolver = new NodeResolver({
+        fs: overlayFS,
+        projectRoot: rootDir,
+        mode: 'development',
+        packageExports: false,
+      });
+      let result = await resolver.resolve({
+        env: BROWSER_ENV,
+        filename: 'package-exports/extensionless-features/test',
+        specifierType: 'esm',
+        parent: path.join(rootDir, 'foo.js'),
+      });
+
+      assert.deepEqual(nullthrows(nullthrows(result).diagnostics)[0], {
+        message: `Cannot load file './extensionless-features/test' from module 'package-exports'`,
+        hints: [
+          'Add "@parcel/resolver-default": { "packageExports": true } to your package.json to enable package exports.',
+        ],
+      });
+    });
+
+    it('should not suggest enabling package exports for unexported subpaths', async function () {
+      let resolver = new NodeResolver({
+        fs: overlayFS,
+        projectRoot: rootDir,
+        mode: 'development',
+        packageExports: false,
+      });
+      let result = await resolver.resolve({
+        env: BROWSER_ENV,
+        filename: 'package-exports/not-exported',
+        specifierType: 'esm',
+        parent: path.join(rootDir, 'foo.js'),
+      });
+
+      assert.deepEqual(nullthrows(nullthrows(result).diagnostics)[0], {
+        message: `Cannot load file './not-exported' from module 'package-exports'`,
+        hints: [],
+      });
+    });
+
     it('should error when a library is missing an external dependency', async function () {
       let result = await resolver.resolve({
         env: new Environment(
@@ -2732,7 +2796,7 @@ describe('resolver', function () {
                     column: 14,
                   },
                   end: {
-                    line: 13,
+                    line: 14,
                     column: 3,
                   },
                 },


### PR DESCRIPTION
# ↪️ Pull Request

Improve the resolver diagnostic when a package subpath is declared in `exports` but package exports support is disabled. The hint is limited to exact or wildcard export keys, so unrelated missing subpaths keep the existing diagnostic.

Refs #10330

## 💻 Examples

A failed import such as `package/redirect`, where `./redirect` is declared in the package's `exports` map, now suggests adding:

```json
"@parcel/resolver-default": { "packageExports": true }
```

## 🚨 Test instructions

```sh
corepack yarn mocha --no-config \
  --require @parcel/babel-register \
  --require @parcel/test-utils/src/mochaSetup.js \
  --exit packages/utils/node-resolver-core/test/resolver.js
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions
- [x] Included links to related issues/PRs
