### PR TITLE
fix(vue): avoid CSS module warning for scoped styles

### DIFF
--- a/packages/core/integration-tests/test/vue.js
+++ b/packages/core/integration-tests/test/vue.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import path from 'path';
+import logger from '@parcel/logger';
 import {bundle, distDir, outputFS, run} from '@parcel/test-utils';
 
 describe('vue', function () {
@@ -47,6 +48,35 @@ describe('vue', function () {
       'utf8',
     );
     assert(contents.includes(`.test[${output.__scopeId}]`));
+  });
+  it('should not warn about CSS modules for scoped styles', async function () {
+    let warnings = [];
+    let disposable = logger.onLog(event => {
+      if (event.type === 'log' && event.level === 'warn') {
+        warnings.push(...event.diagnostics.map(diagnostic => diagnostic.message));
+      }
+    });
+
+    let b;
+    try {
+      b = await bundle(
+        path.join(__dirname, '/integration/vue-scoped/App.vue'),
+        {mode: 'production'},
+      );
+    } finally {
+      disposable.dispose();
+    }
+
+    let cssBundle = b.getBundles().find(bundle => bundle.type === 'css');
+    assert(cssBundle != null);
+    let contents = await outputFS.readFile(cssBundle.filePath, 'utf8');
+    assert(/\.test\[data-v-[0-9a-h]{6}\]/.test(contents));
+    assert(
+      !warnings.includes(
+        'CSS modules cannot be tree shaken when imported with a default specifier',
+      ),
+      warnings.join('\n'),
+    );
   });
   it('should produce a vue bundle using CSS modules', async function () {
     let b = await bundle(

--- a/packages/transformers/vue/src/VueTransformer.js
+++ b/packages/transformers/vue/src/VueTransformer.js
@@ -103,6 +103,11 @@ export default (new Transformer({
     let scopeId = 'data-v-' + id;
     let hmrId = id + '-hmr';
     let basePath = basename(asset.filePath);
+    let hasCSSModules = styles.some(
+      style =>
+        style.module ||
+        (style.src != null && MODULE_BY_NAME_RE.test(style.src)),
+    );
     if (asset.pipeline != null) {
       return processPipeline({
         asset,
@@ -138,7 +143,9 @@ let initialize = () => {
   }
   ${
     styles.length !== 0
-      ? `script.__cssModules = require('style:./${basePath}').default;`
+      ? hasCSSModules
+        ? `script.__cssModules = require('style:./${basePath}').default;`
+        : `require('style:./${basePath}');`
       : ''
   }
   ${


### PR DESCRIPTION
# ↪️ Pull Request

Fixes #10353.

Vue's generated glue currently reads the style dependency's `default` export for every component containing a style block. This marks regular and scoped CSS as a default CSS Modules import, so optimized builds emit the CSS Modules tree-shaking warning even when no module styles are present.

This change distinguishes style-only components from components that actually contain CSS Modules. Regular and scoped styles now load `style:./${basePath}` with a bare `require` for side effects, while module styles keep the existing `.default` assignment to `script.__cssModules`. Module detection covers both boolean/named `<style module>` descriptors and external sources matching the existing `MODULE_BY_NAME_RE` convention.

## 💻 Examples

An optimized build of the existing scoped-style Vue fixture no longer emits:

```text
CSS modules cannot be tree shaken when imported with a default specifier
```

The regression test verifies the optimized scoped selector is still emitted without relying on a production entry's runtime exports. The targeted tests also retain the existing non-production scoped-style and CSS Modules behavior checks.

## 🚨 Test instructions

```sh
yarn exec mocha --config packages/core/integration-tests/.mocharc.json packages/core/integration-tests/test/vue.js --grep 'should produce a vue bundle using scoped styles|should not warn about CSS modules for scoped styles|should produce a vue bundle using CSS modules'
```

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs