### PR TITLE
fix: throw BuildAbortError instead of crashing when all queued builds abort

### DIFF
--- a/packages/core/core/src/Parcel.js
+++ b/packages/core/core/src/Parcel.js
@@ -355,6 +355,14 @@ export default class Parcel {
 
           let results = await this.#watchQueue.run();
           let result = results.filter(Boolean).pop();
+          if (result == null) {
+            // Every queued build in this batch resolved to null, meaning
+            // each was aborted (see _startNextBuild, which swallows
+            // BuildAbortError and resolves null instead of rethrowing).
+            // Surface the same error type here instead of throwing on
+            // `result.type` below.
+            throw new BuildAbortError();
+          }
           if (result.type === 'buildFailure') {
             throw new BuildError(result.diagnostics);
           }


### PR DESCRIPTION
Fixes #10344

## What
`requestBundle()`'s handler takes the last non-null result from the watch queue's batch:

```js
let results = await this.#watchQueue.run();
let result = results.filter(Boolean).pop();
if (result.type === 'buildFailure') { ... }
```

`_startNextBuild()` swallows `BuildAbortError` and resolves to `undefined` instead of rethrowing it (see the `catch` block a few lines up in the same file). So when every build queued in a batch gets aborted — e.g. rapid successive bundle requests each aborting the previous in-flight build via `#watchAbortController.abort()` — `results.filter(Boolean)` is empty, `.pop()` returns `undefined`, and the following `result.type` access throws a raw `TypeError` instead of the `BuildAbortError` that every other abort path in this function already produces and that callers already know how to handle.

## Fix
Guard the empty-batch case and throw `BuildAbortError` there too, matching the existing pattern used one call frame up in `_startNextBuild` and in the `catch` block of `_build`'s caller.

## Testing
- `yarn check` (flow) — 0 errors
- `eslint` on the changed file — clean
- Full `packages/core/core/test/Parcel.test.js` and `packages/core/integration-tests/test/lazy-compile.js` suites pass (567 passing, 0 failing) after this change
- Did **not** add a new regression test reproducing the exact abort race: it requires several builds racing to abort each other inside `#watchQueue`, a private-field-guarded internal timing condition that isn't reproducible deterministically without refactoring for testability, which felt out of scope for a one-line defensive fix. Happy to add one if a maintainer can point at an existing pattern for simulating this.