### PR TITLE
fix: don't crash packaging a CSS Modules composes target shared by 2+ modules

### DIFF
--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -247,6 +247,18 @@ describe('css modules', () => {
     assert(css.includes(`.${cssClass2}`));
   });
 
+  it('should not throw building composes imports shared by two or more ES modules (production)', async () => {
+    // Regression test: when a CSS Modules class is `composes`d from two or
+    // more separate ES modules, packaging in production mode used to throw
+    // "Got unexpected null" in ScopeHoistingPackager, because `composes`
+    // dependency edges don't carry per-symbol usage tracking the way named
+    // JS imports do.
+    await bundle(
+      path.join(__dirname, '/integration/postcss-composes-shared-esm/index.js'),
+      {mode: 'production'},
+    );
+  });
+
   it('should not include css twice for composes imports', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index.js'),

--- a/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/a.module.css
+++ b/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/a.module.css
@@ -1,0 +1,4 @@
+.primary {
+  composes: base from './shared.module.css';
+  background-color: red;
+}

--- a/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/b.module.css
+++ b/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/b.module.css
@@ -1,0 +1,3 @@
+.container {
+  composes: base from './shared.module.css';
+}

--- a/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/index.js
+++ b/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/index.js
@@ -1,0 +1,6 @@
+import * as a from './a.module.css';
+import * as b from './b.module.css';
+
+module.exports = function () {
+  return a.primary + ' ' + b.container;
+};

--- a/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/shared.module.css
+++ b/packages/core/integration-tests/test/integration/postcss-composes-shared-esm/shared.module.css
@@ -1,0 +1,3 @@
+.base {
+  background: inherit;
+}

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1323,7 +1323,14 @@ ${code}
         }
 
         let unused = incomingDeps.every(d => {
-          let symbols = nullthrows(this.bundleGraph.getUsedSymbols(d));
+          let symbols = this.bundleGraph.getUsedSymbols(d);
+          if (symbols == null) {
+            // This dependency doesn't track per-symbol usage (e.g. a CSS
+            // `composes` edge, which has no equivalent of a named import).
+            // Conservatively treat the symbol as used via this edge rather
+            // than risk incorrectly tree-shaking it away.
+            return false;
+          }
           return !symbols.has(symbol) && !symbols.has('*');
         });
         return !unused;


### PR DESCRIPTION
Fixes #10325. Also fixes the crash reported in #10254 (see note below on scope).

## What
`ScopeHoistingPackager`'s used-exports computation checks every incoming dependency's used-symbols set to decide whether a symbol can be tree-shaken:

```js
let symbols = nullthrows(this.bundleGraph.getUsedSymbols(d));
```

`getUsedSymbols` returns `null` for dependency edges that don't carry per-symbol tracking — notably CSS Modules `composes: x from './y.css'` edges, which have no equivalent of a named JS import. As long as a composed class is only reachable through one composing module, this path isn't exercised. Once **two or more modules `composes` the same class** (a common pattern for shared base styles), the shared class becomes a real multi-parent asset that goes through this codepath during production builds, and `nullthrows` throws `Got unexpected null`.

This is reported independently in #10325 (triggered via an MDX build) and #10254 (triggered via the repro below) — same crash, same root cause, different way of hitting it.

## Fix
When a dependency has no per-symbol tracking, conservatively treat the symbol as **used** via that edge rather than crash — or worse, silently default to "unused," which would risk incorrectly tree-shaking a symbol that's actually referenced.

## Verification
Reproduced with the exact repro from #10254 (React + CSS Modules `composes`, two composing modules) against a local build of this checkout:
- On `v2` HEAD: crashes with `Got unexpected null`.
- With this fix: builds successfully.

**Scope note:** this fixes the crash both issues hit, but does **not** address #10254's own underlying complaint — that composed classes are ordered *after* the composing class in the output CSS (should be before, per CSS cascade). Confirmed that's still true post-fix; it's a separate bundle-ordering question in the default bundler, unrelated to this packager, and out of scope here.

## Testing
- `yarn check` (flow) — 0 errors
- `eslint` on changed files — clean
- Added a regression test in `css-modules.js` using a fixture with the same two-ES-module `composes` shape as the report. Verified it fails with the original `Got unexpected null` error when the fix is reverted (`git stash` the packager change, rerun), and passes with it applied.
- Full `css-modules.js` + `scope-hoisting.js` suites: 898 passing, 0 failing (897 before this change + the 1 new test) — no regressions.