### PR TITLE
Fix env invalidation hash and sort comparator in getInvalidationHash

### DIFF
--- a/packages/core/core/src/assetUtils.js
+++ b/packages/core/core/src/assetUtils.js
@@ -221,7 +221,11 @@ export async function getInvalidationHash(
 
   let sortedInvalidations = invalidations
     .slice()
-    .sort((a, b) => (getInvalidationId(a) < getInvalidationId(b) ? -1 : 1));
+    .sort((a, b) => {
+      const idA = getInvalidationId(a);
+      const idB = getInvalidationId(b);
+      return idA < idB ? -1 : idA > idB ? 1 : 0;
+    });
 
   let hashes = '';
   for (let invalidation of sortedInvalidations) {
@@ -241,7 +245,7 @@ export async function getInvalidationHash(
       }
       case 'env':
         hashes +=
-          invalidation.key + ':' + (options.env[invalidation.key] || '');
+          invalidation.key + ':' + (options.env[invalidation.key] ?? '');
         break;
       case 'option':
         hashes +=


### PR DESCRIPTION
## Problem

Two bugs in `packages/core/core/src/assetUtils.js` inside `getInvalidationHash`:

**1. Env var hash uses `||` instead of `??`, swallowing empty-string values**

```js
// before
invalidation.key + ':' + (options.env[invalidation.key] || '');
```

When an env var changes from `undefined` to `''` (or vice-versa), both sides produce `''` via the `||` fallback. The resulting hash is identical, so the cache is not invalidated and bundled output becomes stale.

Fix: use `??` (nullish coalescing) so only `null`/`undefined` fall back to `''`, while an explicit empty string is preserved as a distinct value.

**2. Sort comparator returns `1` in both directions when IDs are equal**

```js
// before
.sort((a, b) => (getInvalidationId(a) < getInvalidationId(b) ? -1 : 1));
```

When `a` and `b` have equal IDs this returns `1` for both `compare(a,b)` and `compare(b,a)`, violating the antisymmetry requirement. V8's TimSort has undefined behaviour under this condition, potentially producing different orderings across Node versions — yielding different hash strings for the same logical invalidation set, causing spurious cache misses.

Fix: add an equality branch that returns `0`.

## Changes

- `packages/core/core/src/assetUtils.js` — two-line fix in `getInvalidationHash`