### PR TITLE
Replace bare process.env references to avoid pulling in the process polyfill

### DIFF
--- a/packages/core/integration-tests/test/integration/env-bare-reference/index.js
+++ b/packages/core/integration-tests/test/integration/env-bare-reference/index.js
@@ -1,0 +1,9 @@
+const debug =
+  process.env &&
+  process.env.NODE_DEBUG &&
+  /\bsemver\b/i.test(process.env.NODE_DEBUG);
+
+module.exports = {
+  debug,
+  hasEnv: !!process.env,
+};

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1298,6 +1298,19 @@ describe('javascript', function () {
     assert.strictEqual(output, false);
   });
 
+  it('should replace bare references to process.env in browser environment', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/env-bare-reference/index.js'),
+    );
+
+    let contents = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(!contents.includes('process.env'));
+
+    let output = await run(b);
+    assert.strictEqual(output.debug, undefined);
+    assert.strictEqual(output.hasEnv, true);
+  });
+
   it('should not insert environment variables in electron-main environment', async function () {
     let b = await bundle(path.join(__dirname, '/integration/env/index.js'), {
       targets: {

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -76,7 +76,27 @@ impl<'a> VisitMut for EnvReplacer<'a> {
               return;
             }
           }
+          // Accesses that are not replaced, e.g. `process.env.hasOwnProperty`
+          // and computed accesses such as `process.env[key]`, keep referencing
+          // the real `process.env`. Only visit the computed property
+          // expression so `process.env` isn't replaced on its own below.
+          if let MemberProp::Computed(computed) = &mut member.prop {
+            computed.expr.visit_mut_with(self);
+          }
+          return;
         }
+      }
+
+      // Replace a bare `process.env` reference (e.g. `process.env && ...`) with
+      // an empty object, like the replacement for `const env = process.env`,
+      // so it doesn't pull the `process` polyfill into browser builds. This
+      // matches the polyfill at run time, which also sets `process.env = {}`.
+      if match_member_expr(member, vec!["process", "env"], self.unresolved_mark) {
+        *node = Expr::Object(ObjectLit {
+          span: member.span,
+          props: vec![],
+        });
+        return;
       }
     }
 
@@ -693,6 +713,66 @@ const { package, ...other } = process.env;
     );
     // tracks that the variable was used
     assert_eq!(used_env, ["package"].iter().map(|s| (*s).into()).collect());
+    assert_eq!(diagnostics, vec![]);
+  }
+
+  #[test]
+  fn test_replace_bare_process_env() {
+    let env: HashMap<JsWord, JsWord> = HashMap::new();
+    let mut used_env = HashSet::new();
+    let mut diagnostics = Vec::new();
+
+    // https://github.com/parcel-bundler/parcel/issues/8156
+    let RunVisitResult { output_code, .. } = run_visit(
+      r#"
+const debug = process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG);
+if (process.env) run(process.env);
+    "#,
+      |run_test_context: RunTestContext| {
+        make_env_replacer(run_test_context, &env, &mut used_env, &mut diagnostics)
+      },
+    );
+
+    assert_eq!(
+      output_code,
+      r#"const debug = {} && undefined && /\bsemver\b/i.test(undefined);
+if ({}) run({});
+"#
+    );
+    // tracks that the variable was used
+    assert_eq!(used_env, HashSet::from(["NODE_DEBUG".into()]));
+    assert_eq!(diagnostics, vec![]);
+  }
+
+  #[test]
+  fn test_does_not_replace_process_env_in_unreplaced_member_accesses() {
+    let mut env: HashMap<JsWord, JsWord> = HashMap::new();
+    let mut used_env = HashSet::new();
+    let mut diagnostics = Vec::new();
+
+    env.insert("KEY".into(), "VERSION".into());
+
+    let RunVisitResult { output_code, .. } = run_visit(
+      r#"
+const version = process.env.hasOwnProperty('version');
+const dynamic = process.env[key];
+const nested = process.env[process.env.KEY];
+    "#,
+      |run_test_context: RunTestContext| {
+        make_env_replacer(run_test_context, &env, &mut used_env, &mut diagnostics)
+      },
+    );
+
+    // computed property expressions are still replaced
+    assert_eq!(
+      output_code,
+      r#"const version = process.env.hasOwnProperty('version');
+const dynamic = process.env[key];
+const nested = process.env["VERSION"];
+"#
+    );
+    // tracks that the variable was used
+    assert_eq!(used_env, HashSet::from(["KEY".into()]));
     assert_eq!(diagnostics, vec![]);
   }
 


### PR DESCRIPTION
# ↪️ Pull Request

Fixes the `process.env` half of #8156 (`typeof process` is already handled by `TypeofReplacer`).

A bare `process.env` reference is not replaced by `EnvReplacer`, so `GlobalReplacer` still sees `process` and injects the polyfill even when every individual env access was inlined. semver's debug helper is the pattern from the issue:

```js
const debug = process.env && process.env.NODE_DEBUG && /\bsemver\b/i.test(process.env.NODE_DEBUG);
```

This PR replaces bare `process.env` with `{}`, matching both the existing replacement for `const env = process.env` and the value the polyfill assigns at runtime (`process.env = {}`). Deliberately unreplaced accesses (`process.env.hasOwnProperty`, computed `process.env[key]`) keep referencing the real `process.env` as before.

## 💻 Examples

Building the issue's pattern for a browser target on v2.16.4: `Auto installing polyfill for Node builtin module "process/"`, 1.72 kB bundle. With this change: no polyfill, 82 B bundle, zero `process` references, identical runtime output.

## 🚨 Test instructions

- `cargo test -p parcel-js-swc-core env_replacer` (2 new unit tests)
- `mocha test/javascript.js -g "bare references to process.env"` (new fixture `env-bare-reference`); the full `javascript.js` suite passes (293 passing)

## ✔️ PR Todo

- [x] Added/updated unit tests for this change
- [x] Filled out test instructions (In case there aren't any unit tests)
- [x] Included links to related issues/PRs