### PR TITLE
feat: add Bun as a recognized package manager

### DIFF
--- a/packages/core/package-manager/src/Bun.js
+++ b/packages/core/package-manager/src/Bun.js
@@ -1,0 +1,85 @@
+// @flow strict-local
+
+import type {PackageInstaller, InstallerOptions} from '@parcel/types';
+
+import commandExists from 'command-exists';
+import spawn from 'cross-spawn';
+import logger from '@parcel/logger';
+import promiseFromProcess from './promiseFromProcess';
+import {registerSerializableClass} from '@parcel/core';
+import {npmSpecifierFromModuleRequest} from './utils';
+
+// $FlowFixMe
+import pkg from '../package.json';
+
+const BUN_CMD = 'bun';
+
+let hasBun: ?boolean;
+
+export class Bun implements PackageInstaller {
+  static async exists(): Promise<boolean> {
+    if (hasBun != null) {
+      return hasBun;
+    }
+
+    try {
+      hasBun = Boolean(await commandExists('bun'));
+    } catch (err) {
+      hasBun = false;
+    }
+
+    return hasBun;
+  }
+
+  async install({
+    modules,
+    cwd,
+    saveDev = true,
+  }: InstallerOptions): Promise<void> {
+    let args = ['add'];
+    if (saveDev) {
+      args.push('--dev');
+    }
+    args = args.concat(modules.map(npmSpecifierFromModuleRequest));
+
+    // Bun reads the same npm_config_* environment variables as npm/yarn, and
+    // forwarding them when Parcel itself was invoked via a package manager
+    // script can cause it to behave unexpectedly, so filter them out (as the
+    // other installers do) when installing packages.
+    let env = {};
+    for (let key in process.env) {
+      if (!key.startsWith('npm_') && key !== 'INIT_CWD' && key !== 'NODE_ENV') {
+        env[key] = process.env[key];
+      }
+    }
+
+    let installProcess = spawn(BUN_CMD, args, {cwd, env});
+
+    let stderr = [];
+    installProcess.stderr.on('data', (buf: Buffer) => {
+      stderr.push(buf.toString().trim());
+    });
+
+    try {
+      await promiseFromProcess(installProcess);
+
+      for (let message of stderr) {
+        if (message.length > 0) {
+          logger.log({
+            origin: '@parcel/package-manager',
+            message,
+          });
+        }
+      }
+    } catch (e) {
+      throw new Error(
+        'bun failed to install modules: ' +
+          e.message +
+          ' - ' +
+          stderr.join('\n'),
+      );
+    }
+  }
+}
+
+registerSerializableClass(`${pkg.version}:Bun`, Bun);

--- a/packages/core/package-manager/src/index.js
+++ b/packages/core/package-manager/src/index.js
@@ -11,6 +11,7 @@ export type {
 export * from './Npm';
 export * from './Pnpm';
 export * from './Yarn';
+export * from './Bun';
 export * from './MockPackageInstaller';
 export * from './NodePackageManager';
 export {_addToInstallQueue} from './installPackage';

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -25,6 +25,7 @@ import WorkerFarm from '@parcel/workers';
 import {Npm} from './Npm';
 import {Yarn} from './Yarn';
 import {Pnpm} from './Pnpm.js';
+import {Bun} from './Bun.js';
 import {getConflictingLocalDependencies} from './utils';
 import getCurrentPackageManager from './getCurrentPackageManager';
 import validateModuleSpecifier from './validateModuleSpecifier';
@@ -158,7 +159,13 @@ async function determinePackageInstaller(
   let configFile = await resolveConfig(
     fs,
     filepath,
-    ['package-lock.json', 'pnpm-lock.yaml', 'yarn.lock'],
+    [
+      'package-lock.json',
+      'pnpm-lock.yaml',
+      'yarn.lock',
+      'bun.lock',
+      'bun.lockb',
+    ],
     projectRoot,
   );
 
@@ -172,6 +179,8 @@ async function determinePackageInstaller(
     return new Pnpm();
   } else if (configName === 'yarn.lock') {
     return new Yarn();
+  } else if (configName === 'bun.lock' || configName === 'bun.lockb') {
+    return new Bun();
   }
 
   let currentPackageManager = getCurrentPackageManager()?.name;
@@ -181,12 +190,16 @@ async function determinePackageInstaller(
     return new Yarn();
   } else if (currentPackageManager === 'pnpm') {
     return new Pnpm();
+  } else if (currentPackageManager === 'bun') {
+    return new Bun();
   }
 
   if (await Yarn.exists()) {
     return new Yarn();
   } else if (await Pnpm.exists()) {
     return new Pnpm();
+  } else if (await Bun.exists()) {
+    return new Bun();
   } else {
     return new Npm();
   }

--- a/packages/core/package-manager/test/getCurrentPackageManager.test.js
+++ b/packages/core/package-manager/test/getCurrentPackageManager.test.js
@@ -25,4 +25,11 @@ describe('getCurrentPackageManager', () => {
     );
     assert(currentPackageManager?.name, 'pnpm');
   });
+  it('bun', () => {
+    const npm_config_user_agent = 'bun/1.0.5 npm/? node/v18.17.1 darwin x64';
+    const currentPackageManager = getCurrentPackageManager(
+      npm_config_user_agent,
+    );
+    assert(currentPackageManager?.name, 'bun');
+  });
 });


### PR DESCRIPTION
Fixes #9302

## What
Parcel's auto-install logic (`installPackage.js`) only recognized npm, Yarn, and pnpm — both for lockfile-based detection and as the fallback chain when no lockfile exists yet. A project using Bun had no lockfile match and no `currentPackageManager` match, so it silently fell through to the Yarn/Pnpm/Npm existence cascade and installed with whichever of those happened to be present instead of Bun. That mismatch (a different installer managing the project than the one the user was actually using) is consistent with the "package.json gets clobbered" behavior described in the issue.

As a maintainer noted in the issue thread, this needed Bun added alongside npm/pnpm/Yarn in that file — this PR does that:

- New `Bun.js` package installer (mirrors the existing `Npm.js`), spawning `bun add [--dev] <modules>`.
- `determinePackageInstaller` now recognizes `bun.lock` / `bun.lockb` for lockfile-based detection.
- Recognizes `bun` from the `npm_config_user_agent`-derived current package manager.
- Adds `Bun.exists()` to the final existence-based fallback cascade (Yarn → Pnpm → Bun → Npm).
- Exported from the package's `index.js` barrel alongside the other installers.

## Testing
- Added a `bun` case to `getCurrentPackageManager`'s existing test suite.
- Built the native Rust addon locally and ran the full unit suite (`mocha`, 562 passing, 0 failing) — no regressions.
- `yarn check` (flow) — 0 errors.
- `eslint` on all changed/added files — no warnings or errors.
- `prettier` — formatted to match repo conventions.