### PR TITLE
Fix UTF-8 BOM parsing in JSON files

### DIFF
--- a/crates/parcel-resolver/src/package_json.rs
+++ b/crates/parcel-resolver/src/package_json.rs
@@ -353,7 +353,8 @@ impl PackageJson {
   }
 
   pub fn parse(path: CachedPath, data: String, cache: &Cache) -> serde_json::Result<PackageJson> {
-    let parsed: SerializedPackageJson = serde_json::from_str(&data)?;
+    let data = data.strip_prefix('\u{feff}').unwrap_or(&data);
+    let parsed: SerializedPackageJson = serde_json::from_str(data)?;
     Ok(PackageJson::from_serialized(path, parsed, cache))
   }
 
@@ -1989,5 +1990,18 @@ mod tests {
     assert_eq!(pkg.module_type, ModuleType::CommonJs);
     let pkg: SerializedPackageJson = serde_json::from_str(r#"{"main":false}"#).unwrap();
     assert_eq!(pkg.main, None);
+  }
+
+  #[test]
+  fn parses_utf8_bom() {
+    let cache = Cache::default();
+    let pkg = PackageJson::parse(
+      cache.get_normalized("/package.json"),
+      "\u{feff}{\"name\":\"foo\"}".into(),
+      &cache,
+    )
+    .unwrap();
+
+    assert_eq!(pkg.name, "foo");
   }
 }

--- a/crates/parcel-resolver/src/tsconfig.rs
+++ b/crates/parcel-resolver/src/tsconfig.rs
@@ -82,6 +82,9 @@ impl TsConfig {
     mut data: String,
     cache: &Cache,
   ) -> serde_json::Result<TsConfigWrapper> {
+    if data.starts_with('\u{feff}') {
+      data.remove(0);
+    }
     let _ = strip_comments_in_place(data.as_mut_str(), Default::default(), true);
     let wrapper: SerializedTsConfigWrapper = serde_json::from_str(&data)?;
     Ok(TsConfigWrapper {
@@ -229,6 +232,22 @@ fn base_url_iter<'a>(
 mod tests {
   use super::*;
   use indexmap::indexmap;
+
+  #[test]
+  fn parses_utf8_bom() {
+    let cache = Cache::default();
+    let tsconfig = TsConfig::parse(
+      cache.get_normalized("/tsconfig.json"),
+      "\u{feff}{\"compilerOptions\":{\"moduleSuffixes\":[\".ios\"]}}".into(),
+      &cache,
+    )
+    .unwrap();
+
+    assert_eq!(
+      tsconfig.compiler_options.module_suffixes,
+      Some(vec![".ios".into()])
+    );
+  }
 
   #[test]
   fn test_paths() {

--- a/packages/core/core/src/requests/EntryRequest.js
+++ b/packages/core/core/src/requests/EntryRequest.js
@@ -362,6 +362,10 @@ export class EntryResolver {
       return null;
     }
 
+    if (content.charCodeAt(0) === 0xfeff) {
+      content = content.slice(1);
+    }
+
     try {
       pkg = JSON.parse(content);
     } catch (err) {

--- a/packages/core/core/test/EntryRequest.test.js
+++ b/packages/core/core/test/EntryRequest.test.js
@@ -2,8 +2,9 @@
 import assert from 'assert';
 import path from 'path';
 import {md} from '@parcel/diagnostic';
-import {inputFS as fs} from '@parcel/test-utils';
+import {inputFS as fs, outputFS} from '@parcel/test-utils';
 import {EntryResolver} from '../src/requests/EntryRequest';
+import {toProjectPath} from '../src/projectPath';
 import {DEFAULT_OPTIONS as _DEFAULT_OPTIONS} from './test-utils';
 
 const DEFAULT_OPTIONS = {
@@ -41,6 +42,29 @@ const GLOB_LIKE_FIXTURE_PATH = path.join(
 
 describe('EntryResolver', function () {
   let entryResolver = new EntryResolver({...DEFAULT_OPTIONS});
+
+  it('supports a UTF-8 BOM in package.json', async function () {
+    let fixturePath = path.join(__dirname, 'fixtures/package-bom');
+    await outputFS.mkdirp(fixturePath);
+    await outputFS.writeFile(
+      path.join(fixturePath, 'package.json'),
+      '\uFEFF' + JSON.stringify({source: 'index.js'}),
+    );
+    await outputFS.writeFile(path.join(fixturePath, 'index.js'), '');
+
+    let result = await new EntryResolver({
+      ...DEFAULT_OPTIONS,
+      inputFS: outputFS,
+      outputFS,
+      projectRoot: fixturePath,
+    }).resolveEntry(fixturePath);
+
+    assert.equal(result.entries.length, 1);
+    assert.equal(
+      result.entries[0].filePath,
+      toProjectPath(fixturePath, path.join(fixturePath, 'index.js')),
+    );
+  });
 
   it('rejects missing source in package.json', async function () {
     this.timeout(10000);


### PR DESCRIPTION
# ↪️ Pull Request

Handle a leading UTF-8 BOM at the current JSON parsing boundaries used by entry package.json files and the Rust resolver's package.json / tsconfig.json parsers.

The change removes exactly one leading U+FEFF before parsing. It does not trim other whitespace, remove BOMs elsewhere in the document, or relax JSON / JSONC syntax.

Fixes #8378

## 💻 Examples

Files beginning with the UTF-8 BOM byte sequence (EF BB BF) now parse normally. This applies to an entry directory's package.json and resolver-loaded package.json / tsconfig.json files.

## 🚨 Test instructions

- Regression test before the fix: 0 passing, 1 failing with Unexpected token U+FEFF.
- Targeted regression after the fix: 1 passing.
- Configured JavaScript unit suite: 562 passing, 1 pending.
- ESLint and Prettier checks pass for the changed JavaScript files.
- Flow reports only the existing intentionally invalid json-error/package.json fixture; the changed files add no Flow errors.
- Rust resolver unit suite: 56 passing, including both new parses_utf8_bom tests. This used an isolated Rust 1.98.0 x86_64-pc-windows-gnu toolchain with rust-lld's self-contained linker; the run emitted one pre-existing mismatched_lifetime_syntaxes warning in unchanged specifier.rs.

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions
- [x] Included links to related issues/PRs