### PR TITLE
fix: add missing peer dependencies

### DIFF
--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -25,5 +25,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.22.11"
+  },
+  "peerDependencies": {
+    "@parcel/core": "^2.16.4"
   }
 }

--- a/packages/utils/node-resolver-core/package.json
+++ b/packages/utils/node-resolver-core/package.json
@@ -57,6 +57,9 @@
     "util": "^0.12.5",
     "vm-browserify": "^1.1.2"
   },
+  "peerDependencies": {
+    "@parcel/core": "^2.16.4"
+  },
   "browser": {
     "./src/builtins.js": "./src/builtins.browser.js"
   }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!
-->

# ↪️ Pull Request

Fixes #9114
Closes #9506
Ref #9304

parcel does not work with Yarn out-of-the-box due to peer dependency issue. The peer tree looks like this:

```
parcel@npm:2.16.4
├─ @parcel/config-default@npm:2.16.4
│  ├─ @parcel/optimizer-image@npm:2.16.4
│  │  └─ @parcel/workers@npm:2.16.4
│  ├─ @parcel/resolver-default@npm:2.16.4   <-------- missing link
│  │  └─ @parcel/node-resolver-core@npm:3.7.4   <---- missing link
│  │     └─ @parcel/fs@npm:2.16.4
│  │        └─ @parcel/workers@npm:2.16.4
│  ├─ @parcel/transformer-image@npm:2.16.4
│  │  └─ @parcel/workers@npm:2.16.4
│  └─ @parcel/transformer-js@npm:2.16.4
│     └─ @parcel/workers@npm:2.16.4
├─ @parcel/fs@npm:2.16.4
│  └─ ...
└─ @parcel/package-manager@npm:2.16.4
   ├─ @parcel/fs@npm:2.16.4
   │  └─ ...
   ├─ @parcel/node-resolver-core@npm:3.7.4   <---- missing link
   │  └─ ...
   └─ @parcel/workers@npm:2.16.4
```

This PR adds the missing links.

## 🚨 Test instructions

In an empty directory, with Yarn v4:

```bash
$ yarn init
$ yarn add --dev parcel
$ touch index.js
$ yarn parcel build index.js
```

## ✔️ PR Todo

- [ ] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs
